### PR TITLE
feat(metrics): add grading calculations for evaluation runs

### DIFF
--- a/src/scylla/metrics/__init__.py
+++ b/src/scylla/metrics/__init__.py
@@ -1,9 +1,20 @@
-"""Metrics module for statistical calculations and aggregation.
+"""Metrics module for statistical calculations and grading.
 
-This module provides statistical functions for analyzing evaluation results
-across multiple runs.
+This module provides statistical functions and grading calculations
+for analyzing evaluation results across multiple runs.
 """
 
+from scylla.metrics.grading import (
+    GradingResult,
+    assign_letter_grade,
+    calculate_composite_score,
+    calculate_cost_delta,
+    calculate_cost_of_pass,
+    calculate_impl_rate,
+    calculate_pass_rate,
+    calculate_tier_uplift,
+    grade_run,
+)
 from scylla.metrics.statistics import (
     Statistics,
     calculate_all,
@@ -16,6 +27,17 @@ from scylla.metrics.statistics import (
 )
 
 __all__ = [
+    # Grading
+    "GradingResult",
+    "assign_letter_grade",
+    "calculate_composite_score",
+    "calculate_cost_delta",
+    "calculate_cost_of_pass",
+    "calculate_impl_rate",
+    "calculate_pass_rate",
+    "calculate_tier_uplift",
+    "grade_run",
+    # Statistics
     "Statistics",
     "calculate_all",
     "calculate_mean",

--- a/src/scylla/metrics/grading.py
+++ b/src/scylla/metrics/grading.py
@@ -1,0 +1,218 @@
+"""Grading calculations for evaluation metrics.
+
+This module provides grading functions for calculating pass rate,
+implementation rate, cost of pass, and composite scores.
+
+Python Justification: Required for grade calculation with edge case handling.
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+from typing import Protocol
+
+
+class JudgmentProtocol(Protocol):
+    """Protocol for judgment objects."""
+
+    @property
+    def summary(self) -> "SummaryProtocol":
+        """Get the summary."""
+        ...
+
+
+class SummaryProtocol(Protocol):
+    """Protocol for summary objects."""
+
+    @property
+    def weighted_score(self) -> float:
+        """Get the weighted score."""
+        ...
+
+
+@dataclass
+class GradingResult:
+    """Result of grading calculations.
+
+    Attributes:
+        pass_rate: Binary pass/fail as 1.0 or 0.0.
+        impl_rate: Implementation rate from judgment.
+        cost_of_pass: Cost per successful run.
+        composite_score: Combined score from metrics.
+        letter_grade: Letter grade (A/B/C/D/F).
+    """
+
+    pass_rate: float
+    impl_rate: float
+    cost_of_pass: float
+    composite_score: float
+    letter_grade: str
+
+
+def calculate_pass_rate(passed: bool) -> float:
+    """Calculate pass rate from boolean result.
+
+    Args:
+        passed: Whether the evaluation passed.
+
+    Returns:
+        1.0 if passed, 0.0 if failed.
+    """
+    return 1.0 if passed else 0.0
+
+
+def calculate_impl_rate(weighted_score: float) -> float:
+    """Calculate implementation rate from weighted score.
+
+    Args:
+        weighted_score: Weighted score from judgment (0.0 to 1.0).
+
+    Returns:
+        Implementation rate (clamped to 0.0-1.0).
+    """
+    return max(0.0, min(1.0, weighted_score))
+
+
+def calculate_cost_of_pass(cost: float, pass_rate: float) -> float:
+    """Calculate cost per successful run.
+
+    If pass_rate is 0, returns infinity to indicate
+    infinitely expensive failures.
+
+    Args:
+        cost: Total cost in USD.
+        pass_rate: Pass rate (0.0 to 1.0).
+
+    Returns:
+        Cost per pass, or infinity if pass_rate is 0.
+    """
+    if pass_rate <= 0:
+        return float("inf")
+
+    return cost / pass_rate
+
+
+def calculate_composite_score(
+    pass_rate: float,
+    impl_rate: float,
+    pass_weight: float = 0.5,
+    impl_weight: float = 0.5,
+) -> float:
+    """Calculate composite score from metrics.
+
+    By default, uses simple average of pass_rate and impl_rate.
+    Custom weights can adjust the relative importance.
+
+    Args:
+        pass_rate: Pass rate (0.0 to 1.0).
+        impl_rate: Implementation rate (0.0 to 1.0).
+        pass_weight: Weight for pass_rate (default 0.5).
+        impl_weight: Weight for impl_rate (default 0.5).
+
+    Returns:
+        Weighted composite score (0.0 to 1.0).
+    """
+    total_weight = pass_weight + impl_weight
+    if total_weight <= 0:
+        return 0.0
+
+    weighted_sum = (pass_rate * pass_weight) + (impl_rate * impl_weight)
+    return weighted_sum / total_weight
+
+
+def assign_letter_grade(score: float) -> str:
+    """Assign letter grade based on score.
+
+    Grade thresholds:
+        A: >= 0.95
+        B: >= 0.85
+        C: >= 0.75
+        D: >= 0.65
+        F: < 0.65
+
+    Args:
+        score: Score (0.0 to 1.0).
+
+    Returns:
+        Letter grade (A/B/C/D/F).
+    """
+    if score >= 0.95:
+        return "A"
+    elif score >= 0.85:
+        return "B"
+    elif score >= 0.75:
+        return "C"
+    elif score >= 0.65:
+        return "D"
+    else:
+        return "F"
+
+
+def calculate_tier_uplift(
+    tier_score: float,
+    baseline_score: float,
+) -> float:
+    """Calculate tier uplift vs baseline (T0).
+
+    Formula: (tier_score - baseline) / baseline
+
+    Args:
+        tier_score: Score for the tier being evaluated.
+        baseline_score: Baseline score (typically T0).
+
+    Returns:
+        Percentage uplift (can be negative for regression).
+        Returns 0.0 if baseline is 0.
+    """
+    if baseline_score <= 0:
+        return 0.0
+
+    return (tier_score - baseline_score) / baseline_score
+
+
+def calculate_cost_delta(costs: list[float]) -> float:
+    """Calculate cost delta between tiers.
+
+    Formula: max(costs) - min(costs)
+
+    Args:
+        costs: List of costs across tiers.
+
+    Returns:
+        Cost delta, or 0.0 if empty.
+    """
+    if not costs:
+        return 0.0
+
+    return max(costs) - min(costs)
+
+
+def grade_run(
+    passed: bool,
+    weighted_score: float,
+    cost_usd: float,
+) -> GradingResult:
+    """Grade a single evaluation run.
+
+    Args:
+        passed: Whether the evaluation passed.
+        weighted_score: Weighted score from judgment.
+        cost_usd: Cost of the run in USD.
+
+    Returns:
+        GradingResult with all calculated metrics.
+    """
+    pass_rate = calculate_pass_rate(passed)
+    impl_rate = calculate_impl_rate(weighted_score)
+    cost_of_pass = calculate_cost_of_pass(cost_usd, pass_rate)
+    composite = calculate_composite_score(pass_rate, impl_rate)
+    grade = assign_letter_grade(composite)
+
+    return GradingResult(
+        pass_rate=pass_rate,
+        impl_rate=impl_rate,
+        cost_of_pass=cost_of_pass,
+        composite_score=composite,
+        letter_grade=grade,
+    )

