### PR TITLE
Fix tier naming inconsistency (T3+ vs T3)

### DIFF
--- a/config/tiers/tiers.yaml
+++ b/config/tiers/tiers.yaml
@@ -4,7 +4,7 @@
 # Each tier represents a different level of agent capability.
 #
 # Important: Tiers are INDEPENDENT, not cumulative.
-# T0 uses tool defaults (null values), T1-T3+ have explicit configurations.
+# T0 uses tool defaults (null values), T1-T3 have explicit configurations.
 
 tiers:
   T0:
@@ -28,7 +28,7 @@ tiers:
     tools_enabled: false
     delegation_enabled: false
 
-  "T3+":
+  T3:
     name: "Tooling"
     description: "External tools, multi-agent orchestration"
     prompt_file: "t3-tooling.md"

--- a/src/scylla/executor/tier_config.py
+++ b/src/scylla/executor/tier_config.py
@@ -31,7 +31,7 @@ class TierDefinition(BaseModel):
 class TierConfig(BaseModel):
     """Complete tier configuration with loaded prompt content."""
 
-    tier_id: str = Field(..., description="Tier identifier (e.g., 'T0', 'T1', 'T2', 'T3+')")
+    tier_id: str = Field(..., description="Tier identifier (e.g., 'T0', 'T1', 'T2', 'T3')")
     name: str = Field(..., description="Human-readable tier name")
     description: str = Field(..., description="Description of the tier's purpose")
     prompt_file: Optional[Path] = Field(
@@ -63,7 +63,7 @@ class TiersDefinitionFile(BaseModel):
         cls, v: dict[str, TierDefinition]
     ) -> dict[str, TierDefinition]:
         """Ensure required tiers are present."""
-        required = {"T0", "T1", "T2", "T3+"}
+        required = {"T0", "T1", "T2", "T3"}
         missing = required - set(v.keys())
         if missing:
             raise ValueError(f"Missing required tier definitions: {missing}")
@@ -126,7 +126,7 @@ class TierConfigLoader:
         """Load configuration for a specific tier.
 
         Args:
-            tier_id: The tier identifier (e.g., "T0", "T1", "T2", "T3+")
+            tier_id: The tier identifier (e.g., "T0", "T1", "T2", "T3")
 
         Returns:
             TierConfig with loaded prompt content

--- a/tests/unit/executor/test_tier_config.py
+++ b/tests/unit/executor/test_tier_config.py
@@ -58,7 +58,7 @@ class TestTiersDefinitionFile:
                 "T0": TierDefinition(name="Vanilla", description="Base"),
                 "T1": TierDefinition(name="Prompted", description="With prompts"),
                 "T2": TierDefinition(name="Skills", description="With skills"),
-                "T3+": TierDefinition(name="Tooling", description="With tools"),
+                "T3": TierDefinition(name="Tooling", description="With tools"),
             }
         )
         assert len(tiers_def.tiers) == 4
@@ -143,7 +143,7 @@ tiers:
     tools_enabled: false
     delegation_enabled: false
 
-  "T3+":
+  T3:
     name: "Tooling"
     description: "With tools"
     prompt_file: "t3-tooling.md"
@@ -187,12 +187,12 @@ tiers:
         assert t1.tools_enabled is False
         assert t1.delegation_enabled is False
 
-    def test_get_t3_plus_tier(self, config_dir: Path) -> None:
-        """Test getting T3+ tier with tools enabled."""
+    def test_get_t3_tier(self, config_dir: Path) -> None:
+        """Test getting T3 tier with tools enabled."""
         loader = TierConfigLoader(config_dir)
-        t3 = loader.get_tier("T3+")
+        t3 = loader.get_tier("T3")
 
-        assert t3.tier_id == "T3+"
+        assert t3.tier_id == "T3"
         assert t3.name == "Tooling"
         assert t3.tools_enabled is True
         assert t3.delegation_enabled is True
@@ -204,7 +204,7 @@ tiers:
 
         assert len(all_tiers) == 4
         tier_ids = [t.tier_id for t in all_tiers]
-        assert set(tier_ids) == {"T0", "T1", "T2", "T3+"}
+        assert set(tier_ids) == {"T0", "T1", "T2", "T3"}
 
     def test_get_tier_ids(self, config_dir: Path) -> None:
         """Test getting list of tier IDs."""
@@ -213,13 +213,13 @@ tiers:
 
         assert len(tier_ids) == 4
         assert "T0" in tier_ids
-        assert "T3+" in tier_ids
+        assert "T3" in tier_ids
 
     def test_validate_tier_id_valid(self, config_dir: Path) -> None:
         """Test validating a valid tier ID."""
         loader = TierConfigLoader(config_dir)
         assert loader.validate_tier_id("T0") is True
-        assert loader.validate_tier_id("T3+") is True
+        assert loader.validate_tier_id("T3") is True
 
     def test_validate_tier_id_invalid(self, config_dir: Path) -> None:
         """Test validating an invalid tier ID."""
@@ -263,7 +263,7 @@ tiers:
     name: "Skills"
     description: "With skills"
 
-  "T3+":
+  T3:
     name: "Tooling"
     description: "With tools"
 """)


### PR DESCRIPTION
## Summary
- Fixes naming inconsistency where config used `"T3+"` but CLI/tests used `T3`
- Updates `config/tiers/tiers.yaml`: `"T3+"` → `T3`
- Updates `tier_config.py`: required tiers set and docstrings
- Updates `test_tier_config.py`: all T3+ references to T3

## Test plan
- [x] All tier config tests pass (`pytest tests/unit/executor/test_tier_config.py`)
- [x] Tier loading works with T3 identifier
- [x] No regressions in existing functionality

Closes #91

🤖 Generated with [Claude Code](https://claude.com/claude-code)