### PR TITLE
feat(judge): add rubric parser for evaluation scoring

### DIFF
--- a/src/scylla/judge/__init__.py
+++ b/src/scylla/judge/__init__.py
@@ -1,1 +1,25 @@
-"""Judge module for evaluating agent outputs."""
+"""Judge module for evaluation and scoring.
+
+This module provides the judge system for evaluating AI agent work
+using rubrics, prompts, and consensus-based scoring.
+"""
+
+from scylla.judge.rubric import (
+    EvaluationType,
+    GradeScale,
+    Requirement,
+    Rubric,
+    RubricError,
+    RubricParser,
+    RubricValidationError,
+)
+
+__all__ = [
+    "EvaluationType",
+    "GradeScale",
+    "Requirement",
+    "Rubric",
+    "RubricError",
+    "RubricParser",
+    "RubricValidationError",
+]

--- a/src/scylla/judge/rubric.py
+++ b/src/scylla/judge/rubric.py
@@ -1,0 +1,319 @@
+"""Rubric parser for evaluation scoring.
+
+This module provides classes for parsing rubric.yaml files and
+calculating weighted scores for judge evaluations.
+
+Python Justification: Required for YAML parsing and complex data structures.
+"""
+
+from __future__ import annotations
+
+from enum import Enum
+from pathlib import Path
+from typing import Any
+
+import yaml
+from pydantic import BaseModel, Field, field_validator
+
+
+class RubricError(Exception):
+    """Base exception for rubric errors."""
+
+    pass
+
+
+class RubricValidationError(RubricError):
+    """Raised when rubric validation fails."""
+
+    pass
+
+
+class EvaluationType(str, Enum):
+    """Type of evaluation for a requirement."""
+
+    BINARY = "binary"  # Pass/fail (0.0 or 1.0)
+    SCALED = "scaled"  # Continuous score (0.0 to 1.0)
+
+
+class Requirement(BaseModel):
+    """A single requirement in the rubric.
+
+    Attributes:
+        id: Unique identifier (e.g., "R001").
+        description: What to evaluate.
+        weight: Scoring weight (1.0 = standard).
+        evaluation: Type of evaluation (binary or scaled).
+        validation_command: Optional command to validate requirement.
+    """
+
+    id: str = Field(..., description="Unique requirement identifier")
+    description: str = Field(..., description="What to evaluate")
+    weight: float = Field(default=1.0, ge=0.0, description="Scoring weight")
+    evaluation: EvaluationType = Field(
+        default=EvaluationType.SCALED, description="Evaluation type"
+    )
+    validation_command: str | None = Field(
+        default=None, description="Optional validation command"
+    )
+
+    @field_validator("id")
+    @classmethod
+    def validate_id(cls, v: str) -> str:
+        """Validate requirement ID format."""
+        if not v or not v.strip():
+            raise ValueError("Requirement ID cannot be empty")
+        return v.strip()
+
+
+class GradeScale(BaseModel):
+    """Grade scale thresholds.
+
+    Attributes:
+        a_threshold: Minimum score for A grade.
+        b_threshold: Minimum score for B grade.
+        c_threshold: Minimum score for C grade.
+        d_threshold: Minimum score for D grade.
+    """
+
+    a_threshold: float = Field(default=0.95, ge=0.0, le=1.0)
+    b_threshold: float = Field(default=0.85, ge=0.0, le=1.0)
+    c_threshold: float = Field(default=0.75, ge=0.0, le=1.0)
+    d_threshold: float = Field(default=0.65, ge=0.0, le=1.0)
+
+    @field_validator("a_threshold", "b_threshold", "c_threshold", "d_threshold")
+    @classmethod
+    def validate_threshold(cls, v: float) -> float:
+        """Validate threshold is between 0 and 1."""
+        if not 0.0 <= v <= 1.0:
+            raise ValueError(f"Threshold must be between 0.0 and 1.0, got {v}")
+        return v
+
+
+class Rubric(BaseModel):
+    """Rubric for evaluating agent work.
+
+    Attributes:
+        name: Rubric name/title.
+        description: Rubric description.
+        requirements: List of requirements to evaluate.
+        pass_threshold: Score threshold for passing (default 0.70).
+        grade_scale: Grade thresholds.
+    """
+
+    name: str = Field(default="Evaluation Rubric", description="Rubric name")
+    description: str = Field(default="", description="Rubric description")
+    requirements: list[Requirement] = Field(
+        default_factory=list, description="Requirements to evaluate"
+    )
+    pass_threshold: float = Field(
+        default=0.70, ge=0.0, le=1.0, description="Pass threshold"
+    )
+    grade_scale: GradeScale = Field(
+        default_factory=GradeScale, description="Grade thresholds"
+    )
+
+    def calculate_weighted_score(self, scores: dict[str, float]) -> float:
+        """Calculate weighted score from requirement scores.
+
+        Args:
+            scores: Dictionary mapping requirement IDs to scores (0.0 to 1.0).
+
+        Returns:
+            Weighted average score (0.0 to 1.0).
+
+        Raises:
+            RubricValidationError: If required scores are missing.
+        """
+        if not self.requirements:
+            return 0.0
+
+        total_weight = 0.0
+        weighted_sum = 0.0
+
+        for req in self.requirements:
+            if req.id not in scores:
+                raise RubricValidationError(
+                    f"Missing score for requirement '{req.id}'"
+                )
+
+            score = scores[req.id]
+            if not 0.0 <= score <= 1.0:
+                raise RubricValidationError(
+                    f"Score for '{req.id}' must be between 0.0 and 1.0, got {score}"
+                )
+
+            weighted_sum += score * req.weight
+            total_weight += req.weight
+
+        if total_weight == 0.0:
+            return 0.0
+
+        return weighted_sum / total_weight
+
+    def assign_grade(self, weighted_score: float) -> str:
+        """Assign letter grade based on weighted score.
+
+        Args:
+            weighted_score: The weighted score (0.0 to 1.0).
+
+        Returns:
+            Letter grade (A, B, C, D, or F).
+        """
+        if weighted_score >= self.grade_scale.a_threshold:
+            return "A"
+        elif weighted_score >= self.grade_scale.b_threshold:
+            return "B"
+        elif weighted_score >= self.grade_scale.c_threshold:
+            return "C"
+        elif weighted_score >= self.grade_scale.d_threshold:
+            return "D"
+        else:
+            return "F"
+
+    def is_passing(self, weighted_score: float) -> bool:
+        """Check if the weighted score passes the threshold.
+
+        Args:
+            weighted_score: The weighted score (0.0 to 1.0).
+
+        Returns:
+            True if passing, False otherwise.
+        """
+        return weighted_score >= self.pass_threshold
+
+    def get_requirement(self, requirement_id: str) -> Requirement | None:
+        """Get a requirement by ID.
+
+        Args:
+            requirement_id: The requirement ID to find.
+
+        Returns:
+            The Requirement if found, None otherwise.
+        """
+        for req in self.requirements:
+            if req.id == requirement_id:
+                return req
+        return None
+
+    def total_weight(self) -> float:
+        """Calculate total weight of all requirements.
+
+        Returns:
+            Sum of all requirement weights.
+        """
+        return sum(req.weight for req in self.requirements)
+
+
+class RubricParser:
+    """Parser for rubric.yaml files."""
+
+    @staticmethod
+    def parse(rubric_path: Path) -> Rubric:
+        """Parse a rubric.yaml file.
+
+        Args:
+            rubric_path: Path to the rubric.yaml file.
+
+        Returns:
+            Parsed Rubric object.
+
+        Raises:
+            RubricError: If the file cannot be read.
+            RubricValidationError: If the rubric is invalid.
+        """
+        if not rubric_path.exists():
+            raise RubricError(f"Rubric file not found: {rubric_path}")
+
+        try:
+            content = rubric_path.read_text()
+        except OSError as e:
+            raise RubricError(f"Failed to read rubric file: {e}") from e
+
+        return RubricParser.parse_yaml(content)
+
+    @staticmethod
+    def parse_yaml(yaml_content: str) -> Rubric:
+        """Parse rubric from YAML string.
+
+        Args:
+            yaml_content: YAML content as string.
+
+        Returns:
+            Parsed Rubric object.
+
+        Raises:
+            RubricValidationError: If the YAML is invalid.
+        """
+        try:
+            data = yaml.safe_load(yaml_content)
+        except yaml.YAMLError as e:
+            raise RubricValidationError(f"Invalid YAML: {e}") from e
+
+        if data is None:
+            raise RubricValidationError("Rubric file is empty")
+
+        if not isinstance(data, dict):
+            raise RubricValidationError("Rubric must be a YAML mapping")
+
+        return RubricParser._parse_rubric_data(data)
+
+    @staticmethod
+    def _parse_rubric_data(data: dict[str, Any]) -> Rubric:
+        """Parse rubric from dictionary data.
+
+        Args:
+            data: Dictionary from YAML parsing.
+
+        Returns:
+            Parsed Rubric object.
+
+        Raises:
+            RubricValidationError: If the data is invalid.
+        """
+        try:
+            # Parse requirements
+            requirements = []
+            raw_requirements = data.get("requirements", [])
+
+            if not isinstance(raw_requirements, list):
+                raise RubricValidationError("'requirements' must be a list")
+
+            for i, req_data in enumerate(raw_requirements):
+                if not isinstance(req_data, dict):
+                    raise RubricValidationError(
+                        f"Requirement {i} must be a mapping"
+                    )
+
+                # Handle evaluation type
+                eval_type = req_data.get("evaluation", "scaled")
+                if isinstance(eval_type, str):
+                    eval_type = EvaluationType(eval_type.lower())
+
+                requirement = Requirement(
+                    id=req_data.get("id", f"R{i+1:03d}"),
+                    description=req_data.get("description", ""),
+                    weight=float(req_data.get("weight", 1.0)),
+                    evaluation=eval_type,
+                    validation_command=req_data.get("validation_command"),
+                )
+                requirements.append(requirement)
+
+            # Parse grade scale
+            grade_data = data.get("grade_scale", {})
+            grade_scale = GradeScale(
+                a_threshold=float(grade_data.get("A", 0.95)),
+                b_threshold=float(grade_data.get("B", 0.85)),
+                c_threshold=float(grade_data.get("C", 0.75)),
+                d_threshold=float(grade_data.get("D", 0.65)),
+            )
+
+            return Rubric(
+                name=data.get("name", "Evaluation Rubric"),
+                description=data.get("description", ""),
+                requirements=requirements,
+                pass_threshold=float(data.get("pass_threshold", 0.70)),
+                grade_scale=grade_scale,
+            )
+
+        except (ValueError, TypeError) as e:
+            raise RubricValidationError(f"Invalid rubric data: {e}") from e

