### PR TITLE
docs: add implementation plan and first test case

### DIFF
--- a/docs/clarifying_prompt.md
+++ b/docs/clarifying_prompt.md
@@ -1,0 +1,286 @@
+# ProjectScylla Implementation Plan Review
+
+You are conducting a thorough review of the ProjectScylla agent testing framework plan. Your goal is to identify gaps, ambiguities, and areas requiring clarification before implementation begins.
+
+## Context Files to Read First
+
+1. `/home/mvillmow/ProjectScylla/docs/plan.md` - Implementation plan with issue links
+2. `/home/mvillmow/.claude/plans/swift-skipping-creek.md` - Detailed 21-part plan
+3. `/home/mvillmow/ProjectScylla/tests/001-justfile-to-makefile/` - First test case
+
+## GitHub Issues to Review
+
+Read each GitHub issue for implementation details using `gh issue view <number>`:
+
+### Phase 1: Foundation
+
+- #3 - Project structure and environment setup
+- #4 - Configuration loading system
+- #5 - Architecture documentation
+- #6 - Test schema specification
+
+### Phase 2: Execution Engine
+
+- #7 - Workspace management
+- #8 - Test runner orchestration (includes Docker/tier support)
+- #9 - Log and metrics capture
+- #10 - Adapter interface specification
+
+### Phase 3: Adapters
+
+- #11 - Base adapter class (includes tier configuration)
+- #12 - Claude Code adapter
+- #13 - OpenAI Codex adapter
+- #14 - Cline adapter
+- #15 - OpenCode adapter
+
+### Phase 4: Judge System
+
+- #16 - Rubric parser
+- #17 - Judge prompt templates (includes 10 quality categories)
+- #18 - Evaluator implementation (includes 3-run consensus)
+- #19 - Judgment parser
+- #20 - Judge protocol documentation
+- #38 - Cleanup script evaluation
+
+### Phase 5: Metrics and Statistics
+
+- #21 - Statistical calculations
+- #22 - Grading calculations
+- #23 - 10-run aggregation (includes cross-tier support)
+- #24 - Metrics formulas documentation
+- #37 - Cross-tier analysis
+
+### Phase 6: Reporting
+
+- #25 - result.json writer
+- #26 - summary.json generator
+- #27 - scorecard.json generator
+- #28 - Markdown report generator (includes tier comparison)
+
+### Phase 7: CLI
+
+- #29 - Command-line interface
+- #30 - Progress display
+
+### Phase 8: First Test Case
+
+- #31 - Create 001-justfile-to-makefile test case (includes cleanup script)
+- #32 - Validate framework with single run
+- #33 - Execute full 10-run suite
+- #34 - Generate first report
+
+### Phase 9: Tier System
+
+- #35 - Docker container orchestration
+- #36 - Tier configuration system
+
+---
+
+## Review Methodology
+
+For each phase, cross-reference the plan with the GitHub issues:
+
+1. Read the issue with `gh issue view <number> --comments`
+2. Compare issue details against plan sections
+3. Identify inconsistencies, gaps, or missing details
+4. Note any assumptions in the issue that aren't validated
+
+---
+
+### 1. Test Execution Model
+
+**Reference Issues**: #7, #8, #9, #35
+
+Questions to clarify:
+
+- How exactly does the adapter invoke the agent CLI inside Docker?
+- What environment variables are passed to the container?
+- How is the tier-specific prompt injected (file mount, env var, CLI flag)?
+- What happens if Docker is unavailable on the host?
+- How are API keys/credentials passed securely to containers?
+- What's the container resource limit (CPU, memory, disk)?
+- How do we handle agents that require internet access vs air-gapped runs?
+
+---
+
+### 2. Tier System Specifics
+
+**Reference Issues**: #36, #11, #8
+
+Questions to clarify:
+
+- What exactly goes in each tier prompt file (t1-prompted.md, t2-skills.md, t3-tooling.md)?
+- For T0 (Vanilla), do we pass ANY prompt or literally nothing?
+- For T3+ (Tooling), what tools are enabled? How are they configured?
+- How do we ensure tier prompts are agent-agnostic (work with Claude Code, Cline, etc.)?
+- Are tiers cumulative (T2 includes T1 content) or independent?
+
+---
+
+### 3. Judge System Details
+
+**Reference Issues**: #16, #17, #18, #19, #20, #38
+
+Questions to clarify:
+
+- How does Claude Code + Opus 4.5 access the workspace for judging?
+- What's the exact invocation command for the judge?
+- How do we capture judge token usage and cost separately from agent runs?
+- What if the judge fails or times out? Retry logic?
+- How do we validate judge consistency across the 3 runs?
+- What's the threshold for "too much disagreement" between judge runs?
+- How does cleanup script evaluation integrate with overall scoring?
+
+---
+
+### 4. Metrics & Statistics
+
+**Reference Issues**: #21, #22, #23, #24, #37
+
+Questions to clarify:
+
+- How do we handle runs that timeout or abort? Include in statistics or exclude?
+- What's the minimum number of successful runs needed to report statistics?
+- How do we calculate Cost-of-Pass when pass_rate is 0?
+- Are there any metrics specific to certain tiers (e.g., T3+ tool call count)?
+- How do we track token usage per component (agent vs judge vs orchestrator)?
+- What statistical tests validate cross-tier differences are significant?
+
+---
+
+### 5. Adapter Interface
+
+**Reference Issues**: #10, #11, #12, #13, #14, #15
+
+Questions to clarify:
+
+- What's the exact subprocess command for each adapter?
+- How do adapters handle different prompt injection methods per agent CLI?
+- What's the contract for adapter success vs failure?
+- How do we detect if an agent "gave up" vs completed unsuccessfully?
+- How do adapters capture structured output (if available) vs just logs?
+- How does tier configuration affect adapter behavior?
+
+---
+
+### 6. First Test Case Specifics
+
+**Reference Issues**: #31, #32, #33, #34
+
+Questions to clarify:
+
+- Is "justfile to Makefile" representative of the types of tests we'll run?
+- What other test case categories are planned?
+- How do we handle tests that require specific environments (GPU, database, etc.)?
+- What's the expected difficulty distribution (easy/medium/hard tests)?
+- What does the cleanup script requirement look like for this test?
+
+---
+
+### 7. Reporting & Output
+
+**Reference Issues**: #25, #26, #27, #28
+
+Questions to clarify:
+
+- Who is the audience for reports (researchers, engineers, executives)?
+- What visualization is needed (charts, graphs) or just tables?
+- Should reports be versioned or timestamped?
+- How do we handle comparing results across different time periods?
+- Is there a dashboard or just static reports?
+- How does the tier comparison section present statistical significance?
+
+---
+
+### 8. Operational Concerns
+
+**Reference Issues**: #3, #4, #29, #30
+
+Questions to clarify:
+
+- How do we run this in CI/CD?
+- What's the expected runtime for a full test suite?
+- How do we handle partial failures (some tiers complete, others fail)?
+- Is there a way to resume interrupted test runs?
+- How do we manage storage for runs/ directory over time?
+- What CLI commands are needed for different workflows?
+
+---
+
+### 9. Edge Cases & Error Handling
+
+**Reference Issues**: #8, #9, #18, #35
+
+Questions to clarify:
+
+- What if an agent produces output but the workspace is corrupted?
+- What if the cleanup script itself causes damage?
+- How do we handle agents that try to escape the container?
+- What if token counting differs between adapters?
+- How do we handle model version changes mid-experiment?
+
+---
+
+### 10. Research Validity
+
+**Reference Issues**: #37, #24, #20
+
+Questions to clarify:
+
+- How do we ensure reproducibility of results?
+- What's the strategy for controlling for external factors (API latency, rate limits)?
+- How do we document and version tier prompts for reproducibility?
+- Is there a control group or baseline beyond T0?
+- How do we handle the variance introduced by different models within the same adapter?
+
+---
+
+## Interview Approach
+
+For each gap identified:
+
+1. State the gap clearly
+2. Reference which GitHub issue(s) it affects
+3. Explain why it matters for implementation
+4. Propose 2-3 possible solutions
+5. Ask the user to choose or provide their preference
+
+Group questions into batches of 3-4 related topics to avoid overwhelming the user.
+
+---
+
+## Output
+
+After the interview:
+
+1. Update `/home/mvillmow/ProjectScylla/docs/plan.md` with clarifications
+2. Update `/home/mvillmow/.claude/plans/swift-skipping-creek.md` with new details
+3. Create new GitHub issues for any newly identified work using `gh issue create`
+4. Update existing issues with additional details using `gh issue edit`
+5. Document all decisions with issue cross-references
+
+---
+
+## Commands Reference
+
+```bash
+# Read issue with comments
+gh issue view <number> --comments
+
+# Update issue body
+gh issue edit <number> --body-file <file>
+
+# Add comment to issue
+gh issue comment <number> --body "..."
+
+# Create new issue
+gh issue create --title "..." --body "..." --label "..."
+
+# List all issues
+gh issue list --limit 50
+```
+
+---
+
+Begin by reading all context files and GitHub issues, then start with the most critical gaps first.

