### PR TITLE
feat(judge): add judge prompt templates for evaluation

### DIFF
--- a/src/scylla/judge/__init__.py
+++ b/src/scylla/judge/__init__.py
@@ -4,6 +4,24 @@ This module provides the judge system for evaluating AI agent work
 using rubrics, prompts, and consensus-based scoring.
 """
 
+from scylla.judge.prompts import (
+    CATEGORY_WEIGHTS,
+    JSON_OUTPUT_SCHEMA,
+    JUDGE_PROMPT_TEMPLATE,
+    TIER_CONTEXT_TEMPLATES,
+    TOTAL_CATEGORY_WEIGHT,
+    CategoryScore,
+    EvaluationCategory,
+    EvaluationSummary,
+    ExploratoryTesting,
+    JudgmentOutput,
+    RequirementScore,
+    build_judge_prompt,
+    calculate_weighted_category_score,
+    get_category_descriptions,
+    get_tier_context,
+    validate_judgment_output,
+)
 from scylla.judge.rubric import (
     EvaluationType,
     GradeScale,
@@ -15,6 +33,24 @@ from scylla.judge.rubric import (
 )
 
 __all__ = [
+    # Prompts
+    "CATEGORY_WEIGHTS",
+    "CategoryScore",
+    "EvaluationCategory",
+    "EvaluationSummary",
+    "ExploratoryTesting",
+    "JSON_OUTPUT_SCHEMA",
+    "JUDGE_PROMPT_TEMPLATE",
+    "JudgmentOutput",
+    "RequirementScore",
+    "TIER_CONTEXT_TEMPLATES",
+    "TOTAL_CATEGORY_WEIGHT",
+    "build_judge_prompt",
+    "calculate_weighted_category_score",
+    "get_category_descriptions",
+    "get_tier_context",
+    "validate_judgment_output",
+    # Rubric
     "EvaluationType",
     "GradeScale",
     "Requirement",

--- a/src/scylla/judge/prompts.py
+++ b/src/scylla/judge/prompts.py
@@ -1,0 +1,398 @@
+"""Judge prompt templates for evaluation.
+
+This module provides prompt templates for the judge system to evaluate
+agent work using a 3-run consensus approach with confidence-weighted scoring.
+
+Python Justification: Required for string templating and JSON schema definitions.
+"""
+
+from __future__ import annotations
+
+from enum import Enum
+from typing import Any
+
+from pydantic import BaseModel, Field
+
+
+class EvaluationCategory(str, Enum):
+    """Quality categories for evaluation."""
+
+    FUNCTIONAL_CORRECTNESS = "functional_correctness"
+    COMPLETENESS = "completeness"
+    CODE_QUALITY = "code_quality"
+    SIMPLICITY = "simplicity"
+    LACK_OF_DUPLICATION = "lack_of_duplication"
+    CLARITY = "clarity"
+    DOCUMENTATION = "documentation"
+    ARCHITECTURAL_CLEANLINESS = "architectural_cleanliness"
+    EFFICIENCY = "efficiency"
+    CLEANUP_SCRIPT_QUALITY = "cleanup_script_quality"
+
+
+# Category weights for weighted scoring
+CATEGORY_WEIGHTS: dict[EvaluationCategory, float] = {
+    EvaluationCategory.FUNCTIONAL_CORRECTNESS: 2.0,
+    EvaluationCategory.COMPLETENESS: 1.5,
+    EvaluationCategory.CODE_QUALITY: 1.0,
+    EvaluationCategory.SIMPLICITY: 1.0,
+    EvaluationCategory.LACK_OF_DUPLICATION: 0.5,
+    EvaluationCategory.CLARITY: 1.0,
+    EvaluationCategory.DOCUMENTATION: 0.5,
+    EvaluationCategory.ARCHITECTURAL_CLEANLINESS: 0.5,
+    EvaluationCategory.EFFICIENCY: 0.5,
+    EvaluationCategory.CLEANUP_SCRIPT_QUALITY: 1.0,
+}
+
+# Total weight for normalization
+TOTAL_CATEGORY_WEIGHT: float = sum(CATEGORY_WEIGHTS.values())
+
+
+class CategoryScore(BaseModel):
+    """A score for a single evaluation category.
+
+    Attributes:
+        score: The score (0.0 to 1.0).
+        confidence: Confidence in the score (0.0 to 1.0).
+        notes: Brief explanation of the score.
+    """
+
+    score: float = Field(..., ge=0.0, le=1.0, description="Score (0.0 to 1.0)")
+    confidence: float = Field(
+        ..., ge=0.0, le=1.0, description="Confidence (0.0 to 1.0)"
+    )
+    notes: str = Field(default="", description="Brief explanation")
+
+
+class RequirementScore(BaseModel):
+    """A score for a rubric requirement.
+
+    Attributes:
+        score: The score (0.0 to 1.0).
+        confidence: Confidence in the score (0.0 to 1.0).
+        notes: Brief explanation of the score.
+    """
+
+    score: float = Field(..., ge=0.0, le=1.0, description="Score (0.0 to 1.0)")
+    confidence: float = Field(
+        ..., ge=0.0, le=1.0, description="Confidence (0.0 to 1.0)"
+    )
+    notes: str = Field(default="", description="Brief explanation")
+
+
+class ExploratoryTesting(BaseModel):
+    """Results from exploratory testing phase.
+
+    Attributes:
+        commands_run: List of commands executed during testing.
+        observations: List of observations made.
+        failures: List of failures encountered.
+    """
+
+    commands_run: list[str] = Field(default_factory=list)
+    observations: list[str] = Field(default_factory=list)
+    failures: list[str] = Field(default_factory=list)
+
+
+class EvaluationSummary(BaseModel):
+    """Summary of the evaluation.
+
+    Attributes:
+        weighted_score: Final weighted score (0.0 to 1.0).
+        passed: Whether the evaluation passed.
+        letter_grade: Letter grade (A/B/C/D/F).
+        overall_confidence: Overall confidence in the evaluation.
+        strengths: List of identified strengths.
+        weaknesses: List of identified weaknesses.
+    """
+
+    weighted_score: float = Field(..., ge=0.0, le=1.0)
+    passed: bool = Field(...)
+    letter_grade: str = Field(..., pattern=r"^[ABCDF]$")
+    overall_confidence: float = Field(..., ge=0.0, le=1.0)
+    strengths: list[str] = Field(default_factory=list)
+    weaknesses: list[str] = Field(default_factory=list)
+
+
+class JudgmentOutput(BaseModel):
+    """Complete judgment output from the evaluator.
+
+    Attributes:
+        exploratory_testing: Results from exploratory testing.
+        requirements: Scores for each requirement by ID.
+        categories: Scores for each evaluation category.
+        summary: Evaluation summary.
+        qualitative_feedback: Free-form qualitative feedback.
+    """
+
+    exploratory_testing: ExploratoryTesting = Field(default_factory=ExploratoryTesting)
+    requirements: dict[str, RequirementScore] = Field(default_factory=dict)
+    categories: dict[str, CategoryScore] = Field(default_factory=dict)
+    summary: EvaluationSummary = Field(...)
+    qualitative_feedback: str = Field(default="")
+
+
+# JSON schema for the expected output format
+JSON_OUTPUT_SCHEMA: str = """{
+  "exploratory_testing": {
+    "commands_run": ["list of commands executed"],
+    "observations": ["list of observations made"],
+    "failures": ["list of failures encountered"]
+  },
+  "requirements": {
+    "<requirement_id>": {
+      "score": 0.0-1.0,
+      "confidence": 0.0-1.0,
+      "notes": "explanation"
+    }
+  },
+  "categories": {
+    "functional_correctness": {"score": 0.0-1.0, "confidence": 0.0-1.0, "notes": "..."},
+    "completeness": {"score": 0.0-1.0, "confidence": 0.0-1.0, "notes": "..."},
+    "code_quality": {"score": 0.0-1.0, "confidence": 0.0-1.0, "notes": "..."},
+    "simplicity": {"score": 0.0-1.0, "confidence": 0.0-1.0, "notes": "..."},
+    "lack_of_duplication": {"score": 0.0-1.0, "confidence": 0.0-1.0, "notes": "..."},
+    "clarity": {"score": 0.0-1.0, "confidence": 0.0-1.0, "notes": "..."},
+    "documentation": {"score": 0.0-1.0, "confidence": 0.0-1.0, "notes": "..."},
+    "architectural_cleanliness": {"score": 0.0-1.0, "confidence": 0.0-1.0, "notes": "..."},
+    "efficiency": {"score": 0.0-1.0, "confidence": 0.0-1.0, "notes": "..."},
+    "cleanup_script_quality": {"score": 0.0-1.0, "confidence": 0.0-1.0, "notes": "..."}
+  },
+  "summary": {
+    "weighted_score": 0.0-1.0,
+    "passed": true/false,
+    "letter_grade": "A/B/C/D/F",
+    "overall_confidence": 0.0-1.0,
+    "strengths": ["list of strengths"],
+    "weaknesses": ["list of weaknesses"]
+  },
+  "qualitative_feedback": "free-form feedback"
+}"""
+
+
+# Main evaluation prompt template
+JUDGE_PROMPT_TEMPLATE: str = """# Agent Work Evaluation
+
+You are an expert evaluator assessing AI agent work. Your task is to evaluate
+the agent's solution against the provided criteria and rubric.
+
+## Your Evaluation Process
+
+### Phase 1: Exploratory Testing
+1. Examine the workspace to understand what the agent produced
+2. Run validation commands to verify behavior
+3. Compare outputs against expected results
+4. Document any failures or discrepancies
+
+### Phase 2: Holistic Assessment
+1. Consider the overall quality of the solution
+2. Assess whether the intent of the task was met
+3. Evaluate code quality, maintainability, and clarity
+4. Note any particularly good or poor aspects
+
+### Phase 3: Rubric Scoring
+For each requirement in the rubric, provide:
+- A score (0.0 to 1.0)
+- A confidence level (0.0 to 1.0) indicating how certain you are
+- Brief notes explaining your score
+
+## Context
+
+### Original Task
+{task_prompt}
+
+### Success Criteria
+{criteria}
+
+### Scoring Rubric
+{rubric}
+
+{tier_context}
+
+## Evaluation Categories
+
+Score each category from 0.0 to 1.0 with confidence:
+
+| Category | Weight | Description |
+|----------|--------|-------------|
+| Functional Correctness | 2.0 | Does the solution work as intended? |
+| Completeness | 1.5 | Are all requirements addressed? |
+| Code Quality | 1.0 | Readability, maintainability, best practices |
+| Simplicity | 1.0 | Prefer simple working solutions over complex ones |
+| Lack of Duplication | 0.5 | DRY principle adherence |
+| Clarity | 1.0 | Clear, understandable implementation |
+| Documentation | 0.5 | Appropriate comments and documentation |
+| Architectural Cleanliness | 0.5 | Clean separation of concerns |
+| Efficiency | 0.5 | Resource usage, performance considerations |
+| Cleanup Script Quality | 1.0 | Proper cleanup/teardown script creation |
+
+**Total Weight**: 9.5
+
+## Required Output Format
+
+Respond with a JSON object:
+
+```json
+{json_schema}
+```
+
+## Instructions
+
+1. First, explore the workspace thoroughly
+2. Run the validation commands specified in the rubric
+3. Score each requirement and category with confidence levels
+4. Provide a holistic summary
+5. Be critical but fair - reward working solutions, penalize complexity
+
+BEGIN EVALUATION
+"""
+
+
+# Tier-specific context templates
+TIER_CONTEXT_TEMPLATES: dict[str, str] = {
+    "T0": """
+## Tier Context: T0 (Vanilla)
+This is a vanilla baseline evaluation. The agent had no special prompting,
+tools, or capabilities beyond the base LLM. Evaluate based on what a raw
+LLM can reasonably achieve with zero-shot prompting.
+""",
+    "T1": """
+## Tier Context: T1 (Prompted)
+This evaluation uses system prompts and chain-of-thought reasoning.
+The agent had access to prompt engineering but no external tools.
+Evaluate based on expected improvements from good prompting.
+""",
+    "T2": """
+## Tier Context: T2 (Skills)
+This evaluation uses prompt-encoded domain expertise.
+The agent had access to reusable skill modules but no external tools.
+Evaluate based on expected improvements from domain knowledge.
+""",
+    "T3": """
+## Tier Context: T3 (Tooling)
+This evaluation includes external function calling.
+The agent had access to tools and APIs for validation and execution.
+Evaluate based on proper tool usage and integration.
+""",
+    "T4": """
+## Tier Context: T4 (Delegation)
+This evaluation uses flat multi-agent systems.
+The agent could delegate to other agents in parallel.
+Evaluate based on effective task distribution.
+""",
+    "T5": """
+## Tier Context: T5 (Hierarchy)
+This evaluation uses nested orchestration with self-correction.
+The agent had iterative refinement and supervision capabilities.
+Evaluate based on effective use of hierarchy and iteration.
+""",
+    "T6": """
+## Tier Context: T6 (Hybrid)
+This evaluation uses optimal combinations of proven components.
+The agent had best-of-breed architecture with all capabilities.
+Evaluate based on effective integration of all components.
+""",
+}
+
+
+def get_tier_context(tier_id: str) -> str:
+    """Get tier-specific context for the evaluation prompt.
+
+    Args:
+        tier_id: The tier identifier (T0-T6).
+
+    Returns:
+        Tier-specific context string, or empty if tier not found.
+    """
+    return TIER_CONTEXT_TEMPLATES.get(tier_id, "")
+
+
+def build_judge_prompt(
+    task_prompt: str,
+    criteria: str,
+    rubric: str,
+    tier_id: str | None = None,
+) -> str:
+    """Build the complete judge prompt.
+
+    Args:
+        task_prompt: The original task given to the agent.
+        criteria: Success criteria for evaluation.
+        rubric: The scoring rubric in text format.
+        tier_id: Optional tier identifier for tier-aware evaluation.
+
+    Returns:
+        Complete prompt string for the judge.
+    """
+    tier_context = get_tier_context(tier_id) if tier_id else ""
+
+    return JUDGE_PROMPT_TEMPLATE.format(
+        task_prompt=task_prompt,
+        criteria=criteria,
+        rubric=rubric,
+        tier_context=tier_context,
+        json_schema=JSON_OUTPUT_SCHEMA,
+    )
+
+
+def calculate_weighted_category_score(categories: dict[str, CategoryScore]) -> float:
+    """Calculate weighted score from category scores.
+
+    Args:
+        categories: Dictionary mapping category names to scores.
+
+    Returns:
+        Weighted average score (0.0 to 1.0).
+    """
+    total_weight = 0.0
+    weighted_sum = 0.0
+
+    for category_str, score in categories.items():
+        try:
+            category = EvaluationCategory(category_str)
+            weight = CATEGORY_WEIGHTS.get(category, 1.0)
+            weighted_sum += score.score * weight
+            total_weight += weight
+        except ValueError:
+            # Unknown category, use default weight
+            weighted_sum += score.score * 1.0
+            total_weight += 1.0
+
+    if total_weight == 0.0:
+        return 0.0
+
+    return weighted_sum / total_weight
+
+
+def get_category_descriptions() -> dict[str, str]:
+    """Get descriptions for all evaluation categories.
+
+    Returns:
+        Dictionary mapping category names to descriptions.
+    """
+    return {
+        EvaluationCategory.FUNCTIONAL_CORRECTNESS.value: "Does the solution work as intended?",
+        EvaluationCategory.COMPLETENESS.value: "Are all requirements addressed?",
+        EvaluationCategory.CODE_QUALITY.value: "Readability, maintainability, best practices",
+        EvaluationCategory.SIMPLICITY.value: "Prefer simple working solutions over complex ones",
+        EvaluationCategory.LACK_OF_DUPLICATION.value: "DRY principle adherence",
+        EvaluationCategory.CLARITY.value: "Clear, understandable implementation",
+        EvaluationCategory.DOCUMENTATION.value: "Appropriate comments and documentation",
+        EvaluationCategory.ARCHITECTURAL_CLEANLINESS.value: "Clean separation of concerns",
+        EvaluationCategory.EFFICIENCY.value: "Resource usage, performance considerations",
+        EvaluationCategory.CLEANUP_SCRIPT_QUALITY.value: "Proper cleanup/teardown script creation",
+    }
+
+
+def validate_judgment_output(output: dict[str, Any]) -> JudgmentOutput:
+    """Validate and parse judgment output.
+
+    Args:
+        output: Raw dictionary output from the judge.
+
+    Returns:
+        Validated JudgmentOutput object.
+
+    Raises:
+        ValueError: If the output is invalid.
+    """
+    return JudgmentOutput.model_validate(output)

--- a/tests/unit/judge/test_prompts.py
+++ b/tests/unit/judge/test_prompts.py
@@ -1,0 +1,477 @@
+"""Tests for judge prompt templates.
+
+Python justification: Required for pytest testing framework.
+"""
+
+import pytest
+
+from scylla.judge.prompts import (
+    CATEGORY_WEIGHTS,
+    JSON_OUTPUT_SCHEMA,
+    JUDGE_PROMPT_TEMPLATE,
+    TIER_CONTEXT_TEMPLATES,
+    TOTAL_CATEGORY_WEIGHT,
+    CategoryScore,
+    EvaluationCategory,
+    EvaluationSummary,
+    ExploratoryTesting,
+    JudgmentOutput,
+    RequirementScore,
+    build_judge_prompt,
+    calculate_weighted_category_score,
+    get_category_descriptions,
+    get_tier_context,
+    validate_judgment_output,
+)
+
+
+class TestEvaluationCategory:
+    """Tests for EvaluationCategory enum."""
+
+    def test_all_categories_present(self) -> None:
+        """Test all 10 categories are defined."""
+        assert len(EvaluationCategory) == 10
+
+    def test_category_values(self) -> None:
+        """Test category enum values."""
+        assert EvaluationCategory.FUNCTIONAL_CORRECTNESS.value == "functional_correctness"
+        assert EvaluationCategory.COMPLETENESS.value == "completeness"
+        assert EvaluationCategory.CODE_QUALITY.value == "code_quality"
+        assert EvaluationCategory.SIMPLICITY.value == "simplicity"
+        assert EvaluationCategory.LACK_OF_DUPLICATION.value == "lack_of_duplication"
+        assert EvaluationCategory.CLARITY.value == "clarity"
+        assert EvaluationCategory.DOCUMENTATION.value == "documentation"
+        assert EvaluationCategory.ARCHITECTURAL_CLEANLINESS.value == "architectural_cleanliness"
+        assert EvaluationCategory.EFFICIENCY.value == "efficiency"
+        assert EvaluationCategory.CLEANUP_SCRIPT_QUALITY.value == "cleanup_script_quality"
+
+
+class TestCategoryWeights:
+    """Tests for category weights."""
+
+    def test_all_categories_have_weights(self) -> None:
+        """Test all categories have defined weights."""
+        for category in EvaluationCategory:
+            assert category in CATEGORY_WEIGHTS
+
+    def test_weights_are_positive(self) -> None:
+        """Test all weights are positive."""
+        for weight in CATEGORY_WEIGHTS.values():
+            assert weight > 0
+
+    def test_total_weight(self) -> None:
+        """Test total weight matches expected value."""
+        assert TOTAL_CATEGORY_WEIGHT == pytest.approx(9.5)
+
+    def test_specific_weights(self) -> None:
+        """Test specific category weights."""
+        assert CATEGORY_WEIGHTS[EvaluationCategory.FUNCTIONAL_CORRECTNESS] == 2.0
+        assert CATEGORY_WEIGHTS[EvaluationCategory.COMPLETENESS] == 1.5
+        assert CATEGORY_WEIGHTS[EvaluationCategory.CODE_QUALITY] == 1.0
+        assert CATEGORY_WEIGHTS[EvaluationCategory.SIMPLICITY] == 1.0
+        assert CATEGORY_WEIGHTS[EvaluationCategory.LACK_OF_DUPLICATION] == 0.5
+        assert CATEGORY_WEIGHTS[EvaluationCategory.CLARITY] == 1.0
+        assert CATEGORY_WEIGHTS[EvaluationCategory.DOCUMENTATION] == 0.5
+        assert CATEGORY_WEIGHTS[EvaluationCategory.ARCHITECTURAL_CLEANLINESS] == 0.5
+        assert CATEGORY_WEIGHTS[EvaluationCategory.EFFICIENCY] == 0.5
+        assert CATEGORY_WEIGHTS[EvaluationCategory.CLEANUP_SCRIPT_QUALITY] == 1.0
+
+
+class TestCategoryScore:
+    """Tests for CategoryScore model."""
+
+    def test_valid_score(self) -> None:
+        """Test creating valid category score."""
+        score = CategoryScore(score=0.8, confidence=0.9, notes="Good work")
+        assert score.score == 0.8
+        assert score.confidence == 0.9
+        assert score.notes == "Good work"
+
+    def test_score_bounds(self) -> None:
+        """Test score is bounded 0-1."""
+        with pytest.raises(ValueError):
+            CategoryScore(score=1.5, confidence=0.5)
+        with pytest.raises(ValueError):
+            CategoryScore(score=-0.1, confidence=0.5)
+
+    def test_confidence_bounds(self) -> None:
+        """Test confidence is bounded 0-1."""
+        with pytest.raises(ValueError):
+            CategoryScore(score=0.5, confidence=1.5)
+        with pytest.raises(ValueError):
+            CategoryScore(score=0.5, confidence=-0.1)
+
+    def test_default_notes(self) -> None:
+        """Test default empty notes."""
+        score = CategoryScore(score=0.5, confidence=0.5)
+        assert score.notes == ""
+
+
+class TestRequirementScore:
+    """Tests for RequirementScore model."""
+
+    def test_valid_score(self) -> None:
+        """Test creating valid requirement score."""
+        score = RequirementScore(score=0.7, confidence=0.85, notes="Met criteria")
+        assert score.score == 0.7
+        assert score.confidence == 0.85
+        assert score.notes == "Met criteria"
+
+
+class TestExploratoryTesting:
+    """Tests for ExploratoryTesting model."""
+
+    def test_default_values(self) -> None:
+        """Test default empty lists."""
+        testing = ExploratoryTesting()
+        assert testing.commands_run == []
+        assert testing.observations == []
+        assert testing.failures == []
+
+    def test_with_data(self) -> None:
+        """Test with provided data."""
+        testing = ExploratoryTesting(
+            commands_run=["pytest", "mypy"],
+            observations=["Tests pass", "Types check"],
+            failures=["One flaky test"],
+        )
+        assert len(testing.commands_run) == 2
+        assert len(testing.observations) == 2
+        assert len(testing.failures) == 1
+
+
+class TestEvaluationSummary:
+    """Tests for EvaluationSummary model."""
+
+    def test_valid_summary(self) -> None:
+        """Test creating valid summary."""
+        summary = EvaluationSummary(
+            weighted_score=0.85,
+            passed=True,
+            letter_grade="B",
+            overall_confidence=0.9,
+            strengths=["Clean code"],
+            weaknesses=["Missing docs"],
+        )
+        assert summary.weighted_score == 0.85
+        assert summary.passed is True
+        assert summary.letter_grade == "B"
+
+    def test_letter_grade_pattern(self) -> None:
+        """Test letter grade validation."""
+        # Valid grades
+        for grade in ["A", "B", "C", "D", "F"]:
+            summary = EvaluationSummary(
+                weighted_score=0.5,
+                passed=False,
+                letter_grade=grade,
+                overall_confidence=0.5,
+            )
+            assert summary.letter_grade == grade
+
+        # Invalid grades
+        with pytest.raises(ValueError):
+            EvaluationSummary(
+                weighted_score=0.5,
+                passed=False,
+                letter_grade="E",
+                overall_confidence=0.5,
+            )
+
+
+class TestJudgmentOutput:
+    """Tests for JudgmentOutput model."""
+
+    def test_minimal_output(self) -> None:
+        """Test minimal valid output."""
+        output = JudgmentOutput(
+            summary=EvaluationSummary(
+                weighted_score=0.7,
+                passed=True,
+                letter_grade="C",
+                overall_confidence=0.8,
+            )
+        )
+        assert output.summary.passed is True
+        assert output.requirements == {}
+        assert output.categories == {}
+
+    def test_full_output(self) -> None:
+        """Test full output with all fields."""
+        output = JudgmentOutput(
+            exploratory_testing=ExploratoryTesting(
+                commands_run=["pytest"],
+                observations=["All pass"],
+                failures=[],
+            ),
+            requirements={
+                "R001": RequirementScore(score=0.9, confidence=0.95, notes="Met"),
+            },
+            categories={
+                "functional_correctness": CategoryScore(
+                    score=0.9, confidence=0.9, notes="Works"
+                ),
+            },
+            summary=EvaluationSummary(
+                weighted_score=0.9,
+                passed=True,
+                letter_grade="A",
+                overall_confidence=0.9,
+                strengths=["Good"],
+                weaknesses=[],
+            ),
+            qualitative_feedback="Excellent work",
+        )
+        assert len(output.requirements) == 1
+        assert len(output.categories) == 1
+        assert output.qualitative_feedback == "Excellent work"
+
+
+class TestTierContext:
+    """Tests for tier context templates."""
+
+    def test_all_tiers_defined(self) -> None:
+        """Test all 7 tiers have context templates."""
+        for tier in ["T0", "T1", "T2", "T3", "T4", "T5", "T6"]:
+            assert tier in TIER_CONTEXT_TEMPLATES
+
+    def test_get_tier_context_valid(self) -> None:
+        """Test getting valid tier context."""
+        context = get_tier_context("T0")
+        assert "Vanilla" in context
+        assert "baseline" in context
+
+        context = get_tier_context("T3")
+        assert "Tooling" in context
+        assert "function calling" in context
+
+    def test_get_tier_context_invalid(self) -> None:
+        """Test getting invalid tier returns empty."""
+        assert get_tier_context("T99") == ""
+        assert get_tier_context("") == ""
+
+
+class TestBuildJudgePrompt:
+    """Tests for build_judge_prompt function."""
+
+    def test_basic_prompt(self) -> None:
+        """Test building basic prompt."""
+        prompt = build_judge_prompt(
+            task_prompt="Implement feature X",
+            criteria="Tests must pass",
+            rubric="R001: Feature works",
+        )
+        assert "Implement feature X" in prompt
+        assert "Tests must pass" in prompt
+        assert "R001: Feature works" in prompt
+        assert "BEGIN EVALUATION" in prompt
+
+    def test_prompt_with_tier(self) -> None:
+        """Test building prompt with tier context."""
+        prompt = build_judge_prompt(
+            task_prompt="Task",
+            criteria="Criteria",
+            rubric="Rubric",
+            tier_id="T3",
+        )
+        assert "Tooling" in prompt
+        assert "function calling" in prompt
+
+    def test_prompt_without_tier(self) -> None:
+        """Test building prompt without tier context."""
+        prompt = build_judge_prompt(
+            task_prompt="Task",
+            criteria="Criteria",
+            rubric="Rubric",
+            tier_id=None,
+        )
+        # Should not contain tier-specific text
+        assert "Tier Context:" not in prompt
+
+    def test_prompt_includes_all_categories(self) -> None:
+        """Test prompt includes all evaluation categories."""
+        prompt = build_judge_prompt(
+            task_prompt="Task",
+            criteria="Criteria",
+            rubric="Rubric",
+        )
+        assert "Functional Correctness" in prompt
+        assert "Completeness" in prompt
+        assert "Code Quality" in prompt
+        assert "Simplicity" in prompt
+        assert "Lack of Duplication" in prompt
+        assert "Clarity" in prompt
+        assert "Documentation" in prompt
+        assert "Architectural Cleanliness" in prompt
+        assert "Efficiency" in prompt
+        assert "Cleanup Script Quality" in prompt
+
+    def test_prompt_includes_json_schema(self) -> None:
+        """Test prompt includes JSON schema."""
+        prompt = build_judge_prompt(
+            task_prompt="Task",
+            criteria="Criteria",
+            rubric="Rubric",
+        )
+        assert "exploratory_testing" in prompt
+        assert "requirements" in prompt
+        assert "categories" in prompt
+        assert "summary" in prompt
+
+    def test_prompt_includes_three_phases(self) -> None:
+        """Test prompt includes all three evaluation phases."""
+        prompt = build_judge_prompt(
+            task_prompt="Task",
+            criteria="Criteria",
+            rubric="Rubric",
+        )
+        assert "Phase 1: Exploratory Testing" in prompt
+        assert "Phase 2: Holistic Assessment" in prompt
+        assert "Phase 3: Rubric Scoring" in prompt
+
+
+class TestCalculateWeightedCategoryScore:
+    """Tests for weighted category score calculation."""
+
+    def test_empty_categories(self) -> None:
+        """Test empty categories returns 0."""
+        assert calculate_weighted_category_score({}) == 0.0
+
+    def test_single_category(self) -> None:
+        """Test single category score."""
+        categories = {
+            "functional_correctness": CategoryScore(score=0.8, confidence=0.9),
+        }
+        # Weight is 2.0, score is 0.8 -> 0.8
+        assert calculate_weighted_category_score(categories) == pytest.approx(0.8)
+
+    def test_multiple_categories(self) -> None:
+        """Test multiple category weighted score."""
+        categories = {
+            "functional_correctness": CategoryScore(score=1.0, confidence=0.9),  # weight 2.0
+            "completeness": CategoryScore(score=0.5, confidence=0.9),  # weight 1.5
+        }
+        # (1.0 * 2.0 + 0.5 * 1.5) / (2.0 + 1.5) = 2.75 / 3.5 = 0.7857...
+        expected = (1.0 * 2.0 + 0.5 * 1.5) / (2.0 + 1.5)
+        assert calculate_weighted_category_score(categories) == pytest.approx(expected)
+
+    def test_all_categories(self) -> None:
+        """Test with all categories at same score."""
+        categories = {
+            category.value: CategoryScore(score=0.8, confidence=0.9)
+            for category in EvaluationCategory
+        }
+        # All same score, so weighted average is same
+        assert calculate_weighted_category_score(categories) == pytest.approx(0.8)
+
+    def test_unknown_category(self) -> None:
+        """Test unknown category uses default weight."""
+        categories = {
+            "unknown_category": CategoryScore(score=0.5, confidence=0.9),
+        }
+        # Unknown category gets weight 1.0
+        assert calculate_weighted_category_score(categories) == pytest.approx(0.5)
+
+
+class TestGetCategoryDescriptions:
+    """Tests for category descriptions."""
+
+    def test_all_categories_have_descriptions(self) -> None:
+        """Test all categories have descriptions."""
+        descriptions = get_category_descriptions()
+        for category in EvaluationCategory:
+            assert category.value in descriptions
+
+    def test_descriptions_are_nonempty(self) -> None:
+        """Test all descriptions are non-empty strings."""
+        descriptions = get_category_descriptions()
+        for desc in descriptions.values():
+            assert isinstance(desc, str)
+            assert len(desc) > 0
+
+
+class TestValidateJudgmentOutput:
+    """Tests for judgment output validation."""
+
+    def test_valid_output(self) -> None:
+        """Test validating valid output."""
+        raw = {
+            "summary": {
+                "weighted_score": 0.8,
+                "passed": True,
+                "letter_grade": "B",
+                "overall_confidence": 0.9,
+            }
+        }
+        output = validate_judgment_output(raw)
+        assert isinstance(output, JudgmentOutput)
+        assert output.summary.passed is True
+
+    def test_full_output(self) -> None:
+        """Test validating full output."""
+        raw = {
+            "exploratory_testing": {
+                "commands_run": ["pytest"],
+                "observations": ["Pass"],
+                "failures": [],
+            },
+            "requirements": {
+                "R001": {"score": 0.9, "confidence": 0.9, "notes": "Good"},
+            },
+            "categories": {
+                "functional_correctness": {"score": 0.9, "confidence": 0.9, "notes": "Works"},
+            },
+            "summary": {
+                "weighted_score": 0.9,
+                "passed": True,
+                "letter_grade": "A",
+                "overall_confidence": 0.9,
+                "strengths": ["Clean"],
+                "weaknesses": [],
+            },
+            "qualitative_feedback": "Great job",
+        }
+        output = validate_judgment_output(raw)
+        assert output.requirements["R001"].score == 0.9
+        assert output.categories["functional_correctness"].score == 0.9
+
+    def test_invalid_output(self) -> None:
+        """Test validating invalid output raises error."""
+        raw = {"invalid": "data"}
+        with pytest.raises(ValueError):
+            validate_judgment_output(raw)
+
+
+class TestJudgePromptTemplate:
+    """Tests for the main prompt template."""
+
+    def test_template_has_placeholders(self) -> None:
+        """Test template has required placeholders."""
+        assert "{task_prompt}" in JUDGE_PROMPT_TEMPLATE
+        assert "{criteria}" in JUDGE_PROMPT_TEMPLATE
+        assert "{rubric}" in JUDGE_PROMPT_TEMPLATE
+        assert "{tier_context}" in JUDGE_PROMPT_TEMPLATE
+        assert "{json_schema}" in JUDGE_PROMPT_TEMPLATE
+
+    def test_template_includes_weights(self) -> None:
+        """Test template includes category weights."""
+        assert "2.0" in JUDGE_PROMPT_TEMPLATE  # Functional Correctness
+        assert "1.5" in JUDGE_PROMPT_TEMPLATE  # Completeness
+        assert "0.5" in JUDGE_PROMPT_TEMPLATE  # Documentation, etc.
+
+
+class TestJsonOutputSchema:
+    """Tests for JSON output schema."""
+
+    def test_schema_includes_all_sections(self) -> None:
+        """Test schema includes all required sections."""
+        assert "exploratory_testing" in JSON_OUTPUT_SCHEMA
+        assert "requirements" in JSON_OUTPUT_SCHEMA
+        assert "categories" in JSON_OUTPUT_SCHEMA
+        assert "summary" in JSON_OUTPUT_SCHEMA
+        assert "qualitative_feedback" in JSON_OUTPUT_SCHEMA
+
+    def test_schema_includes_all_categories(self) -> None:
+        """Test schema includes all evaluation categories."""
+        for category in EvaluationCategory:
+            assert category.value in JSON_OUTPUT_SCHEMA


### PR DESCRIPTION
## Summary
- Implement 3-phase judge evaluation prompt with exploratory testing, holistic assessment, and rubric scoring
- Define all 10 quality categories with weights (total 9.5)
- Add tier-aware evaluation context (T0-T6)
- Define JSON output schema with confidence scores for all scoring

## Test plan
- [x] 40 unit tests for prompts, categories, schemas, and validation
- [x] Tests for weighted score calculation and tier context

Closes #17

🤖 Generated with [Claude Code](https://claude.com/claude-code)