### PR TITLE
feat(reporting): add result.json writer

### DIFF
--- a/src/scylla/reporting/__init__.py
+++ b/src/scylla/reporting/__init__.py
@@ -1,1 +1,24 @@
-"""Reporting module for generating evaluation reports."""
+"""Reporting module for generating evaluation reports.
+
+This module provides result writing and report generation capabilities.
+"""
+
+from scylla.reporting.result import (
+    ExecutionInfo,
+    GradingInfo,
+    JudgmentInfo,
+    MetricsInfo,
+    ResultWriter,
+    RunResult,
+    create_run_result,
+)
+
+__all__ = [
+    "ExecutionInfo",
+    "GradingInfo",
+    "JudgmentInfo",
+    "MetricsInfo",
+    "ResultWriter",
+    "RunResult",
+    "create_run_result",
+]

--- a/src/scylla/reporting/result.py
+++ b/src/scylla/reporting/result.py
@@ -1,0 +1,246 @@
+"""Result writer for per-run evaluation results.
+
+Python justification: JSON serialization and file I/O for result persistence.
+"""
+
+import json
+from dataclasses import asdict, dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+
+
+@dataclass
+class ExecutionInfo:
+    """Execution metadata for a run."""
+
+    status: str
+    duration_seconds: float
+    exit_code: int
+
+
+@dataclass
+class MetricsInfo:
+    """Token and cost metrics for a run."""
+
+    tokens_input: int
+    tokens_output: int
+    cost_usd: float
+    api_calls: int
+
+
+@dataclass
+class JudgmentInfo:
+    """Judge evaluation results for a run."""
+
+    passed: bool
+    impl_rate: float
+    letter_grade: str
+
+
+@dataclass
+class GradingInfo:
+    """Calculated grading metrics for a run."""
+
+    pass_rate: float
+    cost_of_pass: float
+    composite_score: float
+
+
+@dataclass
+class RunResult:
+    """Complete result for a single evaluation run.
+
+    Contains all execution, metrics, judgment, and grading data.
+    """
+
+    test_id: str
+    tier_id: str
+    model_id: str
+    run_number: int
+    timestamp: str
+    execution: ExecutionInfo
+    metrics: MetricsInfo
+    judgment: JudgmentInfo
+    grading: GradingInfo
+
+    def to_dict(self) -> dict:
+        """Convert to dictionary for JSON serialization."""
+        return {
+            "test_id": self.test_id,
+            "tier_id": self.tier_id,
+            "model_id": self.model_id,
+            "run_number": self.run_number,
+            "timestamp": self.timestamp,
+            "execution": asdict(self.execution),
+            "metrics": asdict(self.metrics),
+            "judgment": asdict(self.judgment),
+            "grading": asdict(self.grading),
+        }
+
+    def to_json(self, indent: int = 2) -> str:
+        """Convert to JSON string."""
+        return json.dumps(self.to_dict(), indent=indent)
+
+    def write(self, output_dir: Path) -> Path:
+        """Write result.json to output directory.
+
+        Args:
+            output_dir: Directory to write result.json
+
+        Returns:
+            Path to written file
+        """
+        output_dir.mkdir(parents=True, exist_ok=True)
+        output_path = output_dir / "result.json"
+        output_path.write_text(self.to_json())
+        return output_path
+
+
+class ResultWriter:
+    """Writes run results to the file system."""
+
+    def __init__(self, base_dir: Path) -> None:
+        """Initialize result writer.
+
+        Args:
+            base_dir: Base directory for results (e.g., 'runs/')
+        """
+        self.base_dir = base_dir
+
+    def get_run_dir(
+        self, test_id: str, tier_id: str, run_number: int
+    ) -> Path:
+        """Get the directory path for a specific run.
+
+        Args:
+            test_id: Test identifier
+            tier_id: Tier identifier (T0, T1, etc.)
+            run_number: Run number (1-10)
+
+        Returns:
+            Path to run directory
+        """
+        return self.base_dir / test_id / tier_id / f"run_{run_number:02d}"
+
+    def write_result(self, result: RunResult) -> Path:
+        """Write a run result to the appropriate directory.
+
+        Args:
+            result: Run result to write
+
+        Returns:
+            Path to written result.json
+        """
+        run_dir = self.get_run_dir(
+            result.test_id, result.tier_id, result.run_number
+        )
+        return result.write(run_dir)
+
+    def read_result(
+        self, test_id: str, tier_id: str, run_number: int
+    ) -> RunResult | None:
+        """Read a run result from the file system.
+
+        Args:
+            test_id: Test identifier
+            tier_id: Tier identifier
+            run_number: Run number
+
+        Returns:
+            RunResult if found, None otherwise
+        """
+        run_dir = self.get_run_dir(test_id, tier_id, run_number)
+        result_path = run_dir / "result.json"
+
+        if not result_path.exists():
+            return None
+
+        data = json.loads(result_path.read_text())
+        return RunResult(
+            test_id=data["test_id"],
+            tier_id=data["tier_id"],
+            model_id=data["model_id"],
+            run_number=data["run_number"],
+            timestamp=data["timestamp"],
+            execution=ExecutionInfo(**data["execution"]),
+            metrics=MetricsInfo(**data["metrics"]),
+            judgment=JudgmentInfo(**data["judgment"]),
+            grading=GradingInfo(**data["grading"]),
+        )
+
+
+def create_run_result(
+    test_id: str,
+    tier_id: str,
+    model_id: str,
+    run_number: int,
+    status: str,
+    duration_seconds: float,
+    exit_code: int,
+    tokens_input: int,
+    tokens_output: int,
+    cost_usd: float,
+    api_calls: int,
+    passed: bool,
+    impl_rate: float,
+    letter_grade: str,
+    pass_rate: float,
+    cost_of_pass: float,
+    composite_score: float,
+    timestamp: str | None = None,
+) -> RunResult:
+    """Factory function to create a RunResult with all components.
+
+    Args:
+        test_id: Test identifier
+        tier_id: Tier identifier (T0, T1, etc.)
+        model_id: Model identifier
+        run_number: Run number (1-10)
+        status: Execution status (completed, failed, timeout)
+        duration_seconds: Run duration
+        exit_code: Process exit code
+        tokens_input: Input tokens used
+        tokens_output: Output tokens generated
+        cost_usd: Total cost in USD
+        api_calls: Number of API calls
+        passed: Whether the run passed
+        impl_rate: Implementation rate (0.0-1.0)
+        letter_grade: Letter grade (A, B, C, D, F)
+        pass_rate: Pass rate (0.0 or 1.0)
+        cost_of_pass: Cost per successful pass
+        composite_score: Combined quality score
+
+    Returns:
+        Fully constructed RunResult
+    """
+    if timestamp is None:
+        timestamp = datetime.now(UTC).isoformat().replace("+00:00", "Z")
+
+    return RunResult(
+        test_id=test_id,
+        tier_id=tier_id,
+        model_id=model_id,
+        run_number=run_number,
+        timestamp=timestamp,
+        execution=ExecutionInfo(
+            status=status,
+            duration_seconds=duration_seconds,
+            exit_code=exit_code,
+        ),
+        metrics=MetricsInfo(
+            tokens_input=tokens_input,
+            tokens_output=tokens_output,
+            cost_usd=cost_usd,
+            api_calls=api_calls,
+        ),
+        judgment=JudgmentInfo(
+            passed=passed,
+            impl_rate=impl_rate,
+            letter_grade=letter_grade,
+        ),
+        grading=GradingInfo(
+            pass_rate=pass_rate,
+            cost_of_pass=cost_of_pass,
+            composite_score=composite_score,
+        ),
+    )

