### PR TITLE
feat(executor): add tier configuration system

### DIFF
--- a/config/tiers/t0-vanilla.md
+++ b/config/tiers/t0-vanilla.md
@@ -1,0 +1,5 @@
+# T0: Vanilla
+
+This file exists for reference only. T0 uses tool defaults with no customization.
+
+The agent receives only the task description with no additional prompting.

--- a/config/tiers/t1-prompted.md
+++ b/config/tiers/t1-prompted.md
@@ -1,0 +1,18 @@
+# Instructions
+
+Think step by step before taking action. For each step:
+
+1. **Analyze** - Understand what needs to be done
+2. **Consider** - Evaluate potential approaches
+3. **Choose** - Select the best approach with justification
+4. **Execute** - Implement the action
+5. **Verify** - Check the result before proceeding
+
+Always explain your reasoning before making changes.
+
+## Guidelines
+
+- Break complex tasks into smaller, manageable steps
+- Consider edge cases and error conditions
+- Validate assumptions before proceeding
+- Document your thought process

--- a/config/tiers/t2-skills.md
+++ b/config/tiers/t2-skills.md
@@ -1,0 +1,26 @@
+# Domain Expertise
+
+You have specialized expertise in the following areas:
+
+## Core Competencies
+
+- **Build Systems**: Makefile syntax, GNU Make patterns, build automation
+- **Code Analysis**: Understanding code structure, dependencies, and patterns
+- **Testing**: Test design, coverage analysis, validation strategies
+- **Documentation**: Technical writing, API documentation, code comments
+
+## Approach
+
+Apply your domain expertise systematically:
+
+1. Identify the domain context of the task
+2. Apply relevant best practices and patterns
+3. Consider domain-specific edge cases
+4. Use appropriate terminology and conventions
+
+## Quality Standards
+
+- Follow established conventions for the domain
+- Prioritize correctness over cleverness
+- Document domain-specific decisions
+- Consider maintainability and readability

--- a/config/tiers/t3-tooling.md
+++ b/config/tiers/t3-tooling.md
@@ -1,0 +1,33 @@
+# Advanced Capabilities
+
+You have access to external tools and advanced capabilities.
+
+## Available Tools
+
+Use the following tools as appropriate:
+
+- **File Operations**: Read, write, edit files
+- **Shell Commands**: Execute system commands
+- **Search**: Find files and content across the codebase
+- **Web Access**: Fetch external documentation when needed
+
+## Delegation
+
+For complex tasks, consider delegating to specialized agents:
+
+- Break large tasks into independent subtasks
+- Assign subtasks to appropriate specialists
+- Coordinate results and ensure consistency
+
+## Orchestration Guidelines
+
+1. Plan the overall approach before starting
+2. Identify parallelizable subtasks
+3. Monitor progress and handle failures
+4. Aggregate results coherently
+
+## Error Handling
+
+- Retry transient failures with backoff
+- Escalate persistent issues appropriately
+- Document failures and their context

--- a/config/tiers/tiers.yaml
+++ b/config/tiers/tiers.yaml
@@ -1,0 +1,36 @@
+# Tier Definitions
+#
+# Defines the testing tiers for the agent evaluation framework.
+# Each tier represents a different level of agent capability.
+#
+# Important: Tiers are INDEPENDENT, not cumulative.
+# T0 uses tool defaults (null values), T1-T3+ have explicit configurations.
+
+tiers:
+  T0:
+    name: "Vanilla"
+    description: "Base LLM, tool default, zero customization"
+    prompt_file: null  # Use tool default
+    tools_enabled: null  # Use tool default
+    delegation_enabled: null  # Use tool default
+
+  T1:
+    name: "Prompted"
+    description: "System prompt with chain-of-thought reasoning"
+    prompt_file: "t1-prompted.md"
+    tools_enabled: false
+    delegation_enabled: false
+
+  T2:
+    name: "Skills"
+    description: "Domain expertise encoded in prompts"
+    prompt_file: "t2-skills.md"
+    tools_enabled: false
+    delegation_enabled: false
+
+  "T3+":
+    name: "Tooling"
+    description: "External tools, multi-agent orchestration"
+    prompt_file: "t3-tooling.md"
+    tools_enabled: true
+    delegation_enabled: true

