### PR TITLE
feat(executor): add judge container orchestration

### DIFF
--- a/src/scylla/executor/__init__.py
+++ b/src/scylla/executor/__init__.py
@@ -20,6 +20,11 @@ from scylla.executor.docker import (
     DockerExecutor,
     DockerNotAvailableError,
 )
+from scylla.executor.judge_container import (
+    JudgeContainerConfig,
+    JudgeContainerManager,
+    JudgeResult,
+)
 from scylla.executor.runner import (
     ExecutionInfo,
     ExecutionState,
@@ -68,6 +73,10 @@ __all__ = [
     "DockerError",
     "DockerExecutor",
     "DockerNotAvailableError",
+    # Judge container
+    "JudgeContainerConfig",
+    "JudgeContainerManager",
+    "JudgeResult",
     # Runner
     "ExecutionInfo",
     "ExecutionState",

--- a/src/scylla/executor/judge_container.py
+++ b/src/scylla/executor/judge_container.py
@@ -1,0 +1,422 @@
+"""Judge container orchestration for isolated evaluation.
+
+This module provides Docker container management specifically for running
+the judge (evaluator) in isolation from the agent container.
+
+Python Justification: Required for Docker SDK interaction and subprocess output
+capture (Mojo stdlib limitation - cannot capture stdout/stderr from subprocesses).
+
+Design Decisions:
+- Judge runs in SEPARATE container from agent
+- Agent workspace mounted as READ-ONLY
+- Judge output directory mounted as read-write
+- API keys passed via environment variables
+- Containers preserved for analysis after completion
+"""
+
+from __future__ import annotations
+
+import os
+import uuid
+from dataclasses import dataclass, field
+from pathlib import Path
+
+from scylla.executor.docker import (
+    ContainerConfig,
+    ContainerError,
+    ContainerResult,
+    DockerExecutor,
+)
+
+
+@dataclass
+class JudgeContainerConfig:
+    """Configuration for creating a judge container.
+
+    Attributes:
+        agent_workspace: Path to agent workspace (mounted read-only).
+        output_dir: Path for judge output (mounted read-write).
+        judge_model: Model to use for judging (default: claude-opus-4-5).
+        rubric_path: Path to scoring rubric file.
+        criteria_path: Path to success criteria file.
+        prompt_path: Path to original task prompt file.
+        timeout_seconds: Maximum evaluation time in seconds.
+        image: Docker image to use for judge container.
+    """
+
+    agent_workspace: Path
+    output_dir: Path
+    judge_model: str = "claude-opus-4-5-20251101"
+    rubric_path: Path | None = None
+    criteria_path: Path | None = None
+    prompt_path: Path | None = None
+    timeout_seconds: int = 600  # 10 minutes
+    image: str = "scylla-runner:latest"
+
+
+@dataclass
+class JudgeResult:
+    """Result from running the judge container.
+
+    Attributes:
+        container_id: Docker container ID.
+        exit_code: Container exit code (0 = success).
+        stdout: Captured standard output.
+        stderr: Captured standard error.
+        timed_out: Whether the container was killed due to timeout.
+        tokens_input: Estimated input tokens used.
+        tokens_output: Estimated output tokens used.
+        cost_usd: Estimated cost in USD.
+    """
+
+    container_id: str
+    exit_code: int
+    stdout: str
+    stderr: str
+    timed_out: bool = False
+    tokens_input: int = 0
+    tokens_output: int = 0
+    cost_usd: float = 0.0
+
+
+class JudgeContainerManager:
+    """Manages Docker container lifecycle for judge execution.
+
+    This class handles creating, running, and managing judge containers
+    that evaluate agent work in isolation. The agent workspace is mounted
+    as read-only to prevent modifications during evaluation.
+
+    Example:
+        >>> manager = JudgeContainerManager()
+        >>> config = JudgeContainerConfig(
+        ...     agent_workspace=Path("/runs/test-001/workspace"),
+        ...     output_dir=Path("/runs/test-001/judge_output"),
+        ...     rubric_path=Path("/tests/001/rubric.yaml"),
+        ... )
+        >>> result = manager.run_judge(config)
+        >>> print(f"Exit code: {result.exit_code}")
+    """
+
+    # Default judge image
+    DEFAULT_IMAGE = "scylla-runner:latest"
+
+    # Container mount paths
+    WORKSPACE_MOUNT = "/workspace"
+    OUTPUT_MOUNT = "/output"
+    RUBRIC_MOUNT = "/rubric"
+    CRITERIA_MOUNT = "/criteria"
+    PROMPT_MOUNT = "/prompt"
+
+    def __init__(self, executor: DockerExecutor | None = None) -> None:
+        """Initialize JudgeContainerManager.
+
+        Args:
+            executor: DockerExecutor to use. Created if not provided.
+        """
+        self.executor = executor or DockerExecutor()
+        self._active_containers: list[str] = []
+
+    def _generate_container_name(self) -> str:
+        """Generate unique container name for judge.
+
+        Returns:
+            Unique container name like "scylla-judge-abc123".
+        """
+        short_id = str(uuid.uuid4())[:8]
+        return f"scylla-judge-{short_id}"
+
+    def _build_environment(self, config: JudgeContainerConfig) -> dict[str, str]:
+        """Build environment variables for judge container.
+
+        Args:
+            config: Judge container configuration.
+
+        Returns:
+            Dictionary of environment variables.
+        """
+        env = {
+            "ROLE": "judge",
+            "MODEL": config.judge_model,
+            "WORKSPACE_PATH": self.WORKSPACE_MOUNT,
+            "OUTPUT_PATH": self.OUTPUT_MOUNT,
+        }
+
+        # Add API key from host environment
+        if "ANTHROPIC_API_KEY" in os.environ:
+            env["ANTHROPIC_API_KEY"] = os.environ["ANTHROPIC_API_KEY"]
+
+        # Add rubric path if provided
+        if config.rubric_path:
+            env["RUBRIC_PATH"] = f"{self.RUBRIC_MOUNT}/{config.rubric_path.name}"
+
+        # Add criteria path if provided
+        if config.criteria_path:
+            env["CRITERIA_PATH"] = f"{self.CRITERIA_MOUNT}/{config.criteria_path.name}"
+
+        # Add prompt path if provided
+        if config.prompt_path:
+            env["PROMPT_PATH"] = f"{self.PROMPT_MOUNT}/{config.prompt_path.name}"
+
+        return env
+
+    def _build_volumes(self, config: JudgeContainerConfig) -> dict[str, dict[str, str]]:
+        """Build volume mounts for judge container.
+
+        Args:
+            config: Judge container configuration.
+
+        Returns:
+            Dictionary of volume mounts.
+        """
+        volumes = {
+            # Agent workspace - READ-ONLY
+            str(config.agent_workspace.resolve()): {
+                "bind": self.WORKSPACE_MOUNT,
+                "mode": "ro",
+            },
+            # Judge output - READ-WRITE
+            str(config.output_dir.resolve()): {
+                "bind": self.OUTPUT_MOUNT,
+                "mode": "rw",
+            },
+        }
+
+        # Mount rubric file if provided
+        if config.rubric_path and config.rubric_path.exists():
+            volumes[str(config.rubric_path.parent.resolve())] = {
+                "bind": self.RUBRIC_MOUNT,
+                "mode": "ro",
+            }
+
+        # Mount criteria file if provided
+        if config.criteria_path and config.criteria_path.exists():
+            volumes[str(config.criteria_path.parent.resolve())] = {
+                "bind": self.CRITERIA_MOUNT,
+                "mode": "ro",
+            }
+
+        # Mount prompt file if provided
+        if config.prompt_path and config.prompt_path.exists():
+            volumes[str(config.prompt_path.parent.resolve())] = {
+                "bind": self.PROMPT_MOUNT,
+                "mode": "ro",
+            }
+
+        return volumes
+
+    def create_container_config(
+        self,
+        config: JudgeContainerConfig,
+    ) -> ContainerConfig:
+        """Create Docker container configuration for judge.
+
+        Args:
+            config: Judge-specific configuration.
+
+        Returns:
+            ContainerConfig for DockerExecutor.
+        """
+        # Ensure output directory exists
+        config.output_dir.mkdir(parents=True, exist_ok=True)
+
+        env = self._build_environment(config)
+
+        return ContainerConfig(
+            image=config.image,
+            name=self._generate_container_name(),
+            workspace_path=config.agent_workspace,
+            workspace_mount=self.WORKSPACE_MOUNT,
+            env_vars=env,
+            command=["python", "-m", "scylla.judge.runner"],
+            timeout_seconds=config.timeout_seconds,
+            working_dir=self.OUTPUT_MOUNT,
+            network="none",  # Isolated network (API via env vars)
+        )
+
+    def run_judge(self, config: JudgeContainerConfig) -> JudgeResult:
+        """Run judge evaluation in container.
+
+        Args:
+            config: Judge container configuration.
+
+        Returns:
+            JudgeResult with evaluation output and metrics.
+
+        Raises:
+            ContainerError: If container creation or execution fails.
+        """
+        container_config = self.create_container_config(config)
+
+        try:
+            result = self.executor.run(container_config)
+            self._active_containers.append(result.container_id)
+
+            # Parse token usage from stdout if available
+            tokens_in, tokens_out, cost = self._parse_token_usage(result.stdout)
+
+            return JudgeResult(
+                container_id=result.container_id,
+                exit_code=result.exit_code,
+                stdout=result.stdout,
+                stderr=result.stderr,
+                timed_out=result.timed_out,
+                tokens_input=tokens_in,
+                tokens_output=tokens_out,
+                cost_usd=cost,
+            )
+
+        except Exception as e:
+            raise ContainerError(f"Failed to run judge container: {e}")
+
+    def run_judge_detached(self, config: JudgeContainerConfig) -> str:
+        """Run judge evaluation in detached container.
+
+        Args:
+            config: Judge container configuration.
+
+        Returns:
+            Container ID for later retrieval.
+
+        Raises:
+            ContainerError: If container creation fails.
+        """
+        container_config = self.create_container_config(config)
+        container_id = self.executor.run_detached(container_config)
+        self._active_containers.append(container_id)
+        return container_id
+
+    def wait_for_judge(
+        self,
+        container_id: str,
+        timeout: int | None = None,
+    ) -> JudgeResult:
+        """Wait for detached judge container to complete.
+
+        Args:
+            container_id: Container ID to wait for.
+            timeout: Maximum seconds to wait.
+
+        Returns:
+            JudgeResult with evaluation output and metrics.
+
+        Raises:
+            ContainerError: If wait fails.
+        """
+        exit_code = self.executor.wait(container_id, timeout)
+        stdout, stderr = self.executor.logs(container_id)
+
+        tokens_in, tokens_out, cost = self._parse_token_usage(stdout)
+
+        return JudgeResult(
+            container_id=container_id,
+            exit_code=exit_code,
+            stdout=stdout,
+            stderr=stderr,
+            timed_out=False,
+            tokens_input=tokens_in,
+            tokens_output=tokens_out,
+            cost_usd=cost,
+        )
+
+    def _parse_token_usage(
+        self,
+        output: str,
+    ) -> tuple[int, int, float]:
+        """Parse token usage from judge output.
+
+        Looks for lines like:
+        TOKENS_INPUT: 1234
+        TOKENS_OUTPUT: 567
+        COST_USD: 0.0123
+
+        Args:
+            output: Container stdout.
+
+        Returns:
+            Tuple of (tokens_input, tokens_output, cost_usd).
+        """
+        tokens_in = 0
+        tokens_out = 0
+        cost = 0.0
+
+        for line in output.split("\n"):
+            if line.startswith("TOKENS_INPUT:"):
+                try:
+                    tokens_in = int(line.split(":")[1].strip())
+                except (ValueError, IndexError):
+                    pass
+            elif line.startswith("TOKENS_OUTPUT:"):
+                try:
+                    tokens_out = int(line.split(":")[1].strip())
+                except (ValueError, IndexError):
+                    pass
+            elif line.startswith("COST_USD:"):
+                try:
+                    cost = float(line.split(":")[1].strip())
+                except (ValueError, IndexError):
+                    pass
+
+        return tokens_in, tokens_out, cost
+
+    def stop_judge(self, container_id: str) -> None:
+        """Stop a running judge container.
+
+        Args:
+            container_id: Container ID to stop.
+        """
+        self.executor.stop(container_id)
+        if container_id in self._active_containers:
+            self._active_containers.remove(container_id)
+
+    def cleanup_judge(self, container_id: str, force: bool = False) -> None:
+        """Remove a judge container.
+
+        Note: Per design decisions, containers are typically preserved.
+        Use this only when explicit cleanup is needed.
+
+        Args:
+            container_id: Container ID to remove.
+            force: Force removal of running container.
+        """
+        self.executor.remove(container_id, force=force)
+        if container_id in self._active_containers:
+            self._active_containers.remove(container_id)
+
+    def cleanup_all(self, force: bool = False) -> None:
+        """Remove all judge containers managed by this instance.
+
+        Args:
+            force: Force removal of running containers.
+        """
+        for container_id in list(self._active_containers):
+            try:
+                self.cleanup_judge(container_id, force=force)
+            except ContainerError:
+                pass  # Container may already be removed
+
+    def get_judge_logs(
+        self,
+        container_id: str,
+        tail: int | None = None,
+    ) -> tuple[str, str]:
+        """Get logs from a judge container.
+
+        Args:
+            container_id: Container ID.
+            tail: Number of lines to return from end.
+
+        Returns:
+            Tuple of (stdout, stderr).
+        """
+        return self.executor.logs(container_id, tail=tail)
+
+    def is_judge_running(self, container_id: str) -> bool:
+        """Check if a judge container is currently running.
+
+        Args:
+            container_id: Container ID.
+
+        Returns:
+            True if container is running.
+        """
+        return self.executor.is_running(container_id)

--- a/tests/unit/executor/test_judge_container.py
+++ b/tests/unit/executor/test_judge_container.py
@@ -1,0 +1,381 @@
+"""Tests for judge container orchestration.
+
+Python justification: Required for pytest testing framework.
+"""
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from scylla.executor.docker import ContainerConfig, ContainerResult
+from scylla.executor.judge_container import (
+    JudgeContainerConfig,
+    JudgeContainerManager,
+    JudgeResult,
+)
+
+
+class TestJudgeContainerConfig:
+    """Tests for JudgeContainerConfig dataclass."""
+
+    def test_minimal_config(self, tmp_path: Path) -> None:
+        workspace = tmp_path / "workspace"
+        workspace.mkdir()
+        output = tmp_path / "output"
+
+        config = JudgeContainerConfig(
+            agent_workspace=workspace,
+            output_dir=output,
+        )
+
+        assert config.agent_workspace == workspace
+        assert config.output_dir == output
+        assert config.judge_model == "claude-opus-4-5-20251101"
+        assert config.timeout_seconds == 600
+        assert config.image == "scylla-runner:latest"
+
+    def test_full_config(self, tmp_path: Path) -> None:
+        workspace = tmp_path / "workspace"
+        workspace.mkdir()
+        output = tmp_path / "output"
+        rubric = tmp_path / "rubric.yaml"
+        rubric.write_text("test: rubric")
+
+        config = JudgeContainerConfig(
+            agent_workspace=workspace,
+            output_dir=output,
+            judge_model="custom-model",
+            rubric_path=rubric,
+            timeout_seconds=300,
+            image="custom-image:v1",
+        )
+
+        assert config.judge_model == "custom-model"
+        assert config.rubric_path == rubric
+        assert config.timeout_seconds == 300
+
+
+class TestJudgeResult:
+    """Tests for JudgeResult dataclass."""
+
+    def test_create_result(self) -> None:
+        result = JudgeResult(
+            container_id="abc123",
+            exit_code=0,
+            stdout="output",
+            stderr="",
+            tokens_input=1000,
+            tokens_output=500,
+            cost_usd=0.05,
+        )
+
+        assert result.container_id == "abc123"
+        assert result.exit_code == 0
+        assert result.tokens_input == 1000
+        assert result.cost_usd == 0.05
+
+    def test_default_values(self) -> None:
+        result = JudgeResult(
+            container_id="abc123",
+            exit_code=0,
+            stdout="",
+            stderr="",
+        )
+
+        assert result.timed_out is False
+        assert result.tokens_input == 0
+        assert result.tokens_output == 0
+        assert result.cost_usd == 0.0
+
+
+class TestJudgeContainerManagerInit:
+    """Tests for JudgeContainerManager initialization."""
+
+    def test_init_with_executor(self) -> None:
+        mock_executor = MagicMock()
+        manager = JudgeContainerManager(executor=mock_executor)
+        assert manager.executor == mock_executor
+
+    @patch("scylla.executor.judge_container.DockerExecutor")
+    def test_init_creates_executor(self, mock_executor_class: MagicMock) -> None:
+        manager = JudgeContainerManager()
+        mock_executor_class.assert_called_once()
+
+
+class TestJudgeContainerManagerGenerateName:
+    """Tests for container name generation."""
+
+    def test_unique_names(self) -> None:
+        mock_executor = MagicMock()
+        manager = JudgeContainerManager(executor=mock_executor)
+
+        name1 = manager._generate_container_name()
+        name2 = manager._generate_container_name()
+
+        assert name1.startswith("scylla-judge-")
+        assert name2.startswith("scylla-judge-")
+        assert name1 != name2
+
+
+class TestJudgeContainerManagerBuildEnvironment:
+    """Tests for environment variable building."""
+
+    def test_basic_environment(self, tmp_path: Path) -> None:
+        mock_executor = MagicMock()
+        manager = JudgeContainerManager(executor=mock_executor)
+
+        config = JudgeContainerConfig(
+            agent_workspace=tmp_path,
+            output_dir=tmp_path / "output",
+        )
+
+        env = manager._build_environment(config)
+
+        assert env["ROLE"] == "judge"
+        assert env["MODEL"] == "claude-opus-4-5-20251101"
+        assert env["WORKSPACE_PATH"] == "/workspace"
+        assert env["OUTPUT_PATH"] == "/output"
+
+    @patch.dict("os.environ", {"ANTHROPIC_API_KEY": "test-key"})
+    def test_includes_api_key(self, tmp_path: Path) -> None:
+        mock_executor = MagicMock()
+        manager = JudgeContainerManager(executor=mock_executor)
+
+        config = JudgeContainerConfig(
+            agent_workspace=tmp_path,
+            output_dir=tmp_path / "output",
+        )
+
+        env = manager._build_environment(config)
+
+        assert env["ANTHROPIC_API_KEY"] == "test-key"
+
+    def test_includes_rubric_path(self, tmp_path: Path) -> None:
+        mock_executor = MagicMock()
+        manager = JudgeContainerManager(executor=mock_executor)
+
+        rubric = tmp_path / "rubric.yaml"
+        rubric.write_text("test")
+
+        config = JudgeContainerConfig(
+            agent_workspace=tmp_path,
+            output_dir=tmp_path / "output",
+            rubric_path=rubric,
+        )
+
+        env = manager._build_environment(config)
+
+        assert "RUBRIC_PATH" in env
+        assert "rubric.yaml" in env["RUBRIC_PATH"]
+
+
+class TestJudgeContainerManagerBuildVolumes:
+    """Tests for volume mount building."""
+
+    def test_basic_volumes(self, tmp_path: Path) -> None:
+        mock_executor = MagicMock()
+        manager = JudgeContainerManager(executor=mock_executor)
+
+        workspace = tmp_path / "workspace"
+        workspace.mkdir()
+        output = tmp_path / "output"
+
+        config = JudgeContainerConfig(
+            agent_workspace=workspace,
+            output_dir=output,
+        )
+
+        volumes = manager._build_volumes(config)
+
+        # Workspace should be read-only
+        workspace_key = str(workspace.resolve())
+        assert workspace_key in volumes
+        assert volumes[workspace_key]["mode"] == "ro"
+
+        # Output should be read-write
+        output_key = str(output.resolve())
+        assert output_key in volumes
+        assert volumes[output_key]["mode"] == "rw"
+
+
+class TestJudgeContainerManagerCreateContainerConfig:
+    """Tests for creating container configuration."""
+
+    def test_creates_valid_config(self, tmp_path: Path) -> None:
+        mock_executor = MagicMock()
+        manager = JudgeContainerManager(executor=mock_executor)
+
+        workspace = tmp_path / "workspace"
+        workspace.mkdir()
+        output = tmp_path / "output"
+
+        config = JudgeContainerConfig(
+            agent_workspace=workspace,
+            output_dir=output,
+        )
+
+        container_config = manager.create_container_config(config)
+
+        assert container_config.image == "scylla-runner:latest"
+        assert container_config.name.startswith("scylla-judge-")
+        assert container_config.network == "none"
+        assert output.exists()  # Output dir should be created
+
+
+class TestJudgeContainerManagerRunJudge:
+    """Tests for running judge container."""
+
+    def test_run_success(self, tmp_path: Path) -> None:
+        mock_executor = MagicMock()
+        mock_executor.run.return_value = ContainerResult(
+            container_id="judge-123",
+            exit_code=0,
+            stdout="TOKENS_INPUT: 1000\nTOKENS_OUTPUT: 500\nCOST_USD: 0.05\n",
+            stderr="",
+            timed_out=False,
+        )
+
+        manager = JudgeContainerManager(executor=mock_executor)
+
+        workspace = tmp_path / "workspace"
+        workspace.mkdir()
+
+        config = JudgeContainerConfig(
+            agent_workspace=workspace,
+            output_dir=tmp_path / "output",
+        )
+
+        result = manager.run_judge(config)
+
+        assert result.exit_code == 0
+        assert result.container_id == "judge-123"
+        assert result.tokens_input == 1000
+        assert result.tokens_output == 500
+        assert result.cost_usd == 0.05
+
+    def test_run_timeout(self, tmp_path: Path) -> None:
+        mock_executor = MagicMock()
+        mock_executor.run.return_value = ContainerResult(
+            container_id="judge-123",
+            exit_code=-1,
+            stdout="",
+            stderr="timeout",
+            timed_out=True,
+        )
+
+        manager = JudgeContainerManager(executor=mock_executor)
+
+        workspace = tmp_path / "workspace"
+        workspace.mkdir()
+
+        config = JudgeContainerConfig(
+            agent_workspace=workspace,
+            output_dir=tmp_path / "output",
+        )
+
+        result = manager.run_judge(config)
+
+        assert result.timed_out is True
+        assert result.exit_code == -1
+
+
+class TestJudgeContainerManagerParseTokenUsage:
+    """Tests for token usage parsing."""
+
+    def test_parse_all_fields(self) -> None:
+        mock_executor = MagicMock()
+        manager = JudgeContainerManager(executor=mock_executor)
+
+        output = """
+Some output
+TOKENS_INPUT: 1500
+TOKENS_OUTPUT: 750
+COST_USD: 0.0825
+More output
+"""
+        tokens_in, tokens_out, cost = manager._parse_token_usage(output)
+
+        assert tokens_in == 1500
+        assert tokens_out == 750
+        assert cost == 0.0825
+
+    def test_parse_missing_fields(self) -> None:
+        mock_executor = MagicMock()
+        manager = JudgeContainerManager(executor=mock_executor)
+
+        output = "No token info here"
+        tokens_in, tokens_out, cost = manager._parse_token_usage(output)
+
+        assert tokens_in == 0
+        assert tokens_out == 0
+        assert cost == 0.0
+
+    def test_parse_malformed_values(self) -> None:
+        mock_executor = MagicMock()
+        manager = JudgeContainerManager(executor=mock_executor)
+
+        output = """
+TOKENS_INPUT: not_a_number
+TOKENS_OUTPUT: 500
+COST_USD: invalid
+"""
+        tokens_in, tokens_out, cost = manager._parse_token_usage(output)
+
+        assert tokens_in == 0
+        assert tokens_out == 500
+        assert cost == 0.0
+
+
+class TestJudgeContainerManagerLifecycle:
+    """Tests for container lifecycle management."""
+
+    def test_stop_judge(self) -> None:
+        mock_executor = MagicMock()
+        manager = JudgeContainerManager(executor=mock_executor)
+        manager._active_containers.append("judge-123")
+
+        manager.stop_judge("judge-123")
+
+        mock_executor.stop.assert_called_once_with("judge-123")
+        assert "judge-123" not in manager._active_containers
+
+    def test_cleanup_judge(self) -> None:
+        mock_executor = MagicMock()
+        manager = JudgeContainerManager(executor=mock_executor)
+        manager._active_containers.append("judge-123")
+
+        manager.cleanup_judge("judge-123")
+
+        mock_executor.remove.assert_called_once_with("judge-123", force=False)
+        assert "judge-123" not in manager._active_containers
+
+    def test_cleanup_all(self) -> None:
+        mock_executor = MagicMock()
+        manager = JudgeContainerManager(executor=mock_executor)
+        manager._active_containers = ["judge-1", "judge-2", "judge-3"]
+
+        manager.cleanup_all()
+
+        assert mock_executor.remove.call_count == 3
+
+    def test_is_judge_running(self) -> None:
+        mock_executor = MagicMock()
+        mock_executor.is_running.return_value = True
+        manager = JudgeContainerManager(executor=mock_executor)
+
+        result = manager.is_judge_running("judge-123")
+
+        assert result is True
+        mock_executor.is_running.assert_called_once_with("judge-123")
+
+    def test_get_judge_logs(self) -> None:
+        mock_executor = MagicMock()
+        mock_executor.logs.return_value = ("stdout", "stderr")
+        manager = JudgeContainerManager(executor=mock_executor)
+
+        stdout, stderr = manager.get_judge_logs("judge-123", tail=100)
+
+        assert stdout == "stdout"
+        assert stderr == "stderr"
+        mock_executor.logs.assert_called_once_with("judge-123", tail=100)


### PR DESCRIPTION
## Summary
- Implements `JudgeContainerManager` for running judge evaluations in isolated Docker containers
- `JudgeContainerConfig` for judge-specific configuration
- Agent workspace mounted as read-only for secure evaluation
- Token usage and cost parsing from container output
- Full container lifecycle management

## Design Decisions
- Judge runs in **separate container** from agent
- Agent workspace is **read-only** in judge container
- Containers **preserved** for analysis after completion

## Test plan
- [x] Unit tests for JudgeContainerConfig
- [x] Unit tests for JudgeResult
- [x] Unit tests for container name generation
- [x] Unit tests for environment variable building
- [x] Unit tests for volume mount building
- [x] Unit tests for running judge
- [x] Unit tests for token usage parsing
- [x] Unit tests for container lifecycle management

Closes #41

🤖 Generated with [Claude Code](https://claude.com/claude-code)