--- a/tests/unit/judge/__init__.py
+++ b/tests/unit/judge/__init__.py
@@ -1,0 +1,1 @@
+"""Judge module tests."""

--- a/tests/unit/judge/test_rubric.py
+++ b/tests/unit/judge/test_rubric.py
@@ -1,0 +1,479 @@
+"""Tests for rubric parser.
+
+Python justification: Required for pytest testing framework.
+"""
+
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+import pytest
+
+from scylla.judge.rubric import (
+    EvaluationType,
+    GradeScale,
+    Requirement,
+    Rubric,
+    RubricError,
+    RubricParser,
+    RubricValidationError,
+)
+
+
+class TestEvaluationType:
+    """Tests for EvaluationType enum."""
+
+    def test_binary_value(self) -> None:
+        """Test BINARY enum value."""
+        assert EvaluationType.BINARY.value == "binary"
+
+    def test_scaled_value(self) -> None:
+        """Test SCALED enum value."""
+        assert EvaluationType.SCALED.value == "scaled"
+
+    def test_from_string(self) -> None:
+        """Test creating from string."""
+        assert EvaluationType("binary") == EvaluationType.BINARY
+        assert EvaluationType("scaled") == EvaluationType.SCALED
+
+
+class TestRequirement:
+    """Tests for Requirement model."""
+
+    def test_minimal_requirement(self) -> None:
+        """Test creating requirement with minimal fields."""
+        req = Requirement(id="R001", description="Test requirement")
+        assert req.id == "R001"
+        assert req.description == "Test requirement"
+        assert req.weight == 1.0
+        assert req.evaluation == EvaluationType.SCALED
+        assert req.validation_command is None
+
+    def test_full_requirement(self) -> None:
+        """Test creating requirement with all fields."""
+        req = Requirement(
+            id="R002",
+            description="Binary check",
+            weight=2.0,
+            evaluation=EvaluationType.BINARY,
+            validation_command="pytest tests/",
+        )
+        assert req.id == "R002"
+        assert req.weight == 2.0
+        assert req.evaluation == EvaluationType.BINARY
+        assert req.validation_command == "pytest tests/"
+
+    def test_empty_id_rejected(self) -> None:
+        """Test that empty ID is rejected."""
+        with pytest.raises(ValueError, match="cannot be empty"):
+            Requirement(id="", description="Test")
+
+    def test_whitespace_id_rejected(self) -> None:
+        """Test that whitespace-only ID is rejected."""
+        with pytest.raises(ValueError, match="cannot be empty"):
+            Requirement(id="   ", description="Test")
+
+    def test_id_stripped(self) -> None:
+        """Test that ID is stripped of whitespace."""
+        req = Requirement(id="  R001  ", description="Test")
+        assert req.id == "R001"
+
+    def test_negative_weight_rejected(self) -> None:
+        """Test that negative weight is rejected."""
+        with pytest.raises(ValueError):
+            Requirement(id="R001", description="Test", weight=-1.0)
+
+
+class TestGradeScale:
+    """Tests for GradeScale model."""
+
+    def test_default_thresholds(self) -> None:
+        """Test default grade thresholds."""
+        scale = GradeScale()
+        assert scale.a_threshold == 0.95
+        assert scale.b_threshold == 0.85
+        assert scale.c_threshold == 0.75
+        assert scale.d_threshold == 0.65
+
+    def test_custom_thresholds(self) -> None:
+        """Test custom grade thresholds."""
+        scale = GradeScale(
+            a_threshold=0.90,
+            b_threshold=0.80,
+            c_threshold=0.70,
+            d_threshold=0.60,
+        )
+        assert scale.a_threshold == 0.90
+        assert scale.b_threshold == 0.80
+        assert scale.c_threshold == 0.70
+        assert scale.d_threshold == 0.60
+
+    def test_threshold_over_one_rejected(self) -> None:
+        """Test that threshold over 1.0 is rejected."""
+        with pytest.raises(ValueError):
+            GradeScale(a_threshold=1.5)
+
+    def test_threshold_under_zero_rejected(self) -> None:
+        """Test that threshold under 0.0 is rejected."""
+        with pytest.raises(ValueError):
+            GradeScale(d_threshold=-0.1)
+
+
+class TestRubric:
+    """Tests for Rubric model."""
+
+    def test_default_rubric(self) -> None:
+        """Test default rubric values."""
+        rubric = Rubric()
+        assert rubric.name == "Evaluation Rubric"
+        assert rubric.description == ""
+        assert rubric.requirements == []
+        assert rubric.pass_threshold == 0.70
+        assert isinstance(rubric.grade_scale, GradeScale)
+
+    def test_custom_rubric(self) -> None:
+        """Test rubric with custom values."""
+        reqs = [
+            Requirement(id="R001", description="Test 1"),
+            Requirement(id="R002", description="Test 2"),
+        ]
+        rubric = Rubric(
+            name="Custom Rubric",
+            description="Test description",
+            requirements=reqs,
+            pass_threshold=0.80,
+        )
+        assert rubric.name == "Custom Rubric"
+        assert rubric.description == "Test description"
+        assert len(rubric.requirements) == 2
+        assert rubric.pass_threshold == 0.80
+
+
+class TestCalculateWeightedScore:
+    """Tests for weighted score calculation."""
+
+    def test_empty_requirements(self) -> None:
+        """Test score with no requirements."""
+        rubric = Rubric()
+        assert rubric.calculate_weighted_score({}) == 0.0
+
+    def test_equal_weights(self) -> None:
+        """Test score with equal weights."""
+        rubric = Rubric(
+            requirements=[
+                Requirement(id="R001", description="Test 1", weight=1.0),
+                Requirement(id="R002", description="Test 2", weight=1.0),
+            ]
+        )
+        scores = {"R001": 0.8, "R002": 0.6}
+        assert rubric.calculate_weighted_score(scores) == pytest.approx(0.7)
+
+    def test_unequal_weights(self) -> None:
+        """Test score with unequal weights."""
+        rubric = Rubric(
+            requirements=[
+                Requirement(id="R001", description="Test 1", weight=2.0),
+                Requirement(id="R002", description="Test 2", weight=1.0),
+            ]
+        )
+        scores = {"R001": 0.9, "R002": 0.6}
+        # (0.9 * 2.0 + 0.6 * 1.0) / 3.0 = 2.4 / 3.0 = 0.8
+        assert rubric.calculate_weighted_score(scores) == pytest.approx(0.8)
+
+    def test_missing_score_raises(self) -> None:
+        """Test that missing score raises error."""
+        rubric = Rubric(
+            requirements=[
+                Requirement(id="R001", description="Test 1"),
+            ]
+        )
+        with pytest.raises(RubricValidationError, match="Missing score"):
+            rubric.calculate_weighted_score({})
+
+    def test_score_out_of_range_raises(self) -> None:
+        """Test that score out of range raises error."""
+        rubric = Rubric(
+            requirements=[
+                Requirement(id="R001", description="Test 1"),
+            ]
+        )
+        with pytest.raises(RubricValidationError, match="between 0.0 and 1.0"):
+            rubric.calculate_weighted_score({"R001": 1.5})
+
+    def test_zero_total_weight(self) -> None:
+        """Test score when all weights are zero."""
+        rubric = Rubric(
+            requirements=[
+                Requirement(id="R001", description="Test 1", weight=0.0),
+            ]
+        )
+        assert rubric.calculate_weighted_score({"R001": 0.5}) == 0.0
+
+
+class TestAssignGrade:
+    """Tests for grade assignment."""
+
+    def test_grade_a(self) -> None:
+        """Test A grade assignment."""
+        rubric = Rubric()
+        assert rubric.assign_grade(0.95) == "A"
+        assert rubric.assign_grade(1.0) == "A"
+
+    def test_grade_b(self) -> None:
+        """Test B grade assignment."""
+        rubric = Rubric()
+        assert rubric.assign_grade(0.85) == "B"
+        assert rubric.assign_grade(0.94) == "B"
+
+    def test_grade_c(self) -> None:
+        """Test C grade assignment."""
+        rubric = Rubric()
+        assert rubric.assign_grade(0.75) == "C"
+        assert rubric.assign_grade(0.84) == "C"
+
+    def test_grade_d(self) -> None:
+        """Test D grade assignment."""
+        rubric = Rubric()
+        assert rubric.assign_grade(0.65) == "D"
+        assert rubric.assign_grade(0.74) == "D"
+
+    def test_grade_f(self) -> None:
+        """Test F grade assignment."""
+        rubric = Rubric()
+        assert rubric.assign_grade(0.64) == "F"
+        assert rubric.assign_grade(0.0) == "F"
+
+    def test_custom_scale(self) -> None:
+        """Test grading with custom scale."""
+        rubric = Rubric(
+            grade_scale=GradeScale(
+                a_threshold=0.90,
+                b_threshold=0.80,
+                c_threshold=0.70,
+                d_threshold=0.60,
+            )
+        )
+        assert rubric.assign_grade(0.90) == "A"
+        assert rubric.assign_grade(0.89) == "B"
+
+
+class TestIsPassing:
+    """Tests for passing check."""
+
+    def test_passing(self) -> None:
+        """Test passing score."""
+        rubric = Rubric(pass_threshold=0.70)
+        assert rubric.is_passing(0.70) is True
+        assert rubric.is_passing(0.80) is True
+
+    def test_failing(self) -> None:
+        """Test failing score."""
+        rubric = Rubric(pass_threshold=0.70)
+        assert rubric.is_passing(0.69) is False
+        assert rubric.is_passing(0.0) is False
+
+
+class TestGetRequirement:
+    """Tests for requirement lookup."""
+
+    def test_found(self) -> None:
+        """Test finding existing requirement."""
+        rubric = Rubric(
+            requirements=[
+                Requirement(id="R001", description="Test 1"),
+                Requirement(id="R002", description="Test 2"),
+            ]
+        )
+        req = rubric.get_requirement("R001")
+        assert req is not None
+        assert req.id == "R001"
+
+    def test_not_found(self) -> None:
+        """Test requirement not found."""
+        rubric = Rubric(
+            requirements=[
+                Requirement(id="R001", description="Test 1"),
+            ]
+        )
+        assert rubric.get_requirement("R999") is None
+
+
+class TestTotalWeight:
+    """Tests for total weight calculation."""
+
+    def test_empty(self) -> None:
+        """Test total weight with no requirements."""
+        rubric = Rubric()
+        assert rubric.total_weight() == 0.0
+
+    def test_multiple_requirements(self) -> None:
+        """Test total weight with multiple requirements."""
+        rubric = Rubric(
+            requirements=[
+                Requirement(id="R001", description="Test 1", weight=2.0),
+                Requirement(id="R002", description="Test 2", weight=1.5),
+                Requirement(id="R003", description="Test 3", weight=0.5),
+            ]
+        )
+        assert rubric.total_weight() == pytest.approx(4.0)
+
+
+class TestRubricParserParseYaml:
+    """Tests for YAML parsing."""
+
+    def test_minimal_yaml(self) -> None:
+        """Test parsing minimal YAML."""
+        yaml_content = """
+name: Test Rubric
+requirements:
+  - id: R001
+    description: Test requirement
+"""
+        rubric = RubricParser.parse_yaml(yaml_content)
+        assert rubric.name == "Test Rubric"
+        assert len(rubric.requirements) == 1
+        assert rubric.requirements[0].id == "R001"
+
+    def test_full_yaml(self) -> None:
+        """Test parsing full YAML with all fields."""
+        yaml_content = """
+name: Complete Rubric
+description: Full test rubric
+pass_threshold: 0.80
+grade_scale:
+  A: 0.90
+  B: 0.80
+  C: 0.70
+  D: 0.60
+requirements:
+  - id: R001
+    description: First requirement
+    weight: 2.0
+    evaluation: binary
+    validation_command: "pytest tests/"
+  - id: R002
+    description: Second requirement
+    weight: 1.0
+    evaluation: scaled
+"""
+        rubric = RubricParser.parse_yaml(yaml_content)
+        assert rubric.name == "Complete Rubric"
+        assert rubric.description == "Full test rubric"
+        assert rubric.pass_threshold == 0.80
+        assert rubric.grade_scale.a_threshold == 0.90
+        assert len(rubric.requirements) == 2
+        assert rubric.requirements[0].evaluation == EvaluationType.BINARY
+        assert rubric.requirements[0].validation_command == "pytest tests/"
+        assert rubric.requirements[1].evaluation == EvaluationType.SCALED
+
+    def test_empty_yaml(self) -> None:
+        """Test parsing empty YAML."""
+        with pytest.raises(RubricValidationError, match="empty"):
+            RubricParser.parse_yaml("")
+
+    def test_invalid_yaml(self) -> None:
+        """Test parsing invalid YAML."""
+        with pytest.raises(RubricValidationError, match="Invalid YAML"):
+            RubricParser.parse_yaml("name: [invalid")
+
+    def test_non_mapping_yaml(self) -> None:
+        """Test parsing non-mapping YAML."""
+        with pytest.raises(RubricValidationError, match="must be a YAML mapping"):
+            RubricParser.parse_yaml("- item1\n- item2")
+
+    def test_invalid_requirements_type(self) -> None:
+        """Test parsing with invalid requirements type."""
+        yaml_content = """
+name: Test
+requirements: "not a list"
+"""
+        with pytest.raises(RubricValidationError, match="must be a list"):
+            RubricParser.parse_yaml(yaml_content)
+
+    def test_invalid_requirement_type(self) -> None:
+        """Test parsing with invalid requirement item type."""
+        yaml_content = """
+name: Test
+requirements:
+  - "not a mapping"
+"""
+        with pytest.raises(RubricValidationError, match="must be a mapping"):
+            RubricParser.parse_yaml(yaml_content)
+
+    def test_auto_generated_ids(self) -> None:
+        """Test that IDs are auto-generated when missing."""
+        yaml_content = """
+name: Test
+requirements:
+  - description: First
+  - description: Second
+"""
+        rubric = RubricParser.parse_yaml(yaml_content)
+        assert rubric.requirements[0].id == "R001"
+        assert rubric.requirements[1].id == "R002"
+
+    def test_default_values(self) -> None:
+        """Test default values when fields are omitted."""
+        yaml_content = """
+requirements:
+  - id: R001
+    description: Test
+"""
+        rubric = RubricParser.parse_yaml(yaml_content)
+        assert rubric.name == "Evaluation Rubric"
+        assert rubric.description == ""
+        assert rubric.pass_threshold == 0.70
+        assert rubric.requirements[0].weight == 1.0
+        assert rubric.requirements[0].evaluation == EvaluationType.SCALED
+
+
+class TestRubricParserParse:
+    """Tests for file parsing."""
+
+    def test_parse_file(self) -> None:
+        """Test parsing rubric from file."""
+        yaml_content = """
+name: File Rubric
+requirements:
+  - id: R001
+    description: Test
+"""
+        with TemporaryDirectory() as tmpdir:
+            rubric_file = Path(tmpdir) / "rubric.yaml"
+            rubric_file.write_text(yaml_content)
+
+            rubric = RubricParser.parse(rubric_file)
+            assert rubric.name == "File Rubric"
+
+    def test_parse_missing_file(self) -> None:
+        """Test parsing non-existent file."""
+        with pytest.raises(RubricError, match="not found"):
+            RubricParser.parse(Path("/nonexistent/rubric.yaml"))
+
+    def test_parse_unreadable_file(self) -> None:
+        """Test parsing unreadable file."""
+        with TemporaryDirectory() as tmpdir:
+            rubric_file = Path(tmpdir) / "rubric.yaml"
+            rubric_file.write_text("name: Test")
+            rubric_file.chmod(0o000)
+
+            try:
+                with pytest.raises(RubricError, match="Failed to read"):
+                    RubricParser.parse(rubric_file)
+            finally:
+                # Restore permissions for cleanup
+                rubric_file.chmod(0o644)
+
+
+class TestRubricErrors:
+    """Tests for error classes."""
+
+    def test_rubric_error(self) -> None:
+        """Test RubricError base exception."""
+        error = RubricError("Test error")
+        assert str(error) == "Test error"
+
+    def test_rubric_validation_error(self) -> None:
+        """Test RubricValidationError exception."""
+        error = RubricValidationError("Validation failed")
+        assert str(error) == "Validation failed"
+        assert isinstance(error, RubricError)


### PR DESCRIPTION
## Summary
- Implement rubric parser for loading `rubric.yaml` evaluation definitions
- Support requirements with IDs, descriptions, weights, and evaluation types (binary/scaled)
- Calculate weighted scores and assign grades based on configurable scale
- Full Pydantic validation for type safety

## Test plan
- [x] 47 unit tests for all rubric components
- [x] Tests for YAML parsing, validation, scoring, and grade assignment

Closes #16

🤖 Generated with [Claude Code](https://claude.com/claude-code)