### PR TITLE
Standardize runs_per_tier default to 10

### DIFF
--- a/config/defaults.yaml
+++ b/config/defaults.yaml
@@ -4,7 +4,7 @@
 # Evaluation settings
 evaluation:
   # Number of runs per evaluation
-  runs_per_eval: 3
+  runs_per_eval: 10
   # Default timeout in seconds
   timeout: 300
   # Random seed for reproducibility (null for random)

--- a/src/scylla/config/models.py
+++ b/src/scylla/config/models.py
@@ -230,7 +230,7 @@ class CleanupConfig(BaseModel):
 class EvaluationConfig(BaseModel):
     """Evaluation settings from defaults."""
 
-    runs_per_tier: int = Field(default=9, ge=1, le=100, alias="runs_per_eval")
+    runs_per_tier: int = Field(default=10, ge=1, le=100, alias="runs_per_eval")
     timeout: int = Field(default=300, ge=60, le=86400)
     seed: int | None = Field(default=None)
 
@@ -275,7 +275,7 @@ class DefaultsConfig(BaseModel):
     logging: LoggingConfig = Field(default_factory=LoggingConfig)
 
     # Optional extended settings (for executor)
-    runs_per_tier: int = Field(default=9, ge=1, le=100)
+    runs_per_tier: int = Field(default=10, ge=1, le=100)
     timeout_seconds: int = Field(default=3600, ge=60, le=86400)
     max_cost_usd: float = Field(default=10.0, ge=0.0)
     judge: JudgeConfig = Field(default_factory=JudgeConfig)
@@ -300,7 +300,7 @@ class ScyllaConfig(BaseModel):
     """
 
     # From defaults
-    runs_per_tier: int = Field(default=9, ge=1, le=100)
+    runs_per_tier: int = Field(default=10, ge=1, le=100)
     timeout_seconds: int = Field(default=3600, ge=60, le=86400)
     max_cost_usd: float = Field(default=10.0, ge=0.0)
     judge: JudgeConfig = Field(default_factory=JudgeConfig)

--- a/tests/fixtures/config/defaults.yaml
+++ b/tests/fixtures/config/defaults.yaml
@@ -1,6 +1,6 @@
 # Test fixture: Global defaults
 evaluation:
-  runs_per_eval: 9
+  runs_per_eval: 10
   timeout: 300
   seed: null
 

--- a/tests/integration/test_orchestrator.py
+++ b/tests/integration/test_orchestrator.py
@@ -141,7 +141,7 @@ grading:
         # Create defaults.yaml
         defaults_yaml = config_dir / "defaults.yaml"
         defaults_yaml.write_text("""
-runs_per_tier: 9
+runs_per_tier: 10
 timeout_seconds: 3600
 max_cost_usd: 10.0
 output:

--- a/tests/unit/test_config_loader.py
+++ b/tests/unit/test_config_loader.py
@@ -38,7 +38,7 @@ class TestConfigLoaderDefaults:
         defaults = loader.load_defaults()
 
         assert isinstance(defaults, DefaultsConfig)
-        assert defaults.evaluation.runs_per_tier == 9
+        assert defaults.evaluation.runs_per_tier == 10
         assert defaults.evaluation.timeout == 300
         assert defaults.output.runs_dir == "runs"
         assert defaults.logging.level == "INFO"
@@ -225,7 +225,7 @@ class TestConfigLoaderMerged:
         config = loader.load(test_id="nonexistent", model_id="nonexistent")
 
         assert isinstance(config, ScyllaConfig)
-        assert config.runs_per_tier == 9
+        assert config.runs_per_tier == 10
         assert config.test_id == "nonexistent"
         assert config.model_id == "nonexistent"
         assert config.model is None
@@ -262,7 +262,7 @@ class TestConfigLoaderMerged:
         assert config.max_cost_usd == 5.0  # test override
 
         # Defaults should fill in non-overridden values
-        assert config.runs_per_tier == 9  # from defaults
+        assert config.runs_per_tier == 10  # from defaults
         assert config.output.runs_dir == "runs"  # from defaults
 
     def test_load_merged_immutable(self) -> None:


### PR DESCRIPTION
## Summary
- Standardizes `runs_per_tier` default value to 10 across all configuration sources
- Updates `config/defaults.yaml` from 3 → 10
- Updates Pydantic model defaults from 9 → 10 (EvaluationConfig, DefaultsConfig, ScyllaConfig)
- Updates test fixtures and assertions to match

## Test plan
- [x] All unit tests pass (`pytest tests/unit/test_config_loader.py`)
- [x] All integration tests pass (`pytest tests/integration/test_orchestrator.py`)
- [x] No regressions in existing functionality

Closes #90

🤖 Generated with [Claude Code](https://claude.com/claude-code)