### PR TITLE
feat(metrics): add cross-tier analysis for prompt sensitivity

### DIFF
--- a/src/scylla/metrics/__init__.py
+++ b/src/scylla/metrics/__init__.py
@@ -11,6 +11,12 @@ from scylla.metrics.aggregator import (
     RunResult,
     TierStatistics,
 )
+from scylla.metrics.cross_tier import (
+    CrossTierAnalyzer,
+    PromptSensitivityAnalysis,
+    TierTransitionAssessment,
+    TierUplift,
+)
 from scylla.metrics.grading import (
     GradingResult,
     assign_letter_grade,
@@ -40,6 +46,11 @@ __all__ = [
     "RunAggregator",
     "RunResult",
     "TierStatistics",
+    # Cross-tier analysis
+    "CrossTierAnalyzer",
+    "PromptSensitivityAnalysis",
+    "TierTransitionAssessment",
+    "TierUplift",
     # Grading
     "GradingResult",
     "assign_letter_grade",

--- a/src/scylla/metrics/cross_tier.py
+++ b/src/scylla/metrics/cross_tier.py
@@ -1,0 +1,325 @@
+"""Cross-tier analysis for prompt sensitivity measurement.
+
+This module provides statistical analysis for comparing results across
+evaluation tiers to measure prompt sensitivity and tier transition value.
+
+Python Justification: Required for statistical analysis and complex data structures.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from scylla.metrics.aggregator import TierStatistics
+
+
+@dataclass
+class TierUplift:
+    """Uplift metrics for a tier vs T0 baseline.
+
+    Attributes:
+        tier_id: Tier identifier (T1-T6).
+        pass_rate_uplift: Pass rate change vs T0.
+        impl_rate_uplift: Implementation rate change vs T0.
+        composite_uplift: Composite score change vs T0.
+        cost_change: Cost change vs T0 (positive = more expensive).
+    """
+
+    tier_id: str
+    pass_rate_uplift: float
+    impl_rate_uplift: float
+    composite_uplift: float
+    cost_change: float
+
+
+@dataclass
+class PromptSensitivityAnalysis:
+    """Complete prompt sensitivity analysis across tiers.
+
+    Attributes:
+        pass_rate_variance: Variance in pass rate across tiers.
+        impl_rate_variance: Variance in implementation rate across tiers.
+        cost_variance: Variance in cost across tiers.
+        pass_rate_sensitivity: Sensitivity level (low/medium/high).
+        impl_rate_sensitivity: Sensitivity level (low/medium/high).
+        cost_sensitivity: Sensitivity level (low/medium/high).
+        tier_uplifts: Detailed uplift for each tier vs T0.
+        cost_of_pass_delta: Range between max and min cost-of-pass.
+        best_value_tier: Tier with best quality/cost ratio.
+    """
+
+    pass_rate_variance: float
+    impl_rate_variance: float
+    cost_variance: float
+    pass_rate_sensitivity: str
+    impl_rate_sensitivity: str
+    cost_sensitivity: str
+    tier_uplifts: dict[str, TierUplift] = field(default_factory=dict)
+    cost_of_pass_delta: float = 0.0
+    best_value_tier: str = "T0"
+
+
+@dataclass
+class TierTransitionAssessment:
+    """Assessment of whether upgrading between tiers is worthwhile.
+
+    Attributes:
+        from_tier: Source tier ID.
+        to_tier: Target tier ID.
+        pass_rate_delta: Change in pass rate.
+        impl_rate_delta: Change in implementation rate.
+        cost_delta: Change in cost (positive = more expensive).
+        worth_it: Whether the transition is recommended.
+        reason: Human-readable explanation of assessment.
+    """
+
+    from_tier: str
+    to_tier: str
+    pass_rate_delta: float
+    impl_rate_delta: float
+    cost_delta: float
+    worth_it: bool
+    reason: str
+
+
+def _calculate_variance(values: list[float]) -> float:
+    """Calculate variance of a list of values."""
+    if len(values) < 2:
+        return 0.0
+    mean = sum(values) / len(values)
+    squared_diffs = [(v - mean) ** 2 for v in values]
+    return sum(squared_diffs) / len(values)
+
+
+class CrossTierAnalyzer:
+    """Analyzer for cross-tier metrics and sensitivity.
+
+    Provides statistical analysis for comparing results across
+    evaluation tiers to measure prompt sensitivity.
+    """
+
+    # Sensitivity thresholds
+    LOW_SENSITIVITY_THRESHOLD = 0.05
+    MEDIUM_SENSITIVITY_THRESHOLD = 0.15
+
+    def __init__(self, tier_stats: dict[str, TierStatistics]) -> None:
+        """Initialize with tier statistics.
+
+        Args:
+            tier_stats: Dictionary mapping tier IDs to statistics.
+        """
+        self.tier_stats = tier_stats
+        self.t0_baseline = tier_stats.get("T0")
+
+    def calculate_variance(self, metric: str) -> float:
+        """Calculate variance of a metric across all tiers.
+
+        Args:
+            metric: Name of the metric attribute (pass_rate, impl_rate, cost_usd).
+
+        Returns:
+            Variance of median values across tiers.
+        """
+        values = [
+            getattr(t, metric).median
+            for t in self.tier_stats.values()
+        ]
+        return _calculate_variance(values)
+
+    def interpret_sensitivity(self, variance: float) -> str:
+        """Interpret variance as sensitivity level.
+
+        Args:
+            variance: Calculated variance value.
+
+        Returns:
+            Sensitivity level: "low", "medium", or "high".
+        """
+        if variance < self.LOW_SENSITIVITY_THRESHOLD:
+            return "low"
+        elif variance < self.MEDIUM_SENSITIVITY_THRESHOLD:
+            return "medium"
+        else:
+            return "high"
+
+    def calculate_uplift(self, tier_id: str) -> TierUplift:
+        """Calculate uplift of a tier vs T0 baseline.
+
+        Args:
+            tier_id: Tier identifier to calculate uplift for.
+
+        Returns:
+            TierUplift with detailed metrics.
+        """
+        tier = self.tier_stats[tier_id]
+
+        def safe_uplift(tier_val: float, baseline_val: float) -> float:
+            if baseline_val == 0:
+                return 0.0
+            return (tier_val - baseline_val) / baseline_val
+
+        if self.t0_baseline is None:
+            return TierUplift(
+                tier_id=tier_id,
+                pass_rate_uplift=0.0,
+                impl_rate_uplift=0.0,
+                composite_uplift=0.0,
+                cost_change=0.0,
+            )
+
+        return TierUplift(
+            tier_id=tier_id,
+            pass_rate_uplift=safe_uplift(
+                tier.pass_rate.median,
+                self.t0_baseline.pass_rate.median,
+            ),
+            impl_rate_uplift=safe_uplift(
+                tier.impl_rate.median,
+                self.t0_baseline.impl_rate.median,
+            ),
+            composite_uplift=safe_uplift(
+                tier.composite_score.median,
+                self.t0_baseline.composite_score.median,
+            ),
+            cost_change=safe_uplift(
+                tier.cost_usd.median,
+                self.t0_baseline.cost_usd.median,
+            ),
+        )
+
+    def assess_transition(
+        self,
+        from_tier: str,
+        to_tier: str,
+    ) -> TierTransitionAssessment:
+        """Assess whether upgrading from one tier to another is worthwhile.
+
+        Args:
+            from_tier: Source tier ID.
+            to_tier: Target tier ID.
+
+        Returns:
+            TierTransitionAssessment with recommendation.
+        """
+        from_stats = self.tier_stats[from_tier]
+        to_stats = self.tier_stats[to_tier]
+
+        pass_delta = to_stats.pass_rate.median - from_stats.pass_rate.median
+        impl_delta = to_stats.impl_rate.median - from_stats.impl_rate.median
+        cost_delta = to_stats.cost_usd.median - from_stats.cost_usd.median
+
+        # Calculate quality improvement as average of pass and impl deltas
+        quality_improvement = (pass_delta + impl_delta) / 2
+
+        # Calculate relative cost increase
+        if from_stats.cost_usd.median > 0:
+            cost_increase = cost_delta / from_stats.cost_usd.median
+        else:
+            cost_increase = 0.0
+
+        # Worth it if quality improves more than half the cost increase
+        worth_it = quality_improvement > cost_increase * 0.5
+
+        if worth_it:
+            reason = f"+{quality_improvement:.1%} quality for +{cost_increase:.1%} cost"
+        else:
+            reason = f"Only +{quality_improvement:.1%} quality for +{cost_increase:.1%} cost"
+
+        return TierTransitionAssessment(
+            from_tier=from_tier,
+            to_tier=to_tier,
+            pass_rate_delta=pass_delta,
+            impl_rate_delta=impl_delta,
+            cost_delta=cost_delta,
+            worth_it=worth_it,
+            reason=reason,
+        )
+
+    def _calculate_cost_of_pass(self, stats: TierStatistics) -> float:
+        """Calculate cost-of-pass for a tier."""
+        if stats.pass_rate.median > 0:
+            return stats.cost_usd.median / stats.pass_rate.median
+        return float("inf")
+
+    def _calculate_value_score(self, stats: TierStatistics) -> float:
+        """Calculate value score (quality/cost ratio) for a tier."""
+        if stats.cost_usd.median > 0:
+            return stats.composite_score.median / stats.cost_usd.median
+        return 0.0
+
+    def analyze(self) -> PromptSensitivityAnalysis:
+        """Perform full cross-tier analysis.
+
+        Returns:
+            PromptSensitivityAnalysis with complete metrics.
+        """
+        if not self.tier_stats:
+            return PromptSensitivityAnalysis(
+                pass_rate_variance=0.0,
+                impl_rate_variance=0.0,
+                cost_variance=0.0,
+                pass_rate_sensitivity="low",
+                impl_rate_sensitivity="low",
+                cost_sensitivity="low",
+                tier_uplifts={},
+                cost_of_pass_delta=0.0,
+                best_value_tier="T0",
+            )
+
+        # Calculate variances
+        pass_var = self.calculate_variance("pass_rate")
+        impl_var = self.calculate_variance("impl_rate")
+        cost_var = self.calculate_variance("cost_usd")
+
+        # Calculate uplifts for all tiers (except T0)
+        uplifts: dict[str, TierUplift] = {}
+        for tier_id in self.tier_stats:
+            if tier_id != "T0":
+                uplifts[tier_id] = self.calculate_uplift(tier_id)
+
+        # Calculate cost-of-pass delta
+        cops = [
+            self._calculate_cost_of_pass(t)
+            for t in self.tier_stats.values()
+        ]
+        # Filter out infinity for delta calculation
+        valid_cops = [c for c in cops if c != float("inf")]
+        if valid_cops:
+            cop_delta = max(valid_cops) - min(valid_cops)
+        else:
+            cop_delta = 0.0
+
+        # Find best value tier
+        value_scores = {
+            tier_id: self._calculate_value_score(t)
+            for tier_id, t in self.tier_stats.items()
+        }
+        best_value = max(value_scores, key=lambda k: value_scores[k])
+
+        return PromptSensitivityAnalysis(
+            pass_rate_variance=pass_var,
+            impl_rate_variance=impl_var,
+            cost_variance=cost_var,
+            pass_rate_sensitivity=self.interpret_sensitivity(pass_var),
+            impl_rate_sensitivity=self.interpret_sensitivity(impl_var),
+            cost_sensitivity=self.interpret_sensitivity(cost_var),
+            tier_uplifts=uplifts,
+            cost_of_pass_delta=cop_delta,
+            best_value_tier=best_value,
+        )
+
+    def assess_all_transitions(self) -> list[TierTransitionAssessment]:
+        """Assess all consecutive tier transitions.
+
+        Returns:
+            List of transition assessments for T0→T1, T1→T2, etc.
+        """
+        sorted_tiers = sorted(self.tier_stats.keys())
+        transitions = []
+
+        for i in range(len(sorted_tiers) - 1):
+            from_tier = sorted_tiers[i]
+            to_tier = sorted_tiers[i + 1]
+            transitions.append(self.assess_transition(from_tier, to_tier))
+
+        return transitions

--- a/tests/unit/metrics/test_cross_tier.py
+++ b/tests/unit/metrics/test_cross_tier.py
@@ -1,0 +1,307 @@
+"""Tests for cross-tier analysis.
+
+Python justification: Required for pytest testing framework.
+"""
+
+import pytest
+
+from scylla.metrics.aggregator import AggregatedStats, TierStatistics
+from scylla.metrics.cross_tier import (
+    CrossTierAnalyzer,
+    PromptSensitivityAnalysis,
+    TierTransitionAssessment,
+    TierUplift,
+)
+
+
+def make_stats(
+    median: float = 0.8,
+    mean: float = 0.8,
+    std_dev: float = 0.05,
+    count: int = 10,
+) -> AggregatedStats:
+    """Helper to create AggregatedStats."""
+    return AggregatedStats(
+        median=median,
+        mean=mean,
+        mode=median,
+        min=median - 0.1,
+        max=median + 0.1,
+        std_dev=std_dev,
+        count=count,
+    )
+
+
+def make_tier_stats(
+    tier_id: str,
+    pass_rate: float = 1.0,
+    impl_rate: float = 0.8,
+    cost_usd: float = 1.0,
+    duration: float = 60.0,
+) -> TierStatistics:
+    """Helper to create TierStatistics."""
+    composite = (pass_rate + impl_rate) / 2
+    return TierStatistics(
+        tier_id=tier_id,
+        runs_completed=10,
+        pass_rate=make_stats(pass_rate),
+        impl_rate=make_stats(impl_rate),
+        cost_usd=make_stats(cost_usd),
+        duration_seconds=make_stats(duration),
+        composite_score=make_stats(composite),
+        grade="B",
+    )
+
+
+class TestTierUplift:
+    """Tests for TierUplift dataclass."""
+
+    def test_create_uplift(self) -> None:
+        uplift = TierUplift(
+            tier_id="T1",
+            pass_rate_uplift=0.1,
+            impl_rate_uplift=0.2,
+            composite_uplift=0.15,
+            cost_change=0.05,
+        )
+        assert uplift.tier_id == "T1"
+        assert uplift.pass_rate_uplift == 0.1
+        assert uplift.composite_uplift == 0.15
+
+
+class TestPromptSensitivityAnalysis:
+    """Tests for PromptSensitivityAnalysis dataclass."""
+
+    def test_create_analysis(self) -> None:
+        analysis = PromptSensitivityAnalysis(
+            pass_rate_variance=0.05,
+            impl_rate_variance=0.03,
+            cost_variance=0.10,
+            pass_rate_sensitivity="low",
+            impl_rate_sensitivity="low",
+            cost_sensitivity="medium",
+            tier_uplifts={},
+            cost_of_pass_delta=0.5,
+            best_value_tier="T1",
+        )
+        assert analysis.pass_rate_variance == 0.05
+        assert analysis.pass_rate_sensitivity == "low"
+        assert analysis.best_value_tier == "T1"
+
+
+class TestTierTransitionAssessment:
+    """Tests for TierTransitionAssessment dataclass."""
+
+    def test_create_assessment(self) -> None:
+        assessment = TierTransitionAssessment(
+            from_tier="T0",
+            to_tier="T1",
+            pass_rate_delta=0.1,
+            impl_rate_delta=0.15,
+            cost_delta=0.2,
+            worth_it=True,
+            reason="+12.5% quality for +20.0% cost",
+        )
+        assert assessment.from_tier == "T0"
+        assert assessment.to_tier == "T1"
+        assert assessment.worth_it is True
+
+
+class TestCrossTierAnalyzerCalculateVariance:
+    """Tests for calculate_variance method."""
+
+    def test_single_tier(self) -> None:
+        tier_stats = {"T0": make_tier_stats("T0")}
+        analyzer = CrossTierAnalyzer(tier_stats)
+        variance = analyzer.calculate_variance("pass_rate")
+        assert variance == 0.0
+
+    def test_multiple_tiers_same_values(self) -> None:
+        tier_stats = {
+            "T0": make_tier_stats("T0", pass_rate=1.0),
+            "T1": make_tier_stats("T1", pass_rate=1.0),
+        }
+        analyzer = CrossTierAnalyzer(tier_stats)
+        variance = analyzer.calculate_variance("pass_rate")
+        assert variance == 0.0
+
+    def test_multiple_tiers_different_values(self) -> None:
+        tier_stats = {
+            "T0": make_tier_stats("T0", impl_rate=0.6),
+            "T1": make_tier_stats("T1", impl_rate=0.8),
+        }
+        analyzer = CrossTierAnalyzer(tier_stats)
+        variance = analyzer.calculate_variance("impl_rate")
+        assert variance > 0
+
+
+class TestCrossTierAnalyzerInterpretSensitivity:
+    """Tests for interpret_sensitivity method."""
+
+    def test_low_sensitivity(self) -> None:
+        analyzer = CrossTierAnalyzer({})
+        assert analyzer.interpret_sensitivity(0.01) == "low"
+        assert analyzer.interpret_sensitivity(0.04) == "low"
+
+    def test_medium_sensitivity(self) -> None:
+        analyzer = CrossTierAnalyzer({})
+        assert analyzer.interpret_sensitivity(0.06) == "medium"
+        assert analyzer.interpret_sensitivity(0.14) == "medium"
+
+    def test_high_sensitivity(self) -> None:
+        analyzer = CrossTierAnalyzer({})
+        assert analyzer.interpret_sensitivity(0.16) == "high"
+        assert analyzer.interpret_sensitivity(0.5) == "high"
+
+
+class TestCrossTierAnalyzerCalculateUplift:
+    """Tests for calculate_uplift method."""
+
+    def test_uplift_vs_t0(self) -> None:
+        tier_stats = {
+            "T0": make_tier_stats("T0", pass_rate=1.0, impl_rate=0.6),
+            "T1": make_tier_stats("T1", pass_rate=1.0, impl_rate=0.8),
+        }
+        analyzer = CrossTierAnalyzer(tier_stats)
+        uplift = analyzer.calculate_uplift("T1")
+
+        assert uplift.tier_id == "T1"
+        assert uplift.impl_rate_uplift == pytest.approx(0.333, rel=0.01)
+
+    def test_no_t0_baseline(self) -> None:
+        tier_stats = {
+            "T1": make_tier_stats("T1", pass_rate=1.0, impl_rate=0.8),
+        }
+        analyzer = CrossTierAnalyzer(tier_stats)
+        uplift = analyzer.calculate_uplift("T1")
+
+        assert uplift.pass_rate_uplift == 0.0
+        assert uplift.impl_rate_uplift == 0.0
+
+    def test_cost_change(self) -> None:
+        tier_stats = {
+            "T0": make_tier_stats("T0", cost_usd=1.0),
+            "T1": make_tier_stats("T1", cost_usd=1.5),
+        }
+        analyzer = CrossTierAnalyzer(tier_stats)
+        uplift = analyzer.calculate_uplift("T1")
+
+        assert uplift.cost_change == pytest.approx(0.5)
+
+
+class TestCrossTierAnalyzerAssessTransition:
+    """Tests for assess_transition method."""
+
+    def test_worth_it_transition(self) -> None:
+        """Quality improvement outweighs cost increase."""
+        tier_stats = {
+            "T0": make_tier_stats("T0", pass_rate=0.6, impl_rate=0.5, cost_usd=1.0),
+            "T1": make_tier_stats("T1", pass_rate=0.9, impl_rate=0.8, cost_usd=1.2),
+        }
+        analyzer = CrossTierAnalyzer(tier_stats)
+        assessment = analyzer.assess_transition("T0", "T1")
+
+        assert assessment.from_tier == "T0"
+        assert assessment.to_tier == "T1"
+        assert assessment.pass_rate_delta == pytest.approx(0.3)
+        assert assessment.impl_rate_delta == pytest.approx(0.3)
+        assert assessment.worth_it is True
+
+    def test_not_worth_it_transition(self) -> None:
+        """Cost increase outweighs quality improvement."""
+        tier_stats = {
+            "T0": make_tier_stats("T0", pass_rate=0.9, impl_rate=0.8, cost_usd=1.0),
+            "T1": make_tier_stats("T1", pass_rate=0.91, impl_rate=0.81, cost_usd=2.0),
+        }
+        analyzer = CrossTierAnalyzer(tier_stats)
+        assessment = analyzer.assess_transition("T0", "T1")
+
+        assert assessment.worth_it is False
+        assert "Only" in assessment.reason
+
+
+class TestCrossTierAnalyzerAnalyze:
+    """Tests for analyze method."""
+
+    def test_empty_tiers(self) -> None:
+        analyzer = CrossTierAnalyzer({})
+        analysis = analyzer.analyze()
+
+        assert analysis.pass_rate_variance == 0.0
+        assert analysis.pass_rate_sensitivity == "low"
+        assert analysis.tier_uplifts == {}
+        assert analysis.best_value_tier == "T0"
+
+    def test_single_tier(self) -> None:
+        tier_stats = {"T0": make_tier_stats("T0")}
+        analyzer = CrossTierAnalyzer(tier_stats)
+        analysis = analyzer.analyze()
+
+        assert analysis.pass_rate_variance == 0.0
+        assert analysis.tier_uplifts == {}
+        assert analysis.best_value_tier == "T0"
+
+    def test_multiple_tiers(self) -> None:
+        tier_stats = {
+            "T0": make_tier_stats("T0", pass_rate=1.0, impl_rate=0.6, cost_usd=1.0),
+            "T1": make_tier_stats("T1", pass_rate=1.0, impl_rate=0.8, cost_usd=1.2),
+            "T2": make_tier_stats("T2", pass_rate=1.0, impl_rate=0.9, cost_usd=2.0),
+        }
+        analyzer = CrossTierAnalyzer(tier_stats)
+        analysis = analyzer.analyze()
+
+        assert analysis.impl_rate_variance > 0
+        assert "T1" in analysis.tier_uplifts
+        assert "T2" in analysis.tier_uplifts
+        assert analysis.best_value_tier in ["T0", "T1", "T2"]
+
+    def test_best_value_tier_selection(self) -> None:
+        """Best value tier should be the one with highest quality/cost ratio."""
+        tier_stats = {
+            "T0": make_tier_stats("T0", pass_rate=1.0, impl_rate=0.6, cost_usd=1.0),
+            "T1": make_tier_stats("T1", pass_rate=1.0, impl_rate=0.8, cost_usd=1.0),
+            "T2": make_tier_stats("T2", pass_rate=1.0, impl_rate=0.9, cost_usd=5.0),
+        }
+        analyzer = CrossTierAnalyzer(tier_stats)
+        analysis = analyzer.analyze()
+
+        # T1 has best quality/cost ratio (0.9 composite / 1.0 cost = 0.9)
+        assert analysis.best_value_tier == "T1"
+
+    def test_cost_of_pass_delta(self) -> None:
+        tier_stats = {
+            "T0": make_tier_stats("T0", pass_rate=1.0, cost_usd=1.0),
+            "T1": make_tier_stats("T1", pass_rate=1.0, cost_usd=2.0),
+        }
+        analyzer = CrossTierAnalyzer(tier_stats)
+        analysis = analyzer.analyze()
+
+        # CoP for T0 = 1.0/1.0 = 1.0, CoP for T1 = 2.0/1.0 = 2.0
+        # Delta = 2.0 - 1.0 = 1.0
+        assert analysis.cost_of_pass_delta == pytest.approx(1.0)
+
+
+class TestCrossTierAnalyzerAssessAllTransitions:
+    """Tests for assess_all_transitions method."""
+
+    def test_assess_all(self) -> None:
+        tier_stats = {
+            "T0": make_tier_stats("T0", pass_rate=0.7, impl_rate=0.6),
+            "T1": make_tier_stats("T1", pass_rate=0.8, impl_rate=0.7),
+            "T2": make_tier_stats("T2", pass_rate=0.9, impl_rate=0.8),
+        }
+        analyzer = CrossTierAnalyzer(tier_stats)
+        transitions = analyzer.assess_all_transitions()
+
+        assert len(transitions) == 2
+        assert transitions[0].from_tier == "T0"
+        assert transitions[0].to_tier == "T1"
+        assert transitions[1].from_tier == "T1"
+        assert transitions[1].to_tier == "T2"
+
+    def test_single_tier(self) -> None:
+        tier_stats = {"T0": make_tier_stats("T0")}
+        analyzer = CrossTierAnalyzer(tier_stats)
+        transitions = analyzer.assess_all_transitions()
+
+        assert transitions == []


### PR DESCRIPTION
## Summary
- Implements `CrossTierAnalyzer` class for comprehensive prompt sensitivity analysis
- Adds `TierUplift`, `PromptSensitivityAnalysis`, and `TierTransitionAssessment` dataclasses
- Provides variance calculations, sensitivity interpretation, and tier transition value assessments

## Test plan
- [x] Unit tests for all dataclasses
- [x] Unit tests for variance calculations
- [x] Unit tests for sensitivity interpretation
- [x] Unit tests for uplift calculations
- [x] Unit tests for transition assessments
- [x] Unit tests for full analysis flow

Closes #37

🤖 Generated with [Claude Code](https://claude.com/claude-code)