### PR TITLE
feat(judge): add cleanup script evaluation

### DIFF
--- a/src/scylla/judge/__init__.py
+++ b/src/scylla/judge/__init__.py
@@ -4,6 +4,10 @@ This module provides the judge system for evaluating AI agent work
 using rubrics, prompts, and consensus-based scoring.
 """
 
+from scylla.judge.cleanup_evaluator import (
+    CleanupEvaluation,
+    CleanupEvaluator,
+)
 from scylla.judge.evaluator import (
     ConsensusJudgment,
     EvaluationParseError,
@@ -24,22 +28,10 @@ from scylla.judge.parser import (
     load_judgment,
 )
 from scylla.judge.prompts import (
-    CATEGORY_WEIGHTS,
-    JSON_OUTPUT_SCHEMA,
     JUDGE_PROMPT_TEMPLATE,
     TIER_CONTEXT_TEMPLATES,
-    TOTAL_CATEGORY_WEIGHT,
-    CategoryScore,
-    EvaluationCategory,
-    EvaluationSummary,
-    ExploratoryTesting,
-    JudgmentOutput,
-    RequirementScore,
     build_judge_prompt,
-    calculate_weighted_category_score,
-    get_category_descriptions,
     get_tier_context,
-    validate_judgment_output,
 )
 from scylla.judge.rubric import (
     EvaluationType,
@@ -52,6 +44,9 @@ from scylla.judge.rubric import (
 )
 
 __all__ = [
+    # Cleanup evaluator
+    "CleanupEvaluation",
+    "CleanupEvaluator",
     # Evaluator
     "ConsensusJudgment",
     "EvaluationParseError",
@@ -70,22 +65,10 @@ __all__ = [
     "JudgmentParser",
     "load_judgment",
     # Prompts
-    "CATEGORY_WEIGHTS",
-    "CategoryScore",
-    "EvaluationCategory",
-    "EvaluationSummary",
-    "ExploratoryTesting",
-    "JSON_OUTPUT_SCHEMA",
     "JUDGE_PROMPT_TEMPLATE",
-    "JudgmentOutput",
-    "RequirementScore",
     "TIER_CONTEXT_TEMPLATES",
-    "TOTAL_CATEGORY_WEIGHT",
     "build_judge_prompt",
-    "calculate_weighted_category_score",
-    "get_category_descriptions",
     "get_tier_context",
-    "validate_judgment_output",
     # Rubric
     "EvaluationType",
     "GradeScale",

--- a/src/scylla/judge/cleanup_evaluator.py
+++ b/src/scylla/judge/cleanup_evaluator.py
@@ -1,0 +1,278 @@
+"""Cleanup script evaluation for test scoring.
+
+This module evaluates agent-created cleanup scripts as part of the
+quality scoring system. Tests require agents to create cleanup scripts
+that return the environment to a clean state.
+
+Python Justification: Required for subprocess execution and file system operations.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from dataclasses import dataclass, field
+from pathlib import Path
+
+
+@dataclass
+class CleanupEvaluation:
+    """Result of cleanup script evaluation.
+
+    Attributes:
+        script_exists: Whether a cleanup script was found.
+        script_path: Path to the cleanup script if found.
+        execution_success: Whether the script ran without errors.
+        execution_output: Output from running the script.
+        cleanup_complete: Whether the environment is fully clean.
+        artifacts_remaining: List of artifacts that weren't cleaned up.
+        score: Evaluation score (0.0 to 1.0).
+        notes: Human-readable notes about the evaluation.
+    """
+
+    script_exists: bool
+    script_path: Path | None
+    execution_success: bool
+    execution_output: str
+    cleanup_complete: bool
+    artifacts_remaining: list[str] = field(default_factory=list)
+    score: float = 0.0
+    notes: str = ""
+
+
+class CleanupEvaluator:
+    """Evaluator for agent-created cleanup scripts.
+
+    Evaluates whether agents create proper cleanup scripts that return
+    the workspace environment to a clean state.
+    """
+
+    # Known cleanup script locations in priority order
+    CLEANUP_LOCATIONS = [
+        "cleanup.sh",
+        "scripts/cleanup.sh",
+        "Makefile",
+    ]
+
+    # Common build artifact patterns that should be cleaned
+    BUILD_PATTERNS = [
+        "build/",
+        "dist/",
+        "__pycache__/",
+        "*.o",
+        "*.pyc",
+        "node_modules/",
+        "target/",
+        ".cache/",
+        "*.egg-info/",
+        ".eggs/",
+        "*.so",
+        "*.dylib",
+    ]
+
+    # Scoring thresholds
+    SCORE_FULL_CLEANUP = 1.0
+    SCORE_PARTIAL_CLEANUP = 0.7
+    SCORE_SCRIPT_FAILED = 0.4
+    SCORE_NO_SCRIPT = 0.0
+
+    # Execution timeout in seconds
+    EXECUTION_TIMEOUT = 60
+
+    def __init__(self, workspace: Path) -> None:
+        """Initialize the evaluator.
+
+        Args:
+            workspace: Path to the workspace to evaluate.
+        """
+        self.workspace = workspace
+        self.initial_state: set[str] | None = None
+
+    def capture_initial_state(self) -> None:
+        """Capture workspace state before agent runs.
+
+        Call this before the agent modifies the workspace to establish
+        a baseline for cleanup verification.
+        """
+        self.initial_state = self._get_workspace_state()
+
+    def _get_workspace_state(self) -> set[str]:
+        """Get set of files in workspace.
+
+        Returns:
+            Set of relative file paths in the workspace.
+        """
+        return set(
+            str(p.relative_to(self.workspace))
+            for p in self.workspace.rglob("*")
+            if p.is_file()
+        )
+
+    def find_cleanup_script(self) -> Path | None:
+        """Find cleanup script in workspace.
+
+        Returns:
+            Path to cleanup script if found, None otherwise.
+        """
+        for location in self.CLEANUP_LOCATIONS:
+            path = self.workspace / location
+            if path.exists():
+                if location == "Makefile":
+                    if self._makefile_has_clean(path):
+                        return path
+                else:
+                    return path
+        return None
+
+    def _makefile_has_clean(self, makefile: Path) -> bool:
+        """Check if Makefile has a clean target.
+
+        Args:
+            makefile: Path to the Makefile.
+
+        Returns:
+            True if Makefile has a clean target.
+        """
+        try:
+            content = makefile.read_text()
+            return "clean:" in content or "clean :" in content
+        except OSError:
+            return False
+
+    def run_cleanup(self, script_path: Path) -> tuple[bool, str]:
+        """Execute cleanup script and capture result.
+
+        Args:
+            script_path: Path to the cleanup script.
+
+        Returns:
+            Tuple of (success, output).
+        """
+        try:
+            if script_path.name == "Makefile":
+                result = subprocess.run(
+                    ["make", "clean"],
+                    cwd=self.workspace,
+                    capture_output=True,
+                    text=True,
+                    timeout=self.EXECUTION_TIMEOUT,
+                )
+            else:
+                # Make script executable
+                script_path.chmod(0o755)
+                result = subprocess.run(
+                    [str(script_path)],
+                    cwd=self.workspace,
+                    capture_output=True,
+                    text=True,
+                    timeout=self.EXECUTION_TIMEOUT,
+                )
+
+            success = result.returncode == 0
+            output = result.stdout + result.stderr
+            return success, output
+        except subprocess.TimeoutExpired:
+            return False, "Cleanup script timed out"
+        except OSError as e:
+            return False, str(e)
+
+    def verify_cleanup(self) -> tuple[bool, list[str]]:
+        """Verify workspace is clean after cleanup.
+
+        Returns:
+            Tuple of (cleanup_complete, artifacts_remaining).
+        """
+        if self.initial_state is None:
+            # No initial state captured, assume clean
+            return True, []
+
+        current_state = self._get_workspace_state()
+
+        # Files that appeared during agent run
+        new_files = current_state - self.initial_state
+
+        # Check for build artifacts that should have been cleaned
+        artifacts_remaining = []
+        for f in new_files:
+            if self._is_build_artifact(f):
+                artifacts_remaining.append(f)
+
+        cleanup_complete = len(artifacts_remaining) == 0
+        return cleanup_complete, artifacts_remaining
+
+    def _is_build_artifact(self, filepath: str) -> bool:
+        """Check if a file matches build artifact patterns.
+
+        Args:
+            filepath: Relative path to the file.
+
+        Returns:
+            True if the file is a build artifact.
+        """
+        for pattern in self.BUILD_PATTERNS:
+            if pattern.endswith("/"):
+                # Directory pattern
+                if filepath.startswith(pattern.rstrip("/")):
+                    return True
+            elif pattern.startswith("*"):
+                # Extension pattern
+                if filepath.endswith(pattern.lstrip("*")):
+                    return True
+            else:
+                # Exact match
+                if filepath == pattern:
+                    return True
+        return False
+
+    def evaluate(self) -> CleanupEvaluation:
+        """Perform full cleanup script evaluation.
+
+        Returns:
+            CleanupEvaluation with score and details.
+        """
+        script_path = self.find_cleanup_script()
+
+        if script_path is None:
+            return CleanupEvaluation(
+                script_exists=False,
+                script_path=None,
+                execution_success=False,
+                execution_output="",
+                cleanup_complete=False,
+                artifacts_remaining=[],
+                score=self.SCORE_NO_SCRIPT,
+                notes="No cleanup script found",
+            )
+
+        execution_success, output = self.run_cleanup(script_path)
+
+        if not execution_success:
+            return CleanupEvaluation(
+                script_exists=True,
+                script_path=script_path,
+                execution_success=False,
+                execution_output=output,
+                cleanup_complete=False,
+                artifacts_remaining=[],
+                score=self.SCORE_SCRIPT_FAILED,
+                notes=f"Cleanup script failed: {output[:200]}",
+            )
+
+        cleanup_complete, artifacts = self.verify_cleanup()
+
+        if cleanup_complete:
+            score = self.SCORE_FULL_CLEANUP
+            notes = "Cleanup successful, environment restored"
+        else:
+            score = self.SCORE_PARTIAL_CLEANUP
+            notes = f"Partial cleanup, {len(artifacts)} artifacts remaining"
+
+        return CleanupEvaluation(
+            script_exists=True,
+            script_path=script_path,
+            execution_success=True,
+            execution_output=output,
+            cleanup_complete=cleanup_complete,
+            artifacts_remaining=artifacts,
+            score=score,
+            notes=notes,
+        )