--- a/tests/unit/reporting/__init__.py
+++ b/tests/unit/reporting/__init__.py
@@ -1,0 +1,1 @@
+"""Reporting module tests."""

--- a/tests/unit/reporting/test_result.py
+++ b/tests/unit/reporting/test_result.py
@@ -1,0 +1,464 @@
+"""Tests for result.json writer.
+
+Python justification: Required for pytest testing framework.
+"""
+
+import json
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from scylla.reporting.result import (
+    ExecutionInfo,
+    GradingInfo,
+    JudgmentInfo,
+    MetricsInfo,
+    ResultWriter,
+    RunResult,
+    create_run_result,
+)
+
+
+def make_execution() -> ExecutionInfo:
+    """Create test ExecutionInfo."""
+    return ExecutionInfo(
+        status="completed",
+        duration_seconds=45.0,
+        exit_code=0,
+    )
+
+
+def make_metrics() -> MetricsInfo:
+    """Create test MetricsInfo."""
+    return MetricsInfo(
+        tokens_input=10000,
+        tokens_output=5000,
+        cost_usd=0.50,
+        api_calls=5,
+    )
+
+
+def make_judgment() -> JudgmentInfo:
+    """Create test JudgmentInfo."""
+    return JudgmentInfo(
+        passed=True,
+        impl_rate=0.85,
+        letter_grade="B",
+    )
+
+
+def make_grading() -> GradingInfo:
+    """Create test GradingInfo."""
+    return GradingInfo(
+        pass_rate=1.0,
+        cost_of_pass=0.50,
+        composite_score=0.925,
+    )
+
+
+def make_run_result() -> RunResult:
+    """Create test RunResult."""
+    return RunResult(
+        test_id="001-test",
+        tier_id="T1",
+        model_id="claude-opus-4-5-20251101",
+        run_number=1,
+        timestamp="2024-01-15T14:30:00Z",
+        execution=make_execution(),
+        metrics=make_metrics(),
+        judgment=make_judgment(),
+        grading=make_grading(),
+    )
+
+
+class TestExecutionInfo:
+    """Tests for ExecutionInfo dataclass."""
+
+    def test_create(self) -> None:
+        info = ExecutionInfo(
+            status="completed",
+            duration_seconds=45.0,
+            exit_code=0,
+        )
+        assert info.status == "completed"
+        assert info.duration_seconds == 45.0
+        assert info.exit_code == 0
+
+    def test_failed_status(self) -> None:
+        info = ExecutionInfo(
+            status="failed",
+            duration_seconds=10.0,
+            exit_code=1,
+        )
+        assert info.status == "failed"
+        assert info.exit_code == 1
+
+    def test_timeout_status(self) -> None:
+        info = ExecutionInfo(
+            status="timeout",
+            duration_seconds=300.0,
+            exit_code=-1,
+        )
+        assert info.status == "timeout"
+
+
+class TestMetricsInfo:
+    """Tests for MetricsInfo dataclass."""
+
+    def test_create(self) -> None:
+        info = MetricsInfo(
+            tokens_input=10000,
+            tokens_output=5000,
+            cost_usd=0.50,
+            api_calls=5,
+        )
+        assert info.tokens_input == 10000
+        assert info.tokens_output == 5000
+        assert info.cost_usd == 0.50
+        assert info.api_calls == 5
+
+    def test_zero_values(self) -> None:
+        info = MetricsInfo(
+            tokens_input=0,
+            tokens_output=0,
+            cost_usd=0.0,
+            api_calls=0,
+        )
+        assert info.tokens_input == 0
+        assert info.cost_usd == 0.0
+
+
+class TestJudgmentInfo:
+    """Tests for JudgmentInfo dataclass."""
+
+    def test_passed(self) -> None:
+        info = JudgmentInfo(
+            passed=True,
+            impl_rate=0.95,
+            letter_grade="A",
+        )
+        assert info.passed is True
+        assert info.impl_rate == 0.95
+        assert info.letter_grade == "A"
+
+    def test_failed(self) -> None:
+        info = JudgmentInfo(
+            passed=False,
+            impl_rate=0.3,
+            letter_grade="F",
+        )
+        assert info.passed is False
+        assert info.letter_grade == "F"
+
+
+class TestGradingInfo:
+    """Tests for GradingInfo dataclass."""
+
+    def test_create(self) -> None:
+        info = GradingInfo(
+            pass_rate=1.0,
+            cost_of_pass=0.50,
+            composite_score=0.925,
+        )
+        assert info.pass_rate == 1.0
+        assert info.cost_of_pass == 0.50
+        assert info.composite_score == 0.925
+
+    def test_failed_run(self) -> None:
+        info = GradingInfo(
+            pass_rate=0.0,
+            cost_of_pass=float("inf"),
+            composite_score=0.15,
+        )
+        assert info.pass_rate == 0.0
+        assert info.cost_of_pass == float("inf")
+
+
+class TestRunResult:
+    """Tests for RunResult dataclass."""
+
+    def test_create(self) -> None:
+        result = make_run_result()
+        assert result.test_id == "001-test"
+        assert result.tier_id == "T1"
+        assert result.model_id == "claude-opus-4-5-20251101"
+        assert result.run_number == 1
+        assert result.timestamp == "2024-01-15T14:30:00Z"
+
+    def test_to_dict(self) -> None:
+        result = make_run_result()
+        data = result.to_dict()
+
+        assert data["test_id"] == "001-test"
+        assert data["tier_id"] == "T1"
+        assert data["model_id"] == "claude-opus-4-5-20251101"
+        assert data["run_number"] == 1
+        assert "execution" in data
+        assert "metrics" in data
+        assert "judgment" in data
+        assert "grading" in data
+
+    def test_to_dict_execution(self) -> None:
+        result = make_run_result()
+        data = result.to_dict()
+
+        assert data["execution"]["status"] == "completed"
+        assert data["execution"]["duration_seconds"] == 45.0
+        assert data["execution"]["exit_code"] == 0
+
+    def test_to_dict_metrics(self) -> None:
+        result = make_run_result()
+        data = result.to_dict()
+
+        assert data["metrics"]["tokens_input"] == 10000
+        assert data["metrics"]["tokens_output"] == 5000
+        assert data["metrics"]["cost_usd"] == 0.50
+        assert data["metrics"]["api_calls"] == 5
+
+    def test_to_dict_judgment(self) -> None:
+        result = make_run_result()
+        data = result.to_dict()
+
+        assert data["judgment"]["passed"] is True
+        assert data["judgment"]["impl_rate"] == 0.85
+        assert data["judgment"]["letter_grade"] == "B"
+
+    def test_to_dict_grading(self) -> None:
+        result = make_run_result()
+        data = result.to_dict()
+
+        assert data["grading"]["pass_rate"] == 1.0
+        assert data["grading"]["cost_of_pass"] == 0.50
+        assert data["grading"]["composite_score"] == 0.925
+
+    def test_to_json(self) -> None:
+        result = make_run_result()
+        json_str = result.to_json()
+
+        # Should be valid JSON
+        data = json.loads(json_str)
+        assert data["test_id"] == "001-test"
+
+    def test_to_json_formatting(self) -> None:
+        result = make_run_result()
+
+        # Default indent
+        json_str = result.to_json()
+        assert "\n" in json_str  # Has newlines due to indent
+
+        # Custom indent
+        compact = result.to_json(indent=None)
+        # With indent=None, json.dumps still produces valid JSON
+
+    def test_write(self) -> None:
+        result = make_run_result()
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            output_dir = Path(tmpdir) / "output"
+            output_path = result.write(output_dir)
+
+            assert output_path.exists()
+            assert output_path.name == "result.json"
+
+            # Verify content
+            data = json.loads(output_path.read_text())
+            assert data["test_id"] == "001-test"
+
+    def test_write_creates_directories(self) -> None:
+        result = make_run_result()
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            # Nested directory that doesn't exist
+            output_dir = Path(tmpdir) / "a" / "b" / "c"
+            output_path = result.write(output_dir)
+
+            assert output_path.exists()
+            assert output_dir.exists()
+
+
+class TestResultWriter:
+    """Tests for ResultWriter class."""
+
+    def test_init(self) -> None:
+        writer = ResultWriter(Path("/tmp/runs"))
+        assert writer.base_dir == Path("/tmp/runs")
+
+    def test_get_run_dir(self) -> None:
+        writer = ResultWriter(Path("/tmp/runs"))
+        run_dir = writer.get_run_dir("001-test", "T1", 1)
+
+        assert run_dir == Path("/tmp/runs/001-test/T1/run_01")
+
+    def test_get_run_dir_formatting(self) -> None:
+        writer = ResultWriter(Path("/tmp/runs"))
+
+        # Single digit run number should be zero-padded
+        run_dir = writer.get_run_dir("test", "T0", 5)
+        assert run_dir.name == "run_05"
+
+        # Double digit run number
+        run_dir = writer.get_run_dir("test", "T0", 10)
+        assert run_dir.name == "run_10"
+
+    def test_write_result(self) -> None:
+        result = make_run_result()
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            writer = ResultWriter(Path(tmpdir))
+            output_path = writer.write_result(result)
+
+            assert output_path.exists()
+            expected_path = Path(tmpdir) / "001-test" / "T1" / "run_01" / "result.json"
+            assert output_path == expected_path
+
+    def test_read_result(self) -> None:
+        result = make_run_result()
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            writer = ResultWriter(Path(tmpdir))
+            writer.write_result(result)
+
+            # Read it back
+            read_result = writer.read_result("001-test", "T1", 1)
+
+            assert read_result is not None
+            assert read_result.test_id == "001-test"
+            assert read_result.tier_id == "T1"
+            assert read_result.model_id == "claude-opus-4-5-20251101"
+            assert read_result.execution.status == "completed"
+
+    def test_read_result_not_found(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            writer = ResultWriter(Path(tmpdir))
+
+            result = writer.read_result("nonexistent", "T0", 1)
+            assert result is None
+
+    def test_write_multiple_runs(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            writer = ResultWriter(Path(tmpdir))
+
+            for run_num in range(1, 11):
+                result = RunResult(
+                    test_id="001-test",
+                    tier_id="T1",
+                    model_id="test-model",
+                    run_number=run_num,
+                    timestamp="2024-01-15T14:30:00Z",
+                    execution=make_execution(),
+                    metrics=make_metrics(),
+                    judgment=make_judgment(),
+                    grading=make_grading(),
+                )
+                writer.write_result(result)
+
+            # Verify all 10 runs written
+            tier_dir = Path(tmpdir) / "001-test" / "T1"
+            run_dirs = list(tier_dir.iterdir())
+            assert len(run_dirs) == 10
+
+    def test_write_multiple_tiers(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            writer = ResultWriter(Path(tmpdir))
+
+            for tier in ["T0", "T1", "T2", "T3"]:
+                result = RunResult(
+                    test_id="001-test",
+                    tier_id=tier,
+                    model_id="test-model",
+                    run_number=1,
+                    timestamp="2024-01-15T14:30:00Z",
+                    execution=make_execution(),
+                    metrics=make_metrics(),
+                    judgment=make_judgment(),
+                    grading=make_grading(),
+                )
+                writer.write_result(result)
+
+            # Verify all tiers written
+            test_dir = Path(tmpdir) / "001-test"
+            tier_dirs = list(test_dir.iterdir())
+            assert len(tier_dirs) == 4
+
+
+class TestCreateRunResult:
+    """Tests for create_run_result factory function."""
+
+    def test_create_with_all_params(self) -> None:
+        result = create_run_result(
+            test_id="001-test",
+            tier_id="T1",
+            model_id="test-model",
+            run_number=1,
+            status="completed",
+            duration_seconds=45.0,
+            exit_code=0,
+            tokens_input=10000,
+            tokens_output=5000,
+            cost_usd=0.50,
+            api_calls=5,
+            passed=True,
+            impl_rate=0.85,
+            letter_grade="B",
+            pass_rate=1.0,
+            cost_of_pass=0.50,
+            composite_score=0.925,
+            timestamp="2024-01-15T14:30:00Z",
+        )
+
+        assert result.test_id == "001-test"
+        assert result.execution.status == "completed"
+        assert result.metrics.tokens_input == 10000
+        assert result.judgment.passed is True
+        assert result.grading.pass_rate == 1.0
+
+    def test_create_auto_timestamp(self) -> None:
+        result = create_run_result(
+            test_id="001-test",
+            tier_id="T0",
+            model_id="test-model",
+            run_number=1,
+            status="completed",
+            duration_seconds=45.0,
+            exit_code=0,
+            tokens_input=10000,
+            tokens_output=5000,
+            cost_usd=0.50,
+            api_calls=5,
+            passed=True,
+            impl_rate=0.85,
+            letter_grade="B",
+            pass_rate=1.0,
+            cost_of_pass=0.50,
+            composite_score=0.925,
+        )
+
+        # Timestamp should be auto-generated
+        assert result.timestamp is not None
+        assert result.timestamp.endswith("Z")
+
+    def test_create_failed_run(self) -> None:
+        result = create_run_result(
+            test_id="001-test",
+            tier_id="T0",
+            model_id="test-model",
+            run_number=1,
+            status="failed",
+            duration_seconds=10.0,
+            exit_code=1,
+            tokens_input=5000,
+            tokens_output=1000,
+            cost_usd=0.10,
+            api_calls=2,
+            passed=False,
+            impl_rate=0.2,
+            letter_grade="F",
+            pass_rate=0.0,
+            cost_of_pass=float("inf"),
+            composite_score=0.1,
+        )
+
+        assert result.execution.status == "failed"
+        assert result.judgment.passed is False
+        assert result.grading.pass_rate == 0.0


### PR DESCRIPTION
## Summary
- Add result writer for per-run evaluation results
- ExecutionInfo, MetricsInfo, JudgmentInfo, GradingInfo dataclasses
- RunResult dataclass with to_dict(), to_json(), write() methods
- ResultWriter class for managing result file paths
- create_run_result() factory function

## Test plan
- [x] 30 unit tests pass
- [x] All dataclasses properly serialize to JSON
- [x] Write/read round-trip works correctly

Closes #25

🤖 Generated with [Claude Code](https://claude.com/claude-code)