### PR TITLE
feat(reporting): add Markdown report generator

### DIFF
--- a/src/scylla/reporting/__init__.py
+++ b/src/scylla/reporting/__init__.py
@@ -3,6 +3,15 @@
 This module provides result writing and report generation capabilities.
 """
 
+from scylla.reporting.markdown import (
+    MarkdownReportGenerator,
+    ReportData,
+    SensitivityAnalysis,
+    TierMetrics,
+    TransitionAssessment,
+    create_report_data,
+    create_tier_metrics,
+)
 from scylla.reporting.result import (
     ExecutionInfo,
     GradingInfo,
@@ -30,6 +39,14 @@ from scylla.reporting.summary import (
 )
 
 __all__ = [
+    # Markdown
+    "MarkdownReportGenerator",
+    "ReportData",
+    "SensitivityAnalysis",
+    "TierMetrics",
+    "TransitionAssessment",
+    "create_report_data",
+    "create_tier_metrics",
     # Result
     "ExecutionInfo",
     "GradingInfo",

--- a/src/scylla/reporting/markdown.py
+++ b/src/scylla/reporting/markdown.py
@@ -1,0 +1,366 @@
+"""Markdown report generator for evaluation results.
+
+Python justification: String templating and file I/O for report generation.
+"""
+
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from pathlib import Path
+
+
+@dataclass
+class TierMetrics:
+    """Metrics for a single tier."""
+
+    tier_id: str
+    tier_name: str
+    pass_rate_median: float
+    impl_rate_median: float
+    composite_median: float
+    cost_of_pass_median: float
+    consistency_std_dev: float
+    uplift: float  # Percentage uplift vs T0
+
+
+@dataclass
+class SensitivityAnalysis:
+    """Prompt sensitivity analysis results."""
+
+    pass_rate_variance: float
+    impl_rate_variance: float
+    cost_variance: float
+
+    def get_sensitivity_level(self, variance: float) -> str:
+        """Determine sensitivity level from variance.
+
+        Args:
+            variance: Variance value
+
+        Returns:
+            Sensitivity level string
+        """
+        if variance < 0.05:
+            return "low"
+        elif variance < 0.15:
+            return "medium"
+        else:
+            return "high"
+
+
+@dataclass
+class TransitionAssessment:
+    """Assessment of transitioning between tiers."""
+
+    from_tier: str
+    to_tier: str
+    pass_rate_delta: float
+    impl_rate_delta: float
+    cost_delta: float
+    worth_it: bool
+
+
+@dataclass
+class ReportData:
+    """All data needed to generate a report."""
+
+    test_id: str
+    test_name: str
+    timestamp: str
+    runs_per_tier: int
+    judge_model: str
+    tiers: list[TierMetrics] = field(default_factory=list)
+    sensitivity: SensitivityAnalysis | None = None
+    transitions: list[TransitionAssessment] = field(default_factory=list)
+    key_finding: str = ""
+    recommendations: list[str] = field(default_factory=list)
+
+
+class MarkdownReportGenerator:
+    """Generates Markdown evaluation reports."""
+
+    def __init__(self, base_dir: Path) -> None:
+        """Initialize report generator.
+
+        Args:
+            base_dir: Base directory for reports (e.g., 'reports/')
+        """
+        self.base_dir = base_dir
+
+    def get_report_dir(self, test_id: str) -> Path:
+        """Get the directory path for a test report.
+
+        Args:
+            test_id: Test identifier
+
+        Returns:
+            Path to report directory
+        """
+        return self.base_dir / test_id
+
+    def _find_best_quality_tier(
+        self, tiers: list[TierMetrics]
+    ) -> TierMetrics | None:
+        """Find tier with highest composite score."""
+        if not tiers:
+            return None
+        return max(tiers, key=lambda t: t.composite_median)
+
+    def _find_best_cost_tier(
+        self, tiers: list[TierMetrics]
+    ) -> TierMetrics | None:
+        """Find tier with lowest cost-of-pass."""
+        if not tiers:
+            return None
+        valid_tiers = [t for t in tiers if t.cost_of_pass_median != float("inf")]
+        if not valid_tiers:
+            return None
+        return min(valid_tiers, key=lambda t: t.cost_of_pass_median)
+
+    def _find_most_consistent_tier(
+        self, tiers: list[TierMetrics]
+    ) -> TierMetrics | None:
+        """Find tier with lowest variance (most consistent)."""
+        if not tiers:
+            return None
+        return min(tiers, key=lambda t: t.consistency_std_dev)
+
+    def _format_percentage(self, value: float) -> str:
+        """Format a value as a percentage string."""
+        return f"{value * 100:.1f}%"
+
+    def _format_cost(self, value: float) -> str:
+        """Format a cost value."""
+        if value == float("inf"):
+            return "∞"
+        return f"${value:.2f}"
+
+    def _generate_header(self, data: ReportData) -> str:
+        """Generate report header."""
+        return f"""# Evaluation Report: {data.test_name}
+
+**Generated**: {data.timestamp}
+**Test ID**: {data.test_id}
+**Runs per Tier**: {data.runs_per_tier}
+**Judge Model**: {data.judge_model}
+
+---
+"""
+
+    def _generate_executive_summary(self, data: ReportData) -> str:
+        """Generate executive summary section."""
+        best_quality = self._find_best_quality_tier(data.tiers)
+        best_cost = self._find_best_cost_tier(data.tiers)
+        most_consistent = self._find_most_consistent_tier(data.tiers)
+
+        sections = ["## Executive Summary\n"]
+
+        if best_quality:
+            sections.append(f"""### Winner by Quality
+**{best_quality.tier_name}** achieved the highest median composite score of **{self._format_percentage(best_quality.composite_median)}**.
+""")
+
+        if best_cost:
+            sections.append(f"""### Winner by Cost Efficiency
+**{best_cost.tier_name}** achieved the lowest Cost-of-Pass at **{self._format_cost(best_cost.cost_of_pass_median)}** per successful run.
+""")
+
+        if most_consistent:
+            sections.append(f"""### Winner by Consistency
+**{most_consistent.tier_name}** showed the lowest variance with std_dev of **{most_consistent.consistency_std_dev:.3f}**.
+""")
+
+        if data.key_finding:
+            sections.append(f"""### Key Finding
+{data.key_finding}
+""")
+
+        sections.append("---\n")
+        return "\n".join(sections)
+
+    def _generate_tier_comparison(self, data: ReportData) -> str:
+        """Generate tier comparison table."""
+        if not data.tiers:
+            return ""
+
+        lines = [
+            "## Tier Comparison\n",
+            "### Overall Performance\n",
+            "| Tier | Pass Rate | Impl Rate | Composite | Cost/Pass | Consistency | Uplift |",
+            "|------|-----------|-----------|-----------|-----------|-------------|--------|",
+        ]
+
+        for tier in data.tiers:
+            uplift_str = "-" if tier.tier_id == "T0" else f"+{tier.uplift * 100:.1f}%"
+            lines.append(
+                f"| {tier.tier_name} | "
+                f"{self._format_percentage(tier.pass_rate_median)} | "
+                f"{self._format_percentage(tier.impl_rate_median)} | "
+                f"{self._format_percentage(tier.composite_median)} | "
+                f"{self._format_cost(tier.cost_of_pass_median)} | "
+                f"{tier.consistency_std_dev:.3f} | "
+                f"{uplift_str} |"
+            )
+
+        lines.append("\n---\n")
+        return "\n".join(lines)
+
+    def _generate_sensitivity_analysis(self, data: ReportData) -> str:
+        """Generate prompt sensitivity analysis section."""
+        if not data.sensitivity:
+            return ""
+
+        s = data.sensitivity
+        lines = [
+            "## Prompt Sensitivity Analysis\n",
+            "### Variance Metrics\n",
+            "| Metric | Cross-Tier Variance | Interpretation |",
+            "|--------|---------------------|----------------|",
+            f"| Pass Rate | {s.pass_rate_variance:.4f} | {s.get_sensitivity_level(s.pass_rate_variance)} sensitivity |",
+            f"| Impl Rate | {s.impl_rate_variance:.4f} | {s.get_sensitivity_level(s.impl_rate_variance)} sensitivity |",
+            f"| Cost | {s.cost_variance:.4f} | {s.get_sensitivity_level(s.cost_variance)} sensitivity |",
+        ]
+
+        if data.transitions:
+            lines.extend([
+                "\n### Tier Uplift Analysis\n",
+                "| Transition | Pass Rate Δ | Impl Rate Δ | Cost Δ | Assessment |",
+                "|------------|-------------|-------------|--------|------------|",
+            ])
+
+            for t in data.transitions:
+                assessment = "worth it" if t.worth_it else "not worth it"
+                lines.append(
+                    f"| {t.from_tier} → {t.to_tier} | "
+                    f"{t.pass_rate_delta:+.1%} | "
+                    f"{t.impl_rate_delta:+.1%} | "
+                    f"{self._format_cost(t.cost_delta)} | "
+                    f"{assessment} |"
+                )
+
+        lines.append("\n---\n")
+        return "\n".join(lines)
+
+    def _generate_recommendations(self, data: ReportData) -> str:
+        """Generate recommendations section."""
+        if not data.recommendations:
+            return ""
+
+        lines = ["## Recommendations\n"]
+
+        for i, rec in enumerate(data.recommendations, 1):
+            lines.append(f"{i}. {rec}")
+
+        lines.append("\n---\n")
+        return "\n".join(lines)
+
+    def _generate_footer(self) -> str:
+        """Generate report footer."""
+        return """
+*Generated by ProjectScylla Agent Testing Framework*
+"""
+
+    def generate_report(self, data: ReportData) -> str:
+        """Generate a complete Markdown report.
+
+        Args:
+            data: Report data
+
+        Returns:
+            Complete Markdown report string
+        """
+        sections = [
+            self._generate_header(data),
+            self._generate_executive_summary(data),
+            self._generate_tier_comparison(data),
+            self._generate_sensitivity_analysis(data),
+            self._generate_recommendations(data),
+            self._generate_footer(),
+        ]
+
+        return "".join(sections)
+
+    def write_report(self, data: ReportData) -> Path:
+        """Generate and write a report to file.
+
+        Args:
+            data: Report data
+
+        Returns:
+            Path to written report.md
+        """
+        report_dir = self.get_report_dir(data.test_id)
+        report_dir.mkdir(parents=True, exist_ok=True)
+
+        report_path = report_dir / "report.md"
+        report_content = self.generate_report(data)
+        report_path.write_text(report_content)
+
+        return report_path
+
+
+def create_tier_metrics(
+    tier_id: str,
+    tier_name: str,
+    pass_rate_median: float,
+    impl_rate_median: float,
+    composite_median: float,
+    cost_of_pass_median: float,
+    consistency_std_dev: float,
+    uplift: float = 0.0,
+) -> TierMetrics:
+    """Factory function to create TierMetrics.
+
+    Args:
+        tier_id: Tier identifier (T0, T1, etc.)
+        tier_name: Human-readable tier name
+        pass_rate_median: Median pass rate
+        impl_rate_median: Median implementation rate
+        composite_median: Median composite score
+        cost_of_pass_median: Median cost of pass
+        consistency_std_dev: Standard deviation for consistency
+        uplift: Percentage uplift vs T0
+
+    Returns:
+        TierMetrics object
+    """
+    return TierMetrics(
+        tier_id=tier_id,
+        tier_name=tier_name,
+        pass_rate_median=pass_rate_median,
+        impl_rate_median=impl_rate_median,
+        composite_median=composite_median,
+        cost_of_pass_median=cost_of_pass_median,
+        consistency_std_dev=consistency_std_dev,
+        uplift=uplift,
+    )
+
+
+def create_report_data(
+    test_id: str,
+    test_name: str,
+    runs_per_tier: int = 10,
+    judge_model: str = "Claude Opus 4.5",
+    timestamp: str | None = None,
+) -> ReportData:
+    """Factory function to create ReportData.
+
+    Args:
+        test_id: Test identifier
+        test_name: Human-readable test name
+        runs_per_tier: Number of runs per tier
+        judge_model: Judge model name
+        timestamp: Optional timestamp (auto-generated if not provided)
+
+    Returns:
+        ReportData object
+    """
+    if timestamp is None:
+        timestamp = datetime.now(UTC).isoformat().replace("+00:00", "Z")
+
+    return ReportData(
+        test_id=test_id,
+        test_name=test_name,
+        timestamp=timestamp,
+        runs_per_tier=runs_per_tier,
+        judge_model=judge_model,
+    )

--- a/tests/unit/reporting/test_markdown.py
+++ b/tests/unit/reporting/test_markdown.py
@@ -1,0 +1,398 @@
+"""Tests for Markdown report generator.
+
+Python justification: Required for pytest testing framework.
+"""
+
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from scylla.reporting.markdown import (
+    MarkdownReportGenerator,
+    ReportData,
+    SensitivityAnalysis,
+    TierMetrics,
+    TransitionAssessment,
+    create_report_data,
+    create_tier_metrics,
+)
+
+
+def make_tier_metrics(
+    tier_id: str = "T0",
+    tier_name: str = "T0 (Vanilla)",
+    pass_rate_median: float = 0.8,
+    impl_rate_median: float = 0.75,
+    composite_median: float = 0.775,
+    cost_of_pass_median: float = 1.0,
+    consistency_std_dev: float = 0.1,
+    uplift: float = 0.0,
+) -> TierMetrics:
+    """Create test TierMetrics."""
+    return TierMetrics(
+        tier_id=tier_id,
+        tier_name=tier_name,
+        pass_rate_median=pass_rate_median,
+        impl_rate_median=impl_rate_median,
+        composite_median=composite_median,
+        cost_of_pass_median=cost_of_pass_median,
+        consistency_std_dev=consistency_std_dev,
+        uplift=uplift,
+    )
+
+
+class TestTierMetrics:
+    """Tests for TierMetrics dataclass."""
+
+    def test_create(self) -> None:
+        metrics = TierMetrics(
+            tier_id="T1",
+            tier_name="T1 (Prompted)",
+            pass_rate_median=0.9,
+            impl_rate_median=0.85,
+            composite_median=0.875,
+            cost_of_pass_median=1.5,
+            consistency_std_dev=0.08,
+            uplift=0.13,
+        )
+        assert metrics.tier_id == "T1"
+        assert metrics.pass_rate_median == 0.9
+
+    def test_default_uplift(self) -> None:
+        metrics = make_tier_metrics()
+        assert metrics.uplift == 0.0
+
+
+class TestSensitivityAnalysis:
+    """Tests for SensitivityAnalysis dataclass."""
+
+    def test_create(self) -> None:
+        analysis = SensitivityAnalysis(
+            pass_rate_variance=0.05,
+            impl_rate_variance=0.03,
+            cost_variance=0.10,
+        )
+        assert analysis.pass_rate_variance == 0.05
+
+    def test_get_sensitivity_level_low(self) -> None:
+        analysis = SensitivityAnalysis(0.02, 0.02, 0.02)
+        assert analysis.get_sensitivity_level(0.02) == "low"
+
+    def test_get_sensitivity_level_medium(self) -> None:
+        analysis = SensitivityAnalysis(0.10, 0.10, 0.10)
+        assert analysis.get_sensitivity_level(0.10) == "medium"
+
+    def test_get_sensitivity_level_high(self) -> None:
+        analysis = SensitivityAnalysis(0.20, 0.20, 0.20)
+        assert analysis.get_sensitivity_level(0.20) == "high"
+
+
+class TestTransitionAssessment:
+    """Tests for TransitionAssessment dataclass."""
+
+    def test_create(self) -> None:
+        assessment = TransitionAssessment(
+            from_tier="T0",
+            to_tier="T1",
+            pass_rate_delta=0.1,
+            impl_rate_delta=0.15,
+            cost_delta=0.50,
+            worth_it=True,
+        )
+        assert assessment.from_tier == "T0"
+        assert assessment.worth_it is True
+
+
+class TestReportData:
+    """Tests for ReportData dataclass."""
+
+    def test_create_minimal(self) -> None:
+        data = ReportData(
+            test_id="001-test",
+            test_name="Test Name",
+            timestamp="2024-01-15T14:30:00Z",
+            runs_per_tier=10,
+            judge_model="Claude Opus 4.5",
+        )
+        assert data.test_id == "001-test"
+        assert data.tiers == []
+        assert data.recommendations == []
+
+    def test_create_with_tiers(self) -> None:
+        data = ReportData(
+            test_id="001-test",
+            test_name="Test Name",
+            timestamp="2024-01-15T14:30:00Z",
+            runs_per_tier=10,
+            judge_model="Claude Opus 4.5",
+            tiers=[make_tier_metrics()],
+        )
+        assert len(data.tiers) == 1
+
+    def test_create_with_sensitivity(self) -> None:
+        data = ReportData(
+            test_id="001-test",
+            test_name="Test Name",
+            timestamp="2024-01-15T14:30:00Z",
+            runs_per_tier=10,
+            judge_model="Claude Opus 4.5",
+            sensitivity=SensitivityAnalysis(0.05, 0.03, 0.10),
+        )
+        assert data.sensitivity is not None
+
+
+class TestMarkdownReportGeneratorHelpers:
+    """Tests for MarkdownReportGenerator helper methods."""
+
+    def test_find_best_quality_tier(self) -> None:
+        generator = MarkdownReportGenerator(Path("/tmp"))
+        tiers = [
+            make_tier_metrics(tier_id="T0", composite_median=0.7),
+            make_tier_metrics(tier_id="T1", composite_median=0.9),
+            make_tier_metrics(tier_id="T2", composite_median=0.8),
+        ]
+        best = generator._find_best_quality_tier(tiers)
+
+        assert best is not None
+        assert best.tier_id == "T1"
+
+    def test_find_best_quality_tier_empty(self) -> None:
+        generator = MarkdownReportGenerator(Path("/tmp"))
+        best = generator._find_best_quality_tier([])
+        assert best is None
+
+    def test_find_best_cost_tier(self) -> None:
+        generator = MarkdownReportGenerator(Path("/tmp"))
+        tiers = [
+            make_tier_metrics(tier_id="T0", cost_of_pass_median=2.0),
+            make_tier_metrics(tier_id="T1", cost_of_pass_median=1.0),
+            make_tier_metrics(tier_id="T2", cost_of_pass_median=3.0),
+        ]
+        best = generator._find_best_cost_tier(tiers)
+
+        assert best is not None
+        assert best.tier_id == "T1"
+
+    def test_find_best_cost_tier_ignores_infinity(self) -> None:
+        generator = MarkdownReportGenerator(Path("/tmp"))
+        tiers = [
+            make_tier_metrics(tier_id="T0", cost_of_pass_median=float("inf")),
+            make_tier_metrics(tier_id="T1", cost_of_pass_median=1.0),
+        ]
+        best = generator._find_best_cost_tier(tiers)
+
+        assert best is not None
+        assert best.tier_id == "T1"
+
+    def test_find_most_consistent_tier(self) -> None:
+        generator = MarkdownReportGenerator(Path("/tmp"))
+        tiers = [
+            make_tier_metrics(tier_id="T0", consistency_std_dev=0.15),
+            make_tier_metrics(tier_id="T1", consistency_std_dev=0.05),
+            make_tier_metrics(tier_id="T2", consistency_std_dev=0.10),
+        ]
+        best = generator._find_most_consistent_tier(tiers)
+
+        assert best is not None
+        assert best.tier_id == "T1"
+
+    def test_format_percentage(self) -> None:
+        generator = MarkdownReportGenerator(Path("/tmp"))
+        assert generator._format_percentage(0.85) == "85.0%"
+        assert generator._format_percentage(1.0) == "100.0%"
+        assert generator._format_percentage(0.0) == "0.0%"
+
+    def test_format_cost(self) -> None:
+        generator = MarkdownReportGenerator(Path("/tmp"))
+        assert generator._format_cost(1.50) == "$1.50"
+        assert generator._format_cost(0.0) == "$0.00"
+        assert generator._format_cost(float("inf")) == "∞"
+
+
+class TestMarkdownReportGeneratorSections:
+    """Tests for individual report sections."""
+
+    def test_generate_header(self) -> None:
+        generator = MarkdownReportGenerator(Path("/tmp"))
+        data = create_report_data(
+            test_id="001-test",
+            test_name="Test Name",
+            timestamp="2024-01-15T14:30:00Z",
+        )
+        header = generator._generate_header(data)
+
+        assert "# Evaluation Report: Test Name" in header
+        assert "**Test ID**: 001-test" in header
+        assert "2024-01-15T14:30:00Z" in header
+
+    def test_generate_executive_summary(self) -> None:
+        generator = MarkdownReportGenerator(Path("/tmp"))
+        data = create_report_data(
+            test_id="001-test",
+            test_name="Test Name",
+        )
+        data.tiers = [
+            make_tier_metrics(tier_id="T0", tier_name="T0 (Vanilla)"),
+            make_tier_metrics(
+                tier_id="T1",
+                tier_name="T1 (Prompted)",
+                composite_median=0.9,
+            ),
+        ]
+        data.key_finding = "T1 provides significant improvement."
+
+        summary = generator._generate_executive_summary(data)
+
+        assert "## Executive Summary" in summary
+        assert "Winner by Quality" in summary
+        assert "T1 (Prompted)" in summary
+        assert "T1 provides significant improvement." in summary
+
+    def test_generate_tier_comparison(self) -> None:
+        generator = MarkdownReportGenerator(Path("/tmp"))
+        data = create_report_data(
+            test_id="001-test",
+            test_name="Test Name",
+        )
+        data.tiers = [
+            make_tier_metrics(tier_id="T0", tier_name="T0 (Vanilla)"),
+            make_tier_metrics(
+                tier_id="T1",
+                tier_name="T1 (Prompted)",
+                uplift=0.15,
+            ),
+        ]
+
+        comparison = generator._generate_tier_comparison(data)
+
+        assert "## Tier Comparison" in comparison
+        assert "| Tier | Pass Rate |" in comparison
+        assert "T0 (Vanilla)" in comparison
+        assert "T1 (Prompted)" in comparison
+        assert "+15.0%" in comparison
+
+    def test_generate_tier_comparison_empty(self) -> None:
+        generator = MarkdownReportGenerator(Path("/tmp"))
+        data = create_report_data(test_id="001-test", test_name="Test Name")
+
+        comparison = generator._generate_tier_comparison(data)
+        assert comparison == ""
+
+    def test_generate_sensitivity_analysis(self) -> None:
+        generator = MarkdownReportGenerator(Path("/tmp"))
+        data = create_report_data(test_id="001-test", test_name="Test Name")
+        data.sensitivity = SensitivityAnalysis(0.05, 0.03, 0.10)
+        data.transitions = [
+            TransitionAssessment("T0", "T1", 0.1, 0.15, 0.5, True),
+        ]
+
+        analysis = generator._generate_sensitivity_analysis(data)
+
+        assert "## Prompt Sensitivity Analysis" in analysis
+        assert "Variance Metrics" in analysis
+        assert "low sensitivity" in analysis
+        assert "T0 → T1" in analysis
+        assert "worth it" in analysis
+
+    def test_generate_recommendations(self) -> None:
+        generator = MarkdownReportGenerator(Path("/tmp"))
+        data = create_report_data(test_id="001-test", test_name="Test Name")
+        data.recommendations = [
+            "Use T1 for this task type.",
+            "Consider cost constraints for high-volume use.",
+        ]
+
+        recommendations = generator._generate_recommendations(data)
+
+        assert "## Recommendations" in recommendations
+        assert "1. Use T1 for this task type." in recommendations
+        assert "2. Consider cost constraints" in recommendations
+
+
+class TestMarkdownReportGeneratorFullReport:
+    """Tests for full report generation."""
+
+    def test_generate_report(self) -> None:
+        generator = MarkdownReportGenerator(Path("/tmp"))
+        data = create_report_data(
+            test_id="001-test",
+            test_name="Convert Justfile to Makefile",
+            timestamp="2024-01-15T14:30:00Z",
+        )
+        data.tiers = [
+            make_tier_metrics(tier_id="T0", tier_name="T0 (Vanilla)"),
+            make_tier_metrics(
+                tier_id="T1",
+                tier_name="T1 (Prompted)",
+                composite_median=0.85,
+                uplift=0.10,
+            ),
+        ]
+        data.key_finding = "Prompting improves quality by 10%."
+        data.recommendations = ["Use T1 for production."]
+
+        report = generator.generate_report(data)
+
+        # Verify all major sections are present
+        assert "# Evaluation Report:" in report
+        assert "## Executive Summary" in report
+        assert "## Tier Comparison" in report
+        assert "## Recommendations" in report
+        assert "*Generated by ProjectScylla Agent Testing Framework*" in report
+
+    def test_write_report(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            generator = MarkdownReportGenerator(Path(tmpdir))
+            data = create_report_data(
+                test_id="001-test",
+                test_name="Test Name",
+            )
+            data.tiers = [make_tier_metrics()]
+
+            output_path = generator.write_report(data)
+
+            assert output_path.exists()
+            assert output_path.name == "report.md"
+            expected_path = Path(tmpdir) / "001-test" / "report.md"
+            assert output_path == expected_path
+
+            # Verify content
+            content = output_path.read_text()
+            assert "# Evaluation Report:" in content
+
+
+class TestFactoryFunctions:
+    """Tests for factory functions."""
+
+    def test_create_tier_metrics(self) -> None:
+        metrics = create_tier_metrics(
+            tier_id="T1",
+            tier_name="T1 (Prompted)",
+            pass_rate_median=0.9,
+            impl_rate_median=0.85,
+            composite_median=0.875,
+            cost_of_pass_median=1.5,
+            consistency_std_dev=0.08,
+            uplift=0.13,
+        )
+        assert metrics.tier_id == "T1"
+        assert metrics.uplift == 0.13
+
+    def test_create_report_data(self) -> None:
+        data = create_report_data(
+            test_id="001-test",
+            test_name="Test Name",
+            runs_per_tier=10,
+            timestamp="2024-01-15T14:30:00Z",
+        )
+        assert data.test_id == "001-test"
+        assert data.runs_per_tier == 10
+
+    def test_create_report_data_auto_timestamp(self) -> None:
+        data = create_report_data(
+            test_id="001-test",
+            test_name="Test Name",
+        )
+        assert data.timestamp is not None
+        assert data.timestamp.endswith("Z")


### PR DESCRIPTION
## Summary
- Add Markdown report generator for evaluation results
- TierMetrics, SensitivityAnalysis, TransitionAssessment dataclasses
- ReportData dataclass for complete report data
- MarkdownReportGenerator with section generators:
  - Executive summary (quality, cost, consistency winners)
  - Tier comparison tables
  - Prompt sensitivity analysis
  - Tier uplift analysis
  - Recommendations section

## Test plan
- [x] 28 unit tests pass
- [x] Report includes all major sections
- [x] Tables are properly formatted

Closes #28

🤖 Generated with [Claude Code](https://claude.com/claude-code)