--- a/tests/unit/judge/test_cleanup_evaluator.py
+++ b/tests/unit/judge/test_cleanup_evaluator.py
@@ -1,0 +1,252 @@
+"""Tests for cleanup script evaluation.
+
+Python justification: Required for pytest testing framework.
+"""
+
+import pytest
+from pathlib import Path
+import tempfile
+import os
+
+from scylla.judge.cleanup_evaluator import (
+    CleanupEvaluation,
+    CleanupEvaluator,
+)
+
+
+class TestCleanupEvaluation:
+    """Tests for CleanupEvaluation dataclass."""
+
+    def test_create_evaluation(self) -> None:
+        evaluation = CleanupEvaluation(
+            script_exists=True,
+            script_path=Path("/workspace/cleanup.sh"),
+            execution_success=True,
+            execution_output="Cleaned up",
+            cleanup_complete=True,
+            artifacts_remaining=[],
+            score=1.0,
+            notes="Cleanup successful",
+        )
+        assert evaluation.script_exists is True
+        assert evaluation.score == 1.0
+
+    def test_no_script_evaluation(self) -> None:
+        evaluation = CleanupEvaluation(
+            script_exists=False,
+            script_path=None,
+            execution_success=False,
+            execution_output="",
+            cleanup_complete=False,
+            score=0.0,
+            notes="No cleanup script found",
+        )
+        assert evaluation.script_exists is False
+        assert evaluation.score == 0.0
+
+
+class TestCleanupEvaluatorFindScript:
+    """Tests for find_cleanup_script method."""
+
+    def test_finds_cleanup_sh(self, tmp_path: Path) -> None:
+        (tmp_path / "cleanup.sh").write_text("#!/bin/bash\necho 'clean'")
+        evaluator = CleanupEvaluator(tmp_path)
+        script = evaluator.find_cleanup_script()
+        assert script is not None
+        assert script.name == "cleanup.sh"
+
+    def test_finds_scripts_cleanup_sh(self, tmp_path: Path) -> None:
+        scripts_dir = tmp_path / "scripts"
+        scripts_dir.mkdir()
+        (scripts_dir / "cleanup.sh").write_text("#!/bin/bash\necho 'clean'")
+        evaluator = CleanupEvaluator(tmp_path)
+        script = evaluator.find_cleanup_script()
+        assert script is not None
+        assert str(script).endswith("scripts/cleanup.sh")
+
+    def test_finds_makefile_with_clean(self, tmp_path: Path) -> None:
+        (tmp_path / "Makefile").write_text("clean:\n\trm -rf build\n")
+        evaluator = CleanupEvaluator(tmp_path)
+        script = evaluator.find_cleanup_script()
+        assert script is not None
+        assert script.name == "Makefile"
+
+    def test_ignores_makefile_without_clean(self, tmp_path: Path) -> None:
+        (tmp_path / "Makefile").write_text("build:\n\techo 'building'\n")
+        evaluator = CleanupEvaluator(tmp_path)
+        script = evaluator.find_cleanup_script()
+        assert script is None
+
+    def test_no_script_found(self, tmp_path: Path) -> None:
+        evaluator = CleanupEvaluator(tmp_path)
+        script = evaluator.find_cleanup_script()
+        assert script is None
+
+    def test_priority_order(self, tmp_path: Path) -> None:
+        """cleanup.sh should be found before Makefile."""
+        (tmp_path / "cleanup.sh").write_text("#!/bin/bash\necho 'clean'")
+        (tmp_path / "Makefile").write_text("clean:\n\trm -rf build\n")
+        evaluator = CleanupEvaluator(tmp_path)
+        script = evaluator.find_cleanup_script()
+        assert script is not None
+        assert script.name == "cleanup.sh"
+
+
+class TestCleanupEvaluatorMakefileHasClean:
+    """Tests for _makefile_has_clean method."""
+
+    def test_clean_target(self, tmp_path: Path) -> None:
+        makefile = tmp_path / "Makefile"
+        makefile.write_text("clean:\n\trm -rf build\n")
+        evaluator = CleanupEvaluator(tmp_path)
+        assert evaluator._makefile_has_clean(makefile) is True
+
+    def test_clean_target_with_space(self, tmp_path: Path) -> None:
+        makefile = tmp_path / "Makefile"
+        makefile.write_text("clean :\n\trm -rf build\n")
+        evaluator = CleanupEvaluator(tmp_path)
+        assert evaluator._makefile_has_clean(makefile) is True
+
+    def test_no_clean_target(self, tmp_path: Path) -> None:
+        makefile = tmp_path / "Makefile"
+        makefile.write_text("build:\n\techo 'building'\n")
+        evaluator = CleanupEvaluator(tmp_path)
+        assert evaluator._makefile_has_clean(makefile) is False
+
+
+class TestCleanupEvaluatorRunCleanup:
+    """Tests for run_cleanup method."""
+
+    def test_successful_script(self, tmp_path: Path) -> None:
+        script = tmp_path / "cleanup.sh"
+        script.write_text("#!/bin/bash\necho 'cleaned'\nexit 0\n")
+        evaluator = CleanupEvaluator(tmp_path)
+        success, output = evaluator.run_cleanup(script)
+        assert success is True
+        assert "cleaned" in output
+
+    def test_failing_script(self, tmp_path: Path) -> None:
+        script = tmp_path / "cleanup.sh"
+        script.write_text("#!/bin/bash\nexit 1\n")
+        evaluator = CleanupEvaluator(tmp_path)
+        success, output = evaluator.run_cleanup(script)
+        assert success is False
+
+    def test_makefile_clean(self, tmp_path: Path) -> None:
+        makefile = tmp_path / "Makefile"
+        makefile.write_text(".PHONY: clean\nclean:\n\t@echo 'cleaned'\n")
+        evaluator = CleanupEvaluator(tmp_path)
+        success, output = evaluator.run_cleanup(makefile)
+        assert success is True
+        assert "cleaned" in output
+
+
+class TestCleanupEvaluatorCaptureState:
+    """Tests for state capture and verification."""
+
+    def test_capture_initial_state(self, tmp_path: Path) -> None:
+        (tmp_path / "file1.txt").write_text("content")
+        evaluator = CleanupEvaluator(tmp_path)
+        evaluator.capture_initial_state()
+        assert evaluator.initial_state is not None
+        assert "file1.txt" in evaluator.initial_state
+
+    def test_verify_cleanup_no_artifacts(self, tmp_path: Path) -> None:
+        evaluator = CleanupEvaluator(tmp_path)
+        evaluator.capture_initial_state()
+        # No new files, cleanup complete
+        complete, artifacts = evaluator.verify_cleanup()
+        assert complete is True
+        assert artifacts == []
+
+    def test_verify_cleanup_with_artifacts(self, tmp_path: Path) -> None:
+        evaluator = CleanupEvaluator(tmp_path)
+        evaluator.capture_initial_state()
+        # Create build artifact
+        build_dir = tmp_path / "build"
+        build_dir.mkdir()
+        (build_dir / "output.o").write_text("binary")
+        complete, artifacts = evaluator.verify_cleanup()
+        assert complete is False
+        assert len(artifacts) > 0
+
+    def test_verify_cleanup_no_initial_state(self, tmp_path: Path) -> None:
+        evaluator = CleanupEvaluator(tmp_path)
+        # No initial state captured
+        complete, artifacts = evaluator.verify_cleanup()
+        assert complete is True
+        assert artifacts == []
+
+
+class TestCleanupEvaluatorIsBuildArtifact:
+    """Tests for _is_build_artifact method."""
+
+    def test_build_directory(self, tmp_path: Path) -> None:
+        evaluator = CleanupEvaluator(tmp_path)
+        assert evaluator._is_build_artifact("build/output.txt") is True
+        assert evaluator._is_build_artifact("dist/package.tar.gz") is True
+
+    def test_pycache(self, tmp_path: Path) -> None:
+        evaluator = CleanupEvaluator(tmp_path)
+        assert evaluator._is_build_artifact("__pycache__/module.cpython-311.pyc") is True
+
+    def test_object_files(self, tmp_path: Path) -> None:
+        evaluator = CleanupEvaluator(tmp_path)
+        assert evaluator._is_build_artifact("main.o") is True
+        assert evaluator._is_build_artifact("module.pyc") is True
+
+    def test_not_artifact(self, tmp_path: Path) -> None:
+        evaluator = CleanupEvaluator(tmp_path)
+        assert evaluator._is_build_artifact("src/main.py") is False
+        assert evaluator._is_build_artifact("README.md") is False
+
+
+class TestCleanupEvaluatorEvaluate:
+    """Tests for the full evaluate method."""
+
+    def test_no_script(self, tmp_path: Path) -> None:
+        evaluator = CleanupEvaluator(tmp_path)
+        result = evaluator.evaluate()
+        assert result.script_exists is False
+        assert result.score == CleanupEvaluator.SCORE_NO_SCRIPT
+        assert "No cleanup script" in result.notes
+
+    def test_successful_full_cleanup(self, tmp_path: Path) -> None:
+        script = tmp_path / "cleanup.sh"
+        script.write_text("#!/bin/bash\necho 'cleaned'\n")
+        evaluator = CleanupEvaluator(tmp_path)
+        evaluator.capture_initial_state()
+        result = evaluator.evaluate()
+        assert result.script_exists is True
+        assert result.execution_success is True
+        assert result.cleanup_complete is True
+        assert result.score == CleanupEvaluator.SCORE_FULL_CLEANUP
+
+    def test_script_fails(self, tmp_path: Path) -> None:
+        script = tmp_path / "cleanup.sh"
+        script.write_text("#!/bin/bash\nexit 1\n")
+        evaluator = CleanupEvaluator(tmp_path)
+        result = evaluator.evaluate()
+        assert result.script_exists is True
+        assert result.execution_success is False
+        assert result.score == CleanupEvaluator.SCORE_SCRIPT_FAILED
+
+    def test_partial_cleanup(self, tmp_path: Path) -> None:
+        # Create cleanup script that doesn't remove all artifacts
+        script = tmp_path / "cleanup.sh"
+        script.write_text("#!/bin/bash\necho 'partial cleanup'\n")
+
+        evaluator = CleanupEvaluator(tmp_path)
+        evaluator.capture_initial_state()
+
+        # Add build artifact after initial state
+        build_dir = tmp_path / "build"
+        build_dir.mkdir()
+        (build_dir / "output.o").write_text("binary")
+
+        result = evaluator.evaluate()
+        assert result.script_exists is True
+        assert result.execution_success is True
+        assert result.cleanup_complete is False
+        assert result.score == CleanupEvaluator.SCORE_PARTIAL_CLEANUP
+        assert len(result.artifacts_remaining) > 0


### PR DESCRIPTION
## Summary
- Implements `CleanupEvaluator` class for evaluating agent-created cleanup scripts
- Detects cleanup scripts at standard locations (cleanup.sh, Makefile clean target)
- Executes scripts safely with timeout and captures output
- Verifies cleanup completeness by tracking build artifacts
- Provides scored evaluation (1.0 full, 0.7 partial, 0.4 failed, 0.0 no script)

## Test plan
- [x] Unit tests for script detection
- [x] Unit tests for Makefile clean target detection
- [x] Unit tests for script execution
- [x] Unit tests for state capture and verification
- [x] Unit tests for build artifact detection
- [x] Unit tests for full evaluation flow

Also fixes judge module's __init__.py to only export items that exist in prompts.py.

Closes #38

🤖 Generated with [Claude Code](https://claude.com/claude-code)