### PR TITLE
Add end-to-end integration tests for orchestrator

### DIFF
--- a/tests/integration/test_orchestrator.py
+++ b/tests/integration/test_orchestrator.py
@@ -184,3 +184,273 @@ output:
         assert len(rubric.requirements) == 1
         assert rubric.requirements[0].id == "R001"
         assert rubric.grading.pass_threshold == 0.70
+
+
+class TestEvalOrchestratorEndToEnd:
+    """End-to-end tests with mock adapter and judge."""
+
+    @pytest.fixture
+    def test_env(self, tmp_path: Path) -> Path:
+        """Create complete test environment."""
+        # Create directory structure
+        tests_dir = tmp_path / "tests" / "001-test"
+        expected_dir = tests_dir / "expected"
+        config_dir = tmp_path / "config"
+        runs_dir = tmp_path / "runs"
+
+        tests_dir.mkdir(parents=True)
+        expected_dir.mkdir(parents=True)
+        config_dir.mkdir(parents=True)
+        runs_dir.mkdir(parents=True)
+
+        # Create test.yaml
+        test_yaml = tests_dir / "test.yaml"
+        test_yaml.write_text("""
+id: "001-test"
+name: "Test Case"
+description: "A test case for testing"
+source:
+  repo: "https://github.com/octocat/Hello-World"
+  hash: "7fd1a60b01f91b314f59955a4e4d4e80d8edf11d"
+task:
+  prompt_file: "prompt.md"
+  timeout_seconds: 60
+tiers:
+  - T0
+  - T1
+  - T2
+validation:
+  criteria_file: "expected/criteria.md"
+  rubric_file: "expected/rubric.yaml"
+""")
+
+        # Create prompt.md
+        prompt_md = tests_dir / "prompt.md"
+        prompt_md.write_text("# Test Prompt\nDo something.")
+
+        # Create criteria.md
+        criteria_md = expected_dir / "criteria.md"
+        criteria_md.write_text("# Criteria\n- Must work")
+
+        # Create rubric.yaml
+        rubric_yaml = expected_dir / "rubric.yaml"
+        rubric_yaml.write_text("""
+requirements:
+  - id: "R001"
+    description: "Must work"
+    weight: 1.0
+    evaluation: "binary"
+grading:
+  pass_threshold: 0.70
+  grade_scale:
+    A: 0.95
+    B: 0.85
+    C: 0.75
+    D: 0.65
+    F: 0.0
+""")
+
+        # Create defaults.yaml
+        defaults_yaml = config_dir / "defaults.yaml"
+        defaults_yaml.write_text("""
+runs_per_tier: 10
+timeout_seconds: 3600
+max_cost_usd: 10.0
+output:
+  runs_dir: "runs"
+  summaries_dir: "summaries"
+  reports_dir: "reports"
+""")
+
+        return tmp_path
+
+    def test_run_single_with_mocks(self, test_env: Path) -> None:
+        """Test complete single run flow with mock adapter/judge."""
+        from unittest.mock import patch, MagicMock
+
+        config = OrchestratorConfig(
+            base_path=test_env,
+            quiet=True,
+        )
+        orchestrator = EvalOrchestrator(config)
+
+        # Set mock adapter
+        def mock_adapter(**kwargs):
+            return {
+                "tokens_in": 1000,
+                "tokens_out": 500,
+                "cost_usd": 0.05,
+                "exit_code": 0,
+            }
+
+        # Set mock judge
+        def mock_judge(**kwargs):
+            return {
+                "passed": True,
+                "score": 0.85,
+                "grade": "B",
+            }
+
+        orchestrator.set_adapter(mock_adapter)
+        orchestrator.set_judge(mock_judge)
+
+        # Mock git operations to avoid network calls
+        with patch.object(
+            orchestrator.loader.__class__, "_load_yaml", wraps=orchestrator.loader._load_yaml
+        ):
+            from scylla.executor import WorkspaceManager
+
+            with patch.object(WorkspaceManager, "clone"):
+                with patch.object(WorkspaceManager, "checkout"):
+                    result = orchestrator.run_single(
+                        test_id="001-test",
+                        model_id="test-model",
+                        tier_id="T0",
+                        run_number=1,
+                    )
+
+        # Verify result structure
+        assert result.judgment.passed is True
+        assert result.judgment.impl_rate == 0.85
+        assert result.judgment.letter_grade == "B"
+        assert result.metrics.cost_usd == 0.05
+        assert result.execution.status == "completed"
+
+    def test_run_single_result_file_written(self, test_env: Path) -> None:
+        """Verify result.json is correctly written to disk."""
+        from unittest.mock import patch
+        import json
+
+        config = OrchestratorConfig(
+            base_path=test_env,
+            quiet=True,
+        )
+        orchestrator = EvalOrchestrator(config)
+
+        # Set simple mocks
+        orchestrator.set_adapter(lambda **k: {"tokens_in": 100, "tokens_out": 50, "cost_usd": 0.01, "exit_code": 0})
+        orchestrator.set_judge(lambda **k: {"passed": True, "score": 0.9, "grade": "A"})
+
+        from scylla.executor import WorkspaceManager
+
+        with patch.object(WorkspaceManager, "clone"):
+            with patch.object(WorkspaceManager, "checkout"):
+                result = orchestrator.run_single(
+                    test_id="001-test",
+                    model_id="test-model",
+                    tier_id="T0",
+                    run_number=1,
+                )
+
+        # Find the result file
+        runs_dir = test_env / "runs"
+        result_files = list(runs_dir.rglob("result.json"))
+        assert len(result_files) >= 1
+
+        # Verify JSON content
+        with open(result_files[0]) as f:
+            data = json.load(f)
+
+        assert data["test_id"] == "001-test"
+        assert data["tier_id"] == "T0"
+        assert data["judgment"]["passed"] is True
+
+    def test_run_test_multi_tier(self, test_env: Path) -> None:
+        """Test running same test across T0, T1, T2 tiers."""
+        from unittest.mock import patch
+
+        config = OrchestratorConfig(
+            base_path=test_env,
+            runs_per_tier=1,
+            quiet=True,
+        )
+        orchestrator = EvalOrchestrator(config)
+
+        # Set mocks
+        orchestrator.set_adapter(lambda **k: {"tokens_in": 100, "tokens_out": 50, "cost_usd": 0.01, "exit_code": 0})
+        orchestrator.set_judge(lambda **k: {"passed": True, "score": 0.8, "grade": "B"})
+
+        from scylla.executor import WorkspaceManager
+
+        with patch.object(WorkspaceManager, "clone"):
+            with patch.object(WorkspaceManager, "checkout"):
+                results = orchestrator.run_test(
+                    test_id="001-test",
+                    models=["test-model"],
+                    tiers=["T0", "T1", "T2"],
+                    runs_per_tier=1,
+                )
+
+        # Verify we got 3 results (one per tier)
+        assert len(results) == 3
+        tier_ids = [r.tier_id for r in results]
+        assert set(tier_ids) == {"T0", "T1", "T2"}
+
+        # All results should have correct structure
+        for result in results:
+            assert result.test_id == "001-test"
+            assert result.judgment.passed is True
+
+    def test_run_single_with_failing_judge(self, test_env: Path) -> None:
+        """Test when judge returns passed=False."""
+        from unittest.mock import patch
+
+        config = OrchestratorConfig(
+            base_path=test_env,
+            quiet=True,
+        )
+        orchestrator = EvalOrchestrator(config)
+
+        # Mock with failing judgment
+        orchestrator.set_adapter(lambda **k: {"tokens_in": 100, "tokens_out": 50, "cost_usd": 0.02, "exit_code": 0})
+        orchestrator.set_judge(lambda **k: {"passed": False, "score": 0.3, "grade": "F"})
+
+        from scylla.executor import WorkspaceManager
+
+        with patch.object(WorkspaceManager, "clone"):
+            with patch.object(WorkspaceManager, "checkout"):
+                result = orchestrator.run_single(
+                    test_id="001-test",
+                    model_id="test-model",
+                    tier_id="T0",
+                    run_number=1,
+                )
+
+        # Verify failed result
+        assert result.judgment.passed is False
+        assert result.judgment.impl_rate == 0.3
+        assert result.judgment.letter_grade == "F"
+        # Cost-of-pass should be infinity for failed runs
+        assert result.grading.cost_of_pass == float("inf")
+
+    def test_result_metrics_calculation(self, test_env: Path) -> None:
+        """Verify composite score and cost-of-pass calculations."""
+        from unittest.mock import patch
+
+        config = OrchestratorConfig(
+            base_path=test_env,
+            quiet=True,
+        )
+        orchestrator = EvalOrchestrator(config)
+
+        # Mock with specific values for calculation verification
+        orchestrator.set_adapter(lambda **k: {"tokens_in": 100, "tokens_out": 50, "cost_usd": 0.10, "exit_code": 0})
+        orchestrator.set_judge(lambda **k: {"passed": True, "score": 0.80, "grade": "B"})
+
+        from scylla.executor import WorkspaceManager
+
+        with patch.object(WorkspaceManager, "clone"):
+            with patch.object(WorkspaceManager, "checkout"):
+                result = orchestrator.run_single(
+                    test_id="001-test",
+                    model_id="test-model",
+                    tier_id="T0",
+                    run_number=1,
+                )
+
+        # Verify composite score = (impl_rate * 0.7) + (pass_rate * 0.3)
+        # = (0.80 * 0.7) + (1.0 * 0.3) = 0.56 + 0.30 = 0.86
+        assert abs(result.grading.composite_score - 0.86) < 0.001
+
+        # Verify cost-of-pass = cost_usd / pass_rate = 0.10 / 1.0 = 0.10
+        assert abs(result.grading.cost_of_pass - 0.10) < 0.001


### PR DESCRIPTION
## Summary
Add `TestEvalOrchestratorEndToEnd` class with 5 comprehensive test methods:

- `test_run_single_with_mocks`: Complete single run flow with mock adapter/judge
- `test_run_single_result_file_written`: Verify `result.json` is correctly written
- `test_run_test_multi_tier`: Test running across T0, T1, T2 tiers
- `test_run_single_with_failing_judge`: Test failed judgment handling (CoP = infinity)
- `test_result_metrics_calculation`: Verify composite score and cost-of-pass calculations

All tests use mock adapters/judges (no real API calls) and mock git operations.

## Test plan
- [x] All new E2E tests pass
- [x] All existing tests still pass
- [x] Tests verify result files are written correctly

Closes #93

🤖 Generated with [Claude Code](https://claude.com/claude-code)