--- a/tests/unit/metrics/test_grading.py
+++ b/tests/unit/metrics/test_grading.py
@@ -1,0 +1,208 @@
+"""Tests for grading calculations.
+
+Python justification: Required for pytest testing framework.
+"""
+
+import math
+
+import pytest
+
+from scylla.metrics.grading import (
+    GradingResult,
+    assign_letter_grade,
+    calculate_composite_score,
+    calculate_cost_delta,
+    calculate_cost_of_pass,
+    calculate_impl_rate,
+    calculate_pass_rate,
+    calculate_tier_uplift,
+    grade_run,
+)
+
+
+class TestCalculatePassRate:
+    """Tests for pass rate calculation."""
+
+    def test_passed(self) -> None:
+        assert calculate_pass_rate(True) == 1.0
+
+    def test_failed(self) -> None:
+        assert calculate_pass_rate(False) == 0.0
+
+
+class TestCalculateImplRate:
+    """Tests for implementation rate calculation."""
+
+    def test_valid_score(self) -> None:
+        assert calculate_impl_rate(0.85) == 0.85
+
+    def test_clamps_above_one(self) -> None:
+        assert calculate_impl_rate(1.5) == 1.0
+
+    def test_clamps_below_zero(self) -> None:
+        assert calculate_impl_rate(-0.5) == 0.0
+
+    def test_boundary_values(self) -> None:
+        assert calculate_impl_rate(0.0) == 0.0
+        assert calculate_impl_rate(1.0) == 1.0
+
+
+class TestCalculateCostOfPass:
+    """Tests for cost of pass calculation."""
+
+    def test_normal_case(self) -> None:
+        # Cost $1.00, pass rate 0.5 -> $2.00 per pass
+        assert calculate_cost_of_pass(1.0, 0.5) == 2.0
+
+    def test_full_pass_rate(self) -> None:
+        # Cost $1.00, pass rate 1.0 -> $1.00 per pass
+        assert calculate_cost_of_pass(1.0, 1.0) == 1.0
+
+    def test_zero_pass_rate(self) -> None:
+        # Zero pass rate -> infinity
+        result = calculate_cost_of_pass(1.0, 0.0)
+        assert math.isinf(result)
+
+    def test_negative_pass_rate(self) -> None:
+        # Negative pass rate -> infinity
+        result = calculate_cost_of_pass(1.0, -0.1)
+        assert math.isinf(result)
+
+    def test_zero_cost(self) -> None:
+        # Zero cost -> 0 per pass
+        assert calculate_cost_of_pass(0.0, 0.5) == 0.0
+
+
+class TestCalculateCompositeScore:
+    """Tests for composite score calculation."""
+
+    def test_default_weights(self) -> None:
+        # Equal weights: (0.8 + 0.6) / 2 = 0.7
+        assert calculate_composite_score(0.8, 0.6) == pytest.approx(0.7)
+
+    def test_custom_weights(self) -> None:
+        # pass_rate=0.8 (weight=2), impl_rate=0.6 (weight=1)
+        # (0.8*2 + 0.6*1) / 3 = 2.2/3 = 0.733...
+        result = calculate_composite_score(0.8, 0.6, pass_weight=2.0, impl_weight=1.0)
+        assert result == pytest.approx(2.2 / 3)
+
+    def test_zero_weights(self) -> None:
+        # Zero total weight -> 0
+        assert calculate_composite_score(0.8, 0.6, pass_weight=0.0, impl_weight=0.0) == 0.0
+
+    def test_perfect_scores(self) -> None:
+        assert calculate_composite_score(1.0, 1.0) == 1.0
+
+    def test_zero_scores(self) -> None:
+        assert calculate_composite_score(0.0, 0.0) == 0.0
+
+
+class TestAssignLetterGrade:
+    """Tests for letter grade assignment."""
+
+    def test_grade_a(self) -> None:
+        assert assign_letter_grade(0.95) == "A"
+        assert assign_letter_grade(1.0) == "A"
+
+    def test_grade_b(self) -> None:
+        assert assign_letter_grade(0.85) == "B"
+        assert assign_letter_grade(0.94) == "B"
+
+    def test_grade_c(self) -> None:
+        assert assign_letter_grade(0.75) == "C"
+        assert assign_letter_grade(0.84) == "C"
+
+    def test_grade_d(self) -> None:
+        assert assign_letter_grade(0.65) == "D"
+        assert assign_letter_grade(0.74) == "D"
+
+    def test_grade_f(self) -> None:
+        assert assign_letter_grade(0.64) == "F"
+        assert assign_letter_grade(0.0) == "F"
+
+
+class TestCalculateTierUplift:
+    """Tests for tier uplift calculation."""
+
+    def test_positive_uplift(self) -> None:
+        # T1 = 0.8, T0 = 0.5 -> (0.8-0.5)/0.5 = 0.6 (60% improvement)
+        assert calculate_tier_uplift(0.8, 0.5) == pytest.approx(0.6)
+
+    def test_no_uplift(self) -> None:
+        # Same score -> 0% uplift
+        assert calculate_tier_uplift(0.5, 0.5) == 0.0
+
+    def test_negative_uplift(self) -> None:
+        # Regression: T1 < T0
+        # T1 = 0.4, T0 = 0.5 -> (0.4-0.5)/0.5 = -0.2 (-20%)
+        assert calculate_tier_uplift(0.4, 0.5) == pytest.approx(-0.2)
+
+    def test_zero_baseline(self) -> None:
+        # Zero baseline -> 0 (avoid division by zero)
+        assert calculate_tier_uplift(0.8, 0.0) == 0.0
+
+
+class TestCalculateCostDelta:
+    """Tests for cost delta calculation."""
+
+    def test_multiple_costs(self) -> None:
+        costs = [0.50, 0.75, 1.25, 0.80]
+        # max - min = 1.25 - 0.50 = 0.75
+        assert calculate_cost_delta(costs) == pytest.approx(0.75)
+
+    def test_identical_costs(self) -> None:
+        costs = [1.0, 1.0, 1.0]
+        assert calculate_cost_delta(costs) == 0.0
+
+    def test_single_cost(self) -> None:
+        costs = [1.0]
+        assert calculate_cost_delta(costs) == 0.0
+
+    def test_empty_list(self) -> None:
+        assert calculate_cost_delta([]) == 0.0
+
+
+class TestGradingResult:
+    """Tests for GradingResult dataclass."""
+
+    def test_dataclass_fields(self) -> None:
+        result = GradingResult(
+            pass_rate=1.0,
+            impl_rate=0.85,
+            cost_of_pass=1.50,
+            composite_score=0.925,
+            letter_grade="A",
+        )
+        assert result.pass_rate == 1.0
+        assert result.impl_rate == 0.85
+        assert result.cost_of_pass == 1.50
+        assert result.composite_score == 0.925
+        assert result.letter_grade == "A"
+
+
+class TestGradeRun:
+    """Tests for grade_run function."""
+
+    def test_passing_run(self) -> None:
+        result = grade_run(passed=True, weighted_score=0.9, cost_usd=1.0)
+        assert result.pass_rate == 1.0
+        assert result.impl_rate == 0.9
+        assert result.cost_of_pass == 1.0
+        assert result.composite_score == pytest.approx(0.95)
+        assert result.letter_grade == "A"
+
+    def test_failing_run(self) -> None:
+        result = grade_run(passed=False, weighted_score=0.5, cost_usd=1.0)
+        assert result.pass_rate == 0.0
+        assert result.impl_rate == 0.5
+        assert math.isinf(result.cost_of_pass)
+        assert result.composite_score == pytest.approx(0.25)
+        assert result.letter_grade == "F"
+
+    def test_mixed_run(self) -> None:
+        result = grade_run(passed=True, weighted_score=0.7, cost_usd=2.0)
+        assert result.pass_rate == 1.0
+        assert result.impl_rate == 0.7
+        assert result.cost_of_pass == 2.0
+        assert result.composite_score == pytest.approx(0.85)
+        assert result.letter_grade == "B"


### PR DESCRIPTION
## Summary
- Implement pass rate, implementation rate, cost of pass calculations
- Add composite score with configurable weights
- Add letter grade assignment (A/B/C/D/F)
- Add tier uplift and cost delta for cross-tier analysis
- Add grade_run() for complete single run grading

## Test plan
- [x] 33 unit tests for all grading functions
- [x] Tests for edge cases (zero pass rate, clamping)
- [x] Tests for tier uplift and cost delta

Closes #22

🤖 Generated with [Claude Code](https://claude.com/claude-code)