### PR TITLE
feat(cli): add command-line interface

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,9 +25,13 @@ classifiers = [
 ]
 keywords = ["ai", "agents", "benchmarking", "evaluation", "testing"]
 dependencies = [
+    "click>=8.0",
     "pydantic>=2.0",
     "pyyaml>=6.0",
 ]
+
+[project.scripts]
+scylla = "scylla.cli:main"
 
 [project.optional-dependencies]
 dev = [

--- a/src/scylla/cli.py
+++ b/src/scylla/cli.py
@@ -1,0 +1,247 @@
+"""Command-line interface for ProjectScylla.
+
+Python justification: Click library for CLI parsing and subprocess orchestration.
+"""
+
+import sys
+from pathlib import Path
+
+import click
+
+
+@click.group()
+@click.version_option(version="0.1.0", prog_name="scylla")
+def cli() -> None:
+    """ProjectScylla - AI Agent Testing Framework.
+
+    Evaluate and benchmark AI agent architectures across multiple tiers.
+    """
+    pass
+
+
+@cli.command()
+@click.argument("test_id")
+@click.option(
+    "--tier",
+    "-t",
+    multiple=True,
+    help="Tier(s) to run (e.g., T0, T1). Can be specified multiple times.",
+)
+@click.option(
+    "--model",
+    "-m",
+    help="Run specific model only.",
+)
+@click.option(
+    "--runs",
+    "-r",
+    default=10,
+    type=int,
+    help="Number of runs per tier (default: 10).",
+)
+@click.option(
+    "--output-dir",
+    "-o",
+    type=click.Path(path_type=Path),
+    help="Override output directory.",
+)
+@click.option(
+    "--verbose",
+    "-v",
+    is_flag=True,
+    help="Verbose output.",
+)
+@click.option(
+    "--quiet",
+    "-q",
+    is_flag=True,
+    help="Minimal output (for CI).",
+)
+def run(
+    test_id: str,
+    tier: tuple[str, ...],
+    model: str | None,
+    runs: int,
+    output_dir: Path | None,
+    verbose: bool,
+    quiet: bool,
+) -> None:
+    """Run evaluation for a test case.
+
+    TEST_ID is the identifier of the test to run (e.g., 001-justfile-to-makefile).
+
+    Examples:
+
+        scylla run 001-justfile-to-makefile
+
+        scylla run 001-justfile-to-makefile --tier T0 --tier T1
+
+        scylla run 001-justfile-to-makefile --model claude-opus-4-5 --runs 1
+    """
+    if verbose and quiet:
+        raise click.UsageError("Cannot use --verbose and --quiet together.")
+
+    tiers = list(tier) if tier else ["T0", "T1", "T2", "T3"]
+
+    if not quiet:
+        click.echo(f"Running test: {test_id}")
+        click.echo(f"  Tiers: {', '.join(tiers)}")
+        click.echo(f"  Runs per tier: {runs}")
+        if model:
+            click.echo(f"  Model: {model}")
+        if output_dir:
+            click.echo(f"  Output: {output_dir}")
+
+    # TODO: Integrate with test runner when available
+    if not quiet:
+        click.echo("\nTest execution not yet implemented.")
+        click.echo("This CLI provides the interface structure.")
+
+
+@cli.command()
+@click.argument("test_id")
+@click.option(
+    "--format",
+    "-f",
+    "output_format",
+    type=click.Choice(["markdown", "json", "html"]),
+    default="markdown",
+    help="Report format (default: markdown).",
+)
+@click.option(
+    "--output",
+    "-o",
+    type=click.Path(path_type=Path),
+    help="Output file path.",
+)
+def report(
+    test_id: str,
+    output_format: str,
+    output: Path | None,
+) -> None:
+    """Generate report for a completed test.
+
+    TEST_ID is the identifier of the test (e.g., 001-justfile-to-makefile).
+
+    Examples:
+
+        scylla report 001-justfile-to-makefile
+
+        scylla report 001-justfile-to-makefile --format json
+    """
+    click.echo(f"Generating {output_format} report for: {test_id}")
+
+    if output:
+        click.echo(f"  Output: {output}")
+
+    # TODO: Integrate with report generator when available
+    click.echo("\nReport generation not yet implemented.")
+    click.echo("This CLI provides the interface structure.")
+
+
+@cli.command("list")
+@click.option(
+    "--verbose",
+    "-v",
+    is_flag=True,
+    help="Show detailed test information.",
+)
+def list_tests(verbose: bool) -> None:
+    """List available test cases.
+
+    Examples:
+
+        scylla list
+
+        scylla list --verbose
+    """
+    # TODO: Load from tests directory when available
+    tests = [
+        ("001-justfile-to-makefile", "Convert Justfile to Makefile"),
+    ]
+
+    click.echo("Available tests:\n")
+
+    for test_id, description in tests:
+        if verbose:
+            click.echo(f"  {test_id}")
+            click.echo(f"    Description: {description}")
+            click.echo()
+        else:
+            click.echo(f"  {test_id}: {description}")
+
+
+@cli.command("list-tiers")
+def list_tiers() -> None:
+    """List available evaluation tiers.
+
+    Examples:
+
+        scylla list-tiers
+    """
+    tiers = [
+        ("T0", "Vanilla", "Base LLM with zero-shot prompting"),
+        ("T1", "Prompted", "System prompts and chain-of-thought"),
+        ("T2", "Skills", "Prompt-encoded domain expertise"),
+        ("T3", "Tooling", "External function calling with JSON schemas"),
+        ("T4", "Delegation", "Flat multi-agent systems"),
+        ("T5", "Hierarchy", "Nested orchestration with self-correction"),
+        ("T6", "Hybrid", "Optimal combinations of proven components"),
+    ]
+
+    click.echo("Evaluation tiers:\n")
+
+    for tier_id, name, description in tiers:
+        click.echo(f"  {tier_id} ({name})")
+        click.echo(f"    {description}")
+        click.echo()
+
+
+@cli.command("list-models")
+def list_models() -> None:
+    """List configured models.
+
+    Examples:
+
+        scylla list-models
+    """
+    # TODO: Load from config when available
+    models = [
+        ("claude-opus-4-5-20251101", "Claude Opus 4.5", "$15.00/$75.00 per 1M tokens"),
+        ("claude-sonnet-4-20250514", "Claude Sonnet 4", "$3.00/$15.00 per 1M tokens"),
+    ]
+
+    click.echo("Configured models:\n")
+
+    for model_id, name, pricing in models:
+        click.echo(f"  {model_id}")
+        click.echo(f"    Name: {name}")
+        click.echo(f"    Pricing: {pricing}")
+        click.echo()
+
+
+@cli.command()
+@click.argument("test_id")
+def status(test_id: str) -> None:
+    """Show status of a test evaluation.
+
+    TEST_ID is the identifier of the test (e.g., 001-justfile-to-makefile).
+
+    Examples:
+
+        scylla status 001-justfile-to-makefile
+    """
+    click.echo(f"Status for: {test_id}\n")
+
+    # TODO: Load from results when available
+    click.echo("  No results found.")
+    click.echo("\n  Run 'scylla run {test_id}' to start evaluation.")
+
+
+def main() -> None:
+    """Entry point for the CLI."""
+    cli()
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/unit/cli/__init__.py
+++ b/tests/unit/cli/__init__.py
@@ -1,0 +1,1 @@
+"""CLI module tests."""

--- a/tests/unit/cli/test_cli.py
+++ b/tests/unit/cli/test_cli.py
@@ -1,0 +1,197 @@
+"""Tests for CLI commands.
+
+Python justification: Required for pytest testing framework and Click testing.
+"""
+
+from click.testing import CliRunner
+
+from scylla.cli import cli
+
+
+class TestCLIGroup:
+    """Tests for main CLI group."""
+
+    def test_help(self) -> None:
+        runner = CliRunner()
+        result = runner.invoke(cli, ["--help"])
+
+        assert result.exit_code == 0
+        assert "ProjectScylla" in result.output
+        assert "AI Agent Testing Framework" in result.output
+
+    def test_version(self) -> None:
+        runner = CliRunner()
+        result = runner.invoke(cli, ["--version"])
+
+        assert result.exit_code == 0
+        assert "0.1.0" in result.output
+
+
+class TestRunCommand:
+    """Tests for 'run' command."""
+
+    def test_run_help(self) -> None:
+        runner = CliRunner()
+        result = runner.invoke(cli, ["run", "--help"])
+
+        assert result.exit_code == 0
+        assert "Run evaluation for a test case" in result.output
+        assert "--tier" in result.output
+        assert "--model" in result.output
+        assert "--runs" in result.output
+
+    def test_run_basic(self) -> None:
+        runner = CliRunner()
+        result = runner.invoke(cli, ["run", "001-test"])
+
+        assert result.exit_code == 0
+        assert "Running test: 001-test" in result.output
+        assert "Tiers: T0, T1, T2, T3" in result.output
+        assert "Runs per tier: 10" in result.output
+
+    def test_run_with_tier(self) -> None:
+        runner = CliRunner()
+        result = runner.invoke(cli, ["run", "001-test", "--tier", "T0", "--tier", "T1"])
+
+        assert result.exit_code == 0
+        assert "Tiers: T0, T1" in result.output
+
+    def test_run_with_model(self) -> None:
+        runner = CliRunner()
+        result = runner.invoke(cli, ["run", "001-test", "--model", "claude-opus"])
+
+        assert result.exit_code == 0
+        assert "Model: claude-opus" in result.output
+
+    def test_run_with_runs(self) -> None:
+        runner = CliRunner()
+        result = runner.invoke(cli, ["run", "001-test", "--runs", "1"])
+
+        assert result.exit_code == 0
+        assert "Runs per tier: 1" in result.output
+
+    def test_run_quiet_mode(self) -> None:
+        runner = CliRunner()
+        result = runner.invoke(cli, ["run", "001-test", "--quiet"])
+
+        assert result.exit_code == 0
+        # Quiet mode should not print the test info
+        assert "Running test:" not in result.output
+
+    def test_run_verbose_and_quiet_error(self) -> None:
+        runner = CliRunner()
+        result = runner.invoke(cli, ["run", "001-test", "--verbose", "--quiet"])
+
+        assert result.exit_code != 0
+        assert "Cannot use --verbose and --quiet together" in result.output
+
+
+class TestReportCommand:
+    """Tests for 'report' command."""
+
+    def test_report_help(self) -> None:
+        runner = CliRunner()
+        result = runner.invoke(cli, ["report", "--help"])
+
+        assert result.exit_code == 0
+        assert "Generate report for a completed test" in result.output
+        assert "--format" in result.output
+
+    def test_report_basic(self) -> None:
+        runner = CliRunner()
+        result = runner.invoke(cli, ["report", "001-test"])
+
+        assert result.exit_code == 0
+        assert "Generating markdown report for: 001-test" in result.output
+
+    def test_report_with_format(self) -> None:
+        runner = CliRunner()
+        result = runner.invoke(cli, ["report", "001-test", "--format", "json"])
+
+        assert result.exit_code == 0
+        assert "Generating json report for: 001-test" in result.output
+
+
+class TestListCommand:
+    """Tests for 'list' command."""
+
+    def test_list_help(self) -> None:
+        runner = CliRunner()
+        result = runner.invoke(cli, ["list", "--help"])
+
+        assert result.exit_code == 0
+        assert "List available test cases" in result.output
+
+    def test_list_basic(self) -> None:
+        runner = CliRunner()
+        result = runner.invoke(cli, ["list"])
+
+        assert result.exit_code == 0
+        assert "Available tests:" in result.output
+        assert "001-justfile-to-makefile" in result.output
+
+    def test_list_verbose(self) -> None:
+        runner = CliRunner()
+        result = runner.invoke(cli, ["list", "--verbose"])
+
+        assert result.exit_code == 0
+        assert "Description:" in result.output
+
+
+class TestListTiersCommand:
+    """Tests for 'list-tiers' command."""
+
+    def test_list_tiers_help(self) -> None:
+        runner = CliRunner()
+        result = runner.invoke(cli, ["list-tiers", "--help"])
+
+        assert result.exit_code == 0
+        assert "List available evaluation tiers" in result.output
+
+    def test_list_tiers(self) -> None:
+        runner = CliRunner()
+        result = runner.invoke(cli, ["list-tiers"])
+
+        assert result.exit_code == 0
+        assert "Evaluation tiers:" in result.output
+        assert "T0 (Vanilla)" in result.output
+        assert "T1 (Prompted)" in result.output
+        assert "T2 (Skills)" in result.output
+        assert "T3 (Tooling)" in result.output
+
+
+class TestListModelsCommand:
+    """Tests for 'list-models' command."""
+
+    def test_list_models_help(self) -> None:
+        runner = CliRunner()
+        result = runner.invoke(cli, ["list-models", "--help"])
+
+        assert result.exit_code == 0
+        assert "List configured models" in result.output
+
+    def test_list_models(self) -> None:
+        runner = CliRunner()
+        result = runner.invoke(cli, ["list-models"])
+
+        assert result.exit_code == 0
+        assert "Configured models:" in result.output
+        assert "claude-opus-4-5-20251101" in result.output
+
+
+class TestStatusCommand:
+    """Tests for 'status' command."""
+
+    def test_status_help(self) -> None:
+        runner = CliRunner()
+        result = runner.invoke(cli, ["status", "--help"])
+
+        assert result.exit_code == 0
+        assert "Show status of a test evaluation" in result.output
+
+    def test_status_basic(self) -> None:
+        runner = CliRunner()
+        result = runner.invoke(cli, ["status", "001-test"])
+
+        assert result.exit_code == 0
+        assert "Status for: 001-test" in result.output


### PR DESCRIPTION
## Summary
- Add CLI framework with Click
- Commands: run, report, list, list-tiers, list-models, status
- Entry point `scylla` in pyproject.toml
- Options for tiers, models, runs, output format, verbosity

## Commands
- `scylla run <test-id>` - Run evaluation
- `scylla report <test-id>` - Generate report
- `scylla list` - List available tests
- `scylla list-tiers` - List evaluation tiers
- `scylla list-models` - List configured models
- `scylla status <test-id>` - Show test status

## Test plan
- [x] 21 unit tests pass
- [x] All commands have --help
- [x] Error handling for conflicting options

Closes #29

🤖 Generated with [Claude Code](https://claude.com/claude-code)