--- a/src/scylla/executor/__init__.py
+++ b/src/scylla/executor/__init__.py
@@ -1,7 +1,7 @@
 """Executor module for running agent evaluations.
 
 This module provides workspace management, Docker container orchestration,
-and test execution capabilities.
+tier configuration, and test execution capabilities.
 """
 
 from scylla.executor.docker import (
@@ -12,6 +12,13 @@ from scylla.executor.docker import (
     DockerError,
     DockerExecutor,
     DockerNotAvailableError,
+)
+from scylla.executor.tier_config import (
+    TierConfig,
+    TierConfigError,
+    TierConfigLoader,
+    TierDefinition,
+    TiersDefinitionFile,
 )
 from scylla.executor.workspace import (
     WorkspaceError,
@@ -31,6 +38,12 @@ __all__ = [
     "DockerError",
     "DockerExecutor",
     "DockerNotAvailableError",
+    # Tier Configuration
+    "TierConfig",
+    "TierConfigError",
+    "TierConfigLoader",
+    "TierDefinition",
+    "TiersDefinitionFile",
     # Workspace
     "WorkspaceError",
     "WorkspaceManager",

--- a/src/scylla/executor/tier_config.py
+++ b/src/scylla/executor/tier_config.py
@@ -1,0 +1,189 @@
+"""Tier configuration system for loading and applying tier-specific prompts.
+
+This module provides the TierConfigLoader class for loading tier definitions
+from YAML and their associated prompt templates from markdown files.
+
+Python justification: Required for YAML parsing, file I/O, and Pydantic validation.
+"""
+
+from pathlib import Path
+from typing import Optional
+
+from pydantic import BaseModel, Field, field_validator
+
+
+class TierDefinition(BaseModel):
+    """Definition of a single tier from the YAML configuration."""
+
+    name: str = Field(..., description="Human-readable tier name")
+    description: str = Field(..., description="Description of the tier's purpose")
+    prompt_file: Optional[str] = Field(
+        None, description="Path to prompt markdown file (relative to tiers dir)"
+    )
+    tools_enabled: Optional[bool] = Field(
+        None, description="Whether tools are enabled (None = tool default)"
+    )
+    delegation_enabled: Optional[bool] = Field(
+        None, description="Whether delegation is enabled (None = tool default)"
+    )
+
+
+class TierConfig(BaseModel):
+    """Complete tier configuration with loaded prompt content."""
+
+    tier_id: str = Field(..., description="Tier identifier (e.g., 'T0', 'T1', 'T2', 'T3+')")
+    name: str = Field(..., description="Human-readable tier name")
+    description: str = Field(..., description="Description of the tier's purpose")
+    prompt_file: Optional[Path] = Field(
+        None, description="Absolute path to prompt file"
+    )
+    prompt_content: Optional[str] = Field(
+        None, description="Loaded prompt content"
+    )
+    tools_enabled: Optional[bool] = Field(
+        None, description="Whether tools are enabled"
+    )
+    delegation_enabled: Optional[bool] = Field(
+        None, description="Whether delegation is enabled"
+    )
+
+    model_config = {"arbitrary_types_allowed": True}
+
+
+class TiersDefinitionFile(BaseModel):
+    """Root structure of the tiers.yaml file."""
+
+    tiers: dict[str, TierDefinition] = Field(
+        ..., description="Mapping of tier IDs to their definitions"
+    )
+
+    @field_validator("tiers")
+    @classmethod
+    def validate_required_tiers(
+        cls, v: dict[str, TierDefinition]
+    ) -> dict[str, TierDefinition]:
+        """Ensure required tiers are present."""
+        required = {"T0", "T1", "T2", "T3+"}
+        missing = required - set(v.keys())
+        if missing:
+            raise ValueError(f"Missing required tier definitions: {missing}")
+        return v
+
+
+class TierConfigError(Exception):
+    """Error raised when tier configuration is invalid or unavailable."""
+
+    pass
+
+
+class TierConfigLoader:
+    """Loads and provides access to tier configurations.
+
+    Loads tier definitions from a YAML file and associated prompt templates
+    from markdown files in the tiers directory.
+
+    Example:
+        loader = TierConfigLoader(Path("config"))
+        t1_config = loader.get_tier("T1")
+        print(t1_config.prompt_content)
+    """
+
+    def __init__(self, config_dir: Path) -> None:
+        """Initialize the loader with the config directory.
+
+        Args:
+            config_dir: Path to the config directory containing tiers/tiers.yaml
+        """
+        self.config_dir = Path(config_dir)
+        self.tiers_dir = self.config_dir / "tiers"
+        self.tiers_file = self.tiers_dir / "tiers.yaml"
+        self._tier_definitions: dict[str, TierDefinition] = {}
+        self._load_tiers()
+
+    def _load_tiers(self) -> None:
+        """Load tier definitions from the YAML file."""
+        import yaml
+
+        if not self.tiers_file.exists():
+            raise TierConfigError(f"Tiers file not found: {self.tiers_file}")
+
+        try:
+            with open(self.tiers_file) as f:
+                raw_data = yaml.safe_load(f)
+        except yaml.YAMLError as e:
+            raise TierConfigError(f"Failed to parse tiers.yaml: {e}") from e
+
+        if not raw_data or "tiers" not in raw_data:
+            raise TierConfigError("tiers.yaml must contain a 'tiers' key")
+
+        try:
+            tiers_def = TiersDefinitionFile.model_validate(raw_data)
+            self._tier_definitions = tiers_def.tiers
+        except Exception as e:
+            raise TierConfigError(f"Invalid tier definitions: {e}") from e
+
+    def get_tier(self, tier_id: str) -> TierConfig:
+        """Load configuration for a specific tier.
+
+        Args:
+            tier_id: The tier identifier (e.g., "T0", "T1", "T2", "T3+")
+
+        Returns:
+            TierConfig with loaded prompt content
+
+        Raises:
+            TierConfigError: If tier_id is unknown or prompt file is missing
+        """
+        if tier_id not in self._tier_definitions:
+            raise TierConfigError(
+                f"Unknown tier: {tier_id}. Available: {list(self._tier_definitions.keys())}"
+            )
+
+        tier_def = self._tier_definitions[tier_id]
+        prompt_file: Optional[Path] = None
+        prompt_content: Optional[str] = None
+
+        if tier_def.prompt_file:
+            prompt_file = self.tiers_dir / tier_def.prompt_file
+            if not prompt_file.exists():
+                raise TierConfigError(
+                    f"Prompt file not found for tier {tier_id}: {prompt_file}"
+                )
+            prompt_content = prompt_file.read_text()
+
+        return TierConfig(
+            tier_id=tier_id,
+            name=tier_def.name,
+            description=tier_def.description,
+            prompt_file=prompt_file,
+            prompt_content=prompt_content,
+            tools_enabled=tier_def.tools_enabled,
+            delegation_enabled=tier_def.delegation_enabled,
+        )
+
+    def get_all_tiers(self) -> list[TierConfig]:
+        """Get all tier configurations.
+
+        Returns:
+            List of TierConfig objects for all defined tiers
+        """
+        return [self.get_tier(tid) for tid in self._tier_definitions.keys()]
+
+    def get_tier_ids(self) -> list[str]:
+        """Get list of all available tier IDs.
+
+        Returns:
+            List of tier identifiers in definition order
+        """
+        return list(self._tier_definitions.keys())
+
+    def validate_tier_id(self, tier_id: str) -> bool:
+        """Check if a tier ID is valid.
+
+        Args:
+            tier_id: The tier identifier to validate
+
+        Returns:
+            True if valid, False otherwise
+        """
+        return tier_id in self._tier_definitions

--- a/tests/unit/executor/test_tier_config.py
+++ b/tests/unit/executor/test_tier_config.py
@@ -1,0 +1,319 @@
+"""Tests for tier configuration loading.
+
+Python justification: Required for pytest testing framework.
+"""
+
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+import pytest
+
+from scylla.executor.tier_config import (
+    TierConfig,
+    TierConfigError,
+    TierConfigLoader,
+    TierDefinition,
+    TiersDefinitionFile,
+)
+
+
+class TestTierDefinition:
+    """Tests for the TierDefinition model."""
+
+    def test_tier_definition_with_all_fields(self) -> None:
+        """Test creating a tier definition with all fields."""
+        tier = TierDefinition(
+            name="Test Tier",
+            description="A test tier",
+            prompt_file="test.md",
+            tools_enabled=True,
+            delegation_enabled=False,
+        )
+        assert tier.name == "Test Tier"
+        assert tier.description == "A test tier"
+        assert tier.prompt_file == "test.md"
+        assert tier.tools_enabled is True
+        assert tier.delegation_enabled is False
+
+    def test_tier_definition_with_defaults(self) -> None:
+        """Test creating a tier definition with default values."""
+        tier = TierDefinition(
+            name="Vanilla",
+            description="Base tier",
+        )
+        assert tier.name == "Vanilla"
+        assert tier.description == "Base tier"
+        assert tier.prompt_file is None
+        assert tier.tools_enabled is None
+        assert tier.delegation_enabled is None
+
+
+class TestTiersDefinitionFile:
+    """Tests for the TiersDefinitionFile model."""
+
+    def test_valid_tiers_definition(self) -> None:
+        """Test validating a complete tiers definition."""
+        tiers_def = TiersDefinitionFile(
+            tiers={
+                "T0": TierDefinition(name="Vanilla", description="Base"),
+                "T1": TierDefinition(name="Prompted", description="With prompts"),
+                "T2": TierDefinition(name="Skills", description="With skills"),
+                "T3+": TierDefinition(name="Tooling", description="With tools"),
+            }
+        )
+        assert len(tiers_def.tiers) == 4
+
+    def test_missing_required_tiers(self) -> None:
+        """Test that missing required tiers raises error."""
+        with pytest.raises(ValueError, match="Missing required tier definitions"):
+            TiersDefinitionFile(
+                tiers={
+                    "T0": TierDefinition(name="Vanilla", description="Base"),
+                    "T1": TierDefinition(name="Prompted", description="With prompts"),
+                }
+            )
+
+
+class TestTierConfig:
+    """Tests for the TierConfig model."""
+
+    def test_tier_config_with_prompt(self) -> None:
+        """Test creating a tier config with prompt content."""
+        config = TierConfig(
+            tier_id="T1",
+            name="Prompted",
+            description="With chain-of-thought",
+            prompt_file=Path("/config/tiers/t1.md"),
+            prompt_content="Think step by step",
+            tools_enabled=False,
+            delegation_enabled=False,
+        )
+        assert config.tier_id == "T1"
+        assert config.prompt_content == "Think step by step"
+
+    def test_tier_config_without_prompt(self) -> None:
+        """Test creating a tier config without prompt (T0 style)."""
+        config = TierConfig(
+            tier_id="T0",
+            name="Vanilla",
+            description="Base LLM",
+            prompt_file=None,
+            prompt_content=None,
+            tools_enabled=None,
+            delegation_enabled=None,
+        )
+        assert config.tier_id == "T0"
+        assert config.prompt_file is None
+        assert config.prompt_content is None
+
+
+class TestTierConfigLoader:
+    """Tests for the TierConfigLoader class."""
+
+    @pytest.fixture
+    def config_dir(self) -> Path:
+        """Create a temporary config directory with tier files."""
+        with TemporaryDirectory() as tmpdir:
+            config_path = Path(tmpdir)
+            tiers_dir = config_path / "tiers"
+            tiers_dir.mkdir(parents=True)
+
+            # Create tiers.yaml
+            tiers_yaml = tiers_dir / "tiers.yaml"
+            tiers_yaml.write_text("""
+tiers:
+  T0:
+    name: "Vanilla"
+    description: "Base LLM"
+    prompt_file: null
+    tools_enabled: null
+    delegation_enabled: null
+
+  T1:
+    name: "Prompted"
+    description: "With chain-of-thought"
+    prompt_file: "t1-prompted.md"
+    tools_enabled: false
+    delegation_enabled: false
+
+  T2:
+    name: "Skills"
+    description: "Domain expertise"
+    prompt_file: "t2-skills.md"
+    tools_enabled: false
+    delegation_enabled: false
+
+  "T3+":
+    name: "Tooling"
+    description: "With tools"
+    prompt_file: "t3-tooling.md"
+    tools_enabled: true
+    delegation_enabled: true
+""")
+
+            # Create prompt files
+            (tiers_dir / "t1-prompted.md").write_text("Think step by step.")
+            (tiers_dir / "t2-skills.md").write_text("You have domain expertise.")
+            (tiers_dir / "t3-tooling.md").write_text("Use tools as needed.")
+
+            yield config_path
+
+    def test_load_tiers_successfully(self, config_dir: Path) -> None:
+        """Test loading tier configurations successfully."""
+        loader = TierConfigLoader(config_dir)
+        assert len(loader.get_tier_ids()) == 4
+
+    def test_get_t0_tier(self, config_dir: Path) -> None:
+        """Test getting T0 tier with null values."""
+        loader = TierConfigLoader(config_dir)
+        t0 = loader.get_tier("T0")
+
+        assert t0.tier_id == "T0"
+        assert t0.name == "Vanilla"
+        assert t0.prompt_file is None
+        assert t0.prompt_content is None
+        assert t0.tools_enabled is None
+        assert t0.delegation_enabled is None
+
+    def test_get_t1_tier_with_prompt(self, config_dir: Path) -> None:
+        """Test getting T1 tier with prompt content loaded."""
+        loader = TierConfigLoader(config_dir)
+        t1 = loader.get_tier("T1")
+
+        assert t1.tier_id == "T1"
+        assert t1.name == "Prompted"
+        assert t1.prompt_file is not None
+        assert t1.prompt_content == "Think step by step."
+        assert t1.tools_enabled is False
+        assert t1.delegation_enabled is False
+
+    def test_get_t3_plus_tier(self, config_dir: Path) -> None:
+        """Test getting T3+ tier with tools enabled."""
+        loader = TierConfigLoader(config_dir)
+        t3 = loader.get_tier("T3+")
+
+        assert t3.tier_id == "T3+"
+        assert t3.name == "Tooling"
+        assert t3.tools_enabled is True
+        assert t3.delegation_enabled is True
+
+    def test_get_all_tiers(self, config_dir: Path) -> None:
+        """Test getting all tier configurations."""
+        loader = TierConfigLoader(config_dir)
+        all_tiers = loader.get_all_tiers()
+
+        assert len(all_tiers) == 4
+        tier_ids = [t.tier_id for t in all_tiers]
+        assert set(tier_ids) == {"T0", "T1", "T2", "T3+"}
+
+    def test_get_tier_ids(self, config_dir: Path) -> None:
+        """Test getting list of tier IDs."""
+        loader = TierConfigLoader(config_dir)
+        tier_ids = loader.get_tier_ids()
+
+        assert len(tier_ids) == 4
+        assert "T0" in tier_ids
+        assert "T3+" in tier_ids
+
+    def test_validate_tier_id_valid(self, config_dir: Path) -> None:
+        """Test validating a valid tier ID."""
+        loader = TierConfigLoader(config_dir)
+        assert loader.validate_tier_id("T0") is True
+        assert loader.validate_tier_id("T3+") is True
+
+    def test_validate_tier_id_invalid(self, config_dir: Path) -> None:
+        """Test validating an invalid tier ID."""
+        loader = TierConfigLoader(config_dir)
+        assert loader.validate_tier_id("T99") is False
+        assert loader.validate_tier_id("invalid") is False
+
+    def test_unknown_tier_raises_error(self, config_dir: Path) -> None:
+        """Test that requesting unknown tier raises error."""
+        loader = TierConfigLoader(config_dir)
+        with pytest.raises(TierConfigError, match="Unknown tier"):
+            loader.get_tier("T99")
+
+    def test_missing_tiers_file_raises_error(self) -> None:
+        """Test that missing tiers.yaml raises error."""
+        with TemporaryDirectory() as tmpdir:
+            with pytest.raises(TierConfigError, match="Tiers file not found"):
+                TierConfigLoader(Path(tmpdir))
+
+    def test_missing_prompt_file_raises_error(self) -> None:
+        """Test that missing prompt file raises error."""
+        with TemporaryDirectory() as tmpdir:
+            config_path = Path(tmpdir)
+            tiers_dir = config_path / "tiers"
+            tiers_dir.mkdir(parents=True)
+
+            # Create tiers.yaml with missing prompt file
+            tiers_yaml = tiers_dir / "tiers.yaml"
+            tiers_yaml.write_text("""
+tiers:
+  T0:
+    name: "Vanilla"
+    description: "Base"
+
+  T1:
+    name: "Prompted"
+    description: "With prompts"
+    prompt_file: "missing.md"
+
+  T2:
+    name: "Skills"
+    description: "With skills"
+
+  "T3+":
+    name: "Tooling"
+    description: "With tools"
+""")
+
+            loader = TierConfigLoader(config_path)
+            # T0 should work
+            t0 = loader.get_tier("T0")
+            assert t0.tier_id == "T0"
+
+            # T1 should fail due to missing prompt file
+            with pytest.raises(TierConfigError, match="Prompt file not found"):
+                loader.get_tier("T1")
+
+    def test_invalid_yaml_raises_error(self) -> None:
+        """Test that invalid YAML raises error."""
+        with TemporaryDirectory() as tmpdir:
+            config_path = Path(tmpdir)
+            tiers_dir = config_path / "tiers"
+            tiers_dir.mkdir(parents=True)
+
+            # Create invalid YAML
+            tiers_yaml = tiers_dir / "tiers.yaml"
+            tiers_yaml.write_text("invalid: yaml: content: [")
+
+            with pytest.raises(TierConfigError, match="Failed to parse"):
+                TierConfigLoader(config_path)
+
+
+class TestTierConfigLoaderWithActualConfig:
+    """Integration tests using actual config files."""
+
+    def test_load_actual_config(self) -> None:
+        """Test loading the actual tier configuration."""
+        # This test uses the actual config directory
+        config_dir = Path(__file__).parent.parent.parent.parent / "config"
+
+        if not (config_dir / "tiers" / "tiers.yaml").exists():
+            pytest.skip("Actual config not available")
+
+        loader = TierConfigLoader(config_dir)
+
+        # Verify all tiers can be loaded
+        all_tiers = loader.get_all_tiers()
+        assert len(all_tiers) >= 4
+
+        # Verify T0 has no prompt
+        t0 = loader.get_tier("T0")
+        assert t0.prompt_content is None
+
+        # Verify T1+ have prompts
+        t1 = loader.get_tier("T1")
+        assert t1.prompt_content is not None
+        assert len(t1.prompt_content) > 0


### PR DESCRIPTION
## Summary

- Implement `TierConfigLoader` for loading tier-specific prompts and configuration
- Add Pydantic models for tier definition validation (`TierConfig`, `TierDefinition`, `TiersDefinitionFile`)
- Create tier configuration files in `config/tiers/`:
  - `tiers.yaml`: Tier definitions with capabilities
  - `t0-vanilla.md`: Reference only (tool defaults)
  - `t1-prompted.md`: Chain-of-thought prompting
  - `t2-skills.md`: Domain expertise encoding
  - `t3-tooling.md`: External tools and delegation
- Export tier config classes from executor module
- Add 19 unit tests for comprehensive coverage

## Test plan

- [x] All 19 unit tests pass
- [x] TierConfigLoader loads actual config files
- [x] T0 tier returns null/None for prompts (tool default)
- [x] T1-T3+ tiers load prompt content correctly
- [x] Invalid tier IDs raise appropriate errors

Closes #36

🤖 Generated with [Claude Code](https://claude.com/claude-code)