### PR TITLE
feat(judge): add judgment parser for structured data extraction

### DIFF
--- a/src/scylla/judge/__init__.py
+++ b/src/scylla/judge/__init__.py
@@ -17,6 +17,12 @@ from scylla.judge.evaluator import (
     assign_grade,
     weighted_consensus,
 )
+from scylla.judge.parser import (
+    ExploratoryTestingResult,
+    JudgmentParseError,
+    JudgmentParser,
+    load_judgment,
+)
 from scylla.judge.prompts import (
     CATEGORY_WEIGHTS,
     JSON_OUTPUT_SCHEMA,
@@ -58,6 +64,11 @@ __all__ = [
     "JudgeSummary",
     "assign_grade",
     "weighted_consensus",
+    # Parser
+    "ExploratoryTestingResult",
+    "JudgmentParseError",
+    "JudgmentParser",
+    "load_judgment",
     # Prompts
     "CATEGORY_WEIGHTS",
     "CategoryScore",

--- a/src/scylla/judge/parser.py
+++ b/src/scylla/judge/parser.py
@@ -1,0 +1,392 @@
+"""Judgment parser for extracting structured data from judge output.
+
+This module provides parsing and serialization of judgment data,
+including writing judgment.json to disk.
+
+Python Justification: Required for JSON parsing and file I/O.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import re
+from dataclasses import asdict, dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+
+class JudgmentParseError(Exception):
+    """Raised when parsing judgment output fails."""
+
+    pass
+
+
+@dataclass
+class RequirementScore:
+    """Score for a single requirement.
+
+    Attributes:
+        id: Requirement identifier.
+        score: The score (0.0 to 1.0).
+        confidence: Confidence in the score (0.0 to 1.0).
+        notes: Brief explanation of the score.
+    """
+
+    id: str
+    score: float
+    confidence: float = 0.5
+    notes: str = ""
+
+    def to_dict(self) -> dict[str, Any]:
+        """Convert to JSON-serializable dict."""
+        return {
+            "id": self.id,
+            "score": self.score,
+            "confidence": self.confidence,
+            "notes": self.notes,
+        }
+
+
+@dataclass
+class CategoryScore:
+    """Score for an evaluation category.
+
+    Attributes:
+        name: Category name.
+        score: The score (0.0 to 1.0).
+        confidence: Confidence in the score (0.0 to 1.0).
+        weight: Category weight.
+        notes: Brief explanation of the score.
+    """
+
+    name: str
+    score: float
+    confidence: float = 0.5
+    weight: float = 1.0
+    notes: str = ""
+
+    def to_dict(self) -> dict[str, Any]:
+        """Convert to JSON-serializable dict."""
+        return {
+            "name": self.name,
+            "score": self.score,
+            "confidence": self.confidence,
+            "weight": self.weight,
+            "notes": self.notes,
+        }
+
+
+@dataclass
+class JudgmentSummary:
+    """Summary of a judgment.
+
+    Attributes:
+        weighted_score: The weighted score (0.0 to 1.0).
+        passed: Whether the evaluation passed.
+        letter_grade: Letter grade (A/B/C/D/F).
+        overall_confidence: Overall confidence in the judgment.
+        strengths: List of identified strengths.
+        weaknesses: List of identified weaknesses.
+    """
+
+    weighted_score: float
+    passed: bool
+    letter_grade: str
+    overall_confidence: float = 0.5
+    strengths: list[str] = field(default_factory=list)
+    weaknesses: list[str] = field(default_factory=list)
+
+    def to_dict(self) -> dict[str, Any]:
+        """Convert to JSON-serializable dict."""
+        return {
+            "weighted_score": self.weighted_score,
+            "passed": self.passed,
+            "letter_grade": self.letter_grade,
+            "overall_confidence": self.overall_confidence,
+            "strengths": self.strengths,
+            "weaknesses": self.weaknesses,
+        }
+
+
+@dataclass
+class ExploratoryTestingResult:
+    """Results from exploratory testing phase.
+
+    Attributes:
+        commands_run: Commands executed during testing.
+        observations: Observations made.
+        failures: Failures encountered.
+    """
+
+    commands_run: list[str] = field(default_factory=list)
+    observations: list[str] = field(default_factory=list)
+    failures: list[str] = field(default_factory=list)
+
+    def to_dict(self) -> dict[str, Any]:
+        """Convert to JSON-serializable dict."""
+        return {
+            "commands_run": self.commands_run,
+            "observations": self.observations,
+            "failures": self.failures,
+        }
+
+
+@dataclass
+class Judgment:
+    """Complete judgment from an evaluation.
+
+    Attributes:
+        timestamp: ISO 8601 timestamp of the judgment.
+        judge_model: Model used for judging.
+        requirements: Scores for each requirement.
+        categories: Scores for each category.
+        summary: Judgment summary.
+        exploratory_testing: Results from exploratory testing.
+        qualitative_feedback: Free-form qualitative feedback.
+        raw_output: Raw output from the judge.
+    """
+
+    timestamp: str = ""
+    judge_model: str = ""
+    requirements: dict[str, RequirementScore] = field(default_factory=dict)
+    categories: dict[str, CategoryScore] = field(default_factory=dict)
+    summary: JudgmentSummary | None = None
+    exploratory_testing: ExploratoryTestingResult | None = None
+    qualitative_feedback: str = ""
+    raw_output: str = ""
+
+    def __post_init__(self) -> None:
+        """Set timestamp if not provided."""
+        if not self.timestamp:
+            self.timestamp = datetime.now(timezone.utc).isoformat()
+
+    def to_dict(self) -> dict[str, Any]:
+        """Convert to JSON-serializable dict."""
+        result: dict[str, Any] = {
+            "timestamp": self.timestamp,
+            "judge_model": self.judge_model,
+            "requirements": {
+                req_id: score.to_dict()
+                for req_id, score in self.requirements.items()
+            },
+            "categories": {
+                cat_name: score.to_dict()
+                for cat_name, score in self.categories.items()
+            },
+            "qualitative_feedback": self.qualitative_feedback,
+        }
+
+        if self.summary:
+            result["summary"] = self.summary.to_dict()
+
+        if self.exploratory_testing:
+            result["exploratory_testing"] = self.exploratory_testing.to_dict()
+
+        return result
+
+    def to_json(self, indent: int = 2) -> str:
+        """Convert to JSON string.
+
+        Args:
+            indent: Indentation level for pretty printing.
+
+        Returns:
+            JSON string representation.
+        """
+        return json.dumps(self.to_dict(), indent=indent)
+
+    def write_json(self, output_path: Path) -> None:
+        """Write judgment to JSON file.
+
+        Args:
+            output_path: Path to write the judgment.json file.
+
+        Raises:
+            IOError: If writing fails.
+        """
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        output_path.write_text(self.to_json())
+        logger.info(f"Wrote judgment to {output_path}")
+
+
+class JudgmentParser:
+    """Parser for extracting structured judgment data from output."""
+
+    def parse(self, output: str, judge_model: str = "") -> Judgment:
+        """Parse judgment from raw output.
+
+        Args:
+            output: Raw output from the judge.
+            judge_model: Model used for judging.
+
+        Returns:
+            Parsed Judgment object.
+        """
+        json_data = self._extract_json(output)
+
+        if json_data is None:
+            logger.warning("No valid JSON found in judge output")
+            return Judgment(
+                judge_model=judge_model,
+                raw_output=output,
+            )
+
+        return self._build_judgment(json_data, judge_model, output)
+
+    def parse_file(self, file_path: Path, judge_model: str = "") -> Judgment:
+        """Parse judgment from a file.
+
+        Args:
+            file_path: Path to file containing judge output.
+            judge_model: Model used for judging.
+
+        Returns:
+            Parsed Judgment object.
+
+        Raises:
+            JudgmentParseError: If the file cannot be read.
+        """
+        try:
+            output = file_path.read_text()
+        except OSError as e:
+            raise JudgmentParseError(f"Failed to read file: {e}") from e
+
+        return self.parse(output, judge_model)
+
+    def _extract_json(self, output: str) -> dict[str, Any] | None:
+        """Extract JSON object from output text.
+
+        Args:
+            output: Raw output text.
+
+        Returns:
+            Parsed JSON dict, or None if not found.
+        """
+        # Try to find JSON in code blocks first
+        json_block = re.search(r"```(?:json)?\s*(\{[\s\S]*?\})\s*```", output)
+        if json_block:
+            try:
+                return json.loads(json_block.group(1))
+            except json.JSONDecodeError:
+                pass
+
+        # Try to find raw JSON object
+        start = output.find("{")
+        if start == -1:
+            return None
+
+        # Find matching closing brace
+        depth = 0
+        end = start
+        for i, char in enumerate(output[start:], start):
+            if char == "{":
+                depth += 1
+            elif char == "}":
+                depth -= 1
+                if depth == 0:
+                    end = i + 1
+                    break
+
+        if depth != 0:
+            return None
+
+        try:
+            return json.loads(output[start:end])
+        except json.JSONDecodeError:
+            return None
+
+    def _build_judgment(
+        self,
+        data: dict[str, Any],
+        judge_model: str,
+        raw_output: str,
+    ) -> Judgment:
+        """Build Judgment from parsed JSON data.
+
+        Args:
+            data: Parsed JSON data.
+            judge_model: Model used for judging.
+            raw_output: Raw output string.
+
+        Returns:
+            Judgment object.
+        """
+        judgment = Judgment(
+            judge_model=judge_model,
+            raw_output=raw_output,
+        )
+
+        # Parse requirements
+        requirements = data.get("requirements", {})
+        for req_id, req_data in requirements.items():
+            if isinstance(req_data, dict):
+                judgment.requirements[req_id] = RequirementScore(
+                    id=req_id,
+                    score=float(req_data.get("score", 0.0)),
+                    confidence=float(req_data.get("confidence", 0.5)),
+                    notes=str(req_data.get("notes", "")),
+                )
+
+        # Parse categories
+        categories = data.get("categories", {})
+        for cat_name, cat_data in categories.items():
+            if isinstance(cat_data, dict):
+                judgment.categories[cat_name] = CategoryScore(
+                    name=cat_name,
+                    score=float(cat_data.get("score", 0.0)),
+                    confidence=float(cat_data.get("confidence", 0.5)),
+                    weight=float(cat_data.get("weight", 1.0)),
+                    notes=str(cat_data.get("notes", "")),
+                )
+
+        # Parse summary
+        summary = data.get("summary", {})
+        if summary:
+            judgment.summary = JudgmentSummary(
+                weighted_score=float(summary.get("weighted_score", 0.0)),
+                passed=bool(summary.get("passed", False)),
+                letter_grade=str(summary.get("letter_grade", "F")),
+                overall_confidence=float(summary.get("overall_confidence", 0.5)),
+                strengths=list(summary.get("strengths", [])),
+                weaknesses=list(summary.get("weaknesses", [])),
+            )
+
+        # Parse exploratory testing
+        exploratory = data.get("exploratory_testing", {})
+        if exploratory:
+            judgment.exploratory_testing = ExploratoryTestingResult(
+                commands_run=list(exploratory.get("commands_run", [])),
+                observations=list(exploratory.get("observations", [])),
+                failures=list(exploratory.get("failures", [])),
+            )
+
+        # Parse qualitative feedback
+        judgment.qualitative_feedback = str(data.get("qualitative_feedback", ""))
+
+        return judgment
+
+
+def load_judgment(file_path: Path) -> Judgment:
+    """Load judgment from a JSON file.
+
+    Args:
+        file_path: Path to the judgment.json file.
+
+    Returns:
+        Loaded Judgment object.
+
+    Raises:
+        JudgmentParseError: If the file cannot be read or parsed.
+    """
+    try:
+        content = file_path.read_text()
+        data = json.loads(content)
+    except (OSError, json.JSONDecodeError) as e:
+        raise JudgmentParseError(f"Failed to load judgment: {e}") from e
+
+    parser = JudgmentParser()
+    return parser._build_judgment(data, data.get("judge_model", ""), "")

--- a/tests/unit/judge/test_parser.py
+++ b/tests/unit/judge/test_parser.py
@@ -1,0 +1,244 @@
+"""Tests for judgment parser.
+
+Python justification: Required for pytest testing framework.
+"""
+
+import json
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+import pytest
+
+from scylla.judge.parser import (
+    CategoryScore,
+    ExploratoryTestingResult,
+    Judgment,
+    JudgmentParseError,
+    JudgmentParser,
+    JudgmentSummary,
+    RequirementScore,
+    load_judgment,
+)
+
+
+class TestRequirementScore:
+    """Tests for RequirementScore dataclass."""
+
+    def test_create_score(self) -> None:
+        score = RequirementScore(id="R001", score=0.8, confidence=0.9, notes="Good")
+        assert score.id == "R001"
+        assert score.score == 0.8
+        assert score.confidence == 0.9
+        assert score.notes == "Good"
+
+    def test_to_dict(self) -> None:
+        score = RequirementScore(id="R001", score=0.8, confidence=0.9)
+        d = score.to_dict()
+        assert d["id"] == "R001"
+        assert d["score"] == 0.8
+
+
+class TestCategoryScore:
+    """Tests for CategoryScore dataclass."""
+
+    def test_create_score(self) -> None:
+        score = CategoryScore(name="code_quality", score=0.85, weight=1.5)
+        assert score.name == "code_quality"
+        assert score.score == 0.85
+        assert score.weight == 1.5
+
+    def test_to_dict(self) -> None:
+        score = CategoryScore(name="test", score=0.7)
+        d = score.to_dict()
+        assert d["name"] == "test"
+        assert d["score"] == 0.7
+
+
+class TestJudgmentSummary:
+    """Tests for JudgmentSummary dataclass."""
+
+    def test_create_summary(self) -> None:
+        summary = JudgmentSummary(
+            weighted_score=0.85,
+            passed=True,
+            letter_grade="B",
+            overall_confidence=0.9,
+            strengths=["Good code"],
+            weaknesses=["Missing docs"],
+        )
+        assert summary.weighted_score == 0.85
+        assert summary.passed is True
+        assert summary.letter_grade == "B"
+
+    def test_to_dict(self) -> None:
+        summary = JudgmentSummary(
+            weighted_score=0.8, passed=True, letter_grade="B",
+        )
+        d = summary.to_dict()
+        assert d["weighted_score"] == 0.8
+        assert d["passed"] is True
+
+
+class TestExploratoryTestingResult:
+    """Tests for ExploratoryTestingResult dataclass."""
+
+    def test_default_values(self) -> None:
+        result = ExploratoryTestingResult()
+        assert result.commands_run == []
+        assert result.observations == []
+        assert result.failures == []
+
+    def test_to_dict(self) -> None:
+        result = ExploratoryTestingResult(commands_run=["pytest"])
+        d = result.to_dict()
+        assert d["commands_run"] == ["pytest"]
+
+
+class TestJudgment:
+    """Tests for Judgment dataclass."""
+
+    def test_auto_timestamp(self) -> None:
+        judgment = Judgment()
+        assert judgment.timestamp != ""
+
+    def test_to_dict(self) -> None:
+        judgment = Judgment(
+            judge_model="test-model",
+            requirements={"R001": RequirementScore(id="R001", score=0.9)},
+            summary=JudgmentSummary(
+                weighted_score=0.9, passed=True, letter_grade="A",
+            ),
+        )
+        d = judgment.to_dict()
+        assert d["judge_model"] == "test-model"
+        assert "R001" in d["requirements"]
+        assert d["summary"]["passed"] is True
+
+    def test_to_json(self) -> None:
+        judgment = Judgment(judge_model="test")
+        json_str = judgment.to_json()
+        data = json.loads(json_str)
+        assert data["judge_model"] == "test"
+
+    def test_write_json(self) -> None:
+        with TemporaryDirectory() as tmpdir:
+            output_path = Path(tmpdir) / "judgment.json"
+            judgment = Judgment(judge_model="test")
+            judgment.write_json(output_path)
+            
+            assert output_path.exists()
+            data = json.loads(output_path.read_text())
+            assert data["judge_model"] == "test"
+
+
+class TestJudgmentParser:
+    """Tests for JudgmentParser class."""
+
+    def test_parse_full_json(self) -> None:
+        parser = JudgmentParser()
+        output = '''{
+            "requirements": {"R001": {"score": 0.9, "confidence": 0.8, "notes": "Met"}},
+            "categories": {"code_quality": {"score": 0.85, "weight": 1.0}},
+            "summary": {
+                "weighted_score": 0.87, "passed": true, "letter_grade": "B",
+                "overall_confidence": 0.85
+            },
+            "qualitative_feedback": "Good work"
+        }'''
+        judgment = parser.parse(output, judge_model="test-model")
+        assert judgment.requirements["R001"].score == 0.9
+        assert judgment.categories["code_quality"].score == 0.85
+        assert judgment.summary.passed is True
+        assert judgment.judge_model == "test-model"
+
+    def test_parse_json_in_code_block(self) -> None:
+        parser = JudgmentParser()
+        output = '''Some text
+```json
+{"requirements": {"R001": {"score": 0.8}}}
+```
+More text'''
+        judgment = parser.parse(output)
+        assert judgment.requirements["R001"].score == 0.8
+
+    def test_parse_nested_json(self) -> None:
+        parser = JudgmentParser()
+        output = '{"outer": {"inner": {"score": 0.5}}}'
+        result = parser._extract_json(output)
+        assert result["outer"]["inner"]["score"] == 0.5
+
+    def test_parse_no_json(self) -> None:
+        parser = JudgmentParser()
+        judgment = parser.parse("No JSON here")
+        assert judgment.requirements == {}
+
+    def test_parse_malformed_json(self) -> None:
+        parser = JudgmentParser()
+        judgment = parser.parse("{invalid: json")
+        assert judgment.requirements == {}
+
+    def test_parse_exploratory_testing(self) -> None:
+        parser = JudgmentParser()
+        output = '''{
+            "exploratory_testing": {
+                "commands_run": ["pytest", "mypy"],
+                "observations": ["All pass"],
+                "failures": []
+            }
+        }'''
+        judgment = parser.parse(output)
+        assert judgment.exploratory_testing is not None
+        assert len(judgment.exploratory_testing.commands_run) == 2
+
+    def test_parse_file(self) -> None:
+        parser = JudgmentParser()
+        with TemporaryDirectory() as tmpdir:
+            file_path = Path(tmpdir) / "output.txt"
+            file_path.write_text('{"requirements": {"R001": {"score": 0.7}}}')
+            
+            judgment = parser.parse_file(file_path)
+            assert judgment.requirements["R001"].score == 0.7
+
+    def test_parse_file_not_found(self) -> None:
+        parser = JudgmentParser()
+        with pytest.raises(JudgmentParseError, match="Failed to read"):
+            parser.parse_file(Path("/nonexistent/file.txt"))
+
+
+class TestLoadJudgment:
+    """Tests for load_judgment function."""
+
+    def test_load_valid_judgment(self) -> None:
+        with TemporaryDirectory() as tmpdir:
+            file_path = Path(tmpdir) / "judgment.json"
+            data = {
+                "judge_model": "test",
+                "requirements": {"R001": {"score": 0.8}},
+                "summary": {
+                    "weighted_score": 0.8, "passed": True, "letter_grade": "B",
+                },
+            }
+            file_path.write_text(json.dumps(data))
+            
+            judgment = load_judgment(file_path)
+            assert judgment.requirements["R001"].score == 0.8
+
+    def test_load_missing_file(self) -> None:
+        with pytest.raises(JudgmentParseError, match="Failed to load"):
+            load_judgment(Path("/nonexistent/judgment.json"))
+
+    def test_load_invalid_json(self) -> None:
+        with TemporaryDirectory() as tmpdir:
+            file_path = Path(tmpdir) / "judgment.json"
+            file_path.write_text("not valid json")
+            
+            with pytest.raises(JudgmentParseError, match="Failed to load"):
+                load_judgment(file_path)
+
+
+class TestJudgmentParseError:
+    """Tests for JudgmentParseError exception."""
+
+    def test_error_message(self) -> None:
+        error = JudgmentParseError("Parse failed")
+        assert str(error) == "Parse failed"


### PR DESCRIPTION
## Summary
- Implement JudgmentParser for parsing judge output into structured data
- Define RequirementScore, CategoryScore, JudgmentSummary dataclasses
- Add to_dict(), to_json(), write_json() for serialization
- Handle malformed JSON gracefully with fallback
- Support loading judgments from judgment.json files

## Test plan
- [x] 24 unit tests for dataclasses, parser, and serialization
- [x] Tests for JSON extraction from various formats
- [x] Tests for file I/O and error handling

Closes #19

🤖 Generated with [Claude Code](https://claude.com/claude-code)