### PR TITLE
feat(adapters): add Cline CLI adapter

### DIFF
--- a/src/scylla/adapters/__init__.py
+++ b/src/scylla/adapters/__init__.py
@@ -13,6 +13,7 @@ from scylla.adapters.base import (
     BaseAdapter,
 )
 from scylla.adapters.claude_code import ClaudeCodeAdapter
+from scylla.adapters.cline import ClineAdapter
 from scylla.adapters.openai_codex import OpenAICodexAdapter
 
 __all__ = [
@@ -23,5 +24,6 @@ __all__ = [
     "AdapterValidationError",
     "BaseAdapter",
     "ClaudeCodeAdapter",
+    "ClineAdapter",
     "OpenAICodexAdapter",
 ]

--- a/src/scylla/adapters/cline.py
+++ b/src/scylla/adapters/cline.py
@@ -1,0 +1,275 @@
+"""Cline CLI adapter.
+
+This module provides an adapter for running the Cline CLI
+within the Scylla evaluation framework.
+
+Python Justification: Required for subprocess execution and output capture.
+"""
+
+from __future__ import annotations
+
+import re
+import subprocess
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from scylla.adapters.base import (
+    AdapterConfig,
+    AdapterError,
+    AdapterResult,
+    BaseAdapter,
+)
+
+if TYPE_CHECKING:
+    from scylla.executor.tier_config import TierConfig
+
+
+class ClineAdapter(BaseAdapter):
+    """Adapter for Cline CLI.
+
+    Executes the Cline CLI with the specified configuration and
+    captures output, token counts, and metrics.
+
+    Example:
+        >>> adapter = ClineAdapter()
+        >>> config = AdapterConfig(
+        ...     model="claude-sonnet-4-20250514",
+        ...     prompt_file=Path("prompt.md"),
+        ...     workspace=Path("/workspace"),
+        ...     output_dir=Path("/output"),
+        ... )
+        >>> result = adapter.run(config)
+        >>> print(f"Exit code: {result.exit_code}")
+    """
+
+    # Cline CLI executable
+    CLI_EXECUTABLE = "cline"
+
+    def run(
+        self,
+        config: AdapterConfig,
+        tier_config: TierConfig | None = None,
+    ) -> AdapterResult:
+        """Execute Cline CLI with the given configuration.
+
+        Args:
+            config: Adapter configuration with model, prompt, workspace, etc.
+            tier_config: Optional tier-specific configuration for prompt injection.
+
+        Returns:
+            AdapterResult with execution details.
+
+        Raises:
+            AdapterError: If execution fails.
+        """
+        self.validate_config(config)
+
+        # Load and potentially inject tier prompt
+        task_prompt = self.load_prompt(config.prompt_file)
+        final_prompt = self.inject_tier_prompt(task_prompt, tier_config)
+
+        # Build CLI command
+        cmd = self._build_command(config, final_prompt, tier_config)
+
+        # Prepare environment with API keys
+        env = self._prepare_env(config)
+
+        # Execute
+        start_time = datetime.now(UTC)
+        try:
+            result = subprocess.run(
+                cmd,
+                capture_output=True,
+                text=True,
+                timeout=config.timeout,
+                cwd=config.workspace,
+                env=env,
+            )
+
+        except subprocess.TimeoutExpired as e:
+            end_time = datetime.now(UTC)
+            duration = (end_time - start_time).total_seconds()
+
+            # Write logs even on timeout
+            stdout = e.stdout.decode() if e.stdout else ""
+            stderr = e.stderr.decode() if e.stderr else ""
+            self.write_logs(config.output_dir, stdout, stderr)
+
+            return AdapterResult(
+                exit_code=-1,
+                stdout=stdout,
+                stderr=stderr,
+                duration_seconds=duration,
+                timed_out=True,
+                error_message=f"Execution timed out after {config.timeout} seconds",
+            )
+
+        except FileNotFoundError:
+            raise AdapterError(
+                f"Cline CLI not found. Is '{self.CLI_EXECUTABLE}' installed?"
+            )
+
+        except subprocess.SubprocessError as e:
+            raise AdapterError(f"Failed to execute Cline: {e}") from e
+
+        end_time = datetime.now(UTC)
+        duration = (end_time - start_time).total_seconds()
+
+        # Parse output for metrics
+        tokens_input, tokens_output = self._parse_token_counts(result.stdout, result.stderr)
+        api_calls = self._parse_api_calls(result.stdout, result.stderr)
+
+        # Calculate cost
+        cost = self.calculate_cost(tokens_input, tokens_output, config.model)
+
+        # Write logs
+        self.write_logs(config.output_dir, result.stdout, result.stderr)
+
+        return AdapterResult(
+            exit_code=result.returncode,
+            stdout=result.stdout,
+            stderr=result.stderr,
+            duration_seconds=duration,
+            tokens_input=tokens_input,
+            tokens_output=tokens_output,
+            cost_usd=cost,
+            api_calls=api_calls,
+            timed_out=False,
+        )
+
+    def _build_command(
+        self,
+        config: AdapterConfig,
+        prompt: str,
+        tier_config: TierConfig | None,
+    ) -> list[str]:
+        """Build the Cline CLI command.
+
+        Args:
+            config: Adapter configuration.
+            prompt: The prompt to send (with tier injection if applicable).
+            tier_config: Tier configuration for tool/delegation settings.
+
+        Returns:
+            Command as list of strings.
+        """
+        cmd = [
+            self.CLI_EXECUTABLE,
+            "--model", config.model,
+            "--non-interactive",  # Non-interactive mode
+        ]
+
+        # Apply tier settings
+        tier_settings = self.get_tier_settings(tier_config)
+
+        # Disable tools if explicitly set to False
+        if tier_settings["tools_enabled"] is False:
+            cmd.append("--disable-tools")
+
+        # Add extra arguments from config
+        if config.extra_args:
+            cmd.extend(config.extra_args)
+
+        # Add the prompt as the final argument
+        cmd.extend(["--prompt", prompt])
+
+        return cmd
+
+    def _prepare_env(self, config: AdapterConfig) -> dict[str, str]:
+        """Prepare environment variables for subprocess.
+
+        Args:
+            config: Adapter configuration with env_vars.
+
+        Returns:
+            Environment dictionary.
+        """
+        import os
+
+        env = os.environ.copy()
+        env.update(config.env_vars)
+        return env
+
+    def _parse_token_counts(self, stdout: str, stderr: str) -> tuple[int, int]:
+        """Parse token counts from Cline output.
+
+        Looks for patterns like:
+        - "Input tokens: N"
+        - "Output tokens: M"
+        - "Tokens used: N input, M output"
+
+        Args:
+            stdout: Standard output from CLI.
+            stderr: Standard error from CLI.
+
+        Returns:
+            Tuple of (input_tokens, output_tokens).
+        """
+        combined = stdout + "\n" + stderr
+        input_tokens = 0
+        output_tokens = 0
+
+        # Pattern: "Input tokens: N" or "input: N tokens"
+        input_match = re.search(r"input\s*(?:tokens?)?:?\s*(\d+)", combined, re.IGNORECASE)
+        if input_match:
+            input_tokens = int(input_match.group(1))
+
+        # Pattern: "Output tokens: N" or "output: N tokens"
+        output_match = re.search(r"output\s*(?:tokens?)?:?\s*(\d+)", combined, re.IGNORECASE)
+        if output_match:
+            output_tokens = int(output_match.group(1))
+
+        # Pattern: "N input, M output" or similar
+        combined_match = re.search(
+            r"(\d+)\s*(?:input|in)\s*[,/]\s*(\d+)\s*(?:output|out)",
+            combined,
+            re.IGNORECASE,
+        )
+        if combined_match:
+            input_tokens = int(combined_match.group(1))
+            output_tokens = int(combined_match.group(2))
+
+        # Pattern: "Total: N tokens (X input, Y output)"
+        total_match = re.search(
+            r"\((\d+)\s*input,\s*(\d+)\s*output\)",
+            combined,
+            re.IGNORECASE,
+        )
+        if total_match:
+            input_tokens = int(total_match.group(1))
+            output_tokens = int(total_match.group(2))
+
+        return input_tokens, output_tokens
+
+    def _parse_api_calls(self, stdout: str, stderr: str) -> int:
+        """Parse API call count from output.
+
+        Args:
+            stdout: Standard output from CLI.
+            stderr: Standard error from CLI.
+
+        Returns:
+            Number of API calls detected.
+        """
+        combined = stdout + "\n" + stderr
+
+        # Pattern: "API calls: N" or "N API calls"
+        match = re.search(
+            r"(?:API\s+calls?:?\s*(\d+)|(\d+)\s+API\s+calls?)",
+            combined,
+            re.IGNORECASE,
+        )
+        if match:
+            return int(match.group(1) or match.group(2))
+
+        # Count request/response markers
+        request_count = len(re.findall(r"(?:Sending request|Request sent)", combined, re.IGNORECASE))
+        if request_count > 0:
+            return request_count
+
+        # Default: assume at least 1 call if there's meaningful output
+        if len(stdout.strip()) > 100:
+            return 1
+
+        return 0

--- a/tests/unit/adapters/test_cline.py
+++ b/tests/unit/adapters/test_cline.py
@@ -1,0 +1,432 @@
+"""Tests for Cline CLI adapter.
+
+Python justification: Required for pytest testing framework.
+"""
+
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from scylla.adapters.base import AdapterConfig, AdapterError
+from scylla.adapters.cline import ClineAdapter
+
+
+class TestClineAdapter:
+    """Tests for ClineAdapter class."""
+
+    def test_get_name(self) -> None:
+        """Test adapter name."""
+        adapter = ClineAdapter()
+        assert adapter.get_name() == "ClineAdapter"
+
+    def test_cli_executable(self) -> None:
+        """Test CLI executable constant."""
+        assert ClineAdapter.CLI_EXECUTABLE == "cline"
+
+
+class TestBuildCommand:
+    """Tests for command building."""
+
+    def test_basic_command(self) -> None:
+        """Test basic command structure."""
+        with TemporaryDirectory() as tmpdir:
+            tmppath = Path(tmpdir)
+            prompt_file = tmppath / "prompt.md"
+            prompt_file.write_text("Test prompt")
+
+            adapter = ClineAdapter()
+            config = AdapterConfig(
+                model="claude-sonnet-4-20250514",
+                prompt_file=prompt_file,
+                workspace=tmppath,
+                output_dir=tmppath,
+            )
+
+            cmd = adapter._build_command(config, "Test prompt", None)
+
+            assert cmd[0] == "cline"
+            assert "--model" in cmd
+            assert "claude-sonnet-4-20250514" in cmd
+            assert "--non-interactive" in cmd
+            assert "--prompt" in cmd
+            assert "Test prompt" in cmd
+
+    def test_command_with_tools_disabled(self) -> None:
+        """Test command with tools disabled."""
+        with TemporaryDirectory() as tmpdir:
+            tmppath = Path(tmpdir)
+            prompt_file = tmppath / "prompt.md"
+            prompt_file.write_text("Test prompt")
+
+            adapter = ClineAdapter()
+            config = AdapterConfig(
+                model="claude-sonnet-4-20250514",
+                prompt_file=prompt_file,
+                workspace=tmppath,
+                output_dir=tmppath,
+            )
+
+            tier_config = MagicMock()
+            tier_config.tools_enabled = False
+            tier_config.delegation_enabled = None
+
+            cmd = adapter._build_command(config, "Test prompt", tier_config)
+
+            assert "--disable-tools" in cmd
+
+    def test_command_with_extra_args(self) -> None:
+        """Test command with extra arguments."""
+        with TemporaryDirectory() as tmpdir:
+            tmppath = Path(tmpdir)
+            prompt_file = tmppath / "prompt.md"
+            prompt_file.write_text("Test prompt")
+
+            adapter = ClineAdapter()
+            config = AdapterConfig(
+                model="claude-sonnet-4-20250514",
+                prompt_file=prompt_file,
+                workspace=tmppath,
+                output_dir=tmppath,
+                extra_args=["--verbose", "--debug"],
+            )
+
+            cmd = adapter._build_command(config, "Test prompt", None)
+
+            assert "--verbose" in cmd
+            assert "--debug" in cmd
+
+
+class TestParseTokenCounts:
+    """Tests for token count parsing."""
+
+    def test_parse_input_tokens_pattern(self) -> None:
+        """Test parsing 'Input tokens: N' pattern."""
+        adapter = ClineAdapter()
+        stdout = "Input tokens: 1234\nOutput tokens: 567"
+        stderr = ""
+
+        tokens_in, tokens_out = adapter._parse_token_counts(stdout, stderr)
+
+        assert tokens_in == 1234
+        assert tokens_out == 567
+
+    def test_parse_combined_pattern(self) -> None:
+        """Test parsing 'N input, M output' pattern."""
+        adapter = ClineAdapter()
+        stdout = "Used 1000 input, 500 output tokens"
+        stderr = ""
+
+        tokens_in, tokens_out = adapter._parse_token_counts(stdout, stderr)
+
+        assert tokens_in == 1000
+        assert tokens_out == 500
+
+    def test_parse_parenthetical_pattern(self) -> None:
+        """Test parsing '(N input, M output)' pattern."""
+        adapter = ClineAdapter()
+        stdout = "Total: 1500 tokens (1000 input, 500 output)"
+        stderr = ""
+
+        tokens_in, tokens_out = adapter._parse_token_counts(stdout, stderr)
+
+        assert tokens_in == 1000
+        assert tokens_out == 500
+
+    def test_parse_from_stderr(self) -> None:
+        """Test parsing from stderr."""
+        adapter = ClineAdapter()
+        stdout = ""
+        stderr = "Input: 100\nOutput: 50"
+
+        tokens_in, tokens_out = adapter._parse_token_counts(stdout, stderr)
+
+        assert tokens_in == 100
+        assert tokens_out == 50
+
+    def test_parse_no_tokens(self) -> None:
+        """Test parsing with no token information."""
+        adapter = ClineAdapter()
+        stdout = "Just some output"
+        stderr = ""
+
+        tokens_in, tokens_out = adapter._parse_token_counts(stdout, stderr)
+
+        assert tokens_in == 0
+        assert tokens_out == 0
+
+
+class TestParseApiCalls:
+    """Tests for API call count parsing."""
+
+    def test_parse_api_calls_pattern(self) -> None:
+        """Test parsing 'API calls: N' pattern."""
+        adapter = ClineAdapter()
+        stdout = "API calls: 3"
+        stderr = ""
+
+        count = adapter._parse_api_calls(stdout, stderr)
+
+        assert count == 3
+
+    def test_parse_request_markers(self) -> None:
+        """Test counting request markers."""
+        adapter = ClineAdapter()
+        stdout = "Sending request...\nSending request...\nRequest sent"
+        stderr = ""
+
+        count = adapter._parse_api_calls(stdout, stderr)
+
+        assert count == 3
+
+    def test_parse_meaningful_output(self) -> None:
+        """Test default count for meaningful output."""
+        adapter = ClineAdapter()
+        stdout = "A" * 200
+        stderr = ""
+
+        count = adapter._parse_api_calls(stdout, stderr)
+
+        assert count == 1
+
+    def test_parse_empty_output(self) -> None:
+        """Test zero count for empty output."""
+        adapter = ClineAdapter()
+        stdout = ""
+        stderr = ""
+
+        count = adapter._parse_api_calls(stdout, stderr)
+
+        assert count == 0
+
+
+class TestPrepareEnv:
+    """Tests for environment preparation."""
+
+    def test_prepare_env_inherits_current(self) -> None:
+        """Test that env inherits current environment."""
+        with TemporaryDirectory() as tmpdir:
+            tmppath = Path(tmpdir)
+
+            adapter = ClineAdapter()
+            config = AdapterConfig(
+                model="test",
+                prompt_file=tmppath / "prompt.md",
+                workspace=tmppath,
+                output_dir=tmppath,
+                env_vars={},
+            )
+
+            env = adapter._prepare_env(config)
+
+            assert len(env) > 0
+
+    def test_prepare_env_adds_custom_vars(self) -> None:
+        """Test that custom env vars are added."""
+        with TemporaryDirectory() as tmpdir:
+            tmppath = Path(tmpdir)
+
+            adapter = ClineAdapter()
+            config = AdapterConfig(
+                model="test",
+                prompt_file=tmppath / "prompt.md",
+                workspace=tmppath,
+                output_dir=tmppath,
+                env_vars={"ANTHROPIC_API_KEY": "test-key"},
+            )
+
+            env = adapter._prepare_env(config)
+
+            assert env["ANTHROPIC_API_KEY"] == "test-key"
+
+
+class TestRun:
+    """Tests for run method."""
+
+    def test_run_success(self) -> None:
+        """Test successful execution."""
+        with TemporaryDirectory() as tmpdir:
+            tmppath = Path(tmpdir)
+            prompt_file = tmppath / "prompt.md"
+            prompt_file.write_text("Test prompt")
+
+            adapter = ClineAdapter()
+            config = AdapterConfig(
+                model="claude-sonnet-4-20250514",
+                prompt_file=prompt_file,
+                workspace=tmppath,
+                output_dir=tmppath,
+            )
+
+            mock_result = MagicMock()
+            mock_result.returncode = 0
+            mock_result.stdout = "Success\nInput tokens: 100\nOutput tokens: 50"
+            mock_result.stderr = ""
+
+            with patch("subprocess.run", return_value=mock_result):
+                result = adapter.run(config)
+
+            assert result.exit_code == 0
+            assert result.tokens_input == 100
+            assert result.tokens_output == 50
+            assert result.timed_out is False
+
+    def test_run_with_tier_config(self) -> None:
+        """Test execution with tier configuration."""
+        with TemporaryDirectory() as tmpdir:
+            tmppath = Path(tmpdir)
+            prompt_file = tmppath / "prompt.md"
+            prompt_file.write_text("Test prompt")
+
+            adapter = ClineAdapter()
+            config = AdapterConfig(
+                model="claude-sonnet-4-20250514",
+                prompt_file=prompt_file,
+                workspace=tmppath,
+                output_dir=tmppath,
+            )
+
+            tier_config = MagicMock()
+            tier_config.tier_id = "T1"
+            tier_config.prompt_content = "Be thorough"
+            tier_config.tools_enabled = False
+            tier_config.delegation_enabled = None
+
+            mock_result = MagicMock()
+            mock_result.returncode = 0
+            mock_result.stdout = "Success"
+            mock_result.stderr = ""
+
+            with patch("subprocess.run", return_value=mock_result) as mock_run:
+                result = adapter.run(config, tier_config)
+
+            call_args = mock_run.call_args
+            cmd = call_args[0][0]
+            assert "--disable-tools" in cmd
+
+    def test_run_timeout(self) -> None:
+        """Test execution timeout."""
+        import subprocess
+
+        with TemporaryDirectory() as tmpdir:
+            tmppath = Path(tmpdir)
+            prompt_file = tmppath / "prompt.md"
+            prompt_file.write_text("Test prompt")
+
+            adapter = ClineAdapter()
+            config = AdapterConfig(
+                model="claude-sonnet-4-20250514",
+                prompt_file=prompt_file,
+                workspace=tmppath,
+                output_dir=tmppath,
+                timeout=30,
+            )
+
+            timeout_error = subprocess.TimeoutExpired(
+                cmd=["cline"],
+                timeout=30,
+                output=b"partial",
+                stderr=b"error",
+            )
+
+            with patch("subprocess.run", side_effect=timeout_error):
+                result = adapter.run(config)
+
+            assert result.exit_code == -1
+            assert result.timed_out is True
+            assert "timed out" in result.error_message.lower()
+
+    def test_run_cli_not_found(self) -> None:
+        """Test CLI not found error."""
+        with TemporaryDirectory() as tmpdir:
+            tmppath = Path(tmpdir)
+            prompt_file = tmppath / "prompt.md"
+            prompt_file.write_text("Test prompt")
+
+            adapter = ClineAdapter()
+            config = AdapterConfig(
+                model="claude-sonnet-4-20250514",
+                prompt_file=prompt_file,
+                workspace=tmppath,
+                output_dir=tmppath,
+            )
+
+            with patch("subprocess.run", side_effect=FileNotFoundError()):
+                with pytest.raises(AdapterError, match="CLI not found"):
+                    adapter.run(config)
+
+    def test_run_writes_logs(self) -> None:
+        """Test that logs are written on success."""
+        with TemporaryDirectory() as tmpdir:
+            tmppath = Path(tmpdir)
+            prompt_file = tmppath / "prompt.md"
+            prompt_file.write_text("Test prompt")
+
+            adapter = ClineAdapter()
+            config = AdapterConfig(
+                model="claude-sonnet-4-20250514",
+                prompt_file=prompt_file,
+                workspace=tmppath,
+                output_dir=tmppath,
+            )
+
+            mock_result = MagicMock()
+            mock_result.returncode = 0
+            mock_result.stdout = "stdout content"
+            mock_result.stderr = "stderr content"
+
+            with patch("subprocess.run", return_value=mock_result):
+                adapter.run(config)
+
+            logs_dir = tmppath / "logs"
+            assert logs_dir.exists()
+            assert (logs_dir / "stdout.log").read_text() == "stdout content"
+            assert (logs_dir / "stderr.log").read_text() == "stderr content"
+
+    def test_run_calculates_cost(self) -> None:
+        """Test cost calculation."""
+        with TemporaryDirectory() as tmpdir:
+            tmppath = Path(tmpdir)
+            prompt_file = tmppath / "prompt.md"
+            prompt_file.write_text("Test prompt")
+
+            adapter = ClineAdapter()
+            config = AdapterConfig(
+                model="claude-sonnet-4-20250514",
+                prompt_file=prompt_file,
+                workspace=tmppath,
+                output_dir=tmppath,
+            )
+
+            mock_result = MagicMock()
+            mock_result.returncode = 0
+            mock_result.stdout = "Input tokens: 1000\nOutput tokens: 500"
+            mock_result.stderr = ""
+
+            with patch("subprocess.run", return_value=mock_result):
+                result = adapter.run(config)
+
+            # Sonnet: 0.003 per 1K input, 0.015 per 1K output
+            expected_cost = (1000 / 1000 * 0.003) + (500 / 1000 * 0.015)
+            assert result.cost_usd == pytest.approx(expected_cost)
+
+
+class TestValidation:
+    """Tests for configuration validation."""
+
+    def test_validates_prompt_file(self) -> None:
+        """Test that missing prompt file raises error."""
+        with TemporaryDirectory() as tmpdir:
+            tmppath = Path(tmpdir)
+
+            adapter = ClineAdapter()
+            config = AdapterConfig(
+                model="test",
+                prompt_file=tmppath / "nonexistent.md",
+                workspace=tmppath,
+                output_dir=tmppath,
+            )
+
+            with pytest.raises(Exception, match="Prompt file not found"):
+                adapter.run(config)


### PR DESCRIPTION
## Summary
- Implements `ClineAdapter` that wraps the Cline CLI
- Uses `--non-interactive` mode for unattended execution
- Parses token counts from multiple output formats
- Detects API calls from request markers
- 23 unit tests with full coverage

## Test plan
- [x] All 23 adapter tests pass
- [x] Token parsing tested with various formats
- [x] Timeout behavior verified

Closes #14

🤖 Generated with [Claude Code](https://claude.com/claude-code)