### PR TITLE
feat(metrics): add run aggregation for multi-tier analysis

### DIFF
--- a/src/scylla/metrics/__init__.py
+++ b/src/scylla/metrics/__init__.py
@@ -1,9 +1,16 @@
-"""Metrics module for statistical calculations and grading.
+"""Metrics module for statistical calculations, grading, and aggregation.
 
-This module provides statistical functions and grading calculations
-for analyzing evaluation results across multiple runs.
+This module provides statistical functions, grading calculations,
+and run aggregation for analyzing evaluation results across multiple runs.
 """
 
+from scylla.metrics.aggregator import (
+    AggregatedStats,
+    CrossTierAnalysis,
+    RunAggregator,
+    RunResult,
+    TierStatistics,
+)
 from scylla.metrics.grading import (
     GradingResult,
     assign_letter_grade,
@@ -27,6 +34,12 @@ from scylla.metrics.statistics import (
 )
 
 __all__ = [
+    # Aggregator
+    "AggregatedStats",
+    "CrossTierAnalysis",
+    "RunAggregator",
+    "RunResult",
+    "TierStatistics",
     # Grading
     "GradingResult",
     "assign_letter_grade",

--- a/src/scylla/metrics/aggregator.py
+++ b/src/scylla/metrics/aggregator.py
@@ -1,0 +1,307 @@
+"""Run aggregation for evaluation metrics.
+
+This module provides aggregation of multiple runs into statistical
+summaries per tier with cross-tier analysis.
+
+Python Justification: Required for statistical aggregation and data structures.
+"""
+
+from __future__ import annotations
+
+import math
+from collections import Counter
+from dataclasses import dataclass, field
+
+
+@dataclass
+class AggregatedStats:
+    """Statistical summary of a set of values from aggregation."""
+
+    median: float
+    mean: float
+    mode: float
+    min: float
+    max: float
+    std_dev: float
+    count: int = 0
+
+
+@dataclass
+class RunResult:
+    """Result from a single evaluation run.
+
+    Attributes:
+        run_id: Unique identifier for the run.
+        pass_rate: Binary pass/fail (1.0 or 0.0).
+        impl_rate: Implementation rate (0.0 to 1.0).
+        cost_usd: Cost in USD.
+        duration_seconds: Duration of the run.
+    """
+
+    run_id: str
+    pass_rate: float
+    impl_rate: float
+    cost_usd: float
+    duration_seconds: float
+
+
+@dataclass
+class TierStatistics:
+    """Aggregated statistics for a single tier.
+
+    Attributes:
+        tier_id: Tier identifier (T0-T6).
+        runs_completed: Number of runs aggregated.
+        pass_rate: Statistics for pass rate.
+        impl_rate: Statistics for implementation rate.
+        cost_usd: Statistics for cost.
+        duration_seconds: Statistics for duration.
+        composite_score: Statistics for composite score.
+        grade: Letter grade based on median composite score.
+    """
+
+    tier_id: str
+    runs_completed: int
+    pass_rate: AggregatedStats
+    impl_rate: AggregatedStats
+    cost_usd: AggregatedStats
+    duration_seconds: AggregatedStats
+    composite_score: AggregatedStats
+    grade: str
+
+
+@dataclass
+class CrossTierAnalysis:
+    """Analysis across multiple tiers.
+
+    Attributes:
+        pass_rate_variance: Variance in pass rate across tiers.
+        impl_rate_variance: Variance in implementation rate across tiers.
+        cost_variance: Variance in cost across tiers.
+        tier_uplifts: Percentage uplift vs T0 baseline for each tier.
+    """
+
+    pass_rate_variance: float
+    impl_rate_variance: float
+    cost_variance: float
+    tier_uplifts: dict[str, float] = field(default_factory=dict)
+
+
+def _calculate_median(values: list[float]) -> float:
+    """Calculate median."""
+    if not values:
+        return 0.0
+    sorted_values = sorted(values)
+    n = len(sorted_values)
+    if n % 2 == 1:
+        return sorted_values[n // 2]
+    mid = n // 2
+    return (sorted_values[mid - 1] + sorted_values[mid]) / 2
+
+
+def _calculate_mean(values: list[float]) -> float:
+    """Calculate mean."""
+    if not values:
+        return 0.0
+    return sum(values) / len(values)
+
+
+def _calculate_mode(values: list[float]) -> float:
+    """Calculate mode."""
+    if not values:
+        return 0.0
+    rounded = [round(v, 6) for v in values]
+    counter = Counter(rounded)
+    most_common = counter.most_common()
+    if not most_common:
+        return values[0]
+    max_freq = most_common[0][1]
+    modes = [v for v, freq in most_common if freq == max_freq]
+    return min(modes)
+
+
+def _calculate_variance(values: list[float]) -> float:
+    """Calculate variance."""
+    if len(values) < 2:
+        return 0.0
+    mean = _calculate_mean(values)
+    squared_diffs = [(v - mean) ** 2 for v in values]
+    return sum(squared_diffs) / len(values)
+
+
+def _calculate_std_dev(values: list[float]) -> float:
+    """Calculate standard deviation."""
+    return math.sqrt(_calculate_variance(values))
+
+
+def _calculate_all(values: list[float]) -> AggregatedStats:
+    """Calculate all statistics."""
+    if not values:
+        return AggregatedStats(0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0)
+    return AggregatedStats(
+        median=_calculate_median(values),
+        mean=_calculate_mean(values),
+        mode=_calculate_mode(values),
+        min=min(values),
+        max=max(values),
+        std_dev=_calculate_std_dev(values),
+        count=len(values),
+    )
+
+
+def _calculate_composite_score(pass_rate: float, impl_rate: float) -> float:
+    """Calculate composite score."""
+    return (pass_rate + impl_rate) / 2
+
+
+def _assign_letter_grade(score: float) -> str:
+    """Assign letter grade."""
+    if score >= 0.95:
+        return "A"
+    elif score >= 0.85:
+        return "B"
+    elif score >= 0.75:
+        return "C"
+    elif score >= 0.65:
+        return "D"
+    return "F"
+
+
+class RunAggregator:
+    """Aggregator for multiple evaluation runs.
+
+    Aggregates 10 runs per tier into statistical summaries
+    and provides cross-tier analysis.
+    """
+
+    def aggregate_tier(
+        self,
+        tier_id: str,
+        runs: list[RunResult],
+    ) -> TierStatistics:
+        """Aggregate runs into statistical summary for one tier.
+
+        Args:
+            tier_id: Tier identifier (T0-T6).
+            runs: List of run results for this tier.
+
+        Returns:
+            TierStatistics with aggregated metrics.
+        """
+        if not runs:
+            empty_stats = AggregatedStats(0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0)
+            return TierStatistics(
+                tier_id=tier_id,
+                runs_completed=0,
+                pass_rate=empty_stats,
+                impl_rate=empty_stats,
+                cost_usd=empty_stats,
+                duration_seconds=empty_stats,
+                composite_score=empty_stats,
+                grade="F",
+            )
+
+        # Extract metrics from runs
+        pass_rates = [r.pass_rate for r in runs]
+        impl_rates = [r.impl_rate for r in runs]
+        costs = [r.cost_usd for r in runs]
+        durations = [r.duration_seconds for r in runs]
+
+        # Calculate composite scores
+        composite_scores = [
+            _calculate_composite_score(r.pass_rate, r.impl_rate) for r in runs
+        ]
+
+        # Calculate statistics
+        pass_rate_stats = _calculate_all(pass_rates)
+        impl_rate_stats = _calculate_all(impl_rates)
+        cost_stats = _calculate_all(costs)
+        duration_stats = _calculate_all(durations)
+        composite_stats = _calculate_all(composite_scores)
+
+        # Determine grade from median composite score
+        grade = _assign_letter_grade(composite_stats.median)
+
+        return TierStatistics(
+            tier_id=tier_id,
+            runs_completed=len(runs),
+            pass_rate=pass_rate_stats,
+            impl_rate=impl_rate_stats,
+            cost_usd=cost_stats,
+            duration_seconds=duration_stats,
+            composite_score=composite_stats,
+            grade=grade,
+        )
+
+    def analyze_cross_tier(
+        self,
+        tier_stats: dict[str, TierStatistics],
+    ) -> CrossTierAnalysis:
+        """Analyze variance and uplift across tiers.
+
+        Args:
+            tier_stats: Dictionary mapping tier IDs to statistics.
+
+        Returns:
+            CrossTierAnalysis with variance and uplift metrics.
+        """
+        if not tier_stats:
+            return CrossTierAnalysis(
+                pass_rate_variance=0.0,
+                impl_rate_variance=0.0,
+                cost_variance=0.0,
+                tier_uplifts={},
+            )
+
+        # Extract median values for variance calculation
+        pass_rates = [t.pass_rate.median for t in tier_stats.values()]
+        impl_rates = [t.impl_rate.median for t in tier_stats.values()]
+        costs = [t.cost_usd.median for t in tier_stats.values()]
+
+        # Calculate variances
+        pass_rate_variance = _calculate_variance(pass_rates)
+        impl_rate_variance = _calculate_variance(impl_rates)
+        cost_variance = _calculate_variance(costs)
+
+        # Calculate tier uplifts vs T0 baseline
+        uplifts: dict[str, float] = {}
+        t0_stats = tier_stats.get("T0")
+
+        if t0_stats:
+            t0_baseline = t0_stats.composite_score.median
+            for tier_id, stats in tier_stats.items():
+                if tier_id != "T0":
+                    tier_score = stats.composite_score.median
+                    if t0_baseline > 0:
+                        uplift = (tier_score - t0_baseline) / t0_baseline
+                    else:
+                        uplift = 0.0
+                    uplifts[tier_id] = uplift
+
+        return CrossTierAnalysis(
+            pass_rate_variance=pass_rate_variance,
+            impl_rate_variance=impl_rate_variance,
+            cost_variance=cost_variance,
+            tier_uplifts=uplifts,
+        )
+
+    def aggregate_all_tiers(
+        self,
+        runs_by_tier: dict[str, list[RunResult]],
+    ) -> tuple[dict[str, TierStatistics], CrossTierAnalysis]:
+        """Aggregate all tiers and perform cross-tier analysis.
+
+        Args:
+            runs_by_tier: Dictionary mapping tier IDs to run lists.
+
+        Returns:
+            Tuple of (tier_stats, cross_tier_analysis).
+        """
+        tier_stats = {
+            tier_id: self.aggregate_tier(tier_id, runs)
+            for tier_id, runs in runs_by_tier.items()
+        }
+
+        cross_tier = self.analyze_cross_tier(tier_stats)
+
+        return tier_stats, cross_tier

--- a/tests/unit/metrics/test_aggregator.py
+++ b/tests/unit/metrics/test_aggregator.py
@@ -1,0 +1,237 @@
+"""Tests for run aggregation.
+
+Python justification: Required for pytest testing framework.
+"""
+
+import pytest
+
+from scylla.metrics.aggregator import (
+    AggregatedStats,
+    CrossTierAnalysis,
+    RunAggregator,
+    RunResult,
+    TierStatistics,
+)
+
+
+def make_run(
+    run_id: str,
+    pass_rate: float = 1.0,
+    impl_rate: float = 0.8,
+    cost_usd: float = 1.0,
+    duration_seconds: float = 60.0,
+) -> RunResult:
+    """Helper to create RunResult."""
+    return RunResult(
+        run_id=run_id,
+        pass_rate=pass_rate,
+        impl_rate=impl_rate,
+        cost_usd=cost_usd,
+        duration_seconds=duration_seconds,
+    )
+
+
+class TestRunResult:
+    """Tests for RunResult dataclass."""
+
+    def test_create_result(self) -> None:
+        result = RunResult(
+            run_id="run-001",
+            pass_rate=1.0,
+            impl_rate=0.85,
+            cost_usd=0.50,
+            duration_seconds=45.0,
+        )
+        assert result.run_id == "run-001"
+        assert result.pass_rate == 1.0
+        assert result.impl_rate == 0.85
+
+
+class TestAggregatedStats:
+    """Tests for AggregatedStats dataclass."""
+
+    def test_create_stats(self) -> None:
+        stats = AggregatedStats(
+            median=0.8,
+            mean=0.75,
+            mode=0.8,
+            min=0.6,
+            max=0.9,
+            std_dev=0.1,
+            count=10,
+        )
+        assert stats.median == 0.8
+        assert stats.count == 10
+
+
+class TestTierStatistics:
+    """Tests for TierStatistics dataclass."""
+
+    def test_create_tier_stats(self) -> None:
+        stats = AggregatedStats(0.8, 0.8, 0.8, 0.7, 0.9, 0.05, 10)
+        tier_stats = TierStatistics(
+            tier_id="T1",
+            runs_completed=10,
+            pass_rate=stats,
+            impl_rate=stats,
+            cost_usd=stats,
+            duration_seconds=stats,
+            composite_score=stats,
+            grade="B",
+        )
+        assert tier_stats.tier_id == "T1"
+        assert tier_stats.grade == "B"
+
+
+class TestCrossTierAnalysis:
+    """Tests for CrossTierAnalysis dataclass."""
+
+    def test_create_analysis(self) -> None:
+        analysis = CrossTierAnalysis(
+            pass_rate_variance=0.05,
+            impl_rate_variance=0.03,
+            cost_variance=0.10,
+            tier_uplifts={"T1": 0.15, "T2": 0.25},
+        )
+        assert analysis.pass_rate_variance == 0.05
+        assert analysis.tier_uplifts["T1"] == 0.15
+
+
+class TestRunAggregatorAggregateTier:
+    """Tests for aggregate_tier method."""
+
+    def test_empty_runs(self) -> None:
+        aggregator = RunAggregator()
+        stats = aggregator.aggregate_tier("T0", [])
+        assert stats.tier_id == "T0"
+        assert stats.runs_completed == 0
+        assert stats.grade == "F"
+
+    def test_single_run(self) -> None:
+        aggregator = RunAggregator()
+        runs = [make_run("run-1", pass_rate=1.0, impl_rate=0.9)]
+        stats = aggregator.aggregate_tier("T0", runs)
+        assert stats.runs_completed == 1
+        assert stats.pass_rate.median == 1.0
+        assert stats.impl_rate.median == 0.9
+
+    def test_ten_runs(self) -> None:
+        """Test with 10 runs (typical evaluation scenario)."""
+        aggregator = RunAggregator()
+        runs = [
+            make_run(f"run-{i}", pass_rate=1.0, impl_rate=0.8 + i * 0.01)
+            for i in range(10)
+        ]
+        stats = aggregator.aggregate_tier("T1", runs)
+        assert stats.runs_completed == 10
+        assert stats.pass_rate.median == 1.0
+
+    def test_mixed_results(self) -> None:
+        """Test with mixed pass/fail results."""
+        aggregator = RunAggregator()
+        runs = [
+            make_run("run-1", pass_rate=1.0, impl_rate=0.9),
+            make_run("run-2", pass_rate=0.0, impl_rate=0.5),
+            make_run("run-3", pass_rate=1.0, impl_rate=0.8),
+            make_run("run-4", pass_rate=1.0, impl_rate=0.85),
+            make_run("run-5", pass_rate=0.0, impl_rate=0.6),
+        ]
+        stats = aggregator.aggregate_tier("T0", runs)
+        assert stats.runs_completed == 5
+        # 3 passes, 2 fails
+        assert stats.pass_rate.mean == pytest.approx(0.6)
+
+    def test_grade_assignment(self) -> None:
+        """Test grade is assigned from median composite score."""
+        aggregator = RunAggregator()
+        # All high scores -> A grade
+        runs = [make_run(f"run-{i}", pass_rate=1.0, impl_rate=0.95) for i in range(5)]
+        stats = aggregator.aggregate_tier("T0", runs)
+        assert stats.grade == "A"
+
+        # All low scores -> F grade
+        runs = [make_run(f"run-{i}", pass_rate=0.0, impl_rate=0.3) for i in range(5)]
+        stats = aggregator.aggregate_tier("T0", runs)
+        assert stats.grade == "F"
+
+
+class TestRunAggregatorAnalyzeCrossTier:
+    """Tests for analyze_cross_tier method."""
+
+    def test_empty_tiers(self) -> None:
+        aggregator = RunAggregator()
+        analysis = aggregator.analyze_cross_tier({})
+        assert analysis.pass_rate_variance == 0.0
+        assert analysis.tier_uplifts == {}
+
+    def test_single_tier(self) -> None:
+        aggregator = RunAggregator()
+        runs = [make_run(f"run-{i}") for i in range(5)]
+        stats = aggregator.aggregate_tier("T0", runs)
+        analysis = aggregator.analyze_cross_tier({"T0": stats})
+        assert analysis.pass_rate_variance == 0.0
+        assert analysis.tier_uplifts == {}  # No uplift for T0 baseline
+
+    def test_multiple_tiers(self) -> None:
+        aggregator = RunAggregator()
+        
+        # T0: baseline
+        t0_runs = [make_run(f"t0-{i}", pass_rate=1.0, impl_rate=0.6) for i in range(5)]
+        t0_stats = aggregator.aggregate_tier("T0", t0_runs)
+        
+        # T1: improvement
+        t1_runs = [make_run(f"t1-{i}", pass_rate=1.0, impl_rate=0.8) for i in range(5)]
+        t1_stats = aggregator.aggregate_tier("T1", t1_runs)
+        
+        analysis = aggregator.analyze_cross_tier({"T0": t0_stats, "T1": t1_stats})
+        
+        # Should have variance and uplift
+        assert analysis.impl_rate_variance > 0
+        assert "T1" in analysis.tier_uplifts
+        assert analysis.tier_uplifts["T1"] > 0  # T1 should be better than T0
+
+    def test_tier_uplift_calculation(self) -> None:
+        """Test tier uplift is calculated correctly."""
+        aggregator = RunAggregator()
+        
+        # T0: composite = (1.0 + 0.5) / 2 = 0.75
+        t0_runs = [make_run(f"t0-{i}", pass_rate=1.0, impl_rate=0.5) for i in range(5)]
+        t0_stats = aggregator.aggregate_tier("T0", t0_runs)
+        
+        # T1: composite = (1.0 + 0.8) / 2 = 0.9
+        t1_runs = [make_run(f"t1-{i}", pass_rate=1.0, impl_rate=0.8) for i in range(5)]
+        t1_stats = aggregator.aggregate_tier("T1", t1_runs)
+        
+        analysis = aggregator.analyze_cross_tier({"T0": t0_stats, "T1": t1_stats})
+        
+        # Uplift = (0.9 - 0.75) / 0.75 = 0.2 (20%)
+        assert analysis.tier_uplifts["T1"] == pytest.approx(0.2)
+
+
+class TestRunAggregatorAggregateAllTiers:
+    """Tests for aggregate_all_tiers method."""
+
+    def test_aggregate_all(self) -> None:
+        aggregator = RunAggregator()
+        
+        runs_by_tier = {
+            "T0": [make_run(f"t0-{i}", impl_rate=0.6) for i in range(5)],
+            "T1": [make_run(f"t1-{i}", impl_rate=0.7) for i in range(5)],
+            "T2": [make_run(f"t2-{i}", impl_rate=0.8) for i in range(5)],
+        }
+        
+        tier_stats, cross_tier = aggregator.aggregate_all_tiers(runs_by_tier)
+        
+        assert len(tier_stats) == 3
+        assert "T0" in tier_stats
+        assert "T1" in tier_stats
+        assert "T2" in tier_stats
+        
+        assert "T1" in cross_tier.tier_uplifts
+        assert "T2" in cross_tier.tier_uplifts
+
+    def test_aggregate_empty(self) -> None:
+        aggregator = RunAggregator()
+        tier_stats, cross_tier = aggregator.aggregate_all_tiers({})
+        assert tier_stats == {}
+        assert cross_tier.tier_uplifts == {}


### PR DESCRIPTION
## Summary
- Implement RunAggregator to combine 10 runs into TierStatistics
- Add cross-tier analysis with variance and tier uplift calculations
- Calculate composite scores and assign grades from median
- Support full tier comparison (T0-T6)

## Test plan
- [x] 15 unit tests for aggregation and cross-tier analysis
- [x] Tests for empty, single, and 10-run scenarios
- [x] Tests for tier uplift calculation

Closes #23

🤖 Generated with [Claude Code](https://claude.com/claude-code)