### PR TITLE
feat(cli): add progress display

### DIFF
--- a/src/scylla/cli/__init__.py
+++ b/src/scylla/cli/__init__.py
@@ -1,0 +1,24 @@
+"""CLI module for ProjectScylla.
+
+This module provides command-line interface and progress display.
+"""
+
+from scylla.cli.progress import (
+    ProgressDisplay,
+    RunProgress,
+    RunStatus,
+    TestProgress,
+    TierProgress,
+    format_duration,
+    format_progress_bar,
+)
+
+__all__ = [
+    "ProgressDisplay",
+    "RunProgress",
+    "RunStatus",
+    "TestProgress",
+    "TierProgress",
+    "format_duration",
+    "format_progress_bar",
+]

--- a/src/scylla/cli/progress.py
+++ b/src/scylla/cli/progress.py
@@ -1,0 +1,363 @@
+"""Progress display for test execution.
+
+Python justification: Terminal output formatting and progress tracking.
+"""
+
+import sys
+import time
+from dataclasses import dataclass, field
+from datetime import datetime, timedelta
+from enum import Enum
+
+
+class RunStatus(Enum):
+    """Status of a single run."""
+
+    PENDING = "pending"
+    EXECUTING = "executing"
+    JUDGING = "judging"
+    COMPLETE = "complete"
+    FAILED = "failed"
+
+
+@dataclass
+class RunProgress:
+    """Progress information for a single run."""
+
+    run_number: int
+    status: RunStatus = RunStatus.PENDING
+    start_time: datetime | None = None
+    end_time: datetime | None = None
+    passed: bool | None = None
+    grade: str | None = None
+    cost_usd: float | None = None
+
+    @property
+    def elapsed(self) -> timedelta:
+        """Get elapsed time for this run."""
+        if self.start_time is None:
+            return timedelta(0)
+        end = self.end_time or datetime.now()
+        return end - self.start_time
+
+
+@dataclass
+class TierProgress:
+    """Progress information for a tier."""
+
+    tier_id: str
+    total_runs: int
+    runs: list[RunProgress] = field(default_factory=list)
+    start_time: datetime | None = None
+    end_time: datetime | None = None
+
+    def __post_init__(self) -> None:
+        if not self.runs:
+            self.runs = [RunProgress(i + 1) for i in range(self.total_runs)]
+
+    @property
+    def completed_runs(self) -> int:
+        """Count of completed runs."""
+        return sum(1 for r in self.runs if r.status == RunStatus.COMPLETE)
+
+    @property
+    def passed_runs(self) -> int:
+        """Count of passed runs."""
+        return sum(1 for r in self.runs if r.passed is True)
+
+    @property
+    def pass_rate(self) -> float:
+        """Pass rate as a percentage."""
+        if self.completed_runs == 0:
+            return 0.0
+        return self.passed_runs / self.completed_runs
+
+    @property
+    def total_cost(self) -> float:
+        """Total cost of completed runs."""
+        return sum(r.cost_usd or 0.0 for r in self.runs if r.cost_usd is not None)
+
+    @property
+    def elapsed(self) -> timedelta:
+        """Get elapsed time for this tier."""
+        if self.start_time is None:
+            return timedelta(0)
+        end = self.end_time or datetime.now()
+        return end - self.start_time
+
+
+@dataclass
+class TestProgress:
+    """Progress information for a complete test."""
+
+    test_id: str
+    tiers: list[TierProgress] = field(default_factory=list)
+    start_time: datetime | None = None
+    end_time: datetime | None = None
+
+    @property
+    def total_runs(self) -> int:
+        """Total number of runs across all tiers."""
+        return sum(t.total_runs for t in self.tiers)
+
+    @property
+    def completed_runs(self) -> int:
+        """Total completed runs across all tiers."""
+        return sum(t.completed_runs for t in self.tiers)
+
+    @property
+    def completed_tiers(self) -> int:
+        """Number of fully completed tiers."""
+        return sum(
+            1 for t in self.tiers if t.completed_runs == t.total_runs
+        )
+
+    @property
+    def progress_percent(self) -> float:
+        """Overall progress as percentage."""
+        if self.total_runs == 0:
+            return 0.0
+        return (self.completed_runs / self.total_runs) * 100
+
+    @property
+    def elapsed(self) -> timedelta:
+        """Get elapsed time for this test."""
+        if self.start_time is None:
+            return timedelta(0)
+        end = self.end_time or datetime.now()
+        return end - self.start_time
+
+
+def format_duration(td: timedelta) -> str:
+    """Format a timedelta as HH:MM:SS.
+
+    Args:
+        td: Timedelta to format
+
+    Returns:
+        Formatted string
+    """
+    total_seconds = int(td.total_seconds())
+    hours, remainder = divmod(total_seconds, 3600)
+    minutes, seconds = divmod(remainder, 60)
+    return f"{hours:02d}:{minutes:02d}:{seconds:02d}"
+
+
+def format_progress_bar(percent: float, width: int = 20) -> str:
+    """Create a text progress bar.
+
+    Args:
+        percent: Percentage complete (0-100)
+        width: Width of the bar in characters
+
+    Returns:
+        Progress bar string
+    """
+    filled = int(width * percent / 100)
+    empty = width - filled
+    return f"{'█' * filled}{'░' * empty}"
+
+
+class ProgressDisplay:
+    """Displays progress during test execution."""
+
+    def __init__(
+        self,
+        quiet: bool = False,
+        verbose: bool = False,
+        no_progress: bool = False,
+    ) -> None:
+        """Initialize progress display.
+
+        Args:
+            quiet: Minimal output for CI
+            verbose: Detailed output
+            no_progress: Disable progress bar
+        """
+        self.quiet = quiet
+        self.verbose = verbose
+        self.no_progress = no_progress
+        self._current_progress: TestProgress | None = None
+
+    def _write(self, message: str, newline: bool = True) -> None:
+        """Write a message to stdout."""
+        if self.quiet:
+            return
+        end = "\n" if newline else ""
+        sys.stdout.write(message + end)
+        sys.stdout.flush()
+
+    def start_test(self, test_id: str, tiers: list[str], runs_per_tier: int) -> TestProgress:
+        """Start tracking a new test.
+
+        Args:
+            test_id: Test identifier
+            tiers: List of tier IDs
+            runs_per_tier: Number of runs per tier
+
+        Returns:
+            TestProgress object
+        """
+        progress = TestProgress(
+            test_id=test_id,
+            tiers=[TierProgress(t, runs_per_tier) for t in tiers],
+            start_time=datetime.now(),
+        )
+        self._current_progress = progress
+
+        self._write(f"\n[{test_id}] Running tests...")
+        self._write("")
+
+        return progress
+
+    def start_tier(self, tier_id: str) -> None:
+        """Mark a tier as started.
+
+        Args:
+            tier_id: Tier identifier
+        """
+        if self._current_progress is None:
+            return
+
+        for tier in self._current_progress.tiers:
+            if tier.tier_id == tier_id:
+                tier.start_time = datetime.now()
+                break
+
+        self._write(f"Tier: {tier_id}")
+
+    def start_run(self, tier_id: str, run_number: int) -> None:
+        """Mark a run as started.
+
+        Args:
+            tier_id: Tier identifier
+            run_number: Run number (1-indexed)
+        """
+        if self._current_progress is None:
+            return
+
+        for tier in self._current_progress.tiers:
+            if tier.tier_id == tier_id:
+                run = tier.runs[run_number - 1]
+                run.status = RunStatus.EXECUTING
+                run.start_time = datetime.now()
+                break
+
+        elapsed = format_duration(self._current_progress.elapsed)
+        self._write(f"  Run {run_number}/{tier.total_runs}: Executing... [{elapsed}]")
+
+    def update_run_status(self, tier_id: str, run_number: int, status: RunStatus) -> None:
+        """Update the status of a run.
+
+        Args:
+            tier_id: Tier identifier
+            run_number: Run number (1-indexed)
+            status: New status
+        """
+        if self._current_progress is None:
+            return
+
+        for tier in self._current_progress.tiers:
+            if tier.tier_id == tier_id:
+                run = tier.runs[run_number - 1]
+                run.status = status
+                break
+
+        if status == RunStatus.JUDGING:
+            self._write(f"  Run {run_number}/{tier.total_runs}: Judging...")
+
+    def complete_run(
+        self,
+        tier_id: str,
+        run_number: int,
+        passed: bool,
+        grade: str,
+        cost_usd: float,
+    ) -> None:
+        """Mark a run as complete.
+
+        Args:
+            tier_id: Tier identifier
+            run_number: Run number (1-indexed)
+            passed: Whether the run passed
+            grade: Letter grade
+            cost_usd: Cost in USD
+        """
+        if self._current_progress is None:
+            return
+
+        for tier in self._current_progress.tiers:
+            if tier.tier_id == tier_id:
+                run = tier.runs[run_number - 1]
+                run.status = RunStatus.COMPLETE
+                run.end_time = datetime.now()
+                run.passed = passed
+                run.grade = grade
+                run.cost_usd = cost_usd
+                break
+
+        status = "PASS" if passed else "FAIL"
+        self._write(
+            f"  Run {run_number}/{tier.total_runs}: Complete "
+            f"({status}, Grade: {grade}, Cost: ${cost_usd:.2f})"
+        )
+
+    def complete_tier(self, tier_id: str) -> None:
+        """Mark a tier as complete and show summary.
+
+        Args:
+            tier_id: Tier identifier
+        """
+        if self._current_progress is None:
+            return
+
+        tier: TierProgress | None = None
+        for t in self._current_progress.tiers:
+            if t.tier_id == tier_id:
+                t.end_time = datetime.now()
+                tier = t
+                break
+
+        if tier is None:
+            return
+
+        # Find median grade
+        grades = [r.grade for r in tier.runs if r.grade is not None]
+        median_grade = grades[len(grades) // 2] if grades else "N/A"
+
+        self._write("")
+        self._write(f"Tier {tier_id} Summary:")
+        self._write(
+            f"  Pass Rate: {tier.pass_rate * 100:.0f}% "
+            f"({tier.passed_runs}/{tier.completed_runs})"
+        )
+        self._write(f"  Median Grade: {median_grade}")
+        self._write(f"  Total Cost: ${tier.total_cost:.2f}")
+        self._write(f"  Total Time: {format_duration(tier.elapsed)}")
+        self._write("")
+
+    def show_overall_progress(self) -> None:
+        """Show overall progress bar."""
+        if self._current_progress is None or self.no_progress:
+            return
+
+        progress = self._current_progress
+        bar = format_progress_bar(progress.progress_percent)
+        completed_tiers = progress.completed_tiers
+        total_tiers = len(progress.tiers)
+
+        self._write(
+            f"Overall Progress: {bar} {progress.progress_percent:.0f}% "
+            f"({completed_tiers}/{total_tiers} tiers, "
+            f"{progress.completed_runs}/{progress.total_runs} runs)"
+        )
+
+    def complete_test(self) -> None:
+        """Mark the test as complete."""
+        if self._current_progress is None:
+            return
+
+        self._current_progress.end_time = datetime.now()
+
+        self._write("")
+        self._write(f"Test completed in {format_duration(self._current_progress.elapsed)}")

--- a/tests/unit/cli/__init__.py
+++ b/tests/unit/cli/__init__.py
@@ -1,0 +1,1 @@
+"""CLI module tests."""

--- a/tests/unit/cli/test_progress.py
+++ b/tests/unit/cli/test_progress.py
@@ -1,0 +1,292 @@
+"""Tests for progress display.
+
+Python justification: Required for pytest testing framework.
+"""
+
+from datetime import datetime, timedelta
+from io import StringIO
+import sys
+
+import pytest
+
+from scylla.cli.progress import (
+    ProgressDisplay,
+    RunProgress,
+    RunStatus,
+    TestProgress,
+    TierProgress,
+    format_duration,
+    format_progress_bar,
+)
+
+
+class TestRunProgress:
+    """Tests for RunProgress dataclass."""
+
+    def test_create(self) -> None:
+        run = RunProgress(run_number=1)
+        assert run.run_number == 1
+        assert run.status == RunStatus.PENDING
+
+    def test_elapsed_not_started(self) -> None:
+        run = RunProgress(run_number=1)
+        assert run.elapsed == timedelta(0)
+
+    def test_elapsed_running(self) -> None:
+        run = RunProgress(
+            run_number=1,
+            status=RunStatus.EXECUTING,
+            start_time=datetime.now() - timedelta(seconds=10),
+        )
+        assert run.elapsed >= timedelta(seconds=10)
+
+    def test_elapsed_complete(self) -> None:
+        start = datetime(2024, 1, 1, 12, 0, 0)
+        end = datetime(2024, 1, 1, 12, 0, 20)
+        run = RunProgress(
+            run_number=1,
+            status=RunStatus.COMPLETE,
+            start_time=start,
+            end_time=end,
+        )
+        assert run.elapsed == timedelta(seconds=20)
+
+
+class TestTierProgress:
+    """Tests for TierProgress dataclass."""
+
+    def test_create(self) -> None:
+        tier = TierProgress(tier_id="T0", total_runs=10)
+        assert tier.tier_id == "T0"
+        assert tier.total_runs == 10
+        assert len(tier.runs) == 10
+
+    def test_completed_runs(self) -> None:
+        tier = TierProgress(tier_id="T0", total_runs=5)
+        tier.runs[0].status = RunStatus.COMPLETE
+        tier.runs[1].status = RunStatus.COMPLETE
+        tier.runs[2].status = RunStatus.EXECUTING
+
+        assert tier.completed_runs == 2
+
+    def test_passed_runs(self) -> None:
+        tier = TierProgress(tier_id="T0", total_runs=5)
+        tier.runs[0].status = RunStatus.COMPLETE
+        tier.runs[0].passed = True
+        tier.runs[1].status = RunStatus.COMPLETE
+        tier.runs[1].passed = False
+        tier.runs[2].status = RunStatus.COMPLETE
+        tier.runs[2].passed = True
+
+        assert tier.passed_runs == 2
+
+    def test_pass_rate(self) -> None:
+        tier = TierProgress(tier_id="T0", total_runs=4)
+        tier.runs[0].status = RunStatus.COMPLETE
+        tier.runs[0].passed = True
+        tier.runs[1].status = RunStatus.COMPLETE
+        tier.runs[1].passed = False
+        tier.runs[2].status = RunStatus.COMPLETE
+        tier.runs[2].passed = True
+        tier.runs[3].status = RunStatus.COMPLETE
+        tier.runs[3].passed = True
+
+        assert tier.pass_rate == 0.75
+
+    def test_pass_rate_empty(self) -> None:
+        tier = TierProgress(tier_id="T0", total_runs=5)
+        assert tier.pass_rate == 0.0
+
+    def test_total_cost(self) -> None:
+        tier = TierProgress(tier_id="T0", total_runs=3)
+        tier.runs[0].cost_usd = 1.0
+        tier.runs[1].cost_usd = 2.5
+        tier.runs[2].cost_usd = None
+
+        assert tier.total_cost == 3.5
+
+
+class TestTestProgress:
+    """Tests for TestProgress dataclass."""
+
+    def test_create(self) -> None:
+        progress = TestProgress(test_id="001-test")
+        assert progress.test_id == "001-test"
+        assert progress.tiers == []
+
+    def test_total_runs(self) -> None:
+        progress = TestProgress(
+            test_id="001-test",
+            tiers=[
+                TierProgress("T0", 10),
+                TierProgress("T1", 10),
+            ],
+        )
+        assert progress.total_runs == 20
+
+    def test_completed_runs(self) -> None:
+        progress = TestProgress(
+            test_id="001-test",
+            tiers=[
+                TierProgress("T0", 5),
+                TierProgress("T1", 5),
+            ],
+        )
+        progress.tiers[0].runs[0].status = RunStatus.COMPLETE
+        progress.tiers[0].runs[1].status = RunStatus.COMPLETE
+        progress.tiers[1].runs[0].status = RunStatus.COMPLETE
+
+        assert progress.completed_runs == 3
+
+    def test_completed_tiers(self) -> None:
+        progress = TestProgress(
+            test_id="001-test",
+            tiers=[
+                TierProgress("T0", 2),
+                TierProgress("T1", 2),
+            ],
+        )
+        # Complete all runs in T0
+        for run in progress.tiers[0].runs:
+            run.status = RunStatus.COMPLETE
+        # Only one run in T1
+        progress.tiers[1].runs[0].status = RunStatus.COMPLETE
+
+        assert progress.completed_tiers == 1
+
+    def test_progress_percent(self) -> None:
+        progress = TestProgress(
+            test_id="001-test",
+            tiers=[
+                TierProgress("T0", 4),
+            ],
+        )
+        progress.tiers[0].runs[0].status = RunStatus.COMPLETE
+        progress.tiers[0].runs[1].status = RunStatus.COMPLETE
+
+        assert progress.progress_percent == 50.0
+
+
+class TestFormatDuration:
+    """Tests for format_duration function."""
+
+    def test_zero(self) -> None:
+        assert format_duration(timedelta(0)) == "00:00:00"
+
+    def test_seconds(self) -> None:
+        assert format_duration(timedelta(seconds=45)) == "00:00:45"
+
+    def test_minutes(self) -> None:
+        assert format_duration(timedelta(minutes=5, seconds=30)) == "00:05:30"
+
+    def test_hours(self) -> None:
+        assert format_duration(timedelta(hours=2, minutes=30, seconds=15)) == "02:30:15"
+
+
+class TestFormatProgressBar:
+    """Tests for format_progress_bar function."""
+
+    def test_zero_percent(self) -> None:
+        bar = format_progress_bar(0, width=10)
+        assert bar == "░░░░░░░░░░"
+
+    def test_fifty_percent(self) -> None:
+        bar = format_progress_bar(50, width=10)
+        assert bar == "█████░░░░░"
+
+    def test_hundred_percent(self) -> None:
+        bar = format_progress_bar(100, width=10)
+        assert bar == "██████████"
+
+    def test_custom_width(self) -> None:
+        bar = format_progress_bar(25, width=8)
+        assert bar == "██░░░░░░"
+        assert len(bar) == 8
+
+
+class TestProgressDisplay:
+    """Tests for ProgressDisplay class."""
+
+    def test_quiet_mode_no_output(self) -> None:
+        display = ProgressDisplay(quiet=True)
+        old_stdout = sys.stdout
+        sys.stdout = StringIO()
+
+        display._write("test message")
+
+        output = sys.stdout.getvalue()
+        sys.stdout = old_stdout
+
+        assert output == ""
+
+    def test_start_test(self) -> None:
+        display = ProgressDisplay(quiet=True)
+        progress = display.start_test("001-test", ["T0", "T1"], runs_per_tier=5)
+
+        assert progress.test_id == "001-test"
+        assert len(progress.tiers) == 2
+        assert progress.tiers[0].total_runs == 5
+        assert progress.start_time is not None
+
+    def test_start_tier(self) -> None:
+        display = ProgressDisplay(quiet=True)
+        progress = display.start_test("001-test", ["T0"], runs_per_tier=5)
+        display.start_tier("T0")
+
+        assert progress.tiers[0].start_time is not None
+
+    def test_start_run(self) -> None:
+        display = ProgressDisplay(quiet=True)
+        display.start_test("001-test", ["T0"], runs_per_tier=5)
+        display.start_tier("T0")
+        display.start_run("T0", 1)
+
+        progress = display._current_progress
+        assert progress is not None
+        assert progress.tiers[0].runs[0].status == RunStatus.EXECUTING
+        assert progress.tiers[0].runs[0].start_time is not None
+
+    def test_update_run_status(self) -> None:
+        display = ProgressDisplay(quiet=True)
+        display.start_test("001-test", ["T0"], runs_per_tier=5)
+        display.start_run("T0", 1)
+        display.update_run_status("T0", 1, RunStatus.JUDGING)
+
+        progress = display._current_progress
+        assert progress is not None
+        assert progress.tiers[0].runs[0].status == RunStatus.JUDGING
+
+    def test_complete_run(self) -> None:
+        display = ProgressDisplay(quiet=True)
+        display.start_test("001-test", ["T0"], runs_per_tier=5)
+        display.start_run("T0", 1)
+        display.complete_run("T0", 1, passed=True, grade="A", cost_usd=1.5)
+
+        progress = display._current_progress
+        assert progress is not None
+        run = progress.tiers[0].runs[0]
+        assert run.status == RunStatus.COMPLETE
+        assert run.passed is True
+        assert run.grade == "A"
+        assert run.cost_usd == 1.5
+
+    def test_complete_tier(self) -> None:
+        display = ProgressDisplay(quiet=True)
+        display.start_test("001-test", ["T0"], runs_per_tier=2)
+        display.start_tier("T0")
+        display.complete_run("T0", 1, passed=True, grade="A", cost_usd=1.0)
+        display.complete_run("T0", 2, passed=True, grade="B", cost_usd=1.5)
+        display.complete_tier("T0")
+
+        progress = display._current_progress
+        assert progress is not None
+        assert progress.tiers[0].end_time is not None
+
+    def test_complete_test(self) -> None:
+        display = ProgressDisplay(quiet=True)
+        display.start_test("001-test", ["T0"], runs_per_tier=1)
+        display.complete_test()
+
+        progress = display._current_progress
+        assert progress is not None
+        assert progress.end_time is not None


### PR DESCRIPTION
## Summary
- Add real-time progress tracking for test execution
- Add RunStatus enum for run lifecycle states (pending, executing, judging, complete, failed)
- Add RunProgress, TierProgress, TestProgress dataclasses for hierarchical tracking
- Add ProgressDisplay class for terminal output with quiet/verbose modes
- Add format_duration and format_progress_bar helper functions

## Test plan
- [x] Unit tests for RunProgress elapsed time calculations
- [x] Unit tests for TierProgress aggregation (pass rate, cost)
- [x] Unit tests for TestProgress completion tracking
- [x] Unit tests for format_duration and format_progress_bar
- [x] Unit tests for ProgressDisplay methods
- [x] All 31 tests passing

Closes #30

🤖 Generated with [Claude Code](https://claude.com/claude-code)