### PR TITLE
chore: add claude settings and ignore reports directory

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,5 @@
+{
+  "enabledPlugins": {
+    "plan-export@cc-marketplace": true
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -42,6 +42,9 @@ credentials.json
 runs/
 !runs/.gitkeep
 
+# Generated reports
+reports/
+
 # Coverage reports
 .coverage
 htmlcov/


### PR DESCRIPTION
## Summary

- Add `.claude/settings.json` with enabled plugins configuration
- Add `reports/` to `.gitignore` for generated evaluation reports

## Test plan

- [x] No code changes - configuration only

🤖 Generated with [Claude Code](https://claude.com/claude-code)