### PR TITLE
feat(metrics): add process metrics and token tracking modules

### DIFF
--- a/docs/design/metrics-formulas.md
+++ b/docs/design/metrics-formulas.md
@@ -289,6 +289,130 @@ Variance:
            = 0.00547
 ```
 
+## Process Metrics
+
+These metrics capture the quality of the agent's execution process, not just the final outcome.
+
+### Fine-Grained Progress Rate (R_Prog)
+
+Captures incremental advancements through the execution trajectory.
+
+```
+r_prog = achieved_weighted_steps / expected_weighted_steps
+
+# Simple version (equal weights):
+r_prog = achieved_steps / expected_steps
+```
+
+**Interpretation**:
+- 1.0 = all expected steps completed
+- 0.5 = halfway through expected steps
+- 0.0 = no progress
+
+**Why R_Prog?** Diagnoses where agents fail in multi-step tasks.
+
+### Strategic Drift
+
+Measures how much intermediate actions diverge from the intended goal.
+
+```
+strategic_drift = 1 - (sum(goal_alignment * weight) / sum(weight))
+
+# Simple version (binary alignment):
+strategic_drift = 1 - (goal_aligned_actions / total_actions)
+```
+
+**Interpretation**:
+- 0.0 = perfect alignment (no drift)
+- 1.0 = complete misalignment (all actions off-track)
+
+### Change Fail Percentage (CFP)
+
+DevOps stability metric: percentage of changes that cause service failures.
+
+```
+cfp = failed_changes / total_changes
+```
+
+**Interpretation**:
+- 0.0 = no failures (stable output)
+- 0.1 = 10% of changes cause failures
+- High CFP indicates brittle solutions
+
+### PR Revert Rate
+
+Frequency of agent-generated changes rejected by human reviewers.
+
+```
+pr_revert_rate = reverted_changes / total_changes
+```
+
+## Token Tracking (T2 vs T3 Analysis)
+
+These metrics analyze the "Token Efficiency Chasm" between T2 (Skills) and T3 (Tooling).
+
+### Schema Overhead
+
+Total tokens consumed by tool schemas (T3+).
+
+```
+schema_overhead = sum(tokens for component_type == TOOL_SCHEMA)
+```
+
+**Key insight**: T3 architectures load JSON schemas that can consume 50k+ tokens upfront.
+
+### Skill Efficiency
+
+Ratio of skill tokens to total (skill + schema) tokens.
+
+```
+skill_efficiency = skill_tokens / (skill_tokens + schema_overhead)
+```
+
+**Interpretation**:
+- 1.0 = no schema overhead (pure T2)
+- 0.2 = 80% of tokens are schema overhead
+
+### Token Efficiency Ratio
+
+Comparison of schema tokens to skill tokens.
+
+```
+token_efficiency_ratio = schema_tokens / skill_tokens
+```
+
+**Interpretation**:
+- ratio > 1.0 = schemas use more tokens than skills
+- ratio = 10.0 = schemas use 10x more tokens
+
+### Component Cost Breakdown
+
+Track costs at the component level:
+
+| Component Type | Description |
+|----------------|-------------|
+| `SYSTEM_PROMPT` | Base system prompt |
+| `SKILL_PROMPT` | T2 skill instructions |
+| `DOMAIN_EXPERTISE` | T2 domain knowledge |
+| `TOOL_SCHEMA` | T3 JSON tool definitions |
+| `TOOL_CALL` | T3 tool invocations |
+| `TOOL_RESPONSE` | T3 tool results |
+| `ORCHESTRATOR` | T4/T5 coordination |
+| `SUB_AGENT` | T4/T5 delegated agents |
+| `MONITOR` | T5 error detection |
+| `EVALUATOR` | T5 self-reflection |
+
+```python
+# Calculate per-component costs
+distribution = tracker.calculate_distribution(
+    input_price=3.0,   # $/1M input tokens
+    output_price=15.0, # $/1M output tokens
+)
+
+# Get schema overhead percentage
+schema_pct = distribution.get_type_percentage(ComponentType.TOOL_SCHEMA)
+```
+
 ## Summary Table
 
 | Metric | Formula | Range | Interpretation |
@@ -300,8 +424,13 @@ Variance:
 | composite | `(pass + impl) / 2` | [0, 1] | Higher = better |
 | tier_uplift | `(tier - t0) / t0` | (-∞, ∞) | Positive = improvement |
 | variance | `Σ(x - μ)² / n` | [0, ∞) | Lower = more consistent |
+| r_prog | `achieved / expected` | [0, 1] | Higher = more progress |
+| strategic_drift | `1 - alignment` | [0, 1] | Lower = better alignment |
+| cfp | `failed / total` | [0, 1] | Lower = more stable |
+| schema_overhead | `sum(schema_tokens)` | [0, ∞) | Lower = more efficient |
 
 ## Related Documentation
 
 - [Judge Protocol](./judge-protocol.md) - How judgments produce weighted_score
 - [Evaluation Categories](./judge-protocol.md#evaluation-categories) - 10 quality categories
+- [Research Methodology](../research.md) - Original metrics definitions

--- a/src/scylla/metrics/__init__.py
+++ b/src/scylla/metrics/__init__.py
@@ -1,7 +1,8 @@
 """Metrics module for statistical calculations, grading, and aggregation.
 
 This module provides statistical functions, grading calculations,
-and run aggregation for analyzing evaluation results across multiple runs.
+run aggregation, process metrics, and token tracking for analyzing
+evaluation results across multiple runs.
 """
 
 from scylla.metrics.aggregator import (
@@ -28,6 +29,22 @@ from scylla.metrics.grading import (
     calculate_tier_uplift,
     grade_run,
 )
+from scylla.metrics.process import (
+    ChangeResult,
+    ProcessMetrics,
+    ProgressStep,
+    ProgressTracker,
+    calculate_cfp,
+    calculate_cfp_simple,
+    calculate_pr_revert_rate,
+    calculate_pr_revert_rate_simple,
+    calculate_process_metrics,
+    calculate_process_metrics_simple,
+    calculate_r_prog,
+    calculate_r_prog_simple,
+    calculate_strategic_drift,
+    calculate_strategic_drift_simple,
+)
 from scylla.metrics.statistics import (
     Statistics,
     calculate_all,
@@ -37,6 +54,17 @@ from scylla.metrics.statistics import (
     calculate_range,
     calculate_std_dev,
     calculate_variance,
+)
+from scylla.metrics.token_tracking import (
+    ComponentCost,
+    ComponentType,
+    TierTokenAnalysis,
+    TokenDistribution,
+    TokenTracker,
+    TokenUsage,
+    analyze_tier_tokens,
+    calculate_token_efficiency_ratio,
+    compare_t2_t3_efficiency,
 )
 
 __all__ = [
@@ -61,6 +89,21 @@ __all__ = [
     "calculate_pass_rate",
     "calculate_tier_uplift",
     "grade_run",
+    # Process metrics
+    "ChangeResult",
+    "ProcessMetrics",
+    "ProgressStep",
+    "ProgressTracker",
+    "calculate_cfp",
+    "calculate_cfp_simple",
+    "calculate_pr_revert_rate",
+    "calculate_pr_revert_rate_simple",
+    "calculate_process_metrics",
+    "calculate_process_metrics_simple",
+    "calculate_r_prog",
+    "calculate_r_prog_simple",
+    "calculate_strategic_drift",
+    "calculate_strategic_drift_simple",
     # Statistics
     "Statistics",
     "calculate_all",
@@ -70,4 +113,14 @@ __all__ = [
     "calculate_range",
     "calculate_std_dev",
     "calculate_variance",
+    # Token tracking
+    "ComponentCost",
+    "ComponentType",
+    "TierTokenAnalysis",
+    "TokenDistribution",
+    "TokenTracker",
+    "TokenUsage",
+    "analyze_tier_tokens",
+    "calculate_token_efficiency_ratio",
+    "compare_t2_t3_efficiency",
 ]

--- a/src/scylla/metrics/process.py
+++ b/src/scylla/metrics/process.py
@@ -1,0 +1,348 @@
+"""Process metrics for evaluation tracking.
+
+This module provides process-oriented metrics that capture the quality
+of the agent's execution process, not just the final outcome.
+
+Metrics defined:
+- Fine-Grained Progress Rate (R_Prog): Incremental advancement tracking
+- Strategic Drift: Goal coherence over multi-step tasks
+- Change Fail Percentage (CFP): Stability metric for agent changes
+
+Python Justification: Required for statistical calculations and data structures.
+
+References:
+- docs/research.md: Sections 4.1, 4.2, 4.3
+- docs/summary.md: Section IV (Experimental Protocol)
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass, field
+
+
+@dataclass
+class ProgressStep:
+    """A single step in the agent's execution trajectory.
+
+    Attributes:
+        step_id: Unique identifier for this step.
+        description: Description of what was accomplished.
+        weight: Importance weight (default 1.0).
+        completed: Whether step was successfully completed.
+        goal_alignment: How aligned this step is with the final goal (0.0-1.0).
+    """
+
+    step_id: str
+    description: str
+    weight: float = 1.0
+    completed: bool = False
+    goal_alignment: float = 1.0
+
+
+@dataclass
+class ProgressTracker:
+    """Tracks fine-grained progress through expected steps.
+
+    Attributes:
+        expected_steps: List of expected steps in the trajectory.
+        achieved_steps: List of steps that were completed.
+    """
+
+    expected_steps: list[ProgressStep] = field(default_factory=list)
+    achieved_steps: list[ProgressStep] = field(default_factory=list)
+
+
+@dataclass
+class ChangeResult:
+    """Result of an agent-generated change.
+
+    Attributes:
+        change_id: Unique identifier for the change.
+        description: Description of the change.
+        succeeded: Whether the change was successful.
+        caused_failure: Whether the change caused a service failure.
+        reverted: Whether the change was reverted.
+    """
+
+    change_id: str
+    description: str
+    succeeded: bool = True
+    caused_failure: bool = False
+    reverted: bool = False
+
+
+@dataclass
+class ProcessMetrics:
+    """Aggregated process metrics for a run or tier.
+
+    Attributes:
+        r_prog: Fine-Grained Progress Rate.
+        strategic_drift: Strategic drift score (0 = no drift, 1 = complete drift).
+        cfp: Change Fail Percentage.
+        pr_revert_rate: Pull request revert rate.
+    """
+
+    r_prog: float = 0.0
+    strategic_drift: float = 0.0
+    cfp: float = 0.0
+    pr_revert_rate: float = 0.0
+
+
+def calculate_r_prog(tracker: ProgressTracker) -> float:
+    """Calculate Fine-Grained Progress Rate (R_Prog).
+
+    Formula: achieved_weighted_steps / expected_weighted_steps
+
+    This metric captures incremental advancements through the execution
+    trajectory, providing insight into where agents succeed or fail
+    in multi-step tasks.
+
+    Args:
+        tracker: ProgressTracker with expected and achieved steps.
+
+    Returns:
+        R_Prog value between 0.0 and 1.0.
+        Returns 0.0 if no expected steps.
+    """
+    if not tracker.expected_steps:
+        return 0.0
+
+    # Calculate weighted expected total
+    expected_total = sum(step.weight for step in tracker.expected_steps)
+    if expected_total <= 0:
+        return 0.0
+
+    # Calculate weighted achieved total
+    achieved_total = sum(
+        step.weight for step in tracker.achieved_steps if step.completed
+    )
+
+    return min(1.0, achieved_total / expected_total)
+
+
+def calculate_r_prog_simple(
+    achieved_steps: int,
+    expected_steps: int,
+) -> float:
+    """Calculate Fine-Grained Progress Rate using simple counts.
+
+    Simplified version when step weighting is not needed.
+
+    Args:
+        achieved_steps: Number of steps completed.
+        expected_steps: Total expected steps.
+
+    Returns:
+        R_Prog value between 0.0 and 1.0.
+    """
+    if expected_steps <= 0:
+        return 0.0
+
+    return min(1.0, achieved_steps / expected_steps)
+
+
+def calculate_strategic_drift(tracker: ProgressTracker) -> float:
+    """Calculate Strategic Drift score.
+
+    Strategic drift measures how much the agent's intermediate actions
+    diverge from the intended goal. Higher values indicate more drift.
+
+    Formula: 1 - (sum(goal_alignment * weight) / sum(weight))
+
+    A drift of 0 means perfect alignment; 1 means complete misalignment.
+
+    Args:
+        tracker: ProgressTracker with achieved steps and goal alignments.
+
+    Returns:
+        Strategic drift score between 0.0 and 1.0.
+    """
+    if not tracker.achieved_steps:
+        return 0.0
+
+    total_weight = sum(step.weight for step in tracker.achieved_steps)
+    if total_weight <= 0:
+        return 0.0
+
+    weighted_alignment = sum(
+        step.goal_alignment * step.weight for step in tracker.achieved_steps
+    )
+    average_alignment = weighted_alignment / total_weight
+
+    # Drift is inverse of alignment
+    return 1.0 - average_alignment
+
+
+def calculate_strategic_drift_simple(
+    goal_aligned_actions: int,
+    total_actions: int,
+) -> float:
+    """Calculate Strategic Drift using simple counts.
+
+    Simplified version for binary alignment classification.
+
+    Args:
+        goal_aligned_actions: Number of actions aligned with goal.
+        total_actions: Total number of actions taken.
+
+    Returns:
+        Strategic drift score between 0.0 and 1.0.
+    """
+    if total_actions <= 0:
+        return 0.0
+
+    alignment_rate = goal_aligned_actions / total_actions
+    return 1.0 - alignment_rate
+
+
+def calculate_cfp(changes: list[ChangeResult]) -> float:
+    """Calculate Change Fail Percentage (CFP).
+
+    CFP measures the percentage of agent-generated changes that cause
+    a failure in service, requiring immediate remediation.
+
+    This is a DevOps stability metric that indicates how reliable
+    the agent's changes are in production.
+
+    Args:
+        changes: List of change results.
+
+    Returns:
+        CFP value between 0.0 and 1.0.
+        Returns 0.0 if no changes.
+    """
+    if not changes:
+        return 0.0
+
+    failed_changes = sum(1 for c in changes if c.caused_failure)
+    return failed_changes / len(changes)
+
+
+def calculate_cfp_simple(
+    failed_changes: int,
+    total_changes: int,
+) -> float:
+    """Calculate Change Fail Percentage using simple counts.
+
+    Args:
+        failed_changes: Number of changes that caused failures.
+        total_changes: Total number of changes made.
+
+    Returns:
+        CFP value between 0.0 and 1.0.
+    """
+    if total_changes <= 0:
+        return 0.0
+
+    return failed_changes / total_changes
+
+
+def calculate_pr_revert_rate(changes: list[ChangeResult]) -> float:
+    """Calculate PR Revert Rate.
+
+    Tracks the frequency with which agent-generated changes are
+    discarded or reverted by human reviewers.
+
+    Args:
+        changes: List of change results.
+
+    Returns:
+        Revert rate between 0.0 and 1.0.
+        Returns 0.0 if no changes.
+    """
+    if not changes:
+        return 0.0
+
+    reverted_changes = sum(1 for c in changes if c.reverted)
+    return reverted_changes / len(changes)
+
+
+def calculate_pr_revert_rate_simple(
+    reverted_changes: int,
+    total_changes: int,
+) -> float:
+    """Calculate PR Revert Rate using simple counts.
+
+    Args:
+        reverted_changes: Number of changes that were reverted.
+        total_changes: Total number of changes made.
+
+    Returns:
+        Revert rate between 0.0 and 1.0.
+    """
+    if total_changes <= 0:
+        return 0.0
+
+    return reverted_changes / total_changes
+
+
+def calculate_process_metrics(
+    tracker: ProgressTracker | None = None,
+    changes: list[ChangeResult] | None = None,
+) -> ProcessMetrics:
+    """Calculate all process metrics from tracking data.
+
+    Args:
+        tracker: Optional progress tracker for R_Prog and drift.
+        changes: Optional list of changes for CFP and revert rate.
+
+    Returns:
+        ProcessMetrics with all calculated values.
+    """
+    r_prog = 0.0
+    drift = 0.0
+    cfp = 0.0
+    revert_rate = 0.0
+
+    if tracker:
+        r_prog = calculate_r_prog(tracker)
+        drift = calculate_strategic_drift(tracker)
+
+    if changes:
+        cfp = calculate_cfp(changes)
+        revert_rate = calculate_pr_revert_rate(changes)
+
+    return ProcessMetrics(
+        r_prog=r_prog,
+        strategic_drift=drift,
+        cfp=cfp,
+        pr_revert_rate=revert_rate,
+    )
+
+
+def calculate_process_metrics_simple(
+    achieved_steps: int = 0,
+    expected_steps: int = 0,
+    goal_aligned_actions: int = 0,
+    total_actions: int = 0,
+    failed_changes: int = 0,
+    total_changes: int = 0,
+    reverted_changes: int = 0,
+) -> ProcessMetrics:
+    """Calculate all process metrics from simple counts.
+
+    Convenience function when detailed tracking is not available.
+
+    Args:
+        achieved_steps: Number of steps completed.
+        expected_steps: Total expected steps.
+        goal_aligned_actions: Number of goal-aligned actions.
+        total_actions: Total actions taken.
+        failed_changes: Number of failed changes.
+        total_changes: Total changes made.
+        reverted_changes: Number of reverted changes.
+
+    Returns:
+        ProcessMetrics with all calculated values.
+    """
+    return ProcessMetrics(
+        r_prog=calculate_r_prog_simple(achieved_steps, expected_steps),
+        strategic_drift=calculate_strategic_drift_simple(
+            goal_aligned_actions, total_actions
+        ),
+        cfp=calculate_cfp_simple(failed_changes, total_changes),
+        pr_revert_rate=calculate_pr_revert_rate_simple(
+            reverted_changes, total_changes
+        ),
+    )

--- a/src/scylla/metrics/token_tracking.py
+++ b/src/scylla/metrics/token_tracking.py
@@ -1,0 +1,398 @@
+"""Component-level token tracking for cost analysis.
+
+This module provides detailed token tracking at the component level
+to analyze the "Token Efficiency Chasm" between T2 (Skills) and T3 (Tooling).
+
+Key insight from research: T3 (Tooling) requires loading JSON schemas which
+can consume 50k+ tokens upfront, while T2 (Skills) uses prompt-based
+instructions that are much more token-efficient.
+
+Python Justification: Required for data aggregation and cost calculations.
+
+References:
+- docs/research.md: Section 2.2 (Token Efficiency Chasm)
+- docs/summary.md: Section III.A (Token Efficiency Chasm)
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import Enum
+
+
+class ComponentType(Enum):
+    """Types of components that consume tokens."""
+
+    # Core components
+    SYSTEM_PROMPT = "system_prompt"
+    USER_PROMPT = "user_prompt"
+    RESPONSE = "response"
+
+    # T2-specific (Skills)
+    SKILL_PROMPT = "skill_prompt"
+    DOMAIN_EXPERTISE = "domain_expertise"
+
+    # T3-specific (Tooling)
+    TOOL_SCHEMA = "tool_schema"
+    TOOL_CALL = "tool_call"
+    TOOL_RESPONSE = "tool_response"
+
+    # T4/T5-specific (Delegation/Hierarchy)
+    ORCHESTRATOR = "orchestrator"
+    SUB_AGENT = "sub_agent"
+    MONITOR = "monitor"
+    EVALUATOR = "evaluator"
+
+    # Other
+    CONTEXT = "context"
+    REASONING = "reasoning"
+    OTHER = "other"
+
+
+@dataclass
+class TokenUsage:
+    """Token usage for a single component.
+
+    Attributes:
+        component_type: Type of component.
+        component_name: Specific name/identifier.
+        input_tokens: Number of input tokens consumed.
+        output_tokens: Number of output tokens generated.
+        cached_tokens: Number of tokens served from cache.
+    """
+
+    component_type: ComponentType
+    component_name: str = ""
+    input_tokens: int = 0
+    output_tokens: int = 0
+    cached_tokens: int = 0
+
+    @property
+    def total_tokens(self) -> int:
+        """Total tokens (input + output)."""
+        return self.input_tokens + self.output_tokens
+
+    def calculate_cost(
+        self,
+        input_price_per_million: float,
+        output_price_per_million: float,
+        cached_price_per_million: float = 0.0,
+    ) -> float:
+        """Calculate cost for this component.
+
+        Args:
+            input_price_per_million: Price per million input tokens.
+            output_price_per_million: Price per million output tokens.
+            cached_price_per_million: Price per million cached tokens.
+
+        Returns:
+            Cost in USD.
+        """
+        input_cost = (self.input_tokens / 1_000_000) * input_price_per_million
+        output_cost = (self.output_tokens / 1_000_000) * output_price_per_million
+        cached_cost = (self.cached_tokens / 1_000_000) * cached_price_per_million
+        return input_cost + output_cost + cached_cost
+
+
+@dataclass
+class ComponentCost:
+    """Cost breakdown for a single component.
+
+    Attributes:
+        component_type: Type of component.
+        component_name: Specific name/identifier.
+        input_tokens: Number of input tokens.
+        output_tokens: Number of output tokens.
+        cost_usd: Total cost in USD.
+        percentage: Percentage of total cost.
+    """
+
+    component_type: ComponentType
+    component_name: str
+    input_tokens: int
+    output_tokens: int
+    cost_usd: float
+    percentage: float = 0.0
+
+
+@dataclass
+class TokenDistribution:
+    """Token distribution across components.
+
+    Attributes:
+        components: List of component costs.
+        total_input_tokens: Total input tokens across all components.
+        total_output_tokens: Total output tokens across all components.
+        total_cost_usd: Total cost across all components.
+    """
+
+    components: list[ComponentCost] = field(default_factory=list)
+    total_input_tokens: int = 0
+    total_output_tokens: int = 0
+    total_cost_usd: float = 0.0
+
+    @property
+    def total_tokens(self) -> int:
+        """Total tokens across all components."""
+        return self.total_input_tokens + self.total_output_tokens
+
+    def get_by_type(self, component_type: ComponentType) -> list[ComponentCost]:
+        """Get all components of a specific type."""
+        return [c for c in self.components if c.component_type == component_type]
+
+    def get_type_cost(self, component_type: ComponentType) -> float:
+        """Get total cost for a component type."""
+        return sum(c.cost_usd for c in self.get_by_type(component_type))
+
+    def get_type_percentage(self, component_type: ComponentType) -> float:
+        """Get percentage of total cost for a component type."""
+        if self.total_cost_usd <= 0:
+            return 0.0
+        return (self.get_type_cost(component_type) / self.total_cost_usd) * 100
+
+
+@dataclass
+class TierTokenAnalysis:
+    """Token analysis for a specific tier.
+
+    Attributes:
+        tier_id: Tier identifier (T0-T6).
+        distribution: Token distribution for this tier.
+        schema_overhead: Token overhead from tool schemas (T3+).
+        skill_efficiency: Token efficiency from skills (T2+).
+    """
+
+    tier_id: str
+    distribution: TokenDistribution
+    schema_overhead: int = 0
+    skill_efficiency: float = 0.0
+
+
+class TokenTracker:
+    """Tracks token usage across components for a run.
+
+    Example:
+        tracker = TokenTracker()
+        tracker.add_usage(ComponentType.SYSTEM_PROMPT, "main", 500, 0)
+        tracker.add_usage(ComponentType.TOOL_SCHEMA, "search", 15000, 0)
+        tracker.add_usage(ComponentType.RESPONSE, "main", 0, 1000)
+
+        distribution = tracker.calculate_distribution(
+            input_price=3.0,
+            output_price=15.0,
+        )
+    """
+
+    def __init__(self) -> None:
+        """Initialize empty tracker."""
+        self._usages: list[TokenUsage] = []
+
+    def add_usage(
+        self,
+        component_type: ComponentType,
+        component_name: str = "",
+        input_tokens: int = 0,
+        output_tokens: int = 0,
+        cached_tokens: int = 0,
+    ) -> None:
+        """Add token usage for a component.
+
+        Args:
+            component_type: Type of component.
+            component_name: Specific name/identifier.
+            input_tokens: Number of input tokens.
+            output_tokens: Number of output tokens.
+            cached_tokens: Number of cached tokens.
+        """
+        usage = TokenUsage(
+            component_type=component_type,
+            component_name=component_name,
+            input_tokens=input_tokens,
+            output_tokens=output_tokens,
+            cached_tokens=cached_tokens,
+        )
+        self._usages.append(usage)
+
+    def add_token_usage(self, usage: TokenUsage) -> None:
+        """Add a TokenUsage object directly."""
+        self._usages.append(usage)
+
+    def calculate_distribution(
+        self,
+        input_price: float = 3.0,
+        output_price: float = 15.0,
+        cached_price: float = 0.0,
+    ) -> TokenDistribution:
+        """Calculate token distribution and costs.
+
+        Args:
+            input_price: Price per million input tokens.
+            output_price: Price per million output tokens.
+            cached_price: Price per million cached tokens.
+
+        Returns:
+            TokenDistribution with all component costs.
+        """
+        components: list[ComponentCost] = []
+        total_input = 0
+        total_output = 0
+        total_cost = 0.0
+
+        for usage in self._usages:
+            cost = usage.calculate_cost(input_price, output_price, cached_price)
+            total_input += usage.input_tokens
+            total_output += usage.output_tokens
+            total_cost += cost
+
+            components.append(
+                ComponentCost(
+                    component_type=usage.component_type,
+                    component_name=usage.component_name,
+                    input_tokens=usage.input_tokens,
+                    output_tokens=usage.output_tokens,
+                    cost_usd=cost,
+                )
+            )
+
+        # Calculate percentages
+        for component in components:
+            if total_cost > 0:
+                component.percentage = (component.cost_usd / total_cost) * 100
+
+        return TokenDistribution(
+            components=components,
+            total_input_tokens=total_input,
+            total_output_tokens=total_output,
+            total_cost_usd=total_cost,
+        )
+
+    def get_schema_overhead(self) -> int:
+        """Get total tokens consumed by tool schemas.
+
+        This measures the "Token Efficiency Chasm" overhead
+        introduced by T3 (Tooling) architectures.
+
+        Returns:
+            Total schema tokens.
+        """
+        schema_usages = [
+            u for u in self._usages if u.component_type == ComponentType.TOOL_SCHEMA
+        ]
+        return sum(u.total_tokens for u in schema_usages)
+
+    def get_skill_tokens(self) -> int:
+        """Get total tokens consumed by skills.
+
+        This measures T2 (Skills) token usage for comparison
+        with T3 schema overhead.
+
+        Returns:
+            Total skill tokens.
+        """
+        skill_types = {ComponentType.SKILL_PROMPT, ComponentType.DOMAIN_EXPERTISE}
+        skill_usages = [u for u in self._usages if u.component_type in skill_types]
+        return sum(u.total_tokens for u in skill_usages)
+
+    def clear(self) -> None:
+        """Clear all tracked usage."""
+        self._usages.clear()
+
+
+def calculate_token_efficiency_ratio(
+    skill_tokens: int,
+    schema_tokens: int,
+) -> float:
+    """Calculate token efficiency ratio (T2 vs T3).
+
+    A ratio > 1.0 means skills are more token-efficient than schemas.
+
+    Args:
+        skill_tokens: Total tokens used by T2 skills.
+        schema_tokens: Total tokens used by T3 schemas.
+
+    Returns:
+        Efficiency ratio (schema_tokens / skill_tokens).
+        Returns 0.0 if skill_tokens is 0.
+    """
+    if skill_tokens <= 0:
+        return 0.0 if schema_tokens <= 0 else float("inf")
+
+    return schema_tokens / skill_tokens
+
+
+def analyze_tier_tokens(
+    tracker: TokenTracker,
+    tier_id: str,
+    input_price: float = 3.0,
+    output_price: float = 15.0,
+) -> TierTokenAnalysis:
+    """Analyze token usage for a specific tier.
+
+    Args:
+        tracker: Token tracker with usage data.
+        tier_id: Tier identifier.
+        input_price: Price per million input tokens.
+        output_price: Price per million output tokens.
+
+    Returns:
+        TierTokenAnalysis with distribution and efficiency metrics.
+    """
+    distribution = tracker.calculate_distribution(input_price, output_price)
+    schema_overhead = tracker.get_schema_overhead()
+    skill_tokens = tracker.get_skill_tokens()
+
+    # Calculate skill efficiency (inverse of schema overhead ratio)
+    if schema_overhead > 0 and skill_tokens > 0:
+        skill_efficiency = skill_tokens / (skill_tokens + schema_overhead)
+    elif skill_tokens > 0:
+        skill_efficiency = 1.0
+    else:
+        skill_efficiency = 0.0
+
+    return TierTokenAnalysis(
+        tier_id=tier_id,
+        distribution=distribution,
+        schema_overhead=schema_overhead,
+        skill_efficiency=skill_efficiency,
+    )
+
+
+def compare_t2_t3_efficiency(
+    t2_analysis: TierTokenAnalysis,
+    t3_analysis: TierTokenAnalysis,
+) -> dict[str, float]:
+    """Compare token efficiency between T2 (Skills) and T3 (Tooling).
+
+    This directly measures the "Token Efficiency Chasm" described
+    in the research documentation.
+
+    Args:
+        t2_analysis: Token analysis for T2 tier.
+        t3_analysis: Token analysis for T3 tier.
+
+    Returns:
+        Dictionary with comparison metrics.
+    """
+    t2_total = t2_analysis.distribution.total_tokens
+    t3_total = t3_analysis.distribution.total_tokens
+    t3_schema = t3_analysis.schema_overhead
+
+    # Calculate metrics
+    token_ratio = t3_total / t2_total if t2_total > 0 else 0.0
+    schema_ratio = t3_schema / t2_total if t2_total > 0 else 0.0
+    cost_ratio = (
+        t3_analysis.distribution.total_cost_usd
+        / t2_analysis.distribution.total_cost_usd
+        if t2_analysis.distribution.total_cost_usd > 0
+        else 0.0
+    )
+
+    return {
+        "t2_total_tokens": t2_total,
+        "t3_total_tokens": t3_total,
+        "t3_schema_overhead": t3_schema,
+        "token_ratio": token_ratio,  # T3/T2 (>1 means T3 uses more)
+        "schema_overhead_ratio": schema_ratio,  # Schema/T2 baseline
+        "cost_ratio": cost_ratio,  # T3 cost / T2 cost
+        "efficiency_gain": 1.0 - (1.0 / token_ratio) if token_ratio > 0 else 0.0,
+    }

--- a/src/scylla/orchestrator.py
+++ b/src/scylla/orchestrator.py
@@ -155,8 +155,8 @@ class EvalOrchestrator:
             cost_usd = execution_result.get("cost_usd", 0.0)
             pass_rate = 1.0 if passed else 0.0
             cost_of_pass = cost_usd / pass_rate if pass_rate > 0 else float("inf")
-            # Composite score weights: 70% implementation rate, 30% pass rate
-            composite_score = (impl_rate * 0.7) + (pass_rate * 0.3)
+            # Composite score: equal weight (50/50) per metrics-formulas.md
+            composite_score = (pass_rate + impl_rate) / 2
 
             # Create result
             result = create_run_result(

--- a/tests/integration/test_orchestrator.py
+++ b/tests/integration/test_orchestrator.py
@@ -448,9 +448,9 @@ output:
                     run_number=1,
                 )
 
-        # Verify composite score = (impl_rate * 0.7) + (pass_rate * 0.3)
-        # = (0.80 * 0.7) + (1.0 * 0.3) = 0.56 + 0.30 = 0.86
-        assert abs(result.grading.composite_score - 0.86) < 0.001
+        # Verify composite score = (pass_rate + impl_rate) / 2 (50/50 weights)
+        # = (1.0 + 0.80) / 2 = 0.90
+        assert abs(result.grading.composite_score - 0.90) < 0.001
 
         # Verify cost-of-pass = cost_usd / pass_rate = 0.10 / 1.0 = 0.10
         assert abs(result.grading.cost_of_pass - 0.10) < 0.001

--- a/tests/unit/metrics/test_process.py
+++ b/tests/unit/metrics/test_process.py
@@ -1,0 +1,363 @@
+"""Tests for process metrics calculations.
+
+Python justification: Required for pytest testing framework.
+"""
+
+import pytest
+
+from scylla.metrics.process import (
+    ChangeResult,
+    ProcessMetrics,
+    ProgressStep,
+    ProgressTracker,
+    calculate_cfp,
+    calculate_cfp_simple,
+    calculate_pr_revert_rate,
+    calculate_pr_revert_rate_simple,
+    calculate_process_metrics,
+    calculate_process_metrics_simple,
+    calculate_r_prog,
+    calculate_r_prog_simple,
+    calculate_strategic_drift,
+    calculate_strategic_drift_simple,
+)
+
+
+class TestProgressStep:
+    """Tests for ProgressStep dataclass."""
+
+    def test_default_values(self) -> None:
+        step = ProgressStep(step_id="1", description="Test step")
+        assert step.step_id == "1"
+        assert step.description == "Test step"
+        assert step.weight == 1.0
+        assert step.completed is False
+        assert step.goal_alignment == 1.0
+
+    def test_custom_values(self) -> None:
+        step = ProgressStep(
+            step_id="2",
+            description="Critical step",
+            weight=2.0,
+            completed=True,
+            goal_alignment=0.8,
+        )
+        assert step.weight == 2.0
+        assert step.completed is True
+        assert step.goal_alignment == 0.8
+
+
+class TestCalculateRProg:
+    """Tests for Fine-Grained Progress Rate calculation."""
+
+    def test_all_steps_completed(self) -> None:
+        tracker = ProgressTracker(
+            expected_steps=[
+                ProgressStep("1", "Step 1", weight=1.0, completed=True),
+                ProgressStep("2", "Step 2", weight=1.0, completed=True),
+            ],
+            achieved_steps=[
+                ProgressStep("1", "Step 1", weight=1.0, completed=True),
+                ProgressStep("2", "Step 2", weight=1.0, completed=True),
+            ],
+        )
+        assert calculate_r_prog(tracker) == 1.0
+
+    def test_partial_progress(self) -> None:
+        tracker = ProgressTracker(
+            expected_steps=[
+                ProgressStep("1", "Step 1", weight=1.0),
+                ProgressStep("2", "Step 2", weight=1.0),
+                ProgressStep("3", "Step 3", weight=1.0),
+                ProgressStep("4", "Step 4", weight=1.0),
+            ],
+            achieved_steps=[
+                ProgressStep("1", "Step 1", weight=1.0, completed=True),
+                ProgressStep("2", "Step 2", weight=1.0, completed=True),
+            ],
+        )
+        assert calculate_r_prog(tracker) == pytest.approx(0.5)
+
+    def test_weighted_progress(self) -> None:
+        tracker = ProgressTracker(
+            expected_steps=[
+                ProgressStep("1", "Easy", weight=1.0),
+                ProgressStep("2", "Hard", weight=3.0),  # Total: 4.0
+            ],
+            achieved_steps=[
+                ProgressStep("1", "Easy", weight=1.0, completed=True),
+            ],
+        )
+        # 1.0 / 4.0 = 0.25
+        assert calculate_r_prog(tracker) == pytest.approx(0.25)
+
+    def test_no_expected_steps(self) -> None:
+        tracker = ProgressTracker(expected_steps=[], achieved_steps=[])
+        assert calculate_r_prog(tracker) == 0.0
+
+    def test_no_achieved_steps(self) -> None:
+        tracker = ProgressTracker(
+            expected_steps=[ProgressStep("1", "Step 1", weight=1.0)],
+            achieved_steps=[],
+        )
+        assert calculate_r_prog(tracker) == 0.0
+
+
+class TestCalculateRProgSimple:
+    """Tests for simple R_Prog calculation."""
+
+    def test_full_progress(self) -> None:
+        assert calculate_r_prog_simple(10, 10) == 1.0
+
+    def test_partial_progress(self) -> None:
+        assert calculate_r_prog_simple(5, 10) == 0.5
+
+    def test_no_progress(self) -> None:
+        assert calculate_r_prog_simple(0, 10) == 0.0
+
+    def test_zero_expected(self) -> None:
+        assert calculate_r_prog_simple(5, 0) == 0.0
+
+    def test_over_progress(self) -> None:
+        # Cap at 1.0
+        assert calculate_r_prog_simple(15, 10) == 1.0
+
+
+class TestCalculateStrategicDrift:
+    """Tests for Strategic Drift calculation."""
+
+    def test_no_drift(self) -> None:
+        tracker = ProgressTracker(
+            achieved_steps=[
+                ProgressStep("1", "Step 1", goal_alignment=1.0, completed=True),
+                ProgressStep("2", "Step 2", goal_alignment=1.0, completed=True),
+            ]
+        )
+        assert calculate_strategic_drift(tracker) == 0.0
+
+    def test_complete_drift(self) -> None:
+        tracker = ProgressTracker(
+            achieved_steps=[
+                ProgressStep("1", "Off-track", goal_alignment=0.0, completed=True),
+            ]
+        )
+        assert calculate_strategic_drift(tracker) == 1.0
+
+    def test_partial_drift(self) -> None:
+        tracker = ProgressTracker(
+            achieved_steps=[
+                ProgressStep("1", "Aligned", goal_alignment=1.0, completed=True),
+                ProgressStep("2", "Half-aligned", goal_alignment=0.5, completed=True),
+            ]
+        )
+        # Average alignment = (1.0 + 0.5) / 2 = 0.75
+        # Drift = 1 - 0.75 = 0.25
+        assert calculate_strategic_drift(tracker) == pytest.approx(0.25)
+
+    def test_weighted_drift(self) -> None:
+        tracker = ProgressTracker(
+            achieved_steps=[
+                ProgressStep("1", "Important", weight=3.0, goal_alignment=1.0),
+                ProgressStep("2", "Minor", weight=1.0, goal_alignment=0.0),
+            ]
+        )
+        # Weighted alignment = (3.0*1.0 + 1.0*0.0) / 4.0 = 0.75
+        # Drift = 1 - 0.75 = 0.25
+        assert calculate_strategic_drift(tracker) == pytest.approx(0.25)
+
+    def test_no_achieved_steps(self) -> None:
+        tracker = ProgressTracker(achieved_steps=[])
+        assert calculate_strategic_drift(tracker) == 0.0
+
+
+class TestCalculateStrategicDriftSimple:
+    """Tests for simple Strategic Drift calculation."""
+
+    def test_all_aligned(self) -> None:
+        assert calculate_strategic_drift_simple(10, 10) == 0.0
+
+    def test_none_aligned(self) -> None:
+        assert calculate_strategic_drift_simple(0, 10) == 1.0
+
+    def test_half_aligned(self) -> None:
+        assert calculate_strategic_drift_simple(5, 10) == 0.5
+
+    def test_zero_actions(self) -> None:
+        assert calculate_strategic_drift_simple(0, 0) == 0.0
+
+
+class TestCalculateCFP:
+    """Tests for Change Fail Percentage calculation."""
+
+    def test_no_failures(self) -> None:
+        changes = [
+            ChangeResult("1", "Change 1", caused_failure=False),
+            ChangeResult("2", "Change 2", caused_failure=False),
+        ]
+        assert calculate_cfp(changes) == 0.0
+
+    def test_all_failures(self) -> None:
+        changes = [
+            ChangeResult("1", "Change 1", caused_failure=True),
+            ChangeResult("2", "Change 2", caused_failure=True),
+        ]
+        assert calculate_cfp(changes) == 1.0
+
+    def test_partial_failures(self) -> None:
+        changes = [
+            ChangeResult("1", "Change 1", caused_failure=True),
+            ChangeResult("2", "Change 2", caused_failure=False),
+            ChangeResult("3", "Change 3", caused_failure=False),
+            ChangeResult("4", "Change 4", caused_failure=True),
+        ]
+        # 2 failures / 4 total = 0.5
+        assert calculate_cfp(changes) == 0.5
+
+    def test_empty_changes(self) -> None:
+        assert calculate_cfp([]) == 0.0
+
+
+class TestCalculateCFPSimple:
+    """Tests for simple CFP calculation."""
+
+    def test_normal_case(self) -> None:
+        assert calculate_cfp_simple(2, 10) == 0.2
+
+    def test_no_failures(self) -> None:
+        assert calculate_cfp_simple(0, 10) == 0.0
+
+    def test_all_failures(self) -> None:
+        assert calculate_cfp_simple(10, 10) == 1.0
+
+    def test_zero_changes(self) -> None:
+        assert calculate_cfp_simple(0, 0) == 0.0
+
+
+class TestCalculatePRRevertRate:
+    """Tests for PR Revert Rate calculation."""
+
+    def test_no_reverts(self) -> None:
+        changes = [
+            ChangeResult("1", "Change 1", reverted=False),
+            ChangeResult("2", "Change 2", reverted=False),
+        ]
+        assert calculate_pr_revert_rate(changes) == 0.0
+
+    def test_all_reverted(self) -> None:
+        changes = [
+            ChangeResult("1", "Change 1", reverted=True),
+            ChangeResult("2", "Change 2", reverted=True),
+        ]
+        assert calculate_pr_revert_rate(changes) == 1.0
+
+    def test_partial_reverts(self) -> None:
+        changes = [
+            ChangeResult("1", "Change 1", reverted=True),
+            ChangeResult("2", "Change 2", reverted=False),
+        ]
+        assert calculate_pr_revert_rate(changes) == 0.5
+
+    def test_empty_changes(self) -> None:
+        assert calculate_pr_revert_rate([]) == 0.0
+
+
+class TestCalculatePRRevertRateSimple:
+    """Tests for simple PR Revert Rate calculation."""
+
+    def test_normal_case(self) -> None:
+        assert calculate_pr_revert_rate_simple(3, 10) == 0.3
+
+    def test_zero_changes(self) -> None:
+        assert calculate_pr_revert_rate_simple(0, 0) == 0.0
+
+
+class TestProcessMetrics:
+    """Tests for ProcessMetrics dataclass."""
+
+    def test_default_values(self) -> None:
+        metrics = ProcessMetrics()
+        assert metrics.r_prog == 0.0
+        assert metrics.strategic_drift == 0.0
+        assert metrics.cfp == 0.0
+        assert metrics.pr_revert_rate == 0.0
+
+    def test_custom_values(self) -> None:
+        metrics = ProcessMetrics(
+            r_prog=0.8,
+            strategic_drift=0.1,
+            cfp=0.05,
+            pr_revert_rate=0.02,
+        )
+        assert metrics.r_prog == 0.8
+        assert metrics.strategic_drift == 0.1
+        assert metrics.cfp == 0.05
+        assert metrics.pr_revert_rate == 0.02
+
+
+class TestCalculateProcessMetrics:
+    """Tests for calculate_process_metrics function."""
+
+    def test_with_tracker_and_changes(self) -> None:
+        tracker = ProgressTracker(
+            expected_steps=[ProgressStep("1", "Step 1", weight=1.0)],
+            achieved_steps=[ProgressStep("1", "Step 1", weight=1.0, completed=True)],
+        )
+        changes = [
+            ChangeResult("1", "Change 1", caused_failure=False, reverted=False),
+        ]
+        metrics = calculate_process_metrics(tracker, changes)
+        assert metrics.r_prog == 1.0
+        assert metrics.strategic_drift == 0.0
+        assert metrics.cfp == 0.0
+        assert metrics.pr_revert_rate == 0.0
+
+    def test_with_tracker_only(self) -> None:
+        tracker = ProgressTracker(
+            expected_steps=[ProgressStep("1", "Step 1", weight=1.0)],
+            achieved_steps=[],
+        )
+        metrics = calculate_process_metrics(tracker, None)
+        assert metrics.r_prog == 0.0
+        assert metrics.cfp == 0.0
+
+    def test_with_changes_only(self) -> None:
+        changes = [
+            ChangeResult("1", "Change 1", caused_failure=True, reverted=True),
+        ]
+        metrics = calculate_process_metrics(None, changes)
+        assert metrics.r_prog == 0.0
+        assert metrics.cfp == 1.0
+        assert metrics.pr_revert_rate == 1.0
+
+    def test_with_nothing(self) -> None:
+        metrics = calculate_process_metrics(None, None)
+        assert metrics.r_prog == 0.0
+        assert metrics.strategic_drift == 0.0
+        assert metrics.cfp == 0.0
+        assert metrics.pr_revert_rate == 0.0
+
+
+class TestCalculateProcessMetricsSimple:
+    """Tests for calculate_process_metrics_simple function."""
+
+    def test_all_metrics(self) -> None:
+        metrics = calculate_process_metrics_simple(
+            achieved_steps=8,
+            expected_steps=10,
+            goal_aligned_actions=9,
+            total_actions=10,
+            failed_changes=1,
+            total_changes=20,
+            reverted_changes=2,
+        )
+        assert metrics.r_prog == pytest.approx(0.8)
+        assert metrics.strategic_drift == pytest.approx(0.1)
+        assert metrics.cfp == pytest.approx(0.05)
+        assert metrics.pr_revert_rate == pytest.approx(0.1)
+
+    def test_default_values(self) -> None:
+        metrics = calculate_process_metrics_simple()
+        assert metrics.r_prog == 0.0
+        assert metrics.strategic_drift == 0.0
+        assert metrics.cfp == 0.0
+        assert metrics.pr_revert_rate == 0.0

--- a/tests/unit/metrics/test_token_tracking.py
+++ b/tests/unit/metrics/test_token_tracking.py
@@ -1,0 +1,365 @@
+"""Tests for component-level token tracking.
+
+Python justification: Required for pytest testing framework.
+"""
+
+import math
+
+import pytest
+
+from scylla.metrics.token_tracking import (
+    ComponentCost,
+    ComponentType,
+    TierTokenAnalysis,
+    TokenDistribution,
+    TokenTracker,
+    TokenUsage,
+    analyze_tier_tokens,
+    calculate_token_efficiency_ratio,
+    compare_t2_t3_efficiency,
+)
+
+
+class TestTokenUsage:
+    """Tests for TokenUsage dataclass."""
+
+    def test_default_values(self) -> None:
+        usage = TokenUsage(ComponentType.SYSTEM_PROMPT)
+        assert usage.component_type == ComponentType.SYSTEM_PROMPT
+        assert usage.component_name == ""
+        assert usage.input_tokens == 0
+        assert usage.output_tokens == 0
+        assert usage.cached_tokens == 0
+
+    def test_total_tokens(self) -> None:
+        usage = TokenUsage(
+            ComponentType.RESPONSE,
+            input_tokens=100,
+            output_tokens=500,
+        )
+        assert usage.total_tokens == 600
+
+    def test_calculate_cost(self) -> None:
+        usage = TokenUsage(
+            ComponentType.SYSTEM_PROMPT,
+            input_tokens=1_000_000,  # 1M input
+            output_tokens=500_000,  # 0.5M output
+        )
+        # Cost = 1M * $3/M + 0.5M * $15/M = $3 + $7.50 = $10.50
+        cost = usage.calculate_cost(
+            input_price_per_million=3.0,
+            output_price_per_million=15.0,
+        )
+        assert cost == pytest.approx(10.5)
+
+    def test_calculate_cost_with_cache(self) -> None:
+        usage = TokenUsage(
+            ComponentType.CONTEXT,
+            input_tokens=1_000_000,
+            cached_tokens=500_000,
+        )
+        # Cost = 1M * $3/M + 0.5M * $0.30/M = $3 + $0.15 = $3.15
+        cost = usage.calculate_cost(
+            input_price_per_million=3.0,
+            output_price_per_million=15.0,
+            cached_price_per_million=0.30,
+        )
+        assert cost == pytest.approx(3.15)
+
+
+class TestComponentType:
+    """Tests for ComponentType enum."""
+
+    def test_t2_specific_types(self) -> None:
+        assert ComponentType.SKILL_PROMPT.value == "skill_prompt"
+        assert ComponentType.DOMAIN_EXPERTISE.value == "domain_expertise"
+
+    def test_t3_specific_types(self) -> None:
+        assert ComponentType.TOOL_SCHEMA.value == "tool_schema"
+        assert ComponentType.TOOL_CALL.value == "tool_call"
+        assert ComponentType.TOOL_RESPONSE.value == "tool_response"
+
+    def test_t4_t5_specific_types(self) -> None:
+        assert ComponentType.ORCHESTRATOR.value == "orchestrator"
+        assert ComponentType.SUB_AGENT.value == "sub_agent"
+        assert ComponentType.MONITOR.value == "monitor"
+        assert ComponentType.EVALUATOR.value == "evaluator"
+
+
+class TestTokenTracker:
+    """Tests for TokenTracker class."""
+
+    def test_add_usage(self) -> None:
+        tracker = TokenTracker()
+        tracker.add_usage(
+            ComponentType.SYSTEM_PROMPT,
+            "main",
+            input_tokens=500,
+            output_tokens=0,
+        )
+        tracker.add_usage(
+            ComponentType.RESPONSE,
+            "main",
+            input_tokens=0,
+            output_tokens=1000,
+        )
+
+        distribution = tracker.calculate_distribution()
+        assert len(distribution.components) == 2
+        assert distribution.total_input_tokens == 500
+        assert distribution.total_output_tokens == 1000
+
+    def test_add_token_usage_object(self) -> None:
+        tracker = TokenTracker()
+        usage = TokenUsage(
+            ComponentType.TOOL_SCHEMA,
+            "search_tool",
+            input_tokens=15000,
+        )
+        tracker.add_token_usage(usage)
+
+        distribution = tracker.calculate_distribution()
+        assert distribution.total_input_tokens == 15000
+
+    def test_calculate_distribution_with_pricing(self) -> None:
+        tracker = TokenTracker()
+        tracker.add_usage(
+            ComponentType.SYSTEM_PROMPT,
+            input_tokens=1_000_000,
+        )
+        tracker.add_usage(
+            ComponentType.RESPONSE,
+            output_tokens=100_000,
+        )
+
+        distribution = tracker.calculate_distribution(
+            input_price=3.0,
+            output_price=15.0,
+        )
+        # Cost = 1M * $3/M + 0.1M * $15/M = $3 + $1.50 = $4.50
+        assert distribution.total_cost_usd == pytest.approx(4.5)
+
+    def test_calculate_distribution_percentages(self) -> None:
+        tracker = TokenTracker()
+        tracker.add_usage(ComponentType.SYSTEM_PROMPT, input_tokens=1_000_000)
+        tracker.add_usage(ComponentType.TOOL_SCHEMA, input_tokens=1_000_000)
+
+        distribution = tracker.calculate_distribution(input_price=3.0, output_price=15.0)
+        # Both have same cost, so each should be 50%
+        assert distribution.components[0].percentage == pytest.approx(50.0)
+        assert distribution.components[1].percentage == pytest.approx(50.0)
+
+    def test_get_schema_overhead(self) -> None:
+        tracker = TokenTracker()
+        tracker.add_usage(ComponentType.SYSTEM_PROMPT, input_tokens=500)
+        tracker.add_usage(ComponentType.TOOL_SCHEMA, input_tokens=15000)
+        tracker.add_usage(ComponentType.TOOL_SCHEMA, input_tokens=10000)
+
+        overhead = tracker.get_schema_overhead()
+        assert overhead == 25000
+
+    def test_get_skill_tokens(self) -> None:
+        tracker = TokenTracker()
+        tracker.add_usage(ComponentType.SYSTEM_PROMPT, input_tokens=500)
+        tracker.add_usage(ComponentType.SKILL_PROMPT, input_tokens=2000)
+        tracker.add_usage(ComponentType.DOMAIN_EXPERTISE, input_tokens=1000)
+
+        skill_tokens = tracker.get_skill_tokens()
+        assert skill_tokens == 3000
+
+    def test_clear(self) -> None:
+        tracker = TokenTracker()
+        tracker.add_usage(ComponentType.SYSTEM_PROMPT, input_tokens=500)
+        tracker.clear()
+
+        distribution = tracker.calculate_distribution()
+        assert len(distribution.components) == 0
+
+
+class TestTokenDistribution:
+    """Tests for TokenDistribution dataclass."""
+
+    def test_total_tokens(self) -> None:
+        distribution = TokenDistribution(
+            total_input_tokens=1000,
+            total_output_tokens=500,
+        )
+        assert distribution.total_tokens == 1500
+
+    def test_get_by_type(self) -> None:
+        components = [
+            ComponentCost(ComponentType.TOOL_SCHEMA, "tool1", 1000, 0, 0.03),
+            ComponentCost(ComponentType.TOOL_SCHEMA, "tool2", 2000, 0, 0.06),
+            ComponentCost(ComponentType.SYSTEM_PROMPT, "main", 500, 0, 0.015),
+        ]
+        distribution = TokenDistribution(components=components)
+
+        schema_components = distribution.get_by_type(ComponentType.TOOL_SCHEMA)
+        assert len(schema_components) == 2
+
+    def test_get_type_cost(self) -> None:
+        components = [
+            ComponentCost(ComponentType.TOOL_SCHEMA, "tool1", 1000, 0, 1.0),
+            ComponentCost(ComponentType.TOOL_SCHEMA, "tool2", 2000, 0, 2.0),
+            ComponentCost(ComponentType.SYSTEM_PROMPT, "main", 500, 0, 0.5),
+        ]
+        distribution = TokenDistribution(components=components, total_cost_usd=3.5)
+
+        schema_cost = distribution.get_type_cost(ComponentType.TOOL_SCHEMA)
+        assert schema_cost == 3.0
+
+    def test_get_type_percentage(self) -> None:
+        components = [
+            ComponentCost(ComponentType.TOOL_SCHEMA, "tool1", 1000, 0, 3.0),
+            ComponentCost(ComponentType.SYSTEM_PROMPT, "main", 500, 0, 1.0),
+        ]
+        distribution = TokenDistribution(components=components, total_cost_usd=4.0)
+
+        schema_pct = distribution.get_type_percentage(ComponentType.TOOL_SCHEMA)
+        assert schema_pct == 75.0  # 3.0 / 4.0 * 100
+
+
+class TestCalculateTokenEfficiencyRatio:
+    """Tests for token efficiency ratio calculation."""
+
+    def test_schemas_more_expensive(self) -> None:
+        # Schema uses 10x more tokens than skills
+        ratio = calculate_token_efficiency_ratio(
+            skill_tokens=1000,
+            schema_tokens=10000,
+        )
+        assert ratio == 10.0
+
+    def test_equal_usage(self) -> None:
+        ratio = calculate_token_efficiency_ratio(
+            skill_tokens=5000,
+            schema_tokens=5000,
+        )
+        assert ratio == 1.0
+
+    def test_skills_more_efficient(self) -> None:
+        ratio = calculate_token_efficiency_ratio(
+            skill_tokens=10000,
+            schema_tokens=5000,
+        )
+        assert ratio == 0.5
+
+    def test_zero_skill_tokens(self) -> None:
+        ratio = calculate_token_efficiency_ratio(
+            skill_tokens=0,
+            schema_tokens=10000,
+        )
+        assert math.isinf(ratio)
+
+    def test_both_zero(self) -> None:
+        ratio = calculate_token_efficiency_ratio(
+            skill_tokens=0,
+            schema_tokens=0,
+        )
+        assert ratio == 0.0
+
+
+class TestAnalyzeTierTokens:
+    """Tests for analyze_tier_tokens function."""
+
+    def test_t2_tier_analysis(self) -> None:
+        tracker = TokenTracker()
+        tracker.add_usage(ComponentType.SYSTEM_PROMPT, input_tokens=500)
+        tracker.add_usage(ComponentType.SKILL_PROMPT, input_tokens=2000)
+        tracker.add_usage(ComponentType.RESPONSE, output_tokens=1000)
+
+        analysis = analyze_tier_tokens(tracker, "T2")
+        assert analysis.tier_id == "T2"
+        assert analysis.schema_overhead == 0
+        assert analysis.skill_efficiency == 1.0  # No schema overhead
+
+    def test_t3_tier_analysis(self) -> None:
+        tracker = TokenTracker()
+        tracker.add_usage(ComponentType.SYSTEM_PROMPT, input_tokens=500)
+        tracker.add_usage(ComponentType.TOOL_SCHEMA, input_tokens=50000)
+        tracker.add_usage(ComponentType.RESPONSE, output_tokens=1000)
+
+        analysis = analyze_tier_tokens(tracker, "T3")
+        assert analysis.tier_id == "T3"
+        assert analysis.schema_overhead == 50000
+
+    def test_mixed_tier_analysis(self) -> None:
+        tracker = TokenTracker()
+        tracker.add_usage(ComponentType.SKILL_PROMPT, input_tokens=2000)
+        tracker.add_usage(ComponentType.TOOL_SCHEMA, input_tokens=8000)
+
+        analysis = analyze_tier_tokens(tracker, "T6")
+        # skill_efficiency = 2000 / (2000 + 8000) = 0.2
+        assert analysis.skill_efficiency == pytest.approx(0.2)
+
+
+class TestCompareT2T3Efficiency:
+    """Tests for T2 vs T3 efficiency comparison."""
+
+    def test_t3_uses_more_tokens(self) -> None:
+        t2_tracker = TokenTracker()
+        t2_tracker.add_usage(ComponentType.SKILL_PROMPT, input_tokens=2000)
+
+        t3_tracker = TokenTracker()
+        t3_tracker.add_usage(ComponentType.TOOL_SCHEMA, input_tokens=50000)
+
+        t2_analysis = analyze_tier_tokens(t2_tracker, "T2")
+        t3_analysis = analyze_tier_tokens(t3_tracker, "T3")
+
+        comparison = compare_t2_t3_efficiency(t2_analysis, t3_analysis)
+
+        assert comparison["t2_total_tokens"] == 2000
+        assert comparison["t3_total_tokens"] == 50000
+        assert comparison["t3_schema_overhead"] == 50000
+        assert comparison["token_ratio"] == 25.0  # T3 uses 25x more
+
+    def test_equal_token_usage(self) -> None:
+        t2_tracker = TokenTracker()
+        t2_tracker.add_usage(ComponentType.SKILL_PROMPT, input_tokens=5000)
+
+        t3_tracker = TokenTracker()
+        t3_tracker.add_usage(ComponentType.TOOL_SCHEMA, input_tokens=5000)
+
+        t2_analysis = analyze_tier_tokens(t2_tracker, "T2")
+        t3_analysis = analyze_tier_tokens(t3_tracker, "T3")
+
+        comparison = compare_t2_t3_efficiency(t2_analysis, t3_analysis)
+
+        assert comparison["token_ratio"] == 1.0
+
+    def test_cost_comparison(self) -> None:
+        t2_tracker = TokenTracker()
+        t2_tracker.add_usage(ComponentType.SKILL_PROMPT, input_tokens=1_000_000)
+
+        t3_tracker = TokenTracker()
+        t3_tracker.add_usage(ComponentType.TOOL_SCHEMA, input_tokens=3_000_000)
+
+        # Using $3/M input pricing
+        t2_analysis = analyze_tier_tokens(t2_tracker, "T2", input_price=3.0)
+        t3_analysis = analyze_tier_tokens(t3_tracker, "T3", input_price=3.0)
+
+        comparison = compare_t2_t3_efficiency(t2_analysis, t3_analysis)
+
+        # T2 cost = $3, T3 cost = $9
+        assert comparison["cost_ratio"] == 3.0
+
+
+class TestTierTokenAnalysis:
+    """Tests for TierTokenAnalysis dataclass."""
+
+    def test_dataclass_fields(self) -> None:
+        distribution = TokenDistribution(
+            total_input_tokens=10000,
+            total_output_tokens=5000,
+            total_cost_usd=0.50,
+        )
+        analysis = TierTokenAnalysis(
+            tier_id="T3",
+            distribution=distribution,
+            schema_overhead=8000,
+            skill_efficiency=0.2,
+        )
+        assert analysis.tier_id == "T3"
+        assert analysis.distribution.total_tokens == 15000
+        assert analysis.schema_overhead == 8000
+        assert analysis.skill_efficiency == 0.2


### PR DESCRIPTION
## Summary

- Fix composite score weights to 50/50 (was 70/30) to align with metrics-formulas.md specification
- Add process metrics module (`src/scylla/metrics/process.py`) with:
  - Fine-Grained Progress Rate (R_Prog) for tracking incremental progress
  - Strategic Drift for measuring goal alignment over multi-step tasks
  - Change Fail Percentage (CFP) for DevOps stability measurement
  - PR Revert Rate for tracking human rejection of agent changes
- Add token tracking module (`src/scylla/metrics/token_tracking.py`) for:
  - Component-level token usage tracking
  - T2 vs T3 "Token Efficiency Chasm" analysis
  - Schema overhead and skill efficiency metrics
- Update documentation with all new metrics
- Add 73 new tests with full coverage

## Test plan

- [x] All 837 tests pass (`pixi run pytest tests/`)
- [x] New process metrics tests pass (43 tests)
- [x] New token tracking tests pass (30 tests)
- [x] Integration test updated for 50/50 composite score weights

🤖 Generated with [Claude Code](https://claude.com/claude-code)