### PR TITLE
docs(skill): add prompt-ablation-framework skill plugin

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,0 +1,33 @@
+{
+  "name": "prompt-ablation-framework",
+  "version": "1.0.0",
+  "description": "Framework for testing which components of a prompting system (CLAUDE.md, agents, skills) are essential vs. optional through systematic ablation testing",
+  "category": "tooling",
+  "author": "Claude Code",
+  "created": "2024-12-30",
+  "tags": [
+    "ablation-testing",
+    "prompt-engineering",
+    "tier-testing",
+    "agent-evaluation",
+    "skill-evaluation",
+    "claude-code"
+  ],
+  "skills": [
+    "skills/prompt-ablation-framework/SKILL.md"
+  ],
+  "references": [
+    "references/notes.md"
+  ],
+  "source_project": "ProjectOdyssey",
+  "target_project": "ProjectScylla",
+  "metrics": {
+    "files_created": 191,
+    "lines_added": 19439,
+    "blocks_extracted": 18,
+    "agents_organized": 44,
+    "skills_organized": 62,
+    "test_configurations": 26,
+    "total_test_cases": 78
+  }
+}

--- a/references/notes.md
+++ b/references/notes.md
@@ -1,0 +1,285 @@
+# Prompt Ablation Framework - Raw Notes
+
+## Session Details
+
+- **Date**: 2024-12-30
+- **Duration**: Extended session with context continuation
+- **Model**: Claude Opus 4.5 (claude-opus-4-5-20251101)
+- **Working Directory**: /home/mvillmow/ProjectOdysseyManual
+- **Target Repository**: /tmp/ProjectScylla
+
+## Initial Request
+
+> "Use ultrathink and analyze CLAUDE.md, agents, sub-agents, skills, and the agent test plan
+> from ProjectScylla here: https://github.com/HomericIntelligence/ProjectScylla I need to split
+> up all of the claude, agents, and sub-agents to match the testing hierarchy"
+
+## Clarifications Received
+
+1. **Not integration** - User wanted categorization and testing plan, not code integration
+2. **Tier comparison with sub-tiers** - Structure as `<tool>/<model>/<tier>/<sub-tier>/<test_results>`
+3. **Scope limitation** - Only structure and composition scripts, not running actual tests
+
+## Files Created
+
+### Scripts (3 files)
+
+```
+scripts/
+├── extract_blocks.py      # Extract CLAUDE.md blocks by line range
+├── organize_agents.py     # Organize agents by YAML frontmatter level
+└── organize_skills.py     # Organize skills by prefix/category
+```
+
+### Composition Scripts (4 files)
+
+```
+tests/claude-code/shared/compose/
+├── compose_claude_md.py   # 6,745 bytes - Block composition with presets
+├── compose_agents.py      # 6,563 bytes - Agent selection by level/pattern
+├── compose_skills.py      # 7,802 bytes - Skill selection by category
+└── generate_subtiers.py   # 16,899 bytes - Full sub-tier generator
+```
+
+### CLAUDE.md Blocks (18 files)
+
+```
+tests/claude-code/shared/blocks/
+├── B01-project-overview.md       # Lines 1-11 (11 lines)
+├── B02-critical-rules.md         # Lines 13-67 (55 lines) [CRITICAL]
+├── B03-quick-links.md            # Lines 69-85 (17 lines)
+├── B04-agent-hierarchy-intro.md  # Lines 87-109 (23 lines)
+├── B05-skill-delegation.md       # Lines 110-178 (69 lines) [CRITICAL]
+├── B06-dev-principles.md         # Lines 181-209 (29 lines)
+├── B07-language-preference.md    # Lines 211-258 (48 lines) [CRITICAL]
+├── B08-extended-thinking.md      # Lines 260-326 (67 lines)
+├── B09-skills-vs-subagents.md    # Lines 327-395 (69 lines) [CRITICAL]
+├── B10-hooks-best-practices.md   # Lines 397-462 (66 lines)
+├── B11-output-style.md           # Lines 464-611 (148 lines)
+├── B12-tool-use-optimization.md  # Lines 612-714 (103 lines) [CRITICAL]
+├── B13-agentic-loops.md          # Lines 716-831 (116 lines)
+├── B14-delegation-mojo.md        # Lines 833-880 (48 lines)
+├── B15-common-commands.md        # Lines 882-1099 (218 lines)
+├── B16-repo-architecture.md      # Lines 1101-1234 (134 lines) [CRITICAL]
+├── B17-testing-strategy.md       # Lines 1236-1347 (112 lines)
+└── B18-github-git-workflow.md    # Lines 1349-1787 (438 lines) [CRITICAL]
+```
+
+### Agents by Level (44 files)
+
+```
+tests/claude-code/shared/agents/
+├── L0/ (1 agent)
+│   └── chief-architect.md
+├── L1/ (6 agents)
+│   ├── agentic-workflows-orchestrator.md
+│   ├── cicd-orchestrator.md
+│   ├── foundation-orchestrator.md
+│   ├── papers-orchestrator.md
+│   ├── shared-library-orchestrator.md
+│   └── tooling-orchestrator.md
+├── L2/ (4 agents)
+│   ├── architecture-design.md
+│   ├── code-review-orchestrator.md
+│   ├── integration-design.md
+│   └── security-design.md
+├── L3/ (24 agents)
+│   ├── algorithm-review-specialist.md
+│   ├── architecture-review-specialist.md
+│   ├── blog-writer-specialist.md
+│   ├── ci-failure-analyzer.md
+│   ├── data-engineering-review-specialist.md
+│   ├── dependency-review-specialist.md
+│   ├── documentation-review-specialist.md
+│   ├── documentation-specialist.md
+│   ├── implementation-review-specialist.md
+│   ├── implementation-specialist.md
+│   ├── mojo-language-review-specialist.md
+│   ├── mojo-syntax-validator.md
+│   ├── numerical-stability-specialist.md
+│   ├── paper-review-specialist.md
+│   ├── performance-review-specialist.md
+│   ├── performance-specialist.md
+│   ├── pr-cleanup-specialist.md
+│   ├── research-review-specialist.md
+│   ├── safety-review-specialist.md
+│   ├── security-review-specialist.md
+│   ├── security-specialist.md
+│   ├── test-flakiness-specialist.md
+│   ├── test-review-specialist.md
+│   └── test-specialist.md
+├── L4/ (6 agents)
+│   ├── documentation-engineer.md
+│   ├── implementation-engineer.md
+│   ├── log-analyzer.md
+│   ├── performance-engineer.md
+│   ├── senior-implementation-engineer.md
+│   └── test-engineer.md
+└── L5/ (3 agents)
+    ├── junior-documentation-engineer.md
+    ├── junior-implementation-engineer.md
+    └── junior-test-engineer.md
+```
+
+### Skills by Category (62 directories)
+
+```
+tests/claude-code/shared/skills/
+├── github/ (10 skills)
+│   ├── gh-batch-merge-by-labels/
+│   ├── gh-check-ci-status/
+│   ├── gh-create-pr-linked/
+│   ├── gh-fix-pr-feedback/
+│   ├── gh-get-review-comments/
+│   ├── gh-implement-issue/
+│   ├── gh-post-issue-update/
+│   ├── gh-read-issue-context/
+│   ├── gh-reply-review-comment/
+│   └── gh-review-pr/
+├── mojo/ (10 skills)
+│   ├── analyze-simd-usage/
+│   ├── check-memory-safety/
+│   ├── mojo-build-package/
+│   ├── mojo-format/
+│   ├── mojo-lint-syntax/
+│   ├── mojo-memory-check/
+│   ├── mojo-simd-optimize/
+│   ├── mojo-test-runner/
+│   ├── mojo-type-safety/
+│   └── validate-mojo-patterns/
+├── workflow/ (5 skills)
+│   ├── phase-cleanup/
+│   ├── phase-implement/
+│   ├── phase-package/
+│   ├── phase-plan-generate/
+│   └── phase-test-tdd/
+├── quality/ (5 skills)
+│   ├── quality-complexity-check/
+│   ├── quality-coverage-report/
+│   ├── quality-fix-formatting/
+│   ├── quality-run-linters/
+│   └── quality-security-scan/
+├── worktree/ (4 skills)
+│   ├── worktree-cleanup/
+│   ├── worktree-create/
+│   ├── worktree-switch/
+│   └── worktree-sync/
+├── documentation/ (4 skills)
+│   ├── doc-generate-adr/
+│   ├── doc-issue-readme/
+│   ├── doc-update-blog/
+│   └── doc-validate-markdown/
+├── agent/ (5 skills)
+│   ├── agent-coverage-check/
+│   ├── agent-hierarchy-diagram/
+│   ├── agent-run-orchestrator/
+│   ├── agent-test-delegation/
+│   └── agent-validate-config/
+├── cicd/ (8 skills)
+│   ├── analyze-ci-failure-logs/
+│   ├── build-run-local/
+│   ├── fix-ci-failures/
+│   ├── install-workflow/
+│   ├── run-precommit/
+│   ├── validate-workflow/
+│   └── verify-pr-ready/
+└── other/ (11+ skills)
+    ├── create-review-checklist/
+    ├── extract-test-failures/
+    ├── generate-fix-suggestions/
+    ├── plan-create-component/
+    ├── plan-regenerate-issues/
+    ├── plan-validate-structure/
+    ├── review-pr-changes/
+    ├── test-diff-analyzer/
+    ├── tier-1/
+    ├── tier-2/
+    └── track-implementation-progress/
+```
+
+## Sub-Tier Definitions
+
+### T0-vanilla (1 config)
+- `00-baseline`: No CLAUDE.md, no agents, no skills
+
+### T1-prompted (4 configs)
+- `01-critical-rules-only`: B02 only (~55 lines)
+- `02-minimal-viable`: B02+B07+B18 (~260 lines)
+- `03-core-seven`: 7 critical blocks (~400 lines)
+- `04-no-examples`: All blocks, code stripped (~900 lines)
+
+### T2-skills (5 configs)
+- `01-github-skills-only`: minimal + 10 github skills
+- `02-mojo-skills-only`: minimal + 10 mojo skills
+- `03-workflow-skills-only`: minimal + 5 workflow skills
+- `04-all-skills-minimal-md`: minimal + all 62 skills
+- `05-critical-skills-only`: minimal + top 10 skills
+
+### T3-agents (5 configs)
+- `01-junior-only`: minimal + L5 (3 agents)
+- `02-engineers-only`: minimal + L4+L5 (9 agents)
+- `03-specialists-only`: minimal + L3 (24 agents)
+- `04-orchestrators-only`: minimal + L0+L1 (7 agents)
+- `05-review-agents-only`: minimal + review specialists (13 agents)
+
+### T4-delegation (4 configs)
+- `01-flat-no-hierarchy`: minimal + all 44 agents (no delegation)
+- `02-two-level`: minimal + L0→L4 only
+- `03-three-level`: minimal + L0→L2→L4
+- `04-skills-plus-agents`: minimal + all agents + all skills
+
+### T5-hierarchy (4 configs)
+- `01-full-six-level`: core-seven + full hierarchy + all skills
+- `02-no-juniors`: core-seven + L0-L4 (41 agents) + all skills
+- `03-minimal-hierarchy`: core-seven + L0+L3+L5 + dev-workflow skills
+- `04-orchestrators-plus-juniors`: core-seven + L0+L1+L5 + github+mojo skills
+
+### T6-hybrid (3 configs)
+- `01-full-system`: full CLAUDE.md + all agents + all skills
+- `02-optimized-core`: core-seven + L0+L1+L3 + critical skills
+- `03-domain-optimized`: core-seven + implementation agents + mojo skills
+
+## Git Operations
+
+### Commit 1 (main branch)
+```
+4285c45 - feat(tests): add claude-code testing framework from ProjectOdyssey
+191 files changed, 19439 insertions(+)
+```
+
+### Branch Created
+```
+skill/tooling/prompt-ablation-framework
+```
+
+## Tool Usage Patterns
+
+### Successful Patterns
+- `gh repo clone` for private repos
+- Separate mkdir commands instead of brace expansion
+- Python scripts for complex file operations
+- `--list` flags for verification before generation
+
+### Failed Patterns
+- WebFetch for private GitHub URLs
+- Bash brace expansion `{a,b,c}`
+- Complex shell variable substitution in loops
+
+## Evaluation Metrics (Proposed)
+
+| Metric | Description | Target |
+|--------|-------------|--------|
+| Pass Rate | Task completion rate | >0.8 |
+| Impl Rate | Requirement satisfaction | >0.85 |
+| R_Prog | Fine-grained progress | Continuous |
+| CoP | Cost of Pass (tokens/$) | Minimize |
+| Latency | Time to completion | <5min |
+| Consistency | Output stability | >0.9 |
+
+## Open Questions
+
+1. What task types should be used for evaluation?
+2. How many runs per configuration for statistical significance?
+3. Should evaluation include human review or purely automated?
+4. How to handle non-deterministic model outputs?
+5. What's the minimum sample size per configuration?

