### PR TITLE
feat(judge): add consensus retry logic for disagreeing judges

### DIFF
--- a/src/scylla/judge/__init__.py
+++ b/src/scylla/judge/__init__.py
@@ -9,6 +9,7 @@ from scylla.judge.cleanup_evaluator import (
     CleanupEvaluator,
 )
 from scylla.judge.evaluator import (
+    ConsensusConfig,
     ConsensusJudgment,
     EvaluationParseError,
     EvaluatorConfig,
@@ -19,6 +20,7 @@ from scylla.judge.evaluator import (
     JudgeScore,
     JudgeSummary,
     assign_grade,
+    needs_additional_runs,
     weighted_consensus,
 )
 from scylla.judge.parser import (
@@ -48,6 +50,7 @@ __all__ = [
     "CleanupEvaluation",
     "CleanupEvaluator",
     # Evaluator
+    "ConsensusConfig",
     "ConsensusJudgment",
     "EvaluationParseError",
     "EvaluatorConfig",
@@ -58,6 +61,7 @@ __all__ = [
     "JudgeScore",
     "JudgeSummary",
     "assign_grade",
+    "needs_additional_runs",
     "weighted_consensus",
     # Parser
     "ExploratoryTestingResult",

--- a/src/scylla/judge/evaluator.py
+++ b/src/scylla/judge/evaluator.py
@@ -1,7 +1,7 @@
 """Judge evaluator for running evaluations with consensus.
 
-This module provides the JudgeEvaluator class that runs 3 evaluations
-and calculates confidence-weighted consensus scores.
+This module provides the JudgeEvaluator class that runs evaluations
+with consensus-based scoring and retry logic for disagreement.
 
 Python Justification: Required for subprocess orchestration and JSON parsing.
 """
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import json
 import logging
+import statistics
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Protocol
@@ -115,7 +116,11 @@ class ConsensusJudgment:
         letter_grade: Consensus letter grade.
         overall_confidence: Overall confidence from consensus.
         individual_runs: Individual judgment runs.
-        run_count: Number of runs performed.
+        run_count: Total number of runs performed.
+        initial_runs: Number of initial runs before retry.
+        retry_runs: Number of additional retry runs.
+        consensus_reached: Whether consensus was reached.
+        consensus_reason: Reason for final consensus state.
     """
 
     requirements: dict[str, float] = field(default_factory=dict)
@@ -126,6 +131,10 @@ class ConsensusJudgment:
     overall_confidence: float = 0.0
     individual_runs: list[Judgment] = field(default_factory=list)
     run_count: int = 3
+    initial_runs: int = 3
+    retry_runs: int = 0
+    consensus_reached: bool = True
+    consensus_reason: str = ""
 
 
 class EvaluatorConfig(BaseModel):
@@ -142,6 +151,61 @@ class EvaluatorConfig(BaseModel):
     num_runs: int = Field(default=3, ge=1)
     timeout: int = Field(default=300, ge=30)
     pass_threshold: float = Field(default=0.70, ge=0.0, le=1.0)
+
+
+class ConsensusConfig(BaseModel):
+    """Configuration for consensus retry logic.
+
+    Attributes:
+        initial_runs: Number of initial judge runs (default 3).
+        max_additional_runs: Maximum additional runs on disagreement.
+        variance_threshold: Score variance threshold to trigger retry.
+        min_confidence: Minimum average confidence to avoid retry.
+        score_range_threshold: Maximum allowed score range before retry.
+    """
+
+    initial_runs: int = Field(default=3, ge=1)
+    max_additional_runs: int = Field(default=5, ge=0)
+    variance_threshold: float = Field(default=0.15, ge=0.0, le=1.0)
+    min_confidence: float = Field(default=0.6, ge=0.0, le=1.0)
+    score_range_threshold: float = Field(default=0.3, ge=0.0, le=1.0)
+
+
+def needs_additional_runs(
+    scores: list[JudgeScore],
+    config: ConsensusConfig,
+) -> tuple[bool, str]:
+    """Determine if additional judge runs are needed.
+
+    Args:
+        scores: List of judge scores from runs so far.
+        config: Consensus configuration.
+
+    Returns:
+        Tuple of (needs_retry, reason).
+    """
+    if len(scores) < 2:
+        return False, "insufficient runs"
+
+    values = [s.score for s in scores]
+    confidences = [s.confidence for s in scores]
+
+    # Check variance
+    variance = statistics.variance(values)
+    if variance > config.variance_threshold:
+        return True, f"high variance ({variance:.3f} > {config.variance_threshold})"
+
+    # Check average confidence
+    avg_confidence = statistics.mean(confidences)
+    if avg_confidence < config.min_confidence:
+        return True, f"low confidence ({avg_confidence:.2f} < {config.min_confidence})"
+
+    # Check score range
+    score_range = max(values) - min(values)
+    if score_range > config.score_range_threshold:
+        return True, f"high range ({score_range:.2f} > {config.score_range_threshold})"
+
+    return False, "consensus reached"
 
 
 class EvaluatorError(Exception):
@@ -198,25 +262,32 @@ def assign_grade(score: float) -> str:
 
 
 class JudgeEvaluator:
-    """Evaluator that runs 3 judge evaluations and calculates consensus.
+    """Evaluator that runs judge evaluations with consensus and retry logic.
+
+    Runs initial evaluations and performs additional runs when judges
+    significantly disagree, up to a configurable maximum.
 
     Attributes:
         config: Evaluator configuration.
+        consensus_config: Consensus retry configuration.
         adapter: The adapter to use for running evaluations.
     """
 
     def __init__(
         self,
         config: EvaluatorConfig | None = None,
+        consensus_config: ConsensusConfig | None = None,
         adapter: AdapterProtocol | None = None,
     ) -> None:
         """Initialize the evaluator.
 
         Args:
             config: Evaluator configuration.
+            consensus_config: Consensus retry configuration.
             adapter: Optional adapter for running evaluations.
         """
         self.config = config or EvaluatorConfig()
+        self.consensus_config = consensus_config or ConsensusConfig()
         self.adapter = adapter
 
     def evaluate_with_consensus(
@@ -227,7 +298,11 @@ class JudgeEvaluator:
         rubric: str,
         tier_id: str | None = None,
     ) -> ConsensusJudgment:
-        """Run multiple judge evaluations and calculate consensus.
+        """Run judge evaluations with consensus and retry on disagreement.
+
+        First runs initial_runs evaluations, then checks for disagreement.
+        If disagreement is detected, runs additional evaluations up to
+        max_additional_runs until consensus is reached.
 
         Args:
             workspace: Path to the workspace to evaluate.
@@ -237,15 +312,18 @@ class JudgeEvaluator:
             tier_id: Optional tier identifier.
 
         Returns:
-            ConsensusJudgment with weighted consensus scores.
+            ConsensusJudgment with weighted consensus scores and retry info.
 
         Raises:
             EvaluatorError: If evaluation fails.
         """
         judgments: list[Judgment] = []
+        initial_runs = self.consensus_config.initial_runs
+        retry_runs = 0
 
-        for run_num in range(self.config.num_runs):
-            logger.info(f"Running judge evaluation {run_num + 1}/{self.config.num_runs}")
+        # Run initial evaluations
+        for run_num in range(initial_runs):
+            logger.info(f"Running initial judge evaluation {run_num + 1}/{initial_runs}")
             try:
                 judgment = self._single_evaluation(
                     workspace=workspace,
@@ -260,7 +338,65 @@ class JudgeEvaluator:
                 # Add empty judgment for failed run
                 judgments.append(Judgment())
 
-        return self._calculate_consensus(judgments)
+        # Check for disagreement and retry if needed
+        scores = self._extract_overall_scores(judgments)
+        needs_retry, reason = needs_additional_runs(scores, self.consensus_config)
+
+        while needs_retry and retry_runs < self.consensus_config.max_additional_runs:
+            retry_runs += 1
+            total_runs = initial_runs + retry_runs
+            logger.info(
+                f"Running additional judge evaluation {retry_runs}/"
+                f"{self.consensus_config.max_additional_runs} (reason: {reason})"
+            )
+            try:
+                judgment = self._single_evaluation(
+                    workspace=workspace,
+                    prompt=prompt,
+                    criteria=criteria,
+                    rubric=rubric,
+                    tier_id=tier_id,
+                )
+                judgments.append(judgment)
+            except Exception as e:
+                logger.warning(f"Retry run {retry_runs} failed: {e}")
+                judgments.append(Judgment())
+
+            # Re-check for consensus
+            scores = self._extract_overall_scores(judgments)
+            needs_retry, reason = needs_additional_runs(scores, self.consensus_config)
+
+        # Calculate final consensus with retry information
+        consensus = self._calculate_consensus(judgments)
+        consensus.initial_runs = initial_runs
+        consensus.retry_runs = retry_runs
+        consensus.consensus_reached = not needs_retry
+        consensus.consensus_reason = reason
+
+        return consensus
+
+    def _extract_overall_scores(
+        self,
+        judgments: list[Judgment],
+    ) -> list[JudgeScore]:
+        """Extract overall scores from judgments for disagreement checking.
+
+        Args:
+            judgments: List of judgment runs.
+
+        Returns:
+            List of JudgeScore objects for overall scores.
+        """
+        scores = []
+        for j in judgments:
+            if j.summary:
+                scores.append(
+                    JudgeScore(
+                        score=j.summary.weighted_score,
+                        confidence=j.summary.overall_confidence,
+                    )
+                )
+        return scores
 
     def _single_evaluation(
         self,


### PR DESCRIPTION
## Summary
- Adds `ConsensusConfig` for configurable retry thresholds
- Implements disagreement detection via `needs_additional_runs()`
- Updates `JudgeEvaluator` to run additional evaluations on disagreement
- Tracks retry information in `ConsensusJudgment`

## Disagreement Triggers
- Score variance > 0.15 (configurable)
- Average confidence < 0.6 (configurable)
- Score range > 0.3 (configurable)

## Test plan
- [x] Unit tests for ConsensusConfig
- [x] Unit tests for needs_additional_runs function
- [x] Unit tests for variance/confidence/range triggers
- [x] Unit tests for ConsensusJudgment retry fields
- [x] Integration tests for evaluator with retry logic

Closes #43

🤖 Generated with [Claude Code](https://claude.com/claude-code)