### PR TITLE
[Infra] Configuration loading system

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ classifiers = [
 ]
 keywords = ["ai", "agents", "benchmarking", "evaluation", "testing"]
 dependencies = [
+    "pydantic>=2.0",
     "pyyaml>=6.0",
 ]
 

--- a/src/scylla/__init__.py
+++ b/src/scylla/__init__.py
@@ -7,6 +7,7 @@ the performance and cost-efficiency of agentic AI workflows.
 __version__ = "0.1.0"
 
 __all__ = [
+    "config",
     "executor",
     "adapters",
     "judge",

--- a/src/scylla/config/__init__.py
+++ b/src/scylla/config/__init__.py
@@ -1,0 +1,69 @@
+"""Configuration loading system for ProjectScylla.
+
+This module provides Pydantic models and a ConfigLoader for parsing YAML
+test configurations, tier definitions, and model settings.
+
+Example:
+    from scylla.config import ConfigLoader, TestCase, Rubric
+
+    loader = ConfigLoader()
+    test = loader.load_test("001-justfile-to-makefile")
+    rubric = loader.load_rubric("001-justfile-to-makefile")
+    config = loader.load(test_id="001-justfile-to-makefile", model_id="claude-opus-4-5-20251101")
+"""
+
+from .loader import ConfigLoader
+from .models import (
+    AdaptersConfig,
+    CleanupConfig,
+    ConfigurationError,
+    DefaultsConfig,
+    EvaluationConfig,
+    GradeScale,
+    GradingConfig,
+    JudgeConfig,
+    LoggingConfig,
+    MetricsConfig,
+    ModelConfig,
+    OutputConfig,
+    Requirement,
+    Rubric,
+    ScyllaConfig,
+    SourceConfig,
+    TaskConfig,
+    TestCase,
+    TierConfig,
+    ValidationConfig,
+)
+
+__all__ = [
+    # Loader
+    "ConfigLoader",
+    # Exceptions
+    "ConfigurationError",
+    # Test Case Models
+    "TestCase",
+    "SourceConfig",
+    "TaskConfig",
+    "ValidationConfig",
+    # Rubric Models
+    "Rubric",
+    "Requirement",
+    "GradingConfig",
+    "GradeScale",
+    # Tier Models
+    "TierConfig",
+    # Model Models
+    "ModelConfig",
+    # Defaults Models
+    "DefaultsConfig",
+    "EvaluationConfig",
+    "MetricsConfig",
+    "OutputConfig",
+    "LoggingConfig",
+    "JudgeConfig",
+    "AdaptersConfig",
+    "CleanupConfig",
+    # Merged Config
+    "ScyllaConfig",
+]

--- a/src/scylla/config/loader.py
+++ b/src/scylla/config/loader.py
@@ -1,0 +1,356 @@
+"""Configuration loader for ProjectScylla.
+
+This module provides the ConfigLoader class for loading and merging YAML
+configuration files with a three-level priority hierarchy:
+    test-specific > model defaults > global defaults
+
+Python Justification: Required for YAML parsing (no Mojo stdlib support)
+and complex file operations with error handling.
+"""
+
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from .models import (
+    ConfigurationError,
+    DefaultsConfig,
+    ModelConfig,
+    Rubric,
+    ScyllaConfig,
+    TestCase,
+    TierConfig,
+)
+
+
+def _deep_merge(base: dict[str, Any], override: dict[str, Any]) -> dict[str, Any]:
+    """Deep merge two dictionaries.
+
+    Values in override take precedence. Nested dicts are merged recursively.
+    Lists are replaced entirely (not appended).
+
+    Args:
+        base: Base dictionary
+        override: Override dictionary (values take precedence)
+
+    Returns:
+        Merged dictionary
+    """
+    result = base.copy()
+
+    for key, value in override.items():
+        if value is None:
+            # Skip None values - don't override with None
+            continue
+
+        if key in result and isinstance(result[key], dict) and isinstance(value, dict):
+            # Recursively merge nested dicts
+            result[key] = _deep_merge(result[key], value)
+        else:
+            # Override value (including lists)
+            result[key] = value
+
+    return result
+
+
+class ConfigLoader:
+    """Load and merge configuration files for ProjectScylla.
+
+    Supports a three-level priority hierarchy:
+        1. config/defaults.yaml (REQUIRED - base configuration)
+        2. config/models/<model_id>.yaml (optional - model-specific)
+        3. tests/<test_id>/config.yaml (optional - test-specific)
+
+    Priority order: test > model > defaults
+
+    Example:
+        loader = ConfigLoader()
+        config = loader.load(test_id="001-justfile-to-makefile", model_id="claude-opus-4-5-20251101")
+    """
+
+    def __init__(self, base_path: str | Path | None = None) -> None:
+        """Initialize the ConfigLoader.
+
+        Args:
+            base_path: Base path for configuration files. Defaults to current working directory.
+        """
+        if base_path is None:
+            self.base_path = Path.cwd()
+        else:
+            self.base_path = Path(base_path)
+
+    def _load_yaml(self, path: Path) -> dict[str, Any]:
+        """Load a YAML file.
+
+        Args:
+            path: Path to YAML file
+
+        Returns:
+            Parsed YAML content as dict
+
+        Raises:
+            ConfigurationError: If file cannot be read or parsed
+        """
+        try:
+            with open(path) as f:
+                content = yaml.safe_load(f)
+                return content if content is not None else {}
+        except FileNotFoundError:
+            raise ConfigurationError(f"Configuration file not found: {path}")
+        except yaml.YAMLError as e:
+            raise ConfigurationError(f"Invalid YAML in {path}: {e}")
+        except PermissionError:
+            raise ConfigurationError(f"Permission denied reading: {path}")
+
+    def _load_yaml_optional(self, path: Path) -> dict[str, Any] | None:
+        """Load a YAML file if it exists.
+
+        Args:
+            path: Path to YAML file
+
+        Returns:
+            Parsed YAML content as dict, or None if file doesn't exist
+
+        Raises:
+            ConfigurationError: If file exists but cannot be parsed
+        """
+        if not path.exists():
+            return None
+
+        try:
+            with open(path) as f:
+                content = yaml.safe_load(f)
+                return content if content is not None else {}
+        except yaml.YAMLError as e:
+            raise ConfigurationError(f"Invalid YAML in {path}: {e}")
+        except PermissionError:
+            raise ConfigurationError(f"Permission denied reading: {path}")
+
+    # -------------------------------------------------------------------------
+    # Test Case Loading
+    # -------------------------------------------------------------------------
+
+    def load_test(self, test_id: str) -> TestCase:
+        """Load a test case configuration.
+
+        Args:
+            test_id: Test identifier (e.g., "001-justfile-to-makefile")
+
+        Returns:
+            TestCase model
+
+        Raises:
+            ConfigurationError: If test configuration is invalid or missing
+        """
+        test_path = self.base_path / "tests" / test_id / "test.yaml"
+        data = self._load_yaml(test_path)
+
+        try:
+            return TestCase(**data)
+        except Exception as e:
+            raise ConfigurationError(f"Invalid test configuration in {test_path}: {e}")
+
+    # -------------------------------------------------------------------------
+    # Rubric Loading
+    # -------------------------------------------------------------------------
+
+    def load_rubric(self, test_id: str) -> Rubric:
+        """Load a rubric for a test case.
+
+        Args:
+            test_id: Test identifier
+
+        Returns:
+            Rubric model
+
+        Raises:
+            ConfigurationError: If rubric is invalid or missing
+        """
+        rubric_path = self.base_path / "tests" / test_id / "expected" / "rubric.yaml"
+        data = self._load_yaml(rubric_path)
+
+        try:
+            return Rubric(**data)
+        except Exception as e:
+            raise ConfigurationError(f"Invalid rubric configuration in {rubric_path}: {e}")
+
+    # -------------------------------------------------------------------------
+    # Tier Loading
+    # -------------------------------------------------------------------------
+
+    def load_tier(self, tier: str) -> TierConfig:
+        """Load a tier configuration.
+
+        Args:
+            tier: Tier identifier (e.g., "t0", "t1")
+
+        Returns:
+            TierConfig model
+
+        Raises:
+            ConfigurationError: If tier configuration is invalid or missing
+        """
+        # Normalize tier name
+        tier = tier.lower().strip()
+        if not tier.startswith("t"):
+            tier = f"t{tier}"
+
+        tier_path = self.base_path / "config" / "tiers" / f"{tier}.yaml"
+        data = self._load_yaml(tier_path)
+
+        # Ensure tier field is set
+        if "tier" not in data:
+            data["tier"] = tier
+
+        try:
+            return TierConfig(**data)
+        except Exception as e:
+            raise ConfigurationError(f"Invalid tier configuration in {tier_path}: {e}")
+
+    def load_all_tiers(self) -> dict[str, TierConfig]:
+        """Load all available tier configurations.
+
+        Returns:
+            Dict mapping tier names to TierConfig models
+
+        Raises:
+            ConfigurationError: If any tier configuration is invalid
+        """
+        tiers_dir = self.base_path / "config" / "tiers"
+        result: dict[str, TierConfig] = {}
+
+        if not tiers_dir.exists():
+            return result
+
+        for tier_file in sorted(tiers_dir.glob("t*.yaml")):
+            tier_name = tier_file.stem  # e.g., "t0" from "t0.yaml"
+            result[tier_name] = self.load_tier(tier_name)
+
+        return result
+
+    # -------------------------------------------------------------------------
+    # Model Loading
+    # -------------------------------------------------------------------------
+
+    def load_model(self, model_id: str) -> ModelConfig | None:
+        """Load a model configuration.
+
+        Args:
+            model_id: Model identifier
+
+        Returns:
+            ModelConfig model, or None if not found
+
+        Raises:
+            ConfigurationError: If model configuration exists but is invalid
+        """
+        model_path = self.base_path / "config" / "models" / f"{model_id}.yaml"
+        data = self._load_yaml_optional(model_path)
+
+        if data is None:
+            return None
+
+        # Ensure model_id is set
+        if "model_id" not in data:
+            data["model_id"] = model_id
+
+        try:
+            return ModelConfig(**data)
+        except Exception as e:
+            raise ConfigurationError(f"Invalid model configuration in {model_path}: {e}")
+
+    # -------------------------------------------------------------------------
+    # Defaults Loading
+    # -------------------------------------------------------------------------
+
+    def load_defaults(self) -> DefaultsConfig:
+        """Load global defaults configuration.
+
+        Returns:
+            DefaultsConfig model
+
+        Raises:
+            ConfigurationError: If defaults.yaml is missing or invalid
+        """
+        defaults_path = self.base_path / "config" / "defaults.yaml"
+        data = self._load_yaml(defaults_path)
+
+        try:
+            return DefaultsConfig(**data)
+        except Exception as e:
+            raise ConfigurationError(f"Invalid defaults configuration in {defaults_path}: {e}")
+
+    # -------------------------------------------------------------------------
+    # Merged Configuration Loading
+    # -------------------------------------------------------------------------
+
+    def load(self, test_id: str, model_id: str) -> ScyllaConfig:
+        """Load and merge configuration for a test run.
+
+        Applies three-level priority hierarchy:
+            1. config/defaults.yaml (base)
+            2. config/models/<model_id>.yaml (optional)
+            3. tests/<test_id>/config.yaml (optional)
+
+        Args:
+            test_id: Test identifier
+            model_id: Model identifier
+
+        Returns:
+            ScyllaConfig with merged configuration
+
+        Raises:
+            ConfigurationError: If configuration is invalid
+        """
+        # Load defaults (required)
+        defaults_path = self.base_path / "config" / "defaults.yaml"
+        defaults_data = self._load_yaml(defaults_path)
+
+        # Build base config from defaults
+        config_data: dict[str, Any] = {}
+
+        # Map evaluation settings to top-level
+        if "evaluation" in defaults_data:
+            eval_cfg = defaults_data["evaluation"]
+            if "runs_per_eval" in eval_cfg:
+                config_data["runs_per_tier"] = eval_cfg["runs_per_eval"]
+            if "timeout" in eval_cfg:
+                config_data["timeout_seconds"] = eval_cfg["timeout"]
+
+        # Copy top-level settings
+        for key in ["runs_per_tier", "timeout_seconds", "max_cost_usd", "judge", "adapters", "cleanup"]:
+            if key in defaults_data:
+                config_data[key] = defaults_data[key]
+
+        # Copy other config sections
+        for key in ["output", "logging", "metrics"]:
+            if key in defaults_data:
+                config_data[key] = defaults_data[key]
+
+        # Load model config (optional)
+        model_config = self.load_model(model_id)
+
+        # Apply model overrides
+        if model_config:
+            if model_config.timeout_seconds is not None:
+                config_data["timeout_seconds"] = model_config.timeout_seconds
+            if model_config.max_cost_usd is not None:
+                config_data["max_cost_usd"] = model_config.max_cost_usd
+
+        # Load test-specific config (optional)
+        test_config_path = self.base_path / "tests" / test_id / "config.yaml"
+        test_config_data = self._load_yaml_optional(test_config_path)
+
+        if test_config_data:
+            config_data = _deep_merge(config_data, test_config_data)
+
+        # Add context
+        config_data["test_id"] = test_id
+        config_data["model_id"] = model_id
+        config_data["model"] = model_config
+
+        try:
+            return ScyllaConfig(**config_data)
+        except Exception as e:
+            raise ConfigurationError(f"Failed to create merged configuration: {e}")

--- a/src/scylla/config/models.py
+++ b/src/scylla/config/models.py
@@ -1,0 +1,324 @@
+"""Pydantic models for ProjectScylla configuration.
+
+This module defines the configuration schema for test cases, rubrics,
+tier configurations, and model configurations used by the evaluation framework.
+
+Python Justification: Required for YAML parsing (no Mojo stdlib support)
+and Pydantic validation capabilities.
+"""
+
+from pathlib import Path
+from typing import Any, Literal
+
+from pydantic import BaseModel, Field, field_validator
+
+
+class ConfigurationError(Exception):
+    """Raised when configuration loading or validation fails."""
+
+    pass
+
+
+# -----------------------------------------------------------------------------
+# Test Case Models
+# -----------------------------------------------------------------------------
+
+
+class SourceConfig(BaseModel):
+    """Source repository configuration for a test case."""
+
+    repo: str = Field(..., description="GitHub repository URL")
+    hash: str = Field(..., description="Commit hash to checkout")
+
+
+class TaskConfig(BaseModel):
+    """Task configuration within a test case."""
+
+    prompt_file: str = Field(..., description="Path to prompt file relative to test dir")
+    timeout_seconds: int = Field(default=3600, ge=60, le=86400)
+
+
+class ValidationConfig(BaseModel):
+    """Validation configuration for a test case."""
+
+    criteria_file: str = Field(
+        default="expected/criteria.md",
+        description="Path to criteria file relative to test dir",
+    )
+    rubric_file: str = Field(
+        default="expected/rubric.yaml",
+        description="Path to rubric file relative to test dir",
+    )
+
+
+class TestCase(BaseModel):
+    """Configuration for a test case.
+
+    Maps to tests/<id>/test.yaml
+    """
+
+    id: str = Field(..., description="Unique test identifier")
+    name: str = Field(..., description="Human-readable test name")
+    description: str = Field(..., description="Detailed test description")
+    source: SourceConfig
+    task: TaskConfig
+    validation: ValidationConfig = Field(default_factory=ValidationConfig)
+
+    @field_validator("id")
+    @classmethod
+    def validate_id(cls, v: str) -> str:
+        """Validate test ID format."""
+        if not v or not v.strip():
+            raise ValueError("Test ID cannot be empty")
+        return v.strip()
+
+
+# -----------------------------------------------------------------------------
+# Rubric Models
+# -----------------------------------------------------------------------------
+
+
+class Requirement(BaseModel):
+    """A single requirement in the rubric."""
+
+    id: str = Field(..., description="Requirement identifier (e.g., R001)")
+    description: str = Field(..., description="What this requirement evaluates")
+    weight: float = Field(default=1.0, ge=0.0, le=10.0)
+    evaluation: Literal["binary", "scaled"] = Field(default="binary")
+
+
+class GradeScale(BaseModel):
+    """Grade scale thresholds."""
+
+    A: float = Field(default=0.95, ge=0.0, le=1.0)
+    B: float = Field(default=0.85, ge=0.0, le=1.0)
+    C: float = Field(default=0.75, ge=0.0, le=1.0)
+    D: float = Field(default=0.65, ge=0.0, le=1.0)
+    F: float = Field(default=0.0, ge=0.0, le=1.0)
+
+
+class GradingConfig(BaseModel):
+    """Grading configuration for a rubric."""
+
+    pass_threshold: float = Field(default=0.70, ge=0.0, le=1.0)
+    grade_scale: GradeScale = Field(default_factory=GradeScale)
+
+
+class Rubric(BaseModel):
+    """Rubric for evaluating test results.
+
+    Maps to tests/<id>/expected/rubric.yaml
+    """
+
+    requirements: list[Requirement] = Field(default_factory=list)
+    grading: GradingConfig = Field(default_factory=GradingConfig)
+
+    def total_weight(self) -> float:
+        """Calculate total weight of all requirements."""
+        return sum(r.weight for r in self.requirements)
+
+    def weighted_score(self, scores: dict[str, float]) -> float:
+        """Calculate weighted score from requirement scores.
+
+        Args:
+            scores: Dict mapping requirement IDs to scores (0.0 to 1.0)
+
+        Returns:
+            Weighted score between 0.0 and 1.0
+        """
+        total = self.total_weight()
+        if total == 0:
+            return 0.0
+
+        weighted_sum = 0.0
+        for req in self.requirements:
+            if req.id in scores:
+                weighted_sum += scores[req.id] * req.weight
+
+        return weighted_sum / total
+
+
+# -----------------------------------------------------------------------------
+# Model Configuration
+# -----------------------------------------------------------------------------
+
+
+class ModelConfig(BaseModel):
+    """Configuration for a specific model.
+
+    Maps to config/models/<model_id>.yaml
+    """
+
+    model_id: str = Field(..., description="Model identifier")
+    adapter: str = Field(default="claude_code", description="Adapter to use")
+    temperature: float = Field(default=0.0, ge=0.0, le=2.0)
+    max_tokens: int = Field(default=8192, ge=1, le=200000)
+    cost_per_1k_input: float = Field(default=0.0, ge=0.0)
+    cost_per_1k_output: float = Field(default=0.0, ge=0.0)
+
+    # Optional overrides
+    timeout_seconds: int | None = Field(default=None, ge=60, le=86400)
+    max_cost_usd: float | None = Field(default=None, ge=0.0)
+
+
+# -----------------------------------------------------------------------------
+# Tier Configuration
+# -----------------------------------------------------------------------------
+
+
+class TierConfig(BaseModel):
+    """Configuration for a testing tier.
+
+    Maps to config/tiers/t<n>.yaml (e.g., t0.yaml, t1.yaml)
+    """
+
+    tier: str = Field(..., description="Tier identifier (e.g., t0, t1)")
+    name: str = Field(..., description="Human-readable tier name")
+    description: str = Field(default="", description="Tier description")
+
+    # Tier-specific settings
+    system_prompt: str | None = Field(default=None, description="System prompt for this tier")
+    skills: list[str] = Field(default_factory=list, description="Skills enabled for this tier")
+    tools: list[str] = Field(default_factory=list, description="Tools enabled for this tier")
+
+    # Tier capabilities
+    uses_tools: bool = Field(default=False)
+    uses_delegation: bool = Field(default=False)
+    uses_hierarchy: bool = Field(default=False)
+
+    @field_validator("tier")
+    @classmethod
+    def validate_tier_format(cls, v: str) -> str:
+        """Validate tier format (t0-t6)."""
+        v = v.lower().strip()
+        if not v.startswith("t") or not v[1:].isdigit():
+            raise ValueError(f"Tier must be in format 't<n>' (e.g., t0, t1), got: {v}")
+        tier_num = int(v[1:])
+        if tier_num < 0 or tier_num > 6:
+            raise ValueError(f"Tier number must be 0-6, got: {tier_num}")
+        return v
+
+
+# -----------------------------------------------------------------------------
+# Global/Default Configuration
+# -----------------------------------------------------------------------------
+
+
+class JudgeConfig(BaseModel):
+    """Judge model configuration."""
+
+    model: str = Field(default="claude-opus-4-5-20251101")
+    adapter: str = Field(default="claude_code")
+
+
+class AdaptersConfig(BaseModel):
+    """Adapters configuration."""
+
+    default: str = Field(default="claude_code")
+    available: list[str] = Field(
+        default_factory=lambda: ["claude_code", "openai_codex", "cline", "opencode"]
+    )
+
+
+class CleanupConfig(BaseModel):
+    """Workspace cleanup configuration."""
+
+    delete_workspace: bool = Field(default=True)
+    keep_logs: bool = Field(default=True)
+
+
+class EvaluationConfig(BaseModel):
+    """Evaluation settings from defaults."""
+
+    runs_per_tier: int = Field(default=9, ge=1, le=100, alias="runs_per_eval")
+    timeout: int = Field(default=300, ge=60, le=86400)
+    seed: int | None = Field(default=None)
+
+    model_config = {"populate_by_name": True}
+
+
+class MetricsConfig(BaseModel):
+    """Metrics configuration."""
+
+    quality: list[str] = Field(
+        default_factory=lambda: ["pass_rate", "impl_rate", "progress_rate", "consistency"]
+    )
+    economic: list[str] = Field(
+        default_factory=lambda: ["cost_of_pass", "token_distribution", "change_fail_percentage"]
+    )
+
+
+class OutputConfig(BaseModel):
+    """Output directory configuration."""
+
+    runs_dir: str = Field(default="runs")
+    summaries_dir: str = Field(default="summaries")
+    reports_dir: str = Field(default="reports")
+
+
+class LoggingConfig(BaseModel):
+    """Logging configuration."""
+
+    level: str = Field(default="INFO")
+    format: str = Field(default="%(asctime)s - %(name)s - %(levelname)s - %(message)s")
+
+
+class DefaultsConfig(BaseModel):
+    """Global defaults configuration.
+
+    Maps to config/defaults.yaml
+    """
+
+    evaluation: EvaluationConfig = Field(default_factory=EvaluationConfig)
+    metrics: MetricsConfig = Field(default_factory=MetricsConfig)
+    output: OutputConfig = Field(default_factory=OutputConfig)
+    logging: LoggingConfig = Field(default_factory=LoggingConfig)
+
+    # Optional extended settings (for executor)
+    runs_per_tier: int = Field(default=9, ge=1, le=100)
+    timeout_seconds: int = Field(default=3600, ge=60, le=86400)
+    max_cost_usd: float = Field(default=10.0, ge=0.0)
+    judge: JudgeConfig = Field(default_factory=JudgeConfig)
+    adapters: AdaptersConfig = Field(default_factory=AdaptersConfig)
+    cleanup: CleanupConfig = Field(default_factory=CleanupConfig)
+
+
+# -----------------------------------------------------------------------------
+# Merged Runtime Configuration
+# -----------------------------------------------------------------------------
+
+
+class ScyllaConfig(BaseModel):
+    """Complete merged configuration for a test run.
+
+    This represents the final, validated configuration after merging:
+    1. config/defaults.yaml (base)
+    2. config/models/<model_id>.yaml (optional model overrides)
+    3. tests/<test_id>/config.yaml (optional test overrides)
+
+    Priority: test > model > defaults
+    """
+
+    # From defaults
+    runs_per_tier: int = Field(default=9, ge=1, le=100)
+    timeout_seconds: int = Field(default=3600, ge=60, le=86400)
+    max_cost_usd: float = Field(default=10.0, ge=0.0)
+    judge: JudgeConfig = Field(default_factory=JudgeConfig)
+    adapters: AdaptersConfig = Field(default_factory=AdaptersConfig)
+    cleanup: CleanupConfig = Field(default_factory=CleanupConfig)
+    output: OutputConfig = Field(default_factory=OutputConfig)
+    logging: LoggingConfig = Field(default_factory=LoggingConfig)
+    metrics: MetricsConfig = Field(default_factory=MetricsConfig)
+
+    # From model config (optional)
+    model: ModelConfig | None = Field(default=None)
+
+    # Context
+    test_id: str | None = Field(default=None)
+    model_id: str | None = Field(default=None)
+
+    def is_valid(self) -> bool:
+        """Check if configuration is valid for execution."""
+        return True  # Pydantic validation ensures validity
+
+    model_config = {"frozen": True}

--- a/tests/fixtures/config/defaults.yaml
+++ b/tests/fixtures/config/defaults.yaml
@@ -1,0 +1,21 @@
+# Test fixture: Global defaults
+evaluation:
+  runs_per_eval: 9
+  timeout: 300
+  seed: null
+
+metrics:
+  quality:
+    - pass_rate
+    - impl_rate
+  economic:
+    - cost_of_pass
+
+output:
+  runs_dir: "runs"
+  summaries_dir: "summaries"
+  reports_dir: "reports"
+
+logging:
+  level: "INFO"
+  format: "%(asctime)s - %(name)s - %(levelname)s - %(message)s"

--- a/tests/fixtures/config/models/test-model.yaml
+++ b/tests/fixtures/config/models/test-model.yaml
@@ -1,0 +1,7 @@
+# Test fixture: Model configuration
+model_id: "test-model"
+adapter: "test_adapter"
+temperature: 0.5
+max_tokens: 4096
+cost_per_1k_input: 0.01
+cost_per_1k_output: 0.03

--- a/tests/fixtures/config/tiers/t0.yaml
+++ b/tests/fixtures/config/tiers/t0.yaml
@@ -1,0 +1,7 @@
+# Test fixture: Tier 0 (Vanilla)
+tier: "t0"
+name: "Vanilla"
+description: "Base LLM with zero-shot prompting"
+uses_tools: false
+uses_delegation: false
+uses_hierarchy: false

--- a/tests/fixtures/config/tiers/t1.yaml
+++ b/tests/fixtures/config/tiers/t1.yaml
@@ -1,0 +1,8 @@
+# Test fixture: Tier 1 (Prompted)
+tier: "t1"
+name: "Prompted"
+description: "System prompts and chain-of-thought"
+system_prompt: "You are a helpful assistant."
+uses_tools: false
+uses_delegation: false
+uses_hierarchy: false

--- a/tests/fixtures/invalid/defaults.yaml
+++ b/tests/fixtures/invalid/defaults.yaml
@@ -1,0 +1,4 @@
+# Invalid YAML - missing colon
+evaluation
+  runs_per_eval: 9
+this is not valid yaml [ } {

--- a/tests/fixtures/tests/test-001/config.yaml
+++ b/tests/fixtures/tests/test-001/config.yaml
@@ -1,0 +1,3 @@
+# Test fixture: Test-specific config overrides
+timeout_seconds: 7200
+max_cost_usd: 5.0

--- a/tests/fixtures/tests/test-001/expected/rubric.yaml
+++ b/tests/fixtures/tests/test-001/expected/rubric.yaml
@@ -1,0 +1,20 @@
+# Test fixture: Rubric
+requirements:
+  - id: "R001"
+    description: "First requirement"
+    weight: 2.0
+    evaluation: "binary"
+
+  - id: "R002"
+    description: "Second requirement"
+    weight: 1.0
+    evaluation: "scaled"
+
+grading:
+  pass_threshold: 0.70
+  grade_scale:
+    A: 0.95
+    B: 0.85
+    C: 0.75
+    D: 0.65
+    F: 0.0

--- a/tests/fixtures/tests/test-001/test.yaml
+++ b/tests/fixtures/tests/test-001/test.yaml
@@ -1,0 +1,18 @@
+# Test fixture: Test case
+id: "test-001"
+name: "Test Case 001"
+description: |
+  A test fixture for unit testing the configuration loader.
+  This is not a real test case.
+
+source:
+  repo: "https://github.com/example/repo"
+  hash: "abc123def456"
+
+task:
+  prompt_file: "prompt.md"
+  timeout_seconds: 1800
+
+validation:
+  criteria_file: "expected/criteria.md"
+  rubric_file: "expected/rubric.yaml"

--- a/tests/unit/__init__.py
+++ b/tests/unit/__init__.py
@@ -1,0 +1,1 @@
+"""Unit tests for ProjectScylla."""

--- a/tests/unit/test_config_loader.py
+++ b/tests/unit/test_config_loader.py
@@ -1,0 +1,348 @@
+"""Unit tests for the configuration loading system.
+
+Tests cover:
+- Loading defaults configuration
+- Loading test cases and rubrics
+- Loading tier configurations
+- Loading model configurations
+- Merged configuration with priority hierarchy
+- Error handling for invalid/missing configurations
+"""
+
+from pathlib import Path
+
+import pytest
+
+from scylla.config import (
+    ConfigLoader,
+    ConfigurationError,
+    DefaultsConfig,
+    ModelConfig,
+    Requirement,
+    Rubric,
+    ScyllaConfig,
+    TestCase,
+    TierConfig,
+)
+
+# Path to test fixtures
+FIXTURES_PATH = Path(__file__).parent.parent / "fixtures"
+
+
+class TestConfigLoaderDefaults:
+    """Tests for loading defaults configuration."""
+
+    def test_load_defaults(self) -> None:
+        """Load defaults.yaml successfully."""
+        loader = ConfigLoader(base_path=FIXTURES_PATH)
+        defaults = loader.load_defaults()
+
+        assert isinstance(defaults, DefaultsConfig)
+        assert defaults.evaluation.runs_per_tier == 9
+        assert defaults.evaluation.timeout == 300
+        assert defaults.output.runs_dir == "runs"
+        assert defaults.logging.level == "INFO"
+
+    def test_load_defaults_missing_file(self) -> None:
+        """Missing defaults.yaml raises ConfigurationError."""
+        loader = ConfigLoader(base_path=Path("/nonexistent"))
+
+        with pytest.raises(ConfigurationError, match="not found"):
+            loader.load_defaults()
+
+    def test_load_defaults_invalid_yaml(self) -> None:
+        """Malformed YAML raises ConfigurationError."""
+        loader = ConfigLoader(base_path=FIXTURES_PATH / "invalid")
+
+        with pytest.raises(ConfigurationError, match="Invalid YAML"):
+            loader.load_defaults()
+
+
+class TestConfigLoaderTestCase:
+    """Tests for loading test case configurations."""
+
+    def test_load_test(self) -> None:
+        """Load test.yaml successfully."""
+        loader = ConfigLoader(base_path=FIXTURES_PATH)
+        test = loader.load_test("test-001")
+
+        assert isinstance(test, TestCase)
+        assert test.id == "test-001"
+        assert test.name == "Test Case 001"
+        assert test.source.repo == "https://github.com/example/repo"
+        assert test.source.hash == "abc123def456"
+        assert test.task.prompt_file == "prompt.md"
+        assert test.task.timeout_seconds == 1800
+
+    def test_load_test_missing(self) -> None:
+        """Missing test raises ConfigurationError."""
+        loader = ConfigLoader(base_path=FIXTURES_PATH)
+
+        with pytest.raises(ConfigurationError, match="not found"):
+            loader.load_test("nonexistent-test")
+
+    def test_load_test_with_defaults(self) -> None:
+        """Test case uses default values for optional fields."""
+        loader = ConfigLoader(base_path=FIXTURES_PATH)
+        test = loader.load_test("test-001")
+
+        # ValidationConfig should use defaults
+        assert test.validation.criteria_file == "expected/criteria.md"
+        assert test.validation.rubric_file == "expected/rubric.yaml"
+
+
+class TestConfigLoaderRubric:
+    """Tests for loading rubric configurations."""
+
+    def test_load_rubric(self) -> None:
+        """Load rubric.yaml successfully."""
+        loader = ConfigLoader(base_path=FIXTURES_PATH)
+        rubric = loader.load_rubric("test-001")
+
+        assert isinstance(rubric, Rubric)
+        assert len(rubric.requirements) == 2
+
+        # Check first requirement
+        req1 = rubric.requirements[0]
+        assert req1.id == "R001"
+        assert req1.weight == 2.0
+        assert req1.evaluation == "binary"
+
+        # Check grading
+        assert rubric.grading.pass_threshold == 0.70
+        assert rubric.grading.grade_scale.A == 0.95
+
+    def test_load_rubric_missing(self) -> None:
+        """Missing rubric raises ConfigurationError."""
+        loader = ConfigLoader(base_path=FIXTURES_PATH)
+
+        with pytest.raises(ConfigurationError, match="not found"):
+            loader.load_rubric("nonexistent-test")
+
+    def test_rubric_total_weight(self) -> None:
+        """Calculate total weight of requirements."""
+        loader = ConfigLoader(base_path=FIXTURES_PATH)
+        rubric = loader.load_rubric("test-001")
+
+        assert rubric.total_weight() == 3.0  # 2.0 + 1.0
+
+    def test_rubric_weighted_score(self) -> None:
+        """Calculate weighted score from requirement scores."""
+        loader = ConfigLoader(base_path=FIXTURES_PATH)
+        rubric = loader.load_rubric("test-001")
+
+        scores = {"R001": 1.0, "R002": 0.5}  # Full score, half score
+        weighted = rubric.weighted_score(scores)
+
+        # (2.0 * 1.0 + 1.0 * 0.5) / 3.0 = 2.5 / 3.0 = 0.833...
+        assert abs(weighted - 0.8333333333) < 0.001
+
+
+class TestConfigLoaderTier:
+    """Tests for loading tier configurations."""
+
+    def test_load_tier(self) -> None:
+        """Load tier configuration successfully."""
+        loader = ConfigLoader(base_path=FIXTURES_PATH)
+        tier = loader.load_tier("t0")
+
+        assert isinstance(tier, TierConfig)
+        assert tier.tier == "t0"
+        assert tier.name == "Vanilla"
+        assert tier.uses_tools is False
+
+    def test_load_tier_with_system_prompt(self) -> None:
+        """Load tier with system prompt."""
+        loader = ConfigLoader(base_path=FIXTURES_PATH)
+        tier = loader.load_tier("t1")
+
+        assert tier.tier == "t1"
+        assert tier.name == "Prompted"
+        assert tier.system_prompt == "You are a helpful assistant."
+
+    def test_load_tier_normalize_name(self) -> None:
+        """Tier name is normalized (lowercase, prefixed)."""
+        loader = ConfigLoader(base_path=FIXTURES_PATH)
+
+        # Should work with various formats
+        tier1 = loader.load_tier("T0")  # uppercase
+        tier2 = loader.load_tier("0")  # no prefix
+        tier3 = loader.load_tier(" t0 ")  # whitespace
+
+        assert tier1.tier == "t0"
+        assert tier2.tier == "t0"
+        assert tier3.tier == "t0"
+
+    def test_load_tier_missing(self) -> None:
+        """Missing tier raises ConfigurationError."""
+        loader = ConfigLoader(base_path=FIXTURES_PATH)
+
+        with pytest.raises(ConfigurationError, match="not found"):
+            loader.load_tier("t99")
+
+    def test_load_all_tiers(self) -> None:
+        """Load all tier configurations."""
+        loader = ConfigLoader(base_path=FIXTURES_PATH)
+        tiers = loader.load_all_tiers()
+
+        assert len(tiers) == 2
+        assert "t0" in tiers
+        assert "t1" in tiers
+        assert tiers["t0"].name == "Vanilla"
+        assert tiers["t1"].name == "Prompted"
+
+
+class TestConfigLoaderModel:
+    """Tests for loading model configurations."""
+
+    def test_load_model(self) -> None:
+        """Load model configuration successfully."""
+        loader = ConfigLoader(base_path=FIXTURES_PATH)
+        model = loader.load_model("test-model")
+
+        assert isinstance(model, ModelConfig)
+        assert model.model_id == "test-model"
+        assert model.adapter == "test_adapter"
+        assert model.temperature == 0.5
+        assert model.max_tokens == 4096
+        assert model.cost_per_1k_input == 0.01
+        assert model.cost_per_1k_output == 0.03
+
+    def test_load_model_missing_returns_none(self) -> None:
+        """Missing model config returns None (not error)."""
+        loader = ConfigLoader(base_path=FIXTURES_PATH)
+        model = loader.load_model("nonexistent-model")
+
+        assert model is None
+
+
+class TestConfigLoaderMerged:
+    """Tests for merged configuration loading."""
+
+    def test_load_merged_defaults_only(self) -> None:
+        """Load merged config with only defaults."""
+        loader = ConfigLoader(base_path=FIXTURES_PATH)
+        config = loader.load(test_id="nonexistent", model_id="nonexistent")
+
+        assert isinstance(config, ScyllaConfig)
+        assert config.runs_per_tier == 9
+        assert config.test_id == "nonexistent"
+        assert config.model_id == "nonexistent"
+        assert config.model is None
+
+    def test_load_merged_with_model(self) -> None:
+        """Load merged config with model configuration."""
+        loader = ConfigLoader(base_path=FIXTURES_PATH)
+        config = loader.load(test_id="nonexistent", model_id="test-model")
+
+        assert config.model is not None
+        assert config.model.model_id == "test-model"
+        assert config.model.temperature == 0.5
+
+    def test_load_merged_with_test_override(self) -> None:
+        """Test-specific config overrides other layers."""
+        loader = ConfigLoader(base_path=FIXTURES_PATH)
+        config = loader.load(test_id="test-001", model_id="test-model")
+
+        # Test override should apply
+        assert config.timeout_seconds == 7200  # From test config
+        assert config.max_cost_usd == 5.0  # From test config
+
+        # Model config should still be present
+        assert config.model is not None
+        assert config.model.temperature == 0.5
+
+    def test_load_merged_priority_order(self) -> None:
+        """Verify priority: test > model > defaults."""
+        loader = ConfigLoader(base_path=FIXTURES_PATH)
+        config = loader.load(test_id="test-001", model_id="test-model")
+
+        # Test overrides should take precedence
+        assert config.timeout_seconds == 7200  # test > defaults (300 -> 3600)
+        assert config.max_cost_usd == 5.0  # test override
+
+        # Defaults should fill in non-overridden values
+        assert config.runs_per_tier == 9  # from defaults
+        assert config.output.runs_dir == "runs"  # from defaults
+
+    def test_load_merged_immutable(self) -> None:
+        """Merged config is immutable (frozen)."""
+        loader = ConfigLoader(base_path=FIXTURES_PATH)
+        config = loader.load(test_id="test-001", model_id="test-model")
+
+        # Attempting to modify should raise an error
+        with pytest.raises(Exception):  # Pydantic ValidationError
+            config.timeout_seconds = 9999  # type: ignore
+
+    def test_load_merged_is_valid(self) -> None:
+        """Merged config passes validation."""
+        loader = ConfigLoader(base_path=FIXTURES_PATH)
+        config = loader.load(test_id="test-001", model_id="test-model")
+
+        assert config.is_valid()
+
+
+class TestConfigLoaderEdgeCases:
+    """Edge case and error handling tests."""
+
+    def test_empty_base_path(self) -> None:
+        """ConfigLoader with None base_path uses cwd."""
+        loader = ConfigLoader(base_path=None)
+        assert loader.base_path == Path.cwd()
+
+    def test_string_base_path(self) -> None:
+        """ConfigLoader accepts string base_path."""
+        loader = ConfigLoader(base_path=str(FIXTURES_PATH))
+        assert loader.base_path == FIXTURES_PATH
+
+    def test_tier_invalid_format(self) -> None:
+        """Invalid tier format raises validation error."""
+        from scylla.config.models import TierConfig
+
+        with pytest.raises(ValueError, match="Tier must be in format"):
+            TierConfig(tier="invalid", name="Test")
+
+    def test_tier_out_of_range(self) -> None:
+        """Tier number out of range raises validation error."""
+        from scylla.config.models import TierConfig
+
+        with pytest.raises(ValueError, match="Tier number must be 0-6"):
+            TierConfig(tier="t99", name="Test")
+
+    def test_requirement_defaults(self) -> None:
+        """Requirement uses sensible defaults."""
+        req = Requirement(id="R001", description="Test requirement")
+
+        assert req.weight == 1.0
+        assert req.evaluation == "binary"
+
+    def test_test_case_empty_id_rejected(self) -> None:
+        """Empty test ID is rejected."""
+        with pytest.raises(ValueError, match="cannot be empty"):
+            TestCase(
+                id="",
+                name="Test",
+                description="Test",
+                source={"repo": "https://example.com", "hash": "abc123"},
+                task={"prompt_file": "prompt.md"},
+            )
+
+
+class TestConfigLoaderIntegration:
+    """Integration tests with real project config structure."""
+
+    def test_load_real_test_if_exists(self) -> None:
+        """Load config for real test case if available."""
+        # Use the actual project root
+        project_root = FIXTURES_PATH.parent.parent
+
+        loader = ConfigLoader(base_path=project_root)
+
+        # Try to load the real test - may not exist in fixtures
+        try:
+            test = loader.load_test("001-justfile-to-makefile")
+            assert test.id == "001-justfile-to-makefile"
+            assert "Makefile" in test.name
+        except ConfigurationError:
+            # Test doesn't exist in this worktree, that's ok
+            pytest.skip("Real test case not available in worktree")


### PR DESCRIPTION
## Summary

- Add Pydantic-based configuration loading system with models for TestCase, Rubric, TierConfig, and ModelConfig
- Create ConfigLoader class with methods: `load_test()`, `load_rubric()`, `load_tier()`, `load_all_tiers()`, `load_model()`, and `load()` for merged configs
- Implement three-level priority hierarchy: test-specific > model defaults > global defaults
- Add comprehensive unit tests and test fixtures

## Test plan

- [ ] Run `pixi run pytest tests/unit/test_config_loader.py -v` to verify all unit tests pass
- [ ] Verify `from scylla.config import ConfigLoader` imports correctly
- [ ] Test loading real project configs with `ConfigLoader().load_test("001-justfile-to-makefile")`

Closes #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)