--- a/skills/prompt-ablation-framework/SKILL.md
+++ b/skills/prompt-ablation-framework/SKILL.md
@@ -1,0 +1,247 @@
+# Prompt Ablation Framework
+
+| Field | Value |
+|-------|-------|
+| **Date** | 2024-12-30 |
+| **Category** | tooling |
+| **Objective** | Create a testing framework to evaluate which components of a prompting system are essential vs. optional |
+| **Outcome** | Success - 191 files, 78 test configurations across 3 models |
+| **Source** | ProjectOdyssey (1787-line CLAUDE.md, 44 agents, 62 skills) |
+| **Target** | ProjectScylla (T0-T6 tier methodology) |
+
+## When to Use
+
+Use this skill when you need to:
+
+- **Evaluate prompt effectiveness**: Determine which parts of a CLAUDE.md file are essential
+- **Test agent configurations**: Compare different agent hierarchy levels
+- **Optimize skill sets**: Find the minimal skill set needed for specific tasks
+- **Benchmark model performance**: Compare sonnet/opus/haiku across configurations
+- **Reduce token overhead**: Identify which prompt components can be removed
+
+## Verified Workflow
+
+### Step 1: Decompose CLAUDE.md into Blocks
+
+Extract logical sections from the monolithic CLAUDE.md file:
+
+```bash
+# Extract blocks with line ranges
+python scripts/extract_blocks.py /path/to/CLAUDE.md /output/blocks/
+```
+
+**Block Structure** (18 blocks from ProjectOdyssey):
+
+| Block | Lines | Priority | Purpose |
+|-------|-------|----------|---------|
+| B02 | 55 | Critical | Safety rules |
+| B05 | 69 | Critical | Skill delegation patterns |
+| B07 | 48 | Critical | Language preference |
+| B09 | 69 | Critical | Skills vs sub-agents |
+| B12 | 103 | Critical | Tool use optimization |
+| B16 | 134 | Critical | Repository architecture |
+| B18 | 438 | Critical | GitHub/Git workflow |
+| B06-B08, B10-B11, B13-B14 | ~500 | Important | Extended guidance |
+| B01, B03-B04, B15, B17 | ~380 | Optional | Context/reference |
+
+### Step 2: Organize Agents by Level
+
+Copy agents to level-based directories:
+
+```bash
+python scripts/organize_agents.py
+```
+
+**Hierarchy Levels**:
+
+- L0: Chief Architect (1 agent) - Strategic decisions
+- L1: Orchestrators (6 agents) - Domain coordination
+- L2: Design (4 agents) - Module design
+- L3: Specialists (24 agents) - Specialized execution
+- L4: Engineers (6 agents) - Implementation
+- L5: Junior Engineers (3 agents) - Simple tasks
+
+### Step 3: Organize Skills by Category
+
+Copy skills to category-based directories:
+
+```bash
+python scripts/organize_skills.py
+```
+
+**Categories** (62 total skills):
+
+- github (10): PR, issue, review operations
+- mojo (10): Language-specific tools
+- workflow (5): Phase management
+- quality (5): Linting, formatting
+- worktree (4): Git worktree management
+- documentation (4): ADRs, markdown
+- agent (5): Agent system tools
+- cicd (8): CI/CD operations
+- other (11): Miscellaneous
+
+### Step 4: Create Composition Scripts
+
+Four scripts enable flexible configuration generation:
+
+```bash
+# Compose CLAUDE.md from blocks
+python compose_claude_md.py --preset minimal --output config/CLAUDE.md
+
+# Compose agents by level
+python compose_agents.py --preset engineers-only --output config/agents/
+
+# Compose skills by category
+python compose_skills.py --preset critical --output config/skills/
+
+# Generate all sub-tier configurations
+python generate_subtiers.py --model sonnet --dry-run
+```
+
+### Step 5: Define Test Tiers (T0-T6)
+
+| Tier | Focus | Sub-tiers | Description |
+|------|-------|-----------|-------------|
+| T0 | Baseline | 1 | Vanilla Claude, no prompting |
+| T1 | Prompted | 4 | CLAUDE.md variations (55-1787 lines) |
+| T2 | Skills | 5 | Skill category combinations |
+| T3 | Agents | 5 | Agent level variations |
+| T4 | Delegation | 4 | Hierarchy pattern variations |
+| T5 | Hierarchy | 4 | Full hierarchy variations |
+| T6 | Hybrid | 3 | Complete system variations |
+
+**Total**: 26 configurations × 3 models = 78 test cases
+
+## Failed Attempts
+
+### 1. WebFetch for Private Repos
+
+**What didn't work**: Using `WebFetch` tool to access private GitHub repo
+
+```
+WebFetch("https://github.com/HomericIntelligence/ProjectScylla") → 404
+```
+
+**Why it failed**: WebFetch cannot authenticate to private repositories
+
+**Solution**: Use `gh repo clone` with authenticated GitHub CLI
+
+```bash
+gh repo clone HomericIntelligence/ProjectScylla /tmp/ProjectScylla
+```
+
+### 2. Bash Brace Expansion in Tool
+
+**What didn't work**: Creating multiple directories with brace expansion
+
+```bash
+mkdir -p tests/claude-code/shared/{blocks,agents,skills,compose}
+# Created literal directory named "{blocks,agents,skills,compose}"
+```
+
+**Why it failed**: The Bash tool escapes special characters, preventing shell expansion
+
+**Solution**: Run separate mkdir commands for each directory
+
+```bash
+mkdir -p tests/claude-code/shared/blocks
+mkdir -p tests/claude-code/shared/agents
+mkdir -p tests/claude-code/shared/skills
+mkdir -p tests/claude-code/shared/compose
+```
+
+### 3. Shell Variable Substitution in Loops
+
+**What didn't work**: Complex bash loops with command substitution
+
+```bash
+for l in 0 1 2 3 4 5; do
+  count=$(ls dir/L$l/ | wc -l)  # $l gets escaped
+  echo "L$l: $count"
+done
+```
+
+**Why it failed**: Variables in complex constructs get escaped by the tool
+
+**Solution**: Use simpler commands or Python scripts for complex logic
+
+## Results & Parameters
+
+### Directory Structure
+
+```
+tests/claude-code/
+├── shared/
+│   ├── blocks/          # 18 CLAUDE.md block files
+│   ├── agents/L0-L5/    # 44 agents by level
+│   ├── skills/{9 cats}/ # 62 skills by category
+│   └── compose/         # 4 composition scripts
+├── sonnet/T0-T6/        # Tier directories
+├── opus/T0-T6/
+└── haiku/T0-T6/
+```
+
+### Preset Configurations
+
+**CLAUDE.md Presets** (compose_claude_md.py):
+
+| Preset | Blocks | Lines | Use Case |
+|--------|--------|-------|----------|
+| critical-only | B02 | ~55 | Minimal safety |
+| minimal | B02, B07, B18 | ~260 | Minimum viable |
+| core-seven | B02, B05, B07, B09, B12, B16, B18 | ~400 | Recommended |
+| no-examples | All, stripped | ~900 | Prose only |
+| full | All 18 | 1787 | Reference |
+
+**Agent Presets** (compose_agents.py):
+
+| Preset | Levels | Count | Use Case |
+|--------|--------|-------|----------|
+| junior-only | L5 | 3 | Simple tasks |
+| engineers-only | L4+L5 | 9 | Implementation |
+| specialists-only | L3 | 24 | Specialized work |
+| orchestrators | L0+L1 | 7 | Coordination |
+| full | L0-L5 | 44 | Complete hierarchy |
+
+**Skill Presets** (compose_skills.py):
+
+| Preset | Categories | Count | Use Case |
+|--------|------------|-------|----------|
+| github-only | github | 10 | PR/issue ops |
+| mojo-only | mojo | 10 | Mojo development |
+| critical | top 10 | 10 | Essential tools |
+| dev-workflow | github, worktree, quality, cicd | 27 | Full dev flow |
+| full | all | 62 | Complete set |
+
+### Metrics
+
+| Metric | Value |
+|--------|-------|
+| Files created | 191 |
+| Lines added | 19,439 |
+| CLAUDE.md blocks | 18 |
+| Agents organized | 44 |
+| Skills organized | 62 |
+| Test configurations | 26 |
+| Total test cases | 78 |
+
+## Next Steps
+
+1. **Run baseline tests**: Generate T0 configurations and establish baselines
+2. **Implement test runner**: Create automation for running tests across configurations
+3. **Define evaluation metrics**: Pass rate, implementation rate, token efficiency
+4. **Analyze results**: Identify minimum viable configurations per task type
+5. **Create optimization recommendations**: Document which components are essential
+
+## Related Skills
+
+- `gh-create-pr-linked` - For creating PRs with issue links
+- `run-precommit` - For validation before commits
+- `mojo-format` - For Mojo code formatting
+
+## References
+
+- [ProjectScylla T0-T6 Methodology](https://github.com/HomericIntelligence/ProjectScylla)
+- [ProjectOdyssey Agent Hierarchy](/agents/hierarchy.md)
+- [CLAUDE.md Best Practices](/.claude/shared/)


### PR DESCRIPTION
## Summary

Add retrospective documentation capturing the learnings from creating the prompt ablation testing framework.

## Files Added

| File | Purpose |
|------|---------|
| `.claude-plugin/plugin.json` | Plugin metadata, tags, and metrics |
| `skills/prompt-ablation-framework/SKILL.md` | Full skill documentation with verified workflow |
| `references/notes.md` | Raw session notes and detailed file listings |

## Skill Overview

Framework for systematic ablation testing to determine which components of a prompting system are essential:

- **18 CLAUDE.md blocks** decomposed with priority categorization (7 critical, 6 important, 5 optional)
- **44 agents** organized by hierarchy level (L0-L5)
- **62 skills** organized by functional category (9 categories)
- **26 sub-tier configurations** across T0-T6 tiers
- **78 total test cases** (26 configs × 3 models)

## Key Learnings Documented

### What Worked
- Block extraction with line ranges
- Agent organization by YAML frontmatter level
- Skill organization by prefix pattern
- Composition scripts with flexible presets

### What Didn't Work (and fixes)
- WebFetch for private repos → use `gh repo clone`
- Bash brace expansion `{a,b,c}` → separate mkdir commands
- Complex shell variable substitution → Python scripts

## Related

- Previous commit `4285c45` added the testing framework itself (191 files, 19,439 lines)

🤖 Generated with [Claude Code](https://claude.com/claude-code)