### PR TITLE
feat(test): add 001-justfile-to-makefile test case

### DIFF
--- a/tests/001-justfile-to-makefile/expected/criteria.md
+++ b/tests/001-justfile-to-makefile/expected/criteria.md
@@ -4,6 +4,8 @@
 
 - A `Makefile` must exist in the repository root
 - The file must be syntactically valid (parseable by GNU Make)
+- A `cleanup.sh` script must exist in the repository root
+- The cleanup script must be executable
 
 ## Recipe Coverage
 
@@ -34,3 +36,19 @@ For the following commands, running with just vs make should produce equivalent 
 
 - The Makefile should be readable and well-organized
 - Comments should explain non-obvious translations
+
+## Cleanup Script
+
+The cleanup script (`cleanup.sh`) must:
+
+- Execute without errors (exit code 0)
+- Remove all build artifacts
+- Remove any generated files
+- Return the repository to a clean state
+
+| Score | Criteria |
+|-------|----------|
+| 1.0 | Script exists, runs successfully, returns env to clean state |
+| 0.7 | Script exists, runs successfully, partial cleanup |
+| 0.4 | Script exists but fails or incomplete |
+| 0.0 | No cleanup script provided |

--- a/tests/001-justfile-to-makefile/expected/rubric.yaml
+++ b/tests/001-justfile-to-makefile/expected/rubric.yaml
@@ -34,6 +34,57 @@ requirements:
     weight: 0.5
     evaluation: "scaled"
 
+  - id: "R008"
+    description: "Cleanup script exists and works"
+    weight: 1.0
+    evaluation: "scaled"
+    scoring:
+      1.0: "Script exists, runs successfully, full cleanup"
+      0.7: "Script exists, runs, partial cleanup"
+      0.4: "Script exists but fails"
+      0.0: "No cleanup script"
+
+categories:
+  functional_correctness:
+    weight: 2.0
+    description: "Makefile works as intended"
+
+  completeness:
+    weight: 1.5
+    description: "All recipes converted"
+
+  code_quality:
+    weight: 1.0
+    description: "Readable, maintainable Makefile"
+
+  simplicity:
+    weight: 1.0
+    description: "Simple, not over-engineered"
+
+  lack_of_duplication:
+    weight: 0.5
+    description: "DRY principle followed"
+
+  clarity:
+    weight: 1.0
+    description: "Clear target names and structure"
+
+  documentation:
+    weight: 0.5
+    description: "Comments explain non-obvious parts"
+
+  architectural_cleanliness:
+    weight: 0.5
+    description: "Good organization and separation"
+
+  efficiency:
+    weight: 0.5
+    description: "Efficient make rules"
+
+  cleanup_script_quality:
+    weight: 1.0
+    description: "Proper cleanup/teardown script"
+
 grading:
   pass_threshold: 0.70
   grade_scale:

--- a/tests/001-justfile-to-makefile/prompt.md
+++ b/tests/001-justfile-to-makefile/prompt.md
@@ -12,6 +12,11 @@ provides the same functionality using standard GNU Make.
 3. Handle Docker-related commands correctly
 4. Include a `help` target that lists available commands
 5. Maintain recipe dependencies
+6. Create a cleanup script (`cleanup.sh`) that:
+   - Removes all build artifacts
+   - Removes any generated files
+   - Returns the repository to a clean state
+   - Is executable and runs without errors
 
 ## Constraints
 
@@ -23,9 +28,11 @@ provides the same functionality using standard GNU Make.
 ## Expected Output
 
 - A new file named `Makefile` in the repository root
+- A new file named `cleanup.sh` in the repository root
 - The original `justfile` should remain unchanged
 
 ## Validation
 
 Your solution will be validated by running equivalent commands with both
-build systems and comparing results.
+build systems and comparing results. The cleanup script will be executed
+to verify it properly cleans the environment.

--- a/tests/001-justfile-to-makefile/test.yaml
+++ b/tests/001-justfile-to-makefile/test.yaml
@@ -3,7 +3,7 @@ name: "Convert Justfile to Makefile"
 description: |
   Convert ProjectOdyssey's justfile to an equivalent Makefile.
   The Makefile must support all existing recipes and produce
-  equivalent outputs when run.
+  equivalent outputs when run. Also create a cleanup script.
 
 source:
   repo: "https://github.com/mvillmow/ProjectOdyssey"
@@ -12,6 +12,14 @@ source:
 task:
   prompt_file: "prompt.md"
   timeout_seconds: 3600
+
+tiers:
+  - T0  # Vanilla
+  - T1  # Prompted
+  - T2  # Skills
+  - T3  # Tooling
+
+runs_per_tier: 10
 
 validation:
   criteria_file: "expected/criteria.md"


### PR DESCRIPTION
## Summary
- Update 001-justfile-to-makefile test case with full tier support
- Add tier configuration (T0, T1, T2, T3) with 10 runs per tier
- Add cleanup script requirement to prompt (requirement #6)
- Update criteria with cleanup script evaluation scoring
- Add full 10-category rubric per Issue #31 specification

## Test case structure
- `test.yaml` - Test configuration with tier setup
- `prompt.md` - Agent instructions including cleanup script
- `expected/criteria.md` - Success criteria with scoring table
- `expected/rubric.yaml` - 8 requirements + 10 quality categories

## Categories
1. Functional correctness
2. Completeness
3. Code quality
4. Simplicity
5. Lack of duplication
6. Clarity
7. Documentation
8. Architectural cleanliness
9. Efficiency
10. Cleanup script quality

Closes #31

🤖 Generated with [Claude Code](https://claude.com/claude-code)