### PR TITLE
feat(skills): add plan-review-interview skill from retrospective

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,0 +1,30 @@
+{
+  "name": "plan-review-interview",
+  "version": "1.0.0",
+  "description": "Structured interview workflow for reviewing implementation plans and capturing decisions",
+  "category": "evaluation",
+  "created": "2025-12-30",
+  "author": "ProjectScylla Team",
+  "tags": [
+    "planning",
+    "requirements",
+    "interview",
+    "decision-tracking",
+    "github-issues"
+  ],
+  "skills": [
+    {
+      "name": "plan-review-interview",
+      "path": "skills/plan-review-interview/SKILL.md",
+      "triggers": [
+        "plan review",
+        "clarify requirements",
+        "interview for plan",
+        "gap analysis"
+      ]
+    }
+  ],
+  "references": [
+    "references/notes.md"
+  ]
+}

--- a/references/notes.md
+++ b/references/notes.md
@@ -1,0 +1,134 @@
+# Plan Review Interview - Raw Session Notes
+
+## Session Context
+
+- **Project**: ProjectScylla - Agent testing framework
+- **Date**: 2025-12-30
+- **Preceding work**: Created Epic #2, Issues #3-38, initial plan documents
+
+## Conversation Flow
+
+### Initial State
+
+- 38 GitHub issues existed (Epic #2, Issues #3-38)
+- Plan documented in `docs/plan.md` and `.claude/plans/swift-skipping-creek.md`
+- First test case defined in `tests/001-justfile-to-makefile/`
+- Multiple open questions about execution model, tier system, judge behavior
+
+### User Request
+
+> "I don't want to begin with implementation, instead I want a prompt to do a thorough review and interview me for things that are not clear"
+
+### Interview Batches Conducted
+
+**Batch 1: Core Execution Model**
+- How are API keys passed to containers? -> Environment variables
+- What if Docker unavailable? -> Fail with error
+- Container isolation model? -> Separate containers for agent and judge
+
+**Batch 2: Configuration**
+- Runs per tier? -> 9 runs (changed from 10)
+- What does T0 (Vanilla) mean? -> Tool default behavior
+- Are tiers cumulative? -> No, independent
+
+**Batch 3: Judge System**
+- Where does judge run? -> Separate container
+- How handle disagreement? -> Run additional passes until consensus
+- How access workspace? -> Read-only volume mount
+
+**Batch 4: Scope**
+- Report audience? -> Researchers/Engineers
+- First test adapter scope? -> Claude Code only
+- Test focus? -> Both tiers AND models
+
+## GitHub Operations Performed
+
+### Issues Updated with Comments
+
+```bash
+gh issue comment 4 --body "Decision: runs_per_tier=9, API keys via env vars"
+gh issue comment 8 --body "Decision: 9 runs, test tiers+models, judge in separate container"
+gh issue comment 11 --body "Decision: T0=tool defaults, tiers independent"
+gh issue comment 18 --body "Decision: Judge in separate container, retry on disagreement"
+gh issue comment 35 --body "Decision: Docker required, API keys via env vars"
+gh issue comment 36 --body "Decision: Independent tiers, T0=tool defaults"
+```
+
+### New Issues Created
+
+```bash
+gh issue create --title "[Infra] Dockerfile specification for scylla-runner:latest" --label "infrastructure"
+# Created #40
+
+gh issue create --title "[Core] Judge container orchestration" --label "core"
+# Created #41
+
+gh issue create --title "[Config] Create tier prompt template files" --label "config"
+# Created #42
+
+gh issue create --title "[Core] Judge consensus with retry logic" --label "core"
+# Created #43
+```
+
+## File Changes
+
+### docs/plan.md
+
+- Added decisions summary table at top
+- Changed "10 runs" -> "9 runs" throughout
+- Added "tiers AND models" testing scope
+- Updated issue references (#23, #33 titles)
+
+### docs/clarifying_prompt.md
+
+Transformed from interview prompt to decisions document:
+- Added "Status: COMPLETE"
+- Added decisions summary table
+- Converted questions to "Resolved Questions" with decisions
+- Added "New Issues Created" section (#40-43)
+- Added "Completed Actions" section
+
+## Lessons Learned
+
+1. **Batch questions by topic** - Don't overwhelm with 30+ questions at once
+2. **Reference issue numbers** - Every question should link to affected issues
+3. **Use comments not edits** - `gh issue comment` preserves history better than `gh issue edit`
+4. **Transform prompts to docs** - Review prompts become decision documents
+5. **Track new issues** - Gaps discovered during review become new issues
+
+## Statistics
+
+| Metric | Count |
+|--------|-------|
+| Total questions batches | 4 |
+| Decisions captured | 11 |
+| Existing issues updated | 6 |
+| New issues created | 4 |
+| Plan files updated | 2 |
+| Lines added to docs | ~300 |
+
+## Key Configuration Values
+
+```yaml
+# From decisions
+runs_per_tier: 9
+test_focus: "tiers_and_models"
+t0_baseline: "tool_defaults"
+tier_relationship: "independent"
+docker_required: true
+api_key_method: "environment_variables"
+judge_container: "separate"
+judge_disagreement: "retry_with_passes"
+timeout_handling: "include_as_failures"
+report_audience: "researchers_engineers"
+first_test_adapter: "claude_code_only"
+```
+
+## Open Items (Still TBD)
+
+From interview, explicitly deferred to implementation:
+- Container resource limits (CPU, memory, disk)
+- Internet access handling for containers
+- CI/CD integration details
+- Storage management strategy
+- Visualization (charts/graphs vs tables only)

--- a/skills/plan-review-interview/SKILL.md
+++ b/skills/plan-review-interview/SKILL.md
@@ -1,0 +1,195 @@
+# Plan Review Interview Skill
+
+## Overview
+
+| Field | Value |
+|-------|-------|
+| **Date** | 2025-12-30 |
+| **Objective** | Review implementation plan, identify gaps, interview stakeholder for decisions |
+| **Outcome** | SUCCESS - 11 key decisions captured, 4 new issues created, 6 existing issues updated |
+| **Context** | ProjectScylla agent testing framework planning phase |
+
+## When to Use
+
+Use this skill when:
+
+- You have a draft implementation plan that needs stakeholder validation
+- There are ambiguous requirements or multiple valid approaches
+- GitHub issues exist but lack key decision details
+- You need to systematically identify gaps before implementation begins
+- You want to document decisions alongside the issues they affect
+
+## Verified Workflow
+
+### Phase 1: Prepare Context Files
+
+1. Read all existing plan documents
+2. List all GitHub issues with `gh issue list --limit 50`
+3. Group issues by phase/category
+4. Create a review prompt document with:
+   - Links to context files
+   - Issue numbers organized by phase
+   - Categorized clarifying questions
+   - Reference issue numbers for each question category
+
+### Phase 2: Conduct Structured Interview
+
+1. **Batch questions by topic** (3-4 questions per batch)
+   - Core execution model
+   - Tier/configuration specifics
+   - Judge/evaluation system
+   - Scope and audience
+
+2. **For each question**:
+   - State the gap clearly
+   - Reference affected GitHub issues
+   - Propose 2-3 solutions
+   - Record user's decision
+
+3. **Use AskUserQuestion tool** with multiple related questions per batch
+
+### Phase 3: Update Artifacts
+
+1. **Update plan document** with decisions table at top
+2. **Add comments to GitHub issues** with relevant decisions:
+   ```bash
+   gh issue comment <number> --body "## Decision Update\n\n- Key decision: ..."
+   ```
+3. **Create new issues** for gaps discovered during interview:
+   ```bash
+   gh issue create --title "[Category] Title" --body "..." --label "category"
+   ```
+4. **Transform review prompt** into decisions document (update status, add decisions summary)
+
+### Phase 4: Commit and Document
+
+1. Create feature branch: `git checkout -b skill/<category>/<name>`
+2. Commit all updated files
+3. Create PR with summary of decisions made
+
+## Key Patterns
+
+### Decision Table Format
+
+```markdown
+## Decisions Summary
+
+| Question | Decision |
+|----------|----------|
+| API Key Handling | Environment Variables (docker -e flags) |
+| Runs per Tier | **9 runs** (standardized) |
+| Docker Fallback | **Fail with error** (Docker is required) |
+```
+
+### Issue Reference Pattern
+
+```markdown
+### 1. Test Execution Model
+
+**Reference Issues**: #7, #8, #9, #35
+
+| Question | Decision |
+|----------|----------|
+| How are API keys passed? | **Environment variables** via docker -e flags |
+```
+
+### Batched Interview Questions
+
+Group related questions to avoid overwhelming the user:
+
+```
+Batch 1: Core Execution (API keys, Docker, runs per tier)
+Batch 2: Tier System (T0 definition, tier relationships)
+Batch 3: Judge System (location, disagreement handling)
+Batch 4: Scope (audience, first test scope)
+```
+
+## Failed Attempts
+
+### 1. Asking All Questions at Once
+
+**What happened**: Initially tried to present all 30+ questions in one prompt.
+
+**Why it failed**: Overwhelming for the user; decisions weren't properly linked to issues.
+
+**Solution**: Batch questions by topic (3-4 per batch), reference specific issue numbers.
+
+### 2. Updating Issues Without Comments
+
+**What happened**: Tried to use `gh issue edit --body` to update issue descriptions directly.
+
+**Why it failed**: Lost original issue context; hard to track what changed.
+
+**Solution**: Use `gh issue comment` to add decision updates as comments, preserving history.
+
+### 3. Generic Review Prompt
+
+**What happened**: First review prompt didn't reference specific GitHub issue numbers.
+
+**Why it failed**: Hard to trace which decisions affected which implementation tasks.
+
+**Solution**: Organize questions by phase with explicit issue references (e.g., "Reference Issues: #7, #8, #9").
+
+## Results & Parameters
+
+### Session Statistics
+
+| Metric | Value |
+|--------|-------|
+| Questions asked | 11 batched topics |
+| Decisions captured | 11 key decisions |
+| Issues updated | 6 (#4, #8, #11, #18, #35, #36) |
+| New issues created | 4 (#40, #41, #42, #43) |
+| Documents updated | 2 (plan.md, clarifying_prompt.md) |
+
+### Key Decisions Made
+
+| Decision | Choice | Rationale |
+|----------|--------|-----------|
+| API Key Handling | Environment variables | Security via docker -e flags |
+| Runs per Tier | 9 runs | Statistical validity |
+| Test Focus | Tiers AND models | Cross-model comparison |
+| T0 Baseline | Tool defaults | Clean baseline without prompt injection |
+| Judge Location | Separate container | Isolation from agent |
+| Tier Prompts | Independent | Self-contained, easier to maintain |
+| Docker Fallback | Fail with error | Docker is required infrastructure |
+| Timeout Handling | Include as failures | Don't hide failures in statistics |
+| Report Audience | Researchers/Engineers | Detailed technical analysis |
+| Judge Disagreement | Retry with passes | Consensus through iteration |
+| First Test Scope | Claude Code only | Incremental adapter development |
+
+### Files Produced
+
+```
+docs/plan.md                  # Updated with decisions table
+docs/clarifying_prompt.md     # Transformed to decisions document
+```
+
+## Commands Reference
+
+```bash
+# Read issue with comments
+gh issue view <number> --comments
+
+# Add decision comment to issue
+gh issue comment <number> --body "## Decision Update
+
+- **Key decision**: value
+- **Rationale**: reason
+- **Affects**: list of components"
+
+# Create new issue for discovered gap
+gh issue create \
+  --title "[Category] Brief description" \
+  --body "## Objective\n\n..." \
+  --label "category"
+
+# List all issues for review
+gh issue list --limit 50 --state all
+```
+
+## Related Skills
+
+- `/advise` - Search team knowledge before starting
+- `/commit` - Commit changes with proper format
+- `/review-pr` - Review pull request changes


### PR DESCRIPTION
## Summary

Captures learnings from the ProjectScylla plan review session as a reusable skill.

## Files Added

| File | Description |
|------|-------------|
| `.claude-plugin/plugin.json` | Plugin metadata and skill registration |
| `skills/plan-review-interview/SKILL.md` | Complete skill documentation |
| `references/notes.md` | Raw session notes and configuration values |

## Key Learnings Captured

### Verified Patterns
- **Batched questioning**: Group 3-4 related questions per topic
- **Issue references**: Link every question to affected GitHub issues
- **Comment over edit**: Use `gh issue comment` to preserve history
- **Transform prompts**: Review prompts become decision documents

### Failed Attempts Documented
1. Asking all questions at once - overwhelming
2. Using `gh issue edit` - loses context
3. Generic prompts without issue numbers - hard to trace

## Session Statistics

| Metric | Value |
|--------|-------|
| Decisions captured | 11 |
| Issues updated | 6 |
| New issues created | 4 |
| Documents updated | 2 |

## Test Plan

- [ ] Verify plugin.json is valid JSON
- [ ] Verify SKILL.md follows required sections format
- [ ] Verify references/notes.md contains raw details

🤖 Generated with [Claude Code](https://claude.com/claude-code)