### PR TITLE
feat(e2e): add E2E validation infrastructure with comprehensive logging

### DIFF
--- a/scripts/run_e2e_t0_t1.py
+++ b/scripts/run_e2e_t0_t1.py
@@ -64,6 +64,10 @@ def create_adapter_wrapper():
             timeout=300,  # 5 minutes for validation
         )
 
+        # Capture the final prompt (for logging)
+        task_prompt = adapter.load_prompt(prompt_file)
+        final_prompt = adapter.inject_tier_prompt(task_prompt, tier_config)
+
         # Run adapter
         result = adapter.run(config, tier_config)
 
@@ -76,6 +80,7 @@ def create_adapter_wrapper():
             "stdout": result.stdout,
             "stderr": result.stderr,
             "api_calls": result.api_calls,
+            "final_prompt": final_prompt,  # Include for logging
         }
 
     return adapter_func


### PR DESCRIPTION
## Summary

- Add E2E validation infrastructure for T0/T1 tier testing
- Add comprehensive run logging for independent validation
- Add metrics modules (ablation, latency) and extended tier configs

## Changes

### E2E Infrastructure
- `scripts/run_e2e_t0_t1.py` - E2E runner script for T0/T1 validation
- `tests/fixtures/tests/test-001/prompt.md` - Hello World task prompt

### Orchestrator Improvements
- Add `_write_run_logs()` method for comprehensive logging
- Each run now captures: final_prompt.md, task_prompt.md, stdout.log, stderr.log, response.json, judgment.json, execution.json

### Metrics Modules
- `src/scylla/metrics/ablation.py` - Component contribution analysis
- `src/scylla/metrics/latency.py` - Latency tracking

### Tier Configs
- `config/tiers/t4-delegation.md` - T4 prompt template
- `config/tiers/t5-hierarchy.md` - T5 prompt template
- `config/tiers/t6-hybrid.md` - T6 prompt template
- Fixed T1/T2 `tools_enabled` from `false` to `null` for fair comparison

## Test Results

Both T0 and T1 executed successfully with metrics captured. See `reports/e2e-t0-t1-validation-report.md` for full analysis.

| Tier | Cost | Tokens In | Tokens Out | Grade |
|------|------|-----------|------------|-------|
| T0 | $0.19 | 81,804 | 450 | D |
| T1 | $0.10 | 128,845 | 715 | D |

## Test plan

- [x] Unit tests pass (892 tests)
- [x] E2E test runs successfully
- [x] Logs captured correctly in result directory

🤖 Generated with [Claude Code](https://claude.com/claude-code)