--- a/docs/plan.md
+++ b/docs/plan.md
@@ -1,0 +1,306 @@
+# ProjectScylla Implementation Plan
+
+## Overview
+
+Build an agent testing framework that evaluates AI agent effectiveness across multiple models. Tests are pure configuration (prompt, repo, hash, expected result). **Claude Code + Opus 4.5 serves as the judge** for validating test results.
+
+**Language**: Test Evaluation framework is implemented in Python only. Testing itself can cover any language.
+
+**GitHub Epic**: [#2 - Agent Testing Framework Implementation](https://github.com/mvillmow/ProjectScylla/issues/2)
+
+---
+
+## Research Paradigm
+
+### Core Hypothesis
+
+**Task-dependent value** - Different tasks benefit from different tiers. There is no universal "best" tier.
+
+### Research Question
+
+How sensitive are agents to system prompt changes? Does the complexity of higher tiers (T3-T6) provide proportional value increase?
+
+### Testing Methodology
+
+- Each test runs against **ALL tiers** (T0, T1, T2, T3+)
+- Each tier runs **10 times** for statistical validity
+- Each run executes in **isolated Docker container**
+- **3-run judge consensus** with confidence-weighted averaging
+
+---
+
+## Architecture
+
+```
+┌─────────────────┐     ┌─────────────────┐     ┌─────────────────┐
+│   TEST CASES    │     │    FRAMEWORK    │     │    OUTPUTS      │
+│   (Data/Config) │────▶│    (Python)     │────▶│   (Results)     │
+└─────────────────┘     └─────────────────┘     └─────────────────┘
+        │                       │                       │
+        ▼                       ▼                       ▼
+   - prompt                - executor              - judgment.json
+   - repo URL              - adapter               - result.json
+   - git hash              - judge (Opus 4.5)      - summary.json
+   - criteria              - aggregator            - report.md
+```
+
+### Three-Phase Execution
+
+```
+PHASE 1: EXECUTE                 PHASE 2: JUDGE                 PHASE 3: REPORT
+┌─────────────────┐             ┌─────────────────┐             ┌─────────────────┐
+│ For each tier:  │             │ For each run:   │             │ Aggregate:      │
+│ - Docker container│──────────▶│ - 3-run consensus│───────────▶│ - Statistics    │
+│ - Run adapter   │  workspace  │ - Score rubric  │  judgment   │ - Cross-tier    │
+│ - Capture logs  │             │ - Confidence    │             │ - Report        │
+└─────────────────┘             └─────────────────┘             └─────────────────┘
+     × 10 runs                      × 3 judges                       × 1
+```
+
+---
+
+## Tier System
+
+| Tier | Name | Description | Prompt Source |
+|------|------|-------------|---------------|
+| T0 | Vanilla | Base LLM, tool default, zero customization | Tool default |
+| T1 | Prompted | System prompt with chain-of-thought | `tiers/t1-prompted.md` |
+| T2 | Skills | Domain expertise encoded in prompts | `tiers/t2-skills.md` |
+| T3+ | Tooling | External tools, multi-agent orchestration | `tiers/t3-tooling.md` |
+
+---
+
+## LLM-as-a-Judge Categories
+
+| Category | Weight | Description |
+|----------|--------|-------------|
+| Functional Correctness | 2.0 | Does the solution work as intended? |
+| Completeness | 1.5 | Are all requirements addressed? |
+| Code Quality | 1.0 | Readability, maintainability, best practices |
+| Simplicity | 1.0 | Prefer simple working solutions over complex ones |
+| Lack of Duplication | 0.5 | DRY principle adherence |
+| Clarity | 1.0 | Clear, understandable implementation |
+| Documentation | 0.5 | Appropriate comments and documentation |
+| Architectural Cleanliness | 0.5 | Clean separation of concerns |
+| Efficiency | 0.5 | Resource usage, performance considerations |
+| Cleanup Script Quality | 1.0 | Proper cleanup/teardown script creation |
+
+**Total Weight**: 9.5
+
+---
+
+## Key Metrics
+
+| Metric | Formula | Purpose |
+|--------|---------|---------|
+| **Pass Rate Variance** | `var(pass_rates_by_tier)` | Measure prompt sensitivity |
+| **Cost-of-Pass Delta** | `max(CoP) - min(CoP)` | Cost difference between tiers |
+| **Tier Uplift** | `(T_n - T_0) / T_0` | Percentage improvement over baseline |
+| **Consistency** | `std_dev(scores_within_tier)` | Reliability of each tier |
+
+---
+
+## Implementation Phases
+
+### Phase 1: Foundation
+
+| Issue | Title | Status |
+|-------|-------|--------|
+| [#3](https://github.com/mvillmow/ProjectScylla/issues/3) | [Infra] Project structure and environment setup | Open |
+| [#4](https://github.com/mvillmow/ProjectScylla/issues/4) | [Infra] Configuration loading system | Open |
+| [#5](https://github.com/mvillmow/ProjectScylla/issues/5) | [Docs] Architecture documentation | Open |
+| [#6](https://github.com/mvillmow/ProjectScylla/issues/6) | [Docs] Test schema specification | Open |
+
+### Phase 2: Execution Engine
+
+| Issue | Title | Status |
+|-------|-------|--------|
+| [#7](https://github.com/mvillmow/ProjectScylla/issues/7) | [Core] Workspace management | Open |
+| [#8](https://github.com/mvillmow/ProjectScylla/issues/8) | [Core] Test runner orchestration | Open |
+| [#9](https://github.com/mvillmow/ProjectScylla/issues/9) | [Core] Log and metrics capture | Open |
+| [#10](https://github.com/mvillmow/ProjectScylla/issues/10) | [Docs] Adapter interface specification | Open |
+
+### Phase 3: Adapters
+
+| Issue | Title | Status |
+|-------|-------|--------|
+| [#11](https://github.com/mvillmow/ProjectScylla/issues/11) | [Adapter] Base adapter class | Open |
+| [#12](https://github.com/mvillmow/ProjectScylla/issues/12) | [Adapter] Claude Code adapter | Open |
+| [#13](https://github.com/mvillmow/ProjectScylla/issues/13) | [Adapter] OpenAI Codex adapter | Open |
+| [#14](https://github.com/mvillmow/ProjectScylla/issues/14) | [Adapter] Cline adapter | Open |
+| [#15](https://github.com/mvillmow/ProjectScylla/issues/15) | [Adapter] OpenCode adapter | Open |
+
+### Phase 4: Judge System
+
+| Issue | Title | Status |
+|-------|-------|--------|
+| [#16](https://github.com/mvillmow/ProjectScylla/issues/16) | [Judge] Rubric parser | Open |
+| [#17](https://github.com/mvillmow/ProjectScylla/issues/17) | [Judge] Judge prompt templates | Open |
+| [#18](https://github.com/mvillmow/ProjectScylla/issues/18) | [Judge] Evaluator implementation | Open |
+| [#19](https://github.com/mvillmow/ProjectScylla/issues/19) | [Judge] Judgment parser | Open |
+| [#20](https://github.com/mvillmow/ProjectScylla/issues/20) | [Docs] Judge protocol documentation | Open |
+| [#38](https://github.com/mvillmow/ProjectScylla/issues/38) | [Judge] Cleanup script evaluation | Open |
+
+### Phase 5: Metrics and Statistics
+
+| Issue | Title | Status |
+|-------|-------|--------|
+| [#21](https://github.com/mvillmow/ProjectScylla/issues/21) | [Metrics] Statistical calculations | Open |
+| [#22](https://github.com/mvillmow/ProjectScylla/issues/22) | [Metrics] Grading calculations | Open |
+| [#23](https://github.com/mvillmow/ProjectScylla/issues/23) | [Metrics] 10-run aggregation | Open |
+| [#24](https://github.com/mvillmow/ProjectScylla/issues/24) | [Docs] Metrics formulas documentation | Open |
+| [#37](https://github.com/mvillmow/ProjectScylla/issues/37) | [Metrics] Cross-tier analysis | Open |
+
+### Phase 6: Reporting
+
+| Issue | Title | Status |
+|-------|-------|--------|
+| [#25](https://github.com/mvillmow/ProjectScylla/issues/25) | [Report] result.json writer | Open |
+| [#26](https://github.com/mvillmow/ProjectScylla/issues/26) | [Report] summary.json generator | Open |
+| [#27](https://github.com/mvillmow/ProjectScylla/issues/27) | [Report] scorecard.json generator | Open |
+| [#28](https://github.com/mvillmow/ProjectScylla/issues/28) | [Report] Markdown report generator | Open |
+
+### Phase 7: CLI
+
+| Issue | Title | Status |
+|-------|-------|--------|
+| [#29](https://github.com/mvillmow/ProjectScylla/issues/29) | [CLI] Command-line interface | Open |
+| [#30](https://github.com/mvillmow/ProjectScylla/issues/30) | [CLI] Progress display | Open |
+
+### Phase 8: First Test Case
+
+| Issue | Title | Status |
+|-------|-------|--------|
+| [#31](https://github.com/mvillmow/ProjectScylla/issues/31) | [Test] Create 001-justfile-to-makefile test case | Open |
+| [#32](https://github.com/mvillmow/ProjectScylla/issues/32) | [Test] Validate framework with single run | Open |
+| [#33](https://github.com/mvillmow/ProjectScylla/issues/33) | [Test] Execute full 10-run suite | Open |
+| [#34](https://github.com/mvillmow/ProjectScylla/issues/34) | [Test] Generate first report | Open |
+
+### Phase 9: Tier System (NEW)
+
+| Issue | Title | Status |
+|-------|-------|--------|
+| [#35](https://github.com/mvillmow/ProjectScylla/issues/35) | [Core] Docker container orchestration | Open |
+| [#36](https://github.com/mvillmow/ProjectScylla/issues/36) | [Core] Tier configuration system | Open |
+
+---
+
+## Directory Structure
+
+```
+ProjectScylla/
+├── tests/                              # TEST CASES (Pure Data)
+│   └── <test-id>/
+│       ├── test.yaml                   # Test definition
+│       ├── prompt.md                   # Agent prompt
+│       └── expected/
+│           ├── criteria.md             # Success criteria
+│           └── rubric.yaml             # Scoring rubric
+│
+├── config/
+│   ├── defaults.yaml                   # Global defaults
+│   ├── models/                         # Model-specific configs
+│   └── tiers/                          # Tier definitions (T0-T3+)
+│
+├── src/scylla/
+│   ├── cli.py                          # Command-line interface
+│   ├── executor/                       # Test execution
+│   │   ├── runner.py                   # Main test runner
+│   │   ├── workspace.py                # Git clone management
+│   │   ├── docker.py                   # Container orchestration
+│   │   └── tier_config.py              # Tier configuration
+│   ├── adapters/                       # Agent CLI adapters
+│   ├── judge/                          # Claude + Opus evaluation
+│   ├── metrics/                        # Statistical calculations
+│   └── reporting/                      # Report generation
+│
+├── runs/                               # OUTPUTS (gitignored)
+├── summaries/                          # AGGREGATED RESULTS
+├── reports/                            # HUMAN-READABLE REPORTS
+└── docs/design/                        # DOCUMENTATION
+```
+
+---
+
+## Test Execution Matrix
+
+For each test case:
+
+```
+Test: 001-justfile-to-makefile
+├── Tier: T0 (Vanilla)
+│   ├── Run 01 [container-001-t0-r01]
+│   ├── Run 02 [container-001-t0-r02]
+│   └── ... (10 runs)
+├── Tier: T1 (Prompted)
+│   └── ... (10 runs)
+├── Tier: T2 (Skills)
+│   └── ... (10 runs)
+└── Tier: T3+ (Tooling)
+    └── ... (10 runs)
+
+Total: 40 runs per test × N adapters
+```
+
+---
+
+## Critical Path
+
+```
+#3 Project Structure
+    ↓
+#4 Config Loading → #36 Tier Config
+    ↓
+#7 Workspace → #35 Docker
+    ↓
+#8 Test Runner
+    ↓
+#11 Base Adapter → #12 Claude Adapter
+    ↓
+#16 Rubric Parser → #17 Judge Prompts → #18 Evaluator
+    ↓
+#21 Statistics → #23 Aggregation → #37 Cross-Tier
+    ↓
+#26 Summary → #28 Report
+    ↓
+#31 First Test → #32 Single Run → #33 Full Suite → #34 Report
+```
+
+---
+
+## First Test Case
+
+**Test ID**: `001-justfile-to-makefile`
+
+| Field | Value |
+|-------|-------|
+| **Repository** | https://github.com/mvillmow/ProjectOdyssey |
+| **Git Hash** | ce739d4aa328f1c0815b33e2812c4b889868b740 |
+| **Task** | Convert justfile to Makefile + create cleanup script |
+| **Tiers** | T0, T1, T2, T3+ |
+| **Runs per Tier** | 10 |
+
+---
+
+## Key Decisions
+
+| Decision | Choice | Rationale |
+|----------|--------|-----------|
+| Language | Python only | Simplicity, ecosystem, subprocess capture |
+| Validation | Claude Code + Opus 4.5 | Semantic evaluation beyond programmatic checks |
+| Judge Consensus | 3 runs, confidence-weighted | Ensure consistent evaluations |
+| Runs per tier | 10 | Statistical validity |
+| Container isolation | Docker | Independent runs, reproducibility |
+| Tiers | T0-T3+ | Test prompt sensitivity across complexity levels |
+
+---
+
+## References
+
+- Full plan: `.claude/plans/swift-skipping-creek.md`
+- Research docs: `docs/research.md`
+- Test case: `tests/001-justfile-to-makefile/`
+
+---
+
+*Last updated: 2025-12-28*

--- a/tests/001-justfile-to-makefile/expected/criteria.md
+++ b/tests/001-justfile-to-makefile/expected/criteria.md
@@ -1,0 +1,36 @@
+# Success Criteria: Justfile to Makefile Conversion
+
+## File Creation
+
+- A `Makefile` must exist in the repository root
+- The file must be syntactically valid (parseable by GNU Make)
+
+## Recipe Coverage
+
+- Every recipe in the justfile must have an equivalent Makefile target
+- Recipe names should be identical or clearly mapped (e.g., `build-debug` → `build-debug`)
+
+## Functional Equivalence
+
+For the following commands, running with just vs make should produce equivalent results:
+
+- `just help` ↔ `make help` (list available commands)
+- `just build debug` ↔ `make build-debug` (build in debug mode)
+- `just clean` ↔ `make clean` (clean build artifacts)
+- `just test-mojo` ↔ `make test-mojo` (run Mojo tests)
+
+"Equivalent results" means:
+
+- Same exit code (0 for success, non-zero for failure)
+- Similar output (exact match not required, but core content should match)
+- Same side effects (files created/deleted should be the same)
+
+## Variable Handling
+
+- Justfile variables must be converted to Make variables
+- Variable interpolation must work correctly
+
+## Quality
+
+- The Makefile should be readable and well-organized
+- Comments should explain non-obvious translations

--- a/tests/001-justfile-to-makefile/expected/rubric.yaml
+++ b/tests/001-justfile-to-makefile/expected/rubric.yaml
@@ -1,0 +1,44 @@
+requirements:
+  - id: "R001"
+    description: "Makefile exists and is syntactically valid"
+    weight: 2.0
+    evaluation: "binary"
+
+  - id: "R002"
+    description: "All justfile recipes have Makefile equivalents"
+    weight: 2.0
+    evaluation: "scaled"
+
+  - id: "R003"
+    description: "help command works and lists targets"
+    weight: 1.0
+    evaluation: "binary"
+
+  - id: "R004"
+    description: "build commands produce equivalent output"
+    weight: 1.5
+    evaluation: "scaled"
+
+  - id: "R005"
+    description: "clean command removes correct artifacts"
+    weight: 1.0
+    evaluation: "binary"
+
+  - id: "R006"
+    description: "Variable substitution works correctly"
+    weight: 1.0
+    evaluation: "binary"
+
+  - id: "R007"
+    description: "Code quality: readable, well-commented"
+    weight: 0.5
+    evaluation: "scaled"
+
+grading:
+  pass_threshold: 0.70
+  grade_scale:
+    A: 0.95
+    B: 0.85
+    C: 0.75
+    D: 0.65
+    F: 0.0

--- a/tests/001-justfile-to-makefile/prompt.md
+++ b/tests/001-justfile-to-makefile/prompt.md
@@ -1,0 +1,31 @@
+# Task: Convert Justfile to Makefile
+
+## Objective
+
+Convert the `justfile` in this repository to an equivalent `Makefile` that
+provides the same functionality using standard GNU Make.
+
+## Requirements
+
+1. Create a `Makefile` that includes all recipes from the justfile
+2. Preserve variable definitions and their usage
+3. Handle Docker-related commands correctly
+4. Include a `help` target that lists available commands
+5. Maintain recipe dependencies
+
+## Constraints
+
+- Use standard GNU Make syntax (compatible with Make 4.0+)
+- Do not use third-party Make extensions
+- Preserve comments and documentation
+- Keep the file readable and maintainable
+
+## Expected Output
+
+- A new file named `Makefile` in the repository root
+- The original `justfile` should remain unchanged
+
+## Validation
+
+Your solution will be validated by running equivalent commands with both
+build systems and comparing results.

--- a/tests/001-justfile-to-makefile/test.yaml
+++ b/tests/001-justfile-to-makefile/test.yaml
@@ -1,0 +1,18 @@
+id: "001-justfile-to-makefile"
+name: "Convert Justfile to Makefile"
+description: |
+  Convert ProjectOdyssey's justfile to an equivalent Makefile.
+  The Makefile must support all existing recipes and produce
+  equivalent outputs when run.
+
+source:
+  repo: "https://github.com/mvillmow/ProjectOdyssey"
+  hash: "ce739d4aa328f1c0815b33e2812c4b889868b740"
+
+task:
+  prompt_file: "prompt.md"
+  timeout_seconds: 3600
+
+validation:
+  criteria_file: "expected/criteria.md"
+  rubric_file: "expected/rubric.yaml"


### PR DESCRIPTION
## Summary

- Add implementation plan with GitHub issue links
- Add clarifying prompt for plan review interviews
- Add first test case definition (001-justfile-to-makefile)

## Files Added

| File | Description |
|------|-------------|
| `docs/plan.md` | Full implementation plan with issue links for all 9 phases |
| `docs/clarifying_prompt.md` | Interview prompt for plan review and gap identification |
| `tests/001-justfile-to-makefile/test.yaml` | Test definition (repo, hash, timeout) |
| `tests/001-justfile-to-makefile/prompt.md` | Agent prompt |
| `tests/001-justfile-to-makefile/expected/criteria.md` | Success criteria |
| `tests/001-justfile-to-makefile/expected/rubric.yaml` | Scoring rubric |

## Related Issues

Relates to #2 (Epic: Agent Testing Framework Implementation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)