### PR TITLE
feat(e2e): redesign E2E testing framework with progressive optimization

### DIFF
--- a/scripts/run_e2e_experiment.py
+++ b/scripts/run_e2e_experiment.py
@@ -1,0 +1,329 @@
+#!/usr/bin/env python3
+"""CLI entry point for E2E experiments.
+
+This script provides a command-line interface for running E2E experiments
+with the ProjectScylla evaluation framework.
+
+Usage:
+    python scripts/run_e2e_experiment.py --config experiment.yaml
+    python scripts/run_e2e_experiment.py --repo <url> --commit <hash> --prompt <file>
+
+Python Justification: Required for CLI argument parsing and experiment orchestration.
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import sys
+from pathlib import Path
+
+import yaml
+
+# Add src to path for imports
+sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
+
+from scylla.e2e.models import ExperimentConfig, TierID
+from scylla.e2e.runner import run_experiment
+
+# Configure logging
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s [%(levelname)s] %(name)s: %(message)s",
+    datefmt="%Y-%m-%d %H:%M:%S",
+)
+logger = logging.getLogger(__name__)
+
+
+def parse_args() -> argparse.Namespace:
+    """Parse command-line arguments."""
+    parser = argparse.ArgumentParser(
+        description="Run E2E experiments with ProjectScylla",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""
+Examples:
+    # Run with config file
+    python scripts/run_e2e_experiment.py --config experiments/hello-world.yaml
+
+    # Run with CLI arguments
+    python scripts/run_e2e_experiment.py \\
+        --repo https://github.com/octocat/Hello-World \\
+        --commit 7fd1a60 \\
+        --prompt tests/fixtures/tests/test-001/prompt.md \\
+        --tiers T0 T1 T2
+
+    # Quick test with fewer runs
+    python scripts/run_e2e_experiment.py \\
+        --config experiments/test.yaml \\
+        --runs 3 \\
+        --tiers T0 T1
+        """,
+    )
+
+    # Config file
+    parser.add_argument(
+        "--config",
+        type=Path,
+        help="Path to experiment configuration YAML file",
+    )
+
+    # Direct arguments (override config)
+    parser.add_argument(
+        "--repo",
+        type=str,
+        help="Task repository URL",
+    )
+    parser.add_argument(
+        "--commit",
+        type=str,
+        help="Task commit hash",
+    )
+    parser.add_argument(
+        "--prompt",
+        type=Path,
+        help="Path to task prompt file",
+    )
+    parser.add_argument(
+        "--experiment-id",
+        type=str,
+        default="experiment",
+        help="Experiment identifier (default: experiment)",
+    )
+
+    # Tier selection
+    parser.add_argument(
+        "--tiers",
+        nargs="+",
+        type=str,
+        default=["T0", "T1"],
+        help="Tiers to run (default: T0 T1)",
+    )
+
+    # Run settings
+    parser.add_argument(
+        "--runs",
+        type=int,
+        default=10,
+        help="Runs per sub-test (default: 10)",
+    )
+    parser.add_argument(
+        "--parallel",
+        type=int,
+        default=4,
+        help="Max parallel sub-tests (default: 4)",
+    )
+    parser.add_argument(
+        "--timeout",
+        type=int,
+        default=3600,
+        help="Timeout per run in seconds (default: 3600)",
+    )
+
+    # Model settings
+    parser.add_argument(
+        "--model",
+        type=str,
+        default="claude-sonnet-4-20250514",
+        help="Primary model for task execution",
+    )
+    parser.add_argument(
+        "--judge-model",
+        type=str,
+        default="claude-opus-4-5-20251101",
+        help="Model for judging (default: claude-opus-4-5-20251101)",
+    )
+    parser.add_argument(
+        "--tiebreaker-model",
+        type=str,
+        default="gpt-4",
+        help="Model for tie-breaking (default: gpt-4)",
+    )
+
+    # Paths
+    parser.add_argument(
+        "--tiers-dir",
+        type=Path,
+        default=Path("config/tiers"),
+        help="Path to tier configurations (default: config/tiers)",
+    )
+    parser.add_argument(
+        "--results-dir",
+        type=Path,
+        default=Path("results"),
+        help="Path to results directory (default: results)",
+    )
+
+    # Verbosity
+    parser.add_argument(
+        "-v", "--verbose",
+        action="store_true",
+        help="Enable verbose logging",
+    )
+    parser.add_argument(
+        "-q", "--quiet",
+        action="store_true",
+        help="Suppress non-error output",
+    )
+
+    return parser.parse_args()
+
+
+def load_config_from_yaml(path: Path) -> dict:
+    """Load configuration from YAML file.
+
+    Args:
+        path: Path to YAML file
+
+    Returns:
+        Configuration dictionary
+    """
+    with open(path) as f:
+        return yaml.safe_load(f) or {}
+
+
+def build_config(args: argparse.Namespace) -> ExperimentConfig:
+    """Build experiment configuration from arguments.
+
+    Args:
+        args: Parsed command-line arguments
+
+    Returns:
+        ExperimentConfig instance
+    """
+    # Start with defaults
+    config_dict = {
+        "experiment_id": args.experiment_id,
+        "task_repo": "",
+        "task_commit": "",
+        "task_prompt_file": None,
+        "models": [args.model],
+        "runs_per_subtest": args.runs,
+        "tiers_to_run": [TierID.from_string(t) for t in args.tiers],
+        "judge_model": args.judge_model,
+        "tiebreaker_model": args.tiebreaker_model,
+        "parallel_subtests": args.parallel,
+        "timeout_seconds": args.timeout,
+    }
+
+    # Load from YAML if provided
+    if args.config:
+        yaml_config = load_config_from_yaml(args.config)
+        config_dict.update({
+            "experiment_id": yaml_config.get("experiment_id", config_dict["experiment_id"]),
+            "task_repo": yaml_config.get("task_repo", config_dict["task_repo"]),
+            "task_commit": yaml_config.get("task_commit", config_dict["task_commit"]),
+            "task_prompt_file": Path(yaml_config["task_prompt_file"]) if yaml_config.get("task_prompt_file") else None,
+            "runs_per_subtest": yaml_config.get("runs_per_subtest", config_dict["runs_per_subtest"]),
+            "tiers_to_run": [TierID.from_string(t) for t in yaml_config.get("tiers", args.tiers)],
+        })
+
+    # Override with CLI arguments
+    if args.repo:
+        config_dict["task_repo"] = args.repo
+    if args.commit:
+        config_dict["task_commit"] = args.commit
+    if args.prompt:
+        config_dict["task_prompt_file"] = args.prompt
+
+    # Validate required fields
+    if not config_dict["task_repo"]:
+        raise ValueError("Task repository (--repo) is required")
+    if not config_dict["task_prompt_file"]:
+        raise ValueError("Task prompt file (--prompt) is required")
+
+    return ExperimentConfig(
+        experiment_id=config_dict["experiment_id"],
+        task_repo=config_dict["task_repo"],
+        task_commit=config_dict["task_commit"] or "",
+        task_prompt_file=config_dict["task_prompt_file"],
+        models=config_dict["models"],
+        runs_per_subtest=config_dict["runs_per_subtest"],
+        tiers_to_run=config_dict["tiers_to_run"],
+        judge_model=config_dict["judge_model"],
+        tiebreaker_model=config_dict["tiebreaker_model"],
+        parallel_subtests=config_dict["parallel_subtests"],
+        timeout_seconds=config_dict["timeout_seconds"],
+    )
+
+
+def main() -> int:
+    """Main entry point.
+
+    Returns:
+        Exit code (0 for success, 1 for error)
+    """
+    args = parse_args()
+
+    # Configure logging level
+    if args.verbose:
+        logging.getLogger().setLevel(logging.DEBUG)
+    elif args.quiet:
+        logging.getLogger().setLevel(logging.ERROR)
+
+    try:
+        # Build configuration
+        config = build_config(args)
+
+        logger.info(f"Starting experiment: {config.experiment_id}")
+        logger.info(f"Task repo: {config.task_repo}")
+        logger.info(f"Tiers: {[t.value for t in config.tiers_to_run]}")
+        logger.info(f"Runs per sub-test: {config.runs_per_subtest}")
+
+        # Ensure directories exist
+        args.tiers_dir.mkdir(parents=True, exist_ok=True)
+        args.results_dir.mkdir(parents=True, exist_ok=True)
+
+        # Run experiment
+        result = run_experiment(
+            config=config,
+            tiers_dir=args.tiers_dir,
+            results_dir=args.results_dir,
+        )
+
+        # Print summary
+        print("\n" + "=" * 60)
+        print("EXPERIMENT COMPLETE")
+        print("=" * 60)
+        print(f"Duration: {result.total_duration_seconds:.1f}s")
+        print(f"Total Cost: ${result.total_cost:.4f}")
+        print()
+
+        if result.best_overall_tier:
+            print(f"Best Tier: {result.best_overall_tier.value}")
+            print(f"Best Sub-test: {result.best_overall_subtest}")
+            print(f"Frontier CoP: ${result.frontier_cop:.4f}")
+        else:
+            print("No passing results found")
+
+        print()
+        print("Tier Results:")
+        print("-" * 60)
+        for tier_id in config.tiers_to_run:
+            tier_result = result.tier_results.get(tier_id)
+            if tier_result:
+                status = "PASS" if tier_result.best_subtest_score > 0.5 else "FAIL"
+                print(
+                    f"  {tier_id.value}: {status} "
+                    f"(score: {tier_result.best_subtest_score:.3f}, "
+                    f"cost: ${tier_result.total_cost:.4f})"
+                )
+
+        print("=" * 60)
+
+        return 0
+
+    except KeyboardInterrupt:
+        logger.warning("Experiment interrupted by user")
+        return 130
+
+    except ValueError as e:
+        logger.error(f"Configuration error: {e}")
+        return 1
+
+    except Exception as e:
+        logger.exception(f"Experiment failed: {e}")
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/scylla/e2e/__init__.py
+++ b/src/scylla/e2e/__init__.py
@@ -1,0 +1,32 @@
+"""E2E testing framework for ProjectScylla.
+
+This module provides a progressive optimization framework for evaluating
+AI agent capabilities across tiers T0-T6. Each tier can have multiple
+sub-tests, and the best-performing sub-test becomes the baseline for
+the next tier.
+
+Python Justification: Required for subprocess execution, parallel processing,
+and LLM API calls for judging.
+"""
+
+from scylla.e2e.models import (
+    ExperimentConfig,
+    ExperimentResult,
+    RunResult,
+    SubTestConfig,
+    SubTestResult,
+    TierConfig,
+    TierID,
+    TierResult,
+)
+
+__all__ = [
+    "ExperimentConfig",
+    "ExperimentResult",
+    "RunResult",
+    "SubTestConfig",
+    "SubTestResult",
+    "TierConfig",
+    "TierID",
+    "TierResult",
+]

--- a/src/scylla/e2e/command_logger.py
+++ b/src/scylla/e2e/command_logger.py
@@ -1,0 +1,265 @@
+"""Command logging for E2E test reproducibility.
+
+This module provides command logging functionality that captures all
+executed commands with their context, enabling full reproducibility
+of test runs.
+
+Python Justification: Required for subprocess execution and shell script generation.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shlex
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+
+@dataclass
+class CommandLog:
+    """A single logged command with full context.
+
+    Captures everything needed to reproduce a command execution.
+
+    Attributes:
+        timestamp: ISO format timestamp of execution
+        command: The command as a list of arguments
+        cwd: Working directory when command was executed
+        env_vars: Relevant environment variables
+        exit_code: Process exit code
+        stdout_file: Relative path to stdout log file
+        stderr_file: Relative path to stderr log file
+        duration_seconds: Execution duration in seconds
+    """
+
+    timestamp: str
+    command: list[str]
+    cwd: str
+    env_vars: dict[str, str]
+    exit_code: int
+    stdout_file: str
+    stderr_file: str
+    duration_seconds: float
+
+    def to_dict(self) -> dict[str, Any]:
+        """Convert to dictionary for JSON serialization."""
+        return {
+            "timestamp": self.timestamp,
+            "command": self.command,
+            "cwd": self.cwd,
+            "env_vars": self.env_vars,
+            "exit_code": self.exit_code,
+            "stdout_file": self.stdout_file,
+            "stderr_file": self.stderr_file,
+            "duration_seconds": self.duration_seconds,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> CommandLog:
+        """Create from dictionary."""
+        return cls(
+            timestamp=data["timestamp"],
+            command=data["command"],
+            cwd=data["cwd"],
+            env_vars=data["env_vars"],
+            exit_code=data["exit_code"],
+            stdout_file=data["stdout_file"],
+            stderr_file=data["stderr_file"],
+            duration_seconds=data["duration_seconds"],
+        )
+
+
+# Environment variables relevant for reproducibility
+RELEVANT_ENV_VARS = [
+    "ANTHROPIC_API_KEY",
+    "OPENAI_API_KEY",
+    "PATH",
+    "HOME",
+    "USER",
+    "SHELL",
+    "LANG",
+    "LC_ALL",
+    "PYTHONPATH",
+    "VIRTUAL_ENV",
+]
+
+
+@dataclass
+class CommandLogger:
+    """Logger that captures commands for reproducibility.
+
+    Tracks all executed commands with their context and generates
+    replay scripts for reproducing test runs.
+
+    Example:
+        >>> logger = CommandLogger(Path("/results/run_01/logs"))
+        >>> logger.log_command(
+        ...     cmd=["claude", "--print", "hello"],
+        ...     stdout="Hello!",
+        ...     stderr="",
+        ...     exit_code=0,
+        ...     duration=1.5,
+        ...     cwd="/workspace",
+        ... )
+        >>> logger.save()
+        >>> replay_script = logger.save_replay_script()
+    """
+
+    log_dir: Path
+    commands: list[CommandLog] = field(default_factory=list)
+    _initialized: bool = field(default=False, repr=False)
+
+    def __post_init__(self) -> None:
+        """Initialize the log directory."""
+        if not self._initialized:
+            self.log_dir.mkdir(parents=True, exist_ok=True)
+            self._initialized = True
+
+    def _extract_relevant_env(self) -> dict[str, str]:
+        """Extract relevant environment variables for reproducibility."""
+        env_vars = {}
+        for var in RELEVANT_ENV_VARS:
+            value = os.environ.get(var)
+            if value:
+                # Mask sensitive values
+                if "KEY" in var or "TOKEN" in var or "SECRET" in var:
+                    env_vars[var] = "[REDACTED]"
+                else:
+                    env_vars[var] = value
+        return env_vars
+
+    def log_command(
+        self,
+        cmd: list[str],
+        stdout: str,
+        stderr: str,
+        exit_code: int,
+        duration: float,
+        cwd: str | Path | None = None,
+    ) -> CommandLog:
+        """Log a command execution with all context.
+
+        Args:
+            cmd: The command as a list of arguments
+            stdout: Standard output from the command
+            stderr: Standard error from the command
+            exit_code: Process exit code
+            duration: Execution duration in seconds
+            cwd: Working directory (defaults to current)
+
+        Returns:
+            The created CommandLog entry.
+        """
+        cmd_index = len(self.commands)
+        stdout_file = f"cmd_{cmd_index:04d}_stdout.log"
+        stderr_file = f"cmd_{cmd_index:04d}_stderr.log"
+
+        # Write stdout/stderr to files
+        (self.log_dir / stdout_file).write_text(stdout)
+        (self.log_dir / stderr_file).write_text(stderr)
+
+        log = CommandLog(
+            timestamp=datetime.now(UTC).isoformat(),
+            command=cmd,
+            cwd=str(cwd) if cwd else str(Path.cwd()),
+            env_vars=self._extract_relevant_env(),
+            exit_code=exit_code,
+            stdout_file=stdout_file,
+            stderr_file=stderr_file,
+            duration_seconds=duration,
+        )
+
+        self.commands.append(log)
+        return log
+
+    def save(self) -> Path:
+        """Save the command log to JSON file.
+
+        Returns:
+            Path to the saved JSON file.
+        """
+        log_path = self.log_dir / "command_log.json"
+        with open(log_path, "w") as f:
+            json.dump(
+                {
+                    "generated_at": datetime.now(UTC).isoformat(),
+                    "total_commands": len(self.commands),
+                    "commands": [c.to_dict() for c in self.commands],
+                },
+                f,
+                indent=2,
+            )
+        return log_path
+
+    def save_replay_script(self) -> Path:
+        """Generate an executable bash script to replay all commands.
+
+        The script includes environment setup, directory navigation,
+        and all commands in execution order.
+
+        Returns:
+            Path to the generated replay.sh script.
+        """
+        script_path = self.log_dir / "replay.sh"
+
+        lines = [
+            "#!/bin/bash",
+            f"# Generated: {datetime.now(UTC).isoformat()}",
+            f"# Total commands: {len(self.commands)}",
+            "#",
+            "# This script replays the commands executed during the test run.",
+            "# Review and modify as needed before executing.",
+            "#",
+            "set -e  # Exit on first error",
+            "",
+            "# Environment variables (secrets redacted)",
+            "# Uncomment and fill in as needed:",
+        ]
+
+        # Add env var placeholders
+        for var in RELEVANT_ENV_VARS:
+            if "KEY" in var or "TOKEN" in var or "SECRET" in var:
+                lines.append(f"# export {var}='your-{var.lower().replace('_', '-')}-here'")
+
+        lines.append("")
+        lines.append("# Commands")
+        lines.append("")
+
+        for i, log in enumerate(self.commands):
+            lines.append(f"# Command {i + 1}/{len(self.commands)} at {log.timestamp}")
+            lines.append(f"# Duration: {log.duration_seconds:.2f}s, Exit: {log.exit_code}")
+            lines.append(f"cd {shlex.quote(log.cwd)}")
+
+            # Quote each argument properly
+            cmd_str = " ".join(shlex.quote(arg) for arg in log.command)
+            lines.append(cmd_str)
+            lines.append("")
+
+        script_content = "\n".join(lines)
+        script_path.write_text(script_content)
+
+        # Make executable
+        script_path.chmod(0o755)
+
+        return script_path
+
+    @classmethod
+    def load(cls, log_dir: Path) -> CommandLogger:
+        """Load a command logger from a saved JSON file.
+
+        Args:
+            log_dir: Directory containing command_log.json
+
+        Returns:
+            CommandLogger with loaded commands.
+        """
+        log_path = log_dir / "command_log.json"
+        with open(log_path) as f:
+            data = json.load(f)
+
+        logger = cls(log_dir=log_dir)
+        logger.commands = [CommandLog.from_dict(c) for c in data["commands"]]
+        return logger

--- a/src/scylla/e2e/judge_selection.py
+++ b/src/scylla/e2e/judge_selection.py
@@ -1,0 +1,268 @@
+"""LLM-based judge selection for E2E testing.
+
+This module implements the judge selection algorithm that determines
+the best-performing sub-test within a tier, including tie-breaking
+with an alternate LLM.
+
+Python Justification: Required for LLM API calls and statistical analysis.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from scylla.e2e.models import SubTestResult
+
+
+@dataclass
+class JudgeVote:
+    """A judge's vote for a sub-test.
+
+    Attributes:
+        subtest_id: The sub-test being voted for
+        score: The score assigned (0.0 - 1.0)
+        confidence: Confidence in the vote (0.0 - 1.0)
+        reasoning: Explanation for the vote
+    """
+
+    subtest_id: str
+    score: float
+    confidence: float
+    reasoning: str
+
+    def to_dict(self) -> dict:
+        """Convert to dictionary."""
+        return {
+            "subtest_id": self.subtest_id,
+            "score": self.score,
+            "confidence": self.confidence,
+            "reasoning": self.reasoning,
+        }
+
+
+@dataclass
+class JudgeSelection:
+    """Result of the judge selection process.
+
+    Attributes:
+        winning_subtest: ID of the winning sub-test
+        winning_score: Score of the winning sub-test
+        votes: List of votes from all judges
+        margin: Score difference between winner and runner-up
+        tiebreaker_needed: Whether a tie-breaker was used
+        tiebreaker_result: Result from tie-breaker (if used)
+    """
+
+    winning_subtest: str
+    winning_score: float
+    votes: list[JudgeVote]
+    margin: float
+    tiebreaker_needed: bool = False
+    tiebreaker_result: JudgeVote | None = None
+
+    def to_dict(self) -> dict:
+        """Convert to dictionary."""
+        return {
+            "winning_subtest": self.winning_subtest,
+            "winning_score": self.winning_score,
+            "votes": [v.to_dict() for v in self.votes],
+            "margin": self.margin,
+            "tiebreaker_needed": self.tiebreaker_needed,
+            "tiebreaker_result": self.tiebreaker_result.to_dict() if self.tiebreaker_result else None,
+        }
+
+
+def select_best_subtest(
+    subtest_results: dict[str, SubTestResult],
+    primary_judge_model: str = "claude-opus-4-5-20251101",
+    tiebreaker_model: str = "gpt-4",
+    tie_threshold: float = 0.05,
+) -> JudgeSelection:
+    """Select the best sub-test using LLM judge with tie-breaker.
+
+    Algorithm:
+    1. Rank sub-tests by median judge score (descending)
+    2. If top two are within tie_threshold, invoke tie-breaker
+    3. Tie-breaker uses a different LLM model for independence
+
+    Args:
+        subtest_results: Dict mapping sub-test ID to results
+        primary_judge_model: Model used for primary judging
+        tiebreaker_model: Model used for tie-breaking
+        tie_threshold: Score difference threshold for triggering tie-breaker
+
+    Returns:
+        JudgeSelection with the winning sub-test.
+    """
+    if not subtest_results:
+        raise ValueError("No sub-test results to select from")
+
+    # Single sub-test case
+    if len(subtest_results) == 1:
+        subtest_id, result = next(iter(subtest_results.items()))
+        return JudgeSelection(
+            winning_subtest=subtest_id,
+            winning_score=result.median_score,
+            votes=[
+                JudgeVote(
+                    subtest_id=subtest_id,
+                    score=result.median_score,
+                    confidence=1.0,
+                    reasoning="Only sub-test in tier",
+                )
+            ],
+            margin=1.0,
+            tiebreaker_needed=False,
+        )
+
+    # Rank by median score (descending)
+    ranked = sorted(
+        subtest_results.items(),
+        key=lambda x: x[1].median_score,
+        reverse=True,
+    )
+
+    # Create votes from results
+    votes = [
+        JudgeVote(
+            subtest_id=subtest_id,
+            score=result.median_score,
+            confidence=result.consistency,
+            reasoning=f"Pass rate: {result.pass_rate:.1%}, "
+            f"Mean score: {result.mean_score:.3f}, "
+            f"Consistency: {result.consistency:.3f}",
+        )
+        for subtest_id, result in ranked
+    ]
+
+    first_id, first_result = ranked[0]
+    second_id, second_result = ranked[1]
+    margin = first_result.median_score - second_result.median_score
+
+    # Check if tie-breaker needed
+    if margin < tie_threshold:
+        tiebreaker_result = _run_tiebreaker(
+            first_id,
+            first_result,
+            second_id,
+            second_result,
+            tiebreaker_model,
+        )
+
+        return JudgeSelection(
+            winning_subtest=tiebreaker_result.subtest_id,
+            winning_score=subtest_results[tiebreaker_result.subtest_id].median_score,
+            votes=votes,
+            margin=margin,
+            tiebreaker_needed=True,
+            tiebreaker_result=tiebreaker_result,
+        )
+
+    return JudgeSelection(
+        winning_subtest=first_id,
+        winning_score=first_result.median_score,
+        votes=votes,
+        margin=margin,
+        tiebreaker_needed=False,
+    )
+
+
+def _run_tiebreaker(
+    first_id: str,
+    first_result: SubTestResult,
+    second_id: str,
+    second_result: SubTestResult,
+    model: str,
+) -> JudgeVote:
+    """Run tie-breaker evaluation between two candidates.
+
+    Uses a different LLM to break the tie by considering multiple
+    factors beyond just median score.
+
+    Args:
+        first_id: ID of first candidate
+        first_result: Results for first candidate
+        second_id: ID of second candidate
+        second_result: Results for second candidate
+        model: LLM model to use for tie-breaking
+
+    Returns:
+        JudgeVote indicating the winner.
+    """
+    # TODO: Implement actual LLM call for tie-breaking
+    # For now, use a heuristic based on multiple factors
+
+    # Calculate composite scores
+    first_composite = _calculate_composite_score(first_result)
+    second_composite = _calculate_composite_score(second_result)
+
+    if first_composite >= second_composite:
+        return JudgeVote(
+            subtest_id=first_id,
+            score=first_composite,
+            confidence=0.7,  # Lower confidence for tie-breaker
+            reasoning=f"Tie-breaker selected based on composite score "
+            f"({first_composite:.3f} vs {second_composite:.3f}). "
+            f"Factors: consistency, cost efficiency, pass rate.",
+        )
+    else:
+        return JudgeVote(
+            subtest_id=second_id,
+            score=second_composite,
+            confidence=0.7,
+            reasoning=f"Tie-breaker selected based on composite score "
+            f"({second_composite:.3f} vs {first_composite:.3f}). "
+            f"Factors: consistency, cost efficiency, pass rate.",
+        )
+
+
+def _calculate_composite_score(result: SubTestResult) -> float:
+    """Calculate composite score for tie-breaking.
+
+    Weighs multiple factors:
+    - Median score (40%)
+    - Pass rate (30%)
+    - Consistency (20%)
+    - Cost efficiency (10%)
+
+    Args:
+        result: Sub-test results
+
+    Returns:
+        Composite score between 0 and 1.
+    """
+    # Normalize cost (lower is better, assume $1 is max reasonable)
+    max_cost = 1.0
+    cost_efficiency = 1.0 - min(result.mean_cost / max_cost, 1.0)
+
+    composite = (
+        0.4 * result.median_score
+        + 0.3 * result.pass_rate
+        + 0.2 * result.consistency
+        + 0.1 * cost_efficiency
+    )
+
+    return composite
+
+
+def save_selection(selection: JudgeSelection, path: str | None = None) -> str:
+    """Save selection result to JSON.
+
+    Args:
+        selection: The judge selection result
+        path: Optional file path (if None, returns JSON string)
+
+    Returns:
+        JSON string representation.
+    """
+    json_str = json.dumps(selection.to_dict(), indent=2)
+
+    if path:
+        from pathlib import Path
+
+        Path(path).write_text(json_str)
+
+    return json_str

--- a/src/scylla/e2e/models.py
+++ b/src/scylla/e2e/models.py
@@ -1,0 +1,413 @@
+"""Data models for E2E testing framework.
+
+This module defines the core data structures used throughout the E2E
+testing pipeline, including configurations, results, and aggregations.
+
+Python Justification: Required for dataclass support and JSON serialization.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from enum import Enum
+from pathlib import Path
+from typing import Any
+
+
+class TierID(Enum):
+    """Tier identifiers for the evaluation framework.
+
+    Tiers represent increasing levels of agent capability:
+    - T0: Vanilla - Base LLM with no system prompt
+    - T1: Prompted - Default system prompt
+    - T2: Skills - CLAUDE.md with domain expertise
+    - T3: Tooling - External tools via JSON schemas
+    - T4: Delegation - Flat multi-agent system
+    - T5: Hierarchy - Nested orchestration
+    - T6: Hybrid - Optimal combination
+    """
+
+    T0 = "T0"
+    T1 = "T1"
+    T2 = "T2"
+    T3 = "T3"
+    T4 = "T4"
+    T5 = "T5"
+    T6 = "T6"
+
+    @classmethod
+    def from_string(cls, value: str) -> TierID:
+        """Create TierID from string value."""
+        return cls(value.upper())
+
+    def __lt__(self, other: TierID) -> bool:
+        """Enable sorting of tiers."""
+        order = list(TierID)
+        return order.index(self) < order.index(other)
+
+
+@dataclass
+class SubTestConfig:
+    """Configuration for a single sub-test within a tier.
+
+    Each sub-test represents a variation of the tier configuration,
+    such as different levels of CLAUDE.md complexity.
+
+    Attributes:
+        id: Numeric identifier (e.g., "01", "02")
+        name: Human-readable name
+        description: Description of what this sub-test tests
+        claude_md_path: Path to CLAUDE.md for this sub-test
+        claude_dir_path: Path to .claude/ directory for this sub-test
+        extends_previous: Whether to inherit from best previous tier
+    """
+
+    id: str
+    name: str
+    description: str
+    claude_md_path: Path | None = None
+    claude_dir_path: Path | None = None
+    extends_previous: bool = True
+
+    def to_dict(self) -> dict[str, Any]:
+        """Convert to dictionary for JSON serialization."""
+        return {
+            "id": self.id,
+            "name": self.name,
+            "description": self.description,
+            "claude_md_path": str(self.claude_md_path) if self.claude_md_path else None,
+            "claude_dir_path": str(self.claude_dir_path) if self.claude_dir_path else None,
+            "extends_previous": self.extends_previous,
+        }
+
+
+@dataclass
+class TierConfig:
+    """Configuration for a tier including all sub-tests.
+
+    Attributes:
+        tier_id: The tier identifier
+        subtests: List of sub-test configurations
+        system_prompt_mode: How to handle system prompt ("none", "default", "custom")
+        custom_system_prompt: Custom system prompt if mode is "custom"
+    """
+
+    tier_id: TierID
+    subtests: list[SubTestConfig]
+    system_prompt_mode: str = "default"  # "none", "default", "custom"
+    custom_system_prompt: str | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        """Convert to dictionary for JSON serialization."""
+        return {
+            "tier_id": self.tier_id.value,
+            "subtests": [s.to_dict() for s in self.subtests],
+            "system_prompt_mode": self.system_prompt_mode,
+            "custom_system_prompt": self.custom_system_prompt,
+        }
+
+
+@dataclass
+class RunResult:
+    """Result from a single run of a sub-test.
+
+    Captures all execution details, metrics, and judge evaluation
+    for one run of an agent against the canonical task.
+
+    Attributes:
+        run_number: The run number (1-indexed)
+        exit_code: Process exit code
+        tokens_input: Number of input tokens
+        tokens_output: Number of output tokens
+        cost_usd: Total cost in USD
+        duration_seconds: Execution duration
+        judge_score: LLM judge's score (0.0 - 1.0)
+        judge_passed: Whether the run passed
+        judge_grade: Letter grade (A-F)
+        judge_reasoning: Judge's reasoning text
+        workspace_path: Path to preserved workspace
+        logs_path: Path to execution logs
+        command_log_path: Path to command log JSON
+    """
+
+    run_number: int
+    exit_code: int
+    tokens_input: int
+    tokens_output: int
+    cost_usd: float
+    duration_seconds: float
+    judge_score: float
+    judge_passed: bool
+    judge_grade: str
+    judge_reasoning: str
+    workspace_path: Path
+    logs_path: Path
+    command_log_path: Path | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        """Convert to dictionary for JSON serialization."""
+        return {
+            "run_number": self.run_number,
+            "exit_code": self.exit_code,
+            "tokens_input": self.tokens_input,
+            "tokens_output": self.tokens_output,
+            "cost_usd": self.cost_usd,
+            "duration_seconds": self.duration_seconds,
+            "judge_score": self.judge_score,
+            "judge_passed": self.judge_passed,
+            "judge_grade": self.judge_grade,
+            "judge_reasoning": self.judge_reasoning,
+            "workspace_path": str(self.workspace_path),
+            "logs_path": str(self.logs_path),
+            "command_log_path": str(self.command_log_path) if self.command_log_path else None,
+        }
+
+
+@dataclass
+class SubTestResult:
+    """Aggregated results for a sub-test across all runs.
+
+    Contains statistics computed from all runs of a single sub-test.
+
+    Attributes:
+        subtest_id: The sub-test identifier
+        tier_id: The tier identifier
+        runs: List of individual run results
+        pass_rate: Fraction of runs that passed
+        mean_score: Mean judge score across runs
+        median_score: Median judge score
+        std_dev_score: Standard deviation of scores
+        mean_cost: Mean cost per run
+        total_cost: Total cost across all runs
+        consistency: Score consistency (1 - coefficient of variation)
+        selected_as_best: Whether this sub-test was selected as best
+        selection_reason: Reason for selection (if selected)
+    """
+
+    subtest_id: str
+    tier_id: TierID
+    runs: list[RunResult]
+    pass_rate: float = 0.0
+    mean_score: float = 0.0
+    median_score: float = 0.0
+    std_dev_score: float = 0.0
+    mean_cost: float = 0.0
+    total_cost: float = 0.0
+    consistency: float = 0.0
+    selected_as_best: bool = False
+    selection_reason: str = ""
+
+    def to_dict(self) -> dict[str, Any]:
+        """Convert to dictionary for JSON serialization."""
+        return {
+            "subtest_id": self.subtest_id,
+            "tier_id": self.tier_id.value,
+            "runs": [r.to_dict() for r in self.runs],
+            "pass_rate": self.pass_rate,
+            "mean_score": self.mean_score,
+            "median_score": self.median_score,
+            "std_dev_score": self.std_dev_score,
+            "mean_cost": self.mean_cost,
+            "total_cost": self.total_cost,
+            "consistency": self.consistency,
+            "selected_as_best": self.selected_as_best,
+            "selection_reason": self.selection_reason,
+        }
+
+
+@dataclass
+class TierBaseline:
+    """Reference to a tier's best configuration for inheritance.
+
+    Used to track which sub-test configuration should be inherited
+    by the next tier.
+
+    Attributes:
+        tier_id: The tier this baseline is from
+        subtest_id: The winning sub-test ID
+        claude_md_path: Path to the CLAUDE.md to inherit
+        claude_dir_path: Path to the .claude/ directory to inherit
+    """
+
+    tier_id: TierID
+    subtest_id: str
+    claude_md_path: Path | None
+    claude_dir_path: Path | None
+
+    def to_dict(self) -> dict[str, Any]:
+        """Convert to dictionary for JSON serialization."""
+        return {
+            "tier_id": self.tier_id.value,
+            "subtest_id": self.subtest_id,
+            "claude_md_path": str(self.claude_md_path) if self.claude_md_path else None,
+            "claude_dir_path": str(self.claude_dir_path) if self.claude_dir_path else None,
+        }
+
+
+@dataclass
+class TierResult:
+    """Complete results for a tier including all sub-tests.
+
+    Attributes:
+        tier_id: The tier identifier
+        subtest_results: Mapping of sub-test ID to results
+        best_subtest: ID of the winning sub-test
+        best_subtest_score: Score of the winning sub-test
+        inherited_from: Baseline this tier inherited from
+        tiebreaker_used: Whether a tie-breaker was needed
+        tiebreaker_model: Model used for tie-breaking (if applicable)
+        total_cost: Total cost for this tier
+        total_duration: Total duration for this tier
+    """
+
+    tier_id: TierID
+    subtest_results: dict[str, SubTestResult]
+    best_subtest: str | None = None
+    best_subtest_score: float = 0.0
+    inherited_from: TierBaseline | None = None
+    tiebreaker_used: bool = False
+    tiebreaker_model: str | None = None
+    total_cost: float = 0.0
+    total_duration: float = 0.0
+
+    def to_dict(self) -> dict[str, Any]:
+        """Convert to dictionary for JSON serialization."""
+        return {
+            "tier_id": self.tier_id.value,
+            "subtest_results": {k: v.to_dict() for k, v in self.subtest_results.items()},
+            "best_subtest": self.best_subtest,
+            "best_subtest_score": self.best_subtest_score,
+            "inherited_from": self.inherited_from.to_dict() if self.inherited_from else None,
+            "tiebreaker_used": self.tiebreaker_used,
+            "tiebreaker_model": self.tiebreaker_model,
+            "total_cost": self.total_cost,
+            "total_duration": self.total_duration,
+        }
+
+
+@dataclass
+class ExperimentConfig:
+    """Complete experiment configuration.
+
+    Defines all parameters for running an E2E experiment.
+
+    Attributes:
+        experiment_id: Unique identifier for this experiment
+        task_repo: Git repository URL for the task
+        task_commit: Git commit hash to checkout
+        task_prompt_file: Path to the task prompt file
+        models: List of model identifiers to test
+        runs_per_subtest: Number of runs per sub-test (default: 10)
+        tiers_to_run: List of tiers to evaluate
+        judge_model: Model to use for judging
+        tiebreaker_model: Model to use for tie-breaking
+        parallel_subtests: Max parallel sub-tests (default: 4)
+        timeout_seconds: Timeout per run in seconds
+    """
+
+    experiment_id: str
+    task_repo: str
+    task_commit: str
+    task_prompt_file: Path
+    models: list[str] = field(default_factory=lambda: ["claude-sonnet-4-20250514"])
+    runs_per_subtest: int = 10
+    tiers_to_run: list[TierID] = field(default_factory=lambda: list(TierID))
+    judge_model: str = "claude-opus-4-5-20251101"
+    tiebreaker_model: str = "gpt-4"
+    parallel_subtests: int = 4
+    timeout_seconds: int = 3600
+
+    def to_dict(self) -> dict[str, Any]:
+        """Convert to dictionary for JSON serialization."""
+        return {
+            "experiment_id": self.experiment_id,
+            "task_repo": self.task_repo,
+            "task_commit": self.task_commit,
+            "task_prompt_file": str(self.task_prompt_file),
+            "models": self.models,
+            "runs_per_subtest": self.runs_per_subtest,
+            "tiers_to_run": [t.value for t in self.tiers_to_run],
+            "judge_model": self.judge_model,
+            "tiebreaker_model": self.tiebreaker_model,
+            "parallel_subtests": self.parallel_subtests,
+            "timeout_seconds": self.timeout_seconds,
+        }
+
+    def save(self, path: Path) -> None:
+        """Save configuration to JSON file."""
+        path.parent.mkdir(parents=True, exist_ok=True)
+        with open(path, "w") as f:
+            json.dump(self.to_dict(), f, indent=2)
+
+    @classmethod
+    def load(cls, path: Path) -> ExperimentConfig:
+        """Load configuration from JSON file."""
+        with open(path) as f:
+            data = json.load(f)
+        return cls(
+            experiment_id=data["experiment_id"],
+            task_repo=data["task_repo"],
+            task_commit=data["task_commit"],
+            task_prompt_file=Path(data["task_prompt_file"]),
+            models=data.get("models", ["claude-sonnet-4-20250514"]),
+            runs_per_subtest=data.get("runs_per_subtest", 10),
+            tiers_to_run=[TierID.from_string(t) for t in data.get("tiers_to_run", [])],
+            judge_model=data.get("judge_model", "claude-opus-4-5-20251101"),
+            tiebreaker_model=data.get("tiebreaker_model", "gpt-4"),
+            parallel_subtests=data.get("parallel_subtests", 4),
+            timeout_seconds=data.get("timeout_seconds", 3600),
+        )
+
+
+@dataclass
+class ExperimentResult:
+    """Complete experiment results.
+
+    Contains all results and analysis from running the full experiment.
+
+    Attributes:
+        config: The experiment configuration
+        tier_results: Mapping of tier ID to results
+        best_overall_tier: Tier with best cost-of-pass
+        best_overall_subtest: Sub-test with best performance
+        frontier_cop: Best cost-of-pass across all tiers
+        frontier_cop_tier: Tier achieving frontier cost-of-pass
+        total_cost: Total experiment cost
+        total_duration_seconds: Total experiment duration
+        started_at: Experiment start timestamp
+        completed_at: Experiment completion timestamp
+    """
+
+    config: ExperimentConfig
+    tier_results: dict[TierID, TierResult]
+    best_overall_tier: TierID | None = None
+    best_overall_subtest: str | None = None
+    frontier_cop: float = float("inf")
+    frontier_cop_tier: TierID | None = None
+    total_cost: float = 0.0
+    total_duration_seconds: float = 0.0
+    started_at: str = field(default_factory=lambda: datetime.now(UTC).isoformat())
+    completed_at: str | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        """Convert to dictionary for JSON serialization."""
+        return {
+            "config": self.config.to_dict(),
+            "tier_results": {k.value: v.to_dict() for k, v in self.tier_results.items()},
+            "best_overall_tier": self.best_overall_tier.value if self.best_overall_tier else None,
+            "best_overall_subtest": self.best_overall_subtest,
+            "frontier_cop": self.frontier_cop,
+            "frontier_cop_tier": self.frontier_cop_tier.value if self.frontier_cop_tier else None,
+            "total_cost": self.total_cost,
+            "total_duration_seconds": self.total_duration_seconds,
+            "started_at": self.started_at,
+            "completed_at": self.completed_at,
+        }
+
+    def save(self, path: Path) -> None:
+        """Save results to JSON file."""
+        path.parent.mkdir(parents=True, exist_ok=True)
+        with open(path, "w") as f:
+            json.dump(self.to_dict(), f, indent=2)

--- a/src/scylla/e2e/runner.py
+++ b/src/scylla/e2e/runner.py
@@ -1,0 +1,398 @@
+"""Main E2E experiment runner.
+
+This module provides the main entry point for running E2E experiments,
+coordinating tier execution, inheritance, and result aggregation.
+
+Python Justification: Required for orchestration, filesystem operations,
+and report generation.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from scylla.e2e.judge_selection import JudgeSelection, save_selection, select_best_subtest
+from scylla.e2e.models import (
+    ExperimentConfig,
+    ExperimentResult,
+    TierBaseline,
+    TierID,
+    TierResult,
+)
+from scylla.e2e.subtest_executor import run_tier_subtests_parallel
+from scylla.e2e.tier_manager import TierManager
+
+if TYPE_CHECKING:
+    pass
+
+logger = logging.getLogger(__name__)
+
+
+class E2ERunner:
+    """Main runner for E2E experiments.
+
+    Orchestrates the complete E2E experiment lifecycle:
+    1. Initialize experiment directory
+    2. For each tier (T0 → T6):
+       a. Load tier configuration
+       b. Run all sub-tests in parallel
+       c. Select best sub-test
+       d. Set baseline for next tier
+    3. Generate cross-tier analysis
+    4. Create final report
+
+    Example:
+        >>> config = ExperimentConfig(
+        ...     experiment_id="exp-001",
+        ...     task_repo="https://github.com/example/repo",
+        ...     task_commit="abc123",
+        ...     task_prompt_file=Path("prompt.md"),
+        ... )
+        >>> runner = E2ERunner(config, Path("config/tiers"), Path("results"))
+        >>> result = runner.run()
+    """
+
+    def __init__(
+        self,
+        config: ExperimentConfig,
+        tiers_dir: Path,
+        results_base_dir: Path,
+    ) -> None:
+        """Initialize the E2E runner.
+
+        Args:
+            config: Experiment configuration
+            tiers_dir: Path to tier configurations
+            results_base_dir: Base directory for results
+        """
+        self.config = config
+        self.tier_manager = TierManager(tiers_dir)
+        self.results_base_dir = results_base_dir
+        self.experiment_dir: Path | None = None
+
+    def run(self) -> ExperimentResult:
+        """Run the complete E2E experiment.
+
+        Returns:
+            ExperimentResult with all tier results and analysis.
+        """
+        start_time = datetime.now(UTC)
+
+        # Create experiment directory
+        self.experiment_dir = self._create_experiment_dir()
+
+        # Save configuration
+        self._save_config()
+
+        # Run tiers
+        tier_results: dict[TierID, TierResult] = {}
+        previous_baseline: TierBaseline | None = None
+
+        for tier_id in self.config.tiers_to_run:
+            logger.info(f"Starting tier {tier_id.value}")
+
+            tier_result = self._run_tier(tier_id, previous_baseline)
+            tier_results[tier_id] = tier_result
+
+            # Set baseline for next tier
+            if tier_result.best_subtest:
+                subtest_dir = (
+                    self.experiment_dir
+                    / "tiers"
+                    / tier_id.value
+                    / tier_result.best_subtest
+                )
+                previous_baseline = self.tier_manager.get_baseline_for_subtest(
+                    tier_id=tier_id,
+                    subtest_id=tier_result.best_subtest,
+                    results_dir=subtest_dir,
+                )
+
+            # Save intermediate results
+            self._save_tier_result(tier_id, tier_result)
+
+        # Calculate overall metrics
+        end_time = datetime.now(UTC)
+        total_duration = (end_time - start_time).total_seconds()
+        total_cost = sum(t.total_cost for t in tier_results.values())
+
+        # Find frontier (best cost-of-pass)
+        frontier_tier, frontier_cop = self._find_frontier(tier_results)
+
+        # Create final result
+        result = ExperimentResult(
+            config=self.config,
+            tier_results=tier_results,
+            best_overall_tier=frontier_tier,
+            best_overall_subtest=(
+                tier_results[frontier_tier].best_subtest if frontier_tier else None
+            ),
+            frontier_cop=frontier_cop,
+            frontier_cop_tier=frontier_tier,
+            total_cost=total_cost,
+            total_duration_seconds=total_duration,
+            started_at=start_time.isoformat(),
+            completed_at=end_time.isoformat(),
+        )
+
+        # Save final results
+        self._save_final_results(result)
+
+        # Generate report
+        self._generate_report(result)
+
+        logger.info(
+            f"Experiment completed in {total_duration:.1f}s, "
+            f"total cost: ${total_cost:.2f}"
+        )
+
+        return result
+
+    def _create_experiment_dir(self) -> Path:
+        """Create the experiment results directory.
+
+        Returns:
+            Path to the experiment directory.
+        """
+        timestamp = datetime.now(UTC).strftime("%Y-%m-%dT%H-%M-%S")
+        experiment_dir = self.results_base_dir / f"{timestamp}-{self.config.experiment_id}"
+        experiment_dir.mkdir(parents=True, exist_ok=True)
+
+        # Create subdirectories
+        (experiment_dir / "config").mkdir(exist_ok=True)
+        (experiment_dir / "tiers").mkdir(exist_ok=True)
+        (experiment_dir / "summary").mkdir(exist_ok=True)
+        (experiment_dir / "logs").mkdir(exist_ok=True)
+
+        return experiment_dir
+
+    def _save_config(self) -> None:
+        """Save experiment configuration."""
+        if self.experiment_dir:
+            self.config.save(self.experiment_dir / "config" / "experiment.json")
+
+    def _run_tier(
+        self,
+        tier_id: TierID,
+        baseline: TierBaseline | None,
+    ) -> TierResult:
+        """Run a single tier's evaluation.
+
+        Args:
+            tier_id: The tier to run
+            baseline: Previous tier's winning baseline
+
+        Returns:
+            TierResult with all sub-test results.
+        """
+        start_time = datetime.now(UTC)
+
+        # Load tier configuration
+        tier_config = self.tier_manager.load_tier_config(tier_id)
+
+        logger.info(
+            f"Tier {tier_id.value}: {len(tier_config.subtests)} sub-tests, "
+            f"mode: {tier_config.system_prompt_mode}"
+        )
+
+        # Prepare results directory
+        tier_dir = self.experiment_dir / "tiers" / tier_id.value
+
+        # Run all sub-tests in parallel
+        subtest_results = run_tier_subtests_parallel(
+            config=self.config,
+            tier_id=tier_id,
+            tier_config=tier_config,
+            tier_manager=self.tier_manager,
+            baseline=baseline,
+            results_dir=tier_dir,
+        )
+
+        # Select best sub-test
+        selection = select_best_subtest(
+            subtest_results,
+            primary_judge_model=self.config.judge_model,
+            tiebreaker_model=self.config.tiebreaker_model,
+        )
+
+        # Mark winning sub-test
+        if selection.winning_subtest in subtest_results:
+            subtest_results[selection.winning_subtest].selected_as_best = True
+            subtest_results[selection.winning_subtest].selection_reason = (
+                selection.tiebreaker_result.reasoning
+                if selection.tiebreaker_result
+                else f"Highest median score ({selection.winning_score:.3f})"
+            )
+
+        # Save selection
+        save_selection(selection, str(tier_dir / "best_subtest.json"))
+
+        end_time = datetime.now(UTC)
+        duration = (end_time - start_time).total_seconds()
+
+        return TierResult(
+            tier_id=tier_id,
+            subtest_results=subtest_results,
+            best_subtest=selection.winning_subtest,
+            best_subtest_score=selection.winning_score,
+            inherited_from=baseline,
+            tiebreaker_used=selection.tiebreaker_needed,
+            tiebreaker_model=(
+                self.config.tiebreaker_model if selection.tiebreaker_needed else None
+            ),
+            total_cost=sum(s.total_cost for s in subtest_results.values()),
+            total_duration=duration,
+        )
+
+    def _save_tier_result(self, tier_id: TierID, result: TierResult) -> None:
+        """Save tier results to file.
+
+        Args:
+            tier_id: The tier identifier
+            result: The tier result
+        """
+        if self.experiment_dir:
+            tier_dir = self.experiment_dir / "tiers" / tier_id.value
+            tier_dir.mkdir(parents=True, exist_ok=True)
+
+            with open(tier_dir / "result.json", "w") as f:
+                json.dump(result.to_dict(), f, indent=2)
+
+    def _find_frontier(
+        self,
+        tier_results: dict[TierID, TierResult],
+    ) -> tuple[TierID | None, float]:
+        """Find the frontier tier (best cost-of-pass).
+
+        Args:
+            tier_results: All tier results
+
+        Returns:
+            Tuple of (best tier, cost-of-pass).
+        """
+        best_tier: TierID | None = None
+        best_cop = float("inf")
+
+        for tier_id, result in tier_results.items():
+            if not result.subtest_results:
+                continue
+
+            # Get best sub-test results
+            best_subtest = result.subtest_results.get(result.best_subtest)
+            if not best_subtest or best_subtest.pass_rate == 0:
+                continue
+
+            # Calculate cost-of-pass
+            cop = best_subtest.mean_cost / best_subtest.pass_rate
+
+            if cop < best_cop:
+                best_cop = cop
+                best_tier = tier_id
+
+        return best_tier, best_cop
+
+    def _save_final_results(self, result: ExperimentResult) -> None:
+        """Save final experiment results.
+
+        Args:
+            result: The complete experiment result
+        """
+        if self.experiment_dir:
+            result.save(self.experiment_dir / "summary" / "result.json")
+
+            # Save tier comparison
+            comparison = {
+                tier_id.value: {
+                    "best_subtest": tier_result.best_subtest,
+                    "best_score": tier_result.best_subtest_score,
+                    "total_cost": tier_result.total_cost,
+                    "tiebreaker_used": tier_result.tiebreaker_used,
+                }
+                for tier_id, tier_result in result.tier_results.items()
+            }
+
+            with open(self.experiment_dir / "summary" / "tier_comparison.json", "w") as f:
+                json.dump(comparison, f, indent=2)
+
+    def _generate_report(self, result: ExperimentResult) -> None:
+        """Generate markdown report.
+
+        Args:
+            result: The complete experiment result
+        """
+        if not self.experiment_dir:
+            return
+
+        lines = [
+            f"# E2E Experiment Report: {self.config.experiment_id}",
+            "",
+            f"**Generated**: {datetime.now(UTC).isoformat()}",
+            f"**Duration**: {result.total_duration_seconds:.1f}s",
+            f"**Total Cost**: ${result.total_cost:.4f}",
+            "",
+            "## Summary",
+            "",
+            f"- **Best Tier**: {result.best_overall_tier.value if result.best_overall_tier else 'N/A'}",
+            f"- **Best Sub-test**: {result.best_overall_subtest or 'N/A'}",
+            f"- **Frontier CoP**: ${result.frontier_cop:.4f}" if result.frontier_cop != float("inf") else "- **Frontier CoP**: N/A",
+            "",
+            "## Tier Results",
+            "",
+            "| Tier | Best Sub-test | Score | Cost | Tie-breaker |",
+            "|------|---------------|-------|------|-------------|",
+        ]
+
+        for tier_id in self.config.tiers_to_run:
+            tier_result = result.tier_results.get(tier_id)
+            if tier_result:
+                lines.append(
+                    f"| {tier_id.value} | {tier_result.best_subtest or 'N/A'} | "
+                    f"{tier_result.best_subtest_score:.3f} | "
+                    f"${tier_result.total_cost:.4f} | "
+                    f"{'Yes' if tier_result.tiebreaker_used else 'No'} |"
+                )
+
+        lines.extend(
+            [
+                "",
+                "## Configuration",
+                "",
+                f"- **Task Repo**: {self.config.task_repo}",
+                f"- **Task Commit**: {self.config.task_commit}",
+                f"- **Runs per Sub-test**: {self.config.runs_per_subtest}",
+                f"- **Judge Model**: {self.config.judge_model}",
+                f"- **Tie-breaker Model**: {self.config.tiebreaker_model}",
+                "",
+                "---",
+                "",
+                "*Generated by ProjectScylla E2E Framework*",
+            ]
+        )
+
+        report_path = self.experiment_dir / "report.md"
+        report_path.write_text("\n".join(lines))
+
+        logger.info(f"Report saved to {report_path}")
+
+
+def run_experiment(
+    config: ExperimentConfig,
+    tiers_dir: Path,
+    results_dir: Path,
+) -> ExperimentResult:
+    """Convenience function to run an experiment.
+
+    Args:
+        config: Experiment configuration
+        tiers_dir: Path to tier configurations
+        results_dir: Path to results directory
+
+    Returns:
+        ExperimentResult with all results.
+    """
+    runner = E2ERunner(config, tiers_dir, results_dir)
+    return runner.run()

--- a/src/scylla/e2e/subtest_executor.py
+++ b/src/scylla/e2e/subtest_executor.py
@@ -1,0 +1,570 @@
+"""Sub-test executor for E2E testing.
+
+This module handles executing individual sub-tests, including
+workspace preparation, agent execution, judging, and result aggregation.
+
+Python Justification: Required for subprocess execution, parallel processing,
+and filesystem operations.
+"""
+
+from __future__ import annotations
+
+import shutil
+import statistics
+import subprocess
+import tempfile
+from concurrent.futures import ProcessPoolExecutor, as_completed
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from scylla.adapters.base import AdapterConfig
+from scylla.adapters.claude_code import ClaudeCodeAdapter
+from scylla.e2e.command_logger import CommandLogger
+from scylla.e2e.models import (
+    ExperimentConfig,
+    RunResult,
+    SubTestConfig,
+    SubTestResult,
+    TierBaseline,
+    TierConfig,
+    TierID,
+)
+from scylla.e2e.tier_manager import TierManager
+
+if TYPE_CHECKING:
+    pass
+
+
+class SubTestExecutor:
+    """Executes sub-tests and aggregates results.
+
+    Handles the complete lifecycle of running a sub-test:
+    1. Create workspace (clone repo, checkout commit)
+    2. Prepare tier configuration (inheritance + overlay)
+    3. Execute agent N times
+    4. Judge each run
+    5. Aggregate results
+
+    Example:
+        >>> executor = SubTestExecutor(config, tier_manager)
+        >>> result = executor.run_subtest(
+        ...     tier_id=TierID.T2,
+        ...     subtest=subtest_config,
+        ...     baseline=previous_baseline,
+        ...     results_dir=Path("/results/T2/01"),
+        ... )
+    """
+
+    def __init__(
+        self,
+        config: ExperimentConfig,
+        tier_manager: TierManager,
+        adapter: ClaudeCodeAdapter | None = None,
+    ) -> None:
+        """Initialize the executor.
+
+        Args:
+            config: Experiment configuration
+            tier_manager: Tier configuration manager
+            adapter: Optional adapter (defaults to ClaudeCodeAdapter)
+        """
+        self.config = config
+        self.tier_manager = tier_manager
+        self.adapter = adapter or ClaudeCodeAdapter()
+
+    def run_subtest(
+        self,
+        tier_id: TierID,
+        tier_config: TierConfig,
+        subtest: SubTestConfig,
+        baseline: TierBaseline | None,
+        results_dir: Path,
+    ) -> SubTestResult:
+        """Run a single sub-test N times and aggregate results.
+
+        Args:
+            tier_id: The tier being executed
+            tier_config: Tier configuration
+            subtest: Sub-test configuration
+            baseline: Previous tier's winning baseline (if any)
+            results_dir: Directory to store results
+
+        Returns:
+            SubTestResult with aggregated metrics.
+        """
+        runs: list[RunResult] = []
+        results_dir.mkdir(parents=True, exist_ok=True)
+
+        # Load task prompt once
+        task_prompt = self.config.task_prompt_file.read_text()
+
+        for run_num in range(1, self.config.runs_per_subtest + 1):
+            run_dir = results_dir / f"run_{run_num:02d}"
+            run_dir.mkdir(parents=True, exist_ok=True)
+
+            run_result = self._execute_single_run(
+                tier_id=tier_id,
+                tier_config=tier_config,
+                subtest=subtest,
+                baseline=baseline,
+                run_number=run_num,
+                run_dir=run_dir,
+                task_prompt=task_prompt,
+            )
+            runs.append(run_result)
+
+        # Save sub-test config for inheritance
+        self.tier_manager.save_subtest_config(
+            workspace=run_dir / "workspace",  # Use last run's workspace
+            results_dir=results_dir,
+        )
+
+        # Aggregate results
+        return self._aggregate_results(tier_id, subtest.id, runs)
+
+    def _execute_single_run(
+        self,
+        tier_id: TierID,
+        tier_config: TierConfig,
+        subtest: SubTestConfig,
+        baseline: TierBaseline | None,
+        run_number: int,
+        run_dir: Path,
+        task_prompt: str,
+    ) -> RunResult:
+        """Execute a single run of the sub-test.
+
+        Args:
+            tier_id: The tier being executed
+            tier_config: Tier configuration
+            subtest: Sub-test configuration
+            baseline: Previous tier's baseline
+            run_number: The run number (1-indexed)
+            run_dir: Directory for this run's outputs
+            task_prompt: The task prompt text
+
+        Returns:
+            RunResult with execution details.
+        """
+        logs_dir = run_dir / "logs"
+        logs_dir.mkdir(parents=True, exist_ok=True)
+        command_logger = CommandLogger(logs_dir)
+
+        # Create workspace
+        workspace = run_dir / "workspace"
+        workspace.mkdir(parents=True, exist_ok=True)
+
+        # Clone and checkout
+        self._setup_workspace(workspace, command_logger)
+
+        # Prepare tier configuration
+        self.tier_manager.prepare_workspace(
+            workspace=workspace,
+            tier_id=tier_id,
+            subtest_id=subtest.id,
+            baseline=baseline,
+        )
+
+        # Create adapter config
+        prompt_file = logs_dir / "task_prompt.md"
+        prompt_file.write_text(task_prompt)
+
+        adapter_config = AdapterConfig(
+            model=self.config.models[0],
+            prompt_file=prompt_file,
+            workspace=workspace,
+            output_dir=logs_dir,
+            timeout=self.config.timeout_seconds,
+        )
+
+        # Execute agent
+        start_time = datetime.now(UTC)
+        try:
+            result = self.adapter.run(
+                config=adapter_config,
+                tier_config=None,  # Tier config handled by workspace preparation
+                system_prompt_mode=tier_config.system_prompt_mode,
+            )
+        except Exception as e:
+            # Handle execution errors
+            result = type(
+                "ErrorResult",
+                (),
+                {
+                    "exit_code": -1,
+                    "stdout": "",
+                    "stderr": str(e),
+                    "tokens_input": 0,
+                    "tokens_output": 0,
+                    "cost_usd": 0.0,
+                    "api_calls": 0,
+                },
+            )()
+
+        duration = (datetime.now(UTC) - start_time).total_seconds()
+
+        # Log the command
+        cmd = self.adapter._build_command(
+            adapter_config,
+            task_prompt,
+            None,
+            tier_config.system_prompt_mode,
+        )
+        command_logger.log_command(
+            cmd=cmd,
+            stdout=result.stdout,
+            stderr=result.stderr,
+            exit_code=result.exit_code,
+            duration=duration,
+            cwd=str(workspace),
+        )
+
+        # Save command logs
+        command_logger.save()
+        command_logger.save_replay_script()
+
+        # Run judge evaluation
+        judgment = self._run_judge(
+            workspace=workspace,
+            task_prompt=task_prompt,
+            stdout=result.stdout,
+            logs_dir=logs_dir,
+        )
+
+        return RunResult(
+            run_number=run_number,
+            exit_code=result.exit_code,
+            tokens_input=result.tokens_input,
+            tokens_output=result.tokens_output,
+            cost_usd=result.cost_usd,
+            duration_seconds=duration,
+            judge_score=judgment["score"],
+            judge_passed=judgment["passed"],
+            judge_grade=judgment["grade"],
+            judge_reasoning=judgment["reasoning"],
+            workspace_path=workspace,
+            logs_path=logs_dir,
+            command_log_path=logs_dir / "command_log.json",
+        )
+
+    def _setup_workspace(
+        self,
+        workspace: Path,
+        command_logger: CommandLogger,
+    ) -> None:
+        """Set up workspace by cloning repo and checking out commit.
+
+        Args:
+            workspace: Target workspace directory
+            command_logger: Logger for commands
+        """
+        start_time = datetime.now(UTC)
+
+        # Clone repository
+        clone_cmd = [
+            "git",
+            "clone",
+            "--depth=1",
+            self.config.task_repo,
+            str(workspace),
+        ]
+
+        result = subprocess.run(
+            clone_cmd,
+            capture_output=True,
+            text=True,
+            timeout=300,
+        )
+
+        duration = (datetime.now(UTC) - start_time).total_seconds()
+        command_logger.log_command(
+            cmd=clone_cmd,
+            stdout=result.stdout,
+            stderr=result.stderr,
+            exit_code=result.returncode,
+            duration=duration,
+        )
+
+        if result.returncode != 0:
+            raise RuntimeError(f"Failed to clone repo: {result.stderr}")
+
+        # Fetch specific commit if needed
+        if self.config.task_commit:
+            fetch_cmd = [
+                "git",
+                "-C",
+                str(workspace),
+                "fetch",
+                "--depth=1",
+                "origin",
+                self.config.task_commit,
+            ]
+
+            start_time = datetime.now(UTC)
+            result = subprocess.run(
+                fetch_cmd,
+                capture_output=True,
+                text=True,
+                timeout=300,
+            )
+            duration = (datetime.now(UTC) - start_time).total_seconds()
+            command_logger.log_command(
+                cmd=fetch_cmd,
+                stdout=result.stdout,
+                stderr=result.stderr,
+                exit_code=result.returncode,
+                duration=duration,
+            )
+
+            # Checkout commit
+            checkout_cmd = [
+                "git",
+                "-C",
+                str(workspace),
+                "checkout",
+                self.config.task_commit,
+            ]
+
+            start_time = datetime.now(UTC)
+            result = subprocess.run(
+                checkout_cmd,
+                capture_output=True,
+                text=True,
+                timeout=60,
+            )
+            duration = (datetime.now(UTC) - start_time).total_seconds()
+            command_logger.log_command(
+                cmd=checkout_cmd,
+                stdout=result.stdout,
+                stderr=result.stderr,
+                exit_code=result.returncode,
+                duration=duration,
+            )
+
+    def _run_judge(
+        self,
+        workspace: Path,
+        task_prompt: str,
+        stdout: str,
+        logs_dir: Path,
+    ) -> dict:
+        """Run LLM judge evaluation on the result.
+
+        Args:
+            workspace: Workspace with agent's output
+            task_prompt: The original task prompt
+            stdout: Agent's stdout output
+            logs_dir: Directory for judge logs
+
+        Returns:
+            Dict with score, passed, grade, and reasoning.
+        """
+        # TODO: Implement proper LLM judge
+        # For now, use a simple heuristic judge
+        import json
+
+        # Check for success indicators
+        passed = False
+        score = 0.0
+        reasoning = "Unable to evaluate"
+
+        # Parse JSON output if available
+        try:
+            data = json.loads(stdout.strip())
+            # Check if result indicates success
+            if data.get("subtype") == "success":
+                passed = True
+                score = 0.7
+                reasoning = "Agent reported success"
+            elif data.get("is_error"):
+                passed = False
+                score = 0.0
+                reasoning = f"Agent error: {data.get('error', 'Unknown error')}"
+            else:
+                # Partial success
+                score = 0.5
+                reasoning = "Agent completed but unclear if successful"
+        except (json.JSONDecodeError, AttributeError):
+            # Non-JSON output
+            if len(stdout) > 100:
+                score = 0.3
+                reasoning = "Agent produced output but format unclear"
+
+        # Determine grade
+        if score >= 0.9:
+            grade = "A"
+        elif score >= 0.8:
+            grade = "B"
+        elif score >= 0.7:
+            grade = "C"
+        elif score >= 0.6:
+            grade = "D"
+        else:
+            grade = "F"
+
+        judgment = {
+            "passed": passed,
+            "score": score,
+            "grade": grade,
+            "reasoning": reasoning,
+        }
+
+        # Save judgment to file
+        judgment_file = logs_dir / "judgment.json"
+        with open(judgment_file, "w") as f:
+            json.dump(judgment, f, indent=2)
+
+        return judgment
+
+    def _aggregate_results(
+        self,
+        tier_id: TierID,
+        subtest_id: str,
+        runs: list[RunResult],
+    ) -> SubTestResult:
+        """Aggregate results from multiple runs.
+
+        Args:
+            tier_id: The tier identifier
+            subtest_id: The sub-test identifier
+            runs: List of run results
+
+        Returns:
+            SubTestResult with aggregated statistics.
+        """
+        if not runs:
+            return SubTestResult(
+                subtest_id=subtest_id,
+                tier_id=tier_id,
+                runs=[],
+            )
+
+        scores = [r.judge_score for r in runs]
+        costs = [r.cost_usd for r in runs]
+
+        pass_count = sum(1 for r in runs if r.judge_passed)
+        pass_rate = pass_count / len(runs)
+
+        mean_score = statistics.mean(scores)
+        median_score = statistics.median(scores)
+        std_dev = statistics.stdev(scores) if len(scores) > 1 else 0.0
+
+        # Consistency: 1 - coefficient of variation
+        cv = std_dev / mean_score if mean_score > 0 else 1.0
+        consistency = max(0.0, 1.0 - cv)
+
+        return SubTestResult(
+            subtest_id=subtest_id,
+            tier_id=tier_id,
+            runs=runs,
+            pass_rate=pass_rate,
+            mean_score=mean_score,
+            median_score=median_score,
+            std_dev_score=std_dev,
+            mean_cost=statistics.mean(costs),
+            total_cost=sum(costs),
+            consistency=consistency,
+        )
+
+
+def run_tier_subtests_parallel(
+    config: ExperimentConfig,
+    tier_id: TierID,
+    tier_config: TierConfig,
+    tier_manager: TierManager,
+    baseline: TierBaseline | None,
+    results_dir: Path,
+) -> dict[str, SubTestResult]:
+    """Run all sub-tests for a tier in parallel.
+
+    Args:
+        config: Experiment configuration
+        tier_id: The tier being executed
+        tier_config: Tier configuration with sub-tests
+        tier_manager: Tier configuration manager
+        baseline: Previous tier's winning baseline
+        results_dir: Base directory for tier results
+
+    Returns:
+        Dict mapping sub-test ID to results.
+    """
+    results: dict[str, SubTestResult] = {}
+    executor = SubTestExecutor(config, tier_manager)
+
+    # For single sub-test (T0, T1), run directly
+    if len(tier_config.subtests) <= 1:
+        for subtest in tier_config.subtests:
+            subtest_dir = results_dir / subtest.id
+            results[subtest.id] = executor.run_subtest(
+                tier_id=tier_id,
+                tier_config=tier_config,
+                subtest=subtest,
+                baseline=baseline,
+                results_dir=subtest_dir,
+            )
+        return results
+
+    # For multiple sub-tests, run in parallel
+    with ProcessPoolExecutor(max_workers=config.parallel_subtests) as pool:
+        futures = {}
+
+        for subtest in tier_config.subtests:
+            subtest_dir = results_dir / subtest.id
+            future = pool.submit(
+                _run_subtest_in_process,
+                config=config,
+                tier_id=tier_id,
+                tier_config=tier_config,
+                subtest=subtest,
+                baseline=baseline,
+                results_dir=subtest_dir,
+                tiers_dir=tier_manager.tiers_dir,
+            )
+            futures[future] = subtest.id
+
+        for future in as_completed(futures):
+            subtest_id = futures[future]
+            try:
+                results[subtest_id] = future.result()
+            except Exception as e:
+                # Create error result
+                results[subtest_id] = SubTestResult(
+                    subtest_id=subtest_id,
+                    tier_id=tier_id,
+                    runs=[],
+                    pass_rate=0.0,
+                    mean_score=0.0,
+                    median_score=0.0,
+                    std_dev_score=0.0,
+                    mean_cost=0.0,
+                    total_cost=0.0,
+                    consistency=0.0,
+                    selection_reason=f"Error: {e}",
+                )
+
+    return results
+
+
+def _run_subtest_in_process(
+    config: ExperimentConfig,
+    tier_id: TierID,
+    tier_config: TierConfig,
+    subtest: SubTestConfig,
+    baseline: TierBaseline | None,
+    results_dir: Path,
+    tiers_dir: Path,
+) -> SubTestResult:
+    """Run a sub-test in a separate process.
+
+    This is a helper for parallel execution.
+    """
+    tier_manager = TierManager(tiers_dir)
+    executor = SubTestExecutor(config, tier_manager)
+    return executor.run_subtest(
+        tier_id=tier_id,
+        tier_config=tier_config,
+        subtest=subtest,
+        baseline=baseline,
+        results_dir=results_dir,
+    )

--- a/src/scylla/e2e/tier_manager.py
+++ b/src/scylla/e2e/tier_manager.py
@@ -1,0 +1,311 @@
+"""Tier configuration management with inheritance.
+
+This module handles loading tier configurations, managing sub-tests,
+and implementing the copy+extend inheritance pattern between tiers.
+
+Python Justification: Required for filesystem operations and YAML parsing.
+"""
+
+from __future__ import annotations
+
+import shutil
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import yaml
+
+from scylla.e2e.models import SubTestConfig, TierBaseline, TierConfig, TierID
+
+if TYPE_CHECKING:
+    pass
+
+
+class TierManager:
+    """Manages tier configurations and inheritance.
+
+    Handles loading tier configs from the filesystem, discovering
+    sub-tests, and preparing workspaces with inherited configurations.
+
+    Example:
+        >>> manager = TierManager(Path("config/tiers"))
+        >>> tier_config = manager.load_tier_config(TierID.T2)
+        >>> manager.prepare_workspace(
+        ...     workspace=Path("/tmp/workspace"),
+        ...     tier_id=TierID.T3,
+        ...     subtest_id="01",
+        ...     baseline=previous_baseline,
+        ... )
+    """
+
+    def __init__(self, tiers_dir: Path) -> None:
+        """Initialize the tier manager.
+
+        Args:
+            tiers_dir: Path to the config/tiers directory
+        """
+        self.tiers_dir = tiers_dir
+
+    def load_tier_config(self, tier_id: TierID) -> TierConfig:
+        """Load configuration for a specific tier.
+
+        Discovers all sub-tests for the tier and returns a complete
+        TierConfig object.
+
+        Args:
+            tier_id: The tier to load configuration for
+
+        Returns:
+            TierConfig with all sub-tests for the tier.
+        """
+        tier_dir = self.tiers_dir / tier_id.value.lower()
+
+        # Determine system prompt mode based on tier
+        if tier_id == TierID.T0:
+            system_prompt_mode = "none"
+        elif tier_id == TierID.T1:
+            system_prompt_mode = "default"
+        else:
+            system_prompt_mode = "custom"  # T2+ use CLAUDE.md
+
+        # Discover sub-tests
+        subtests = self._discover_subtests(tier_id, tier_dir)
+
+        return TierConfig(
+            tier_id=tier_id,
+            subtests=subtests,
+            system_prompt_mode=system_prompt_mode,
+        )
+
+    def _discover_subtests(self, tier_id: TierID, tier_dir: Path) -> list[SubTestConfig]:
+        """Discover sub-test configurations in a tier directory.
+
+        Args:
+            tier_id: The tier identifier
+            tier_dir: Path to the tier directory
+
+        Returns:
+            List of SubTestConfig for each discovered sub-test.
+        """
+        subtests = []
+
+        # For T0 and T1, there's only a baseline (no numbered sub-tests)
+        if tier_id in (TierID.T0, TierID.T1):
+            subtests.append(
+                SubTestConfig(
+                    id="baseline",
+                    name=f"{tier_id.value} Baseline",
+                    description=f"Baseline configuration for {tier_id.value}",
+                    claude_md_path=None,
+                    claude_dir_path=None,
+                    extends_previous=False,
+                )
+            )
+            return subtests
+
+        # For T2+, look for numbered subdirectories
+        if not tier_dir.exists():
+            return subtests
+
+        for subdir in sorted(tier_dir.iterdir()):
+            if subdir.is_dir() and subdir.name.isdigit():
+                claude_md = subdir / "CLAUDE.md"
+                claude_dir = subdir / ".claude"
+
+                # Load metadata if config.yaml exists
+                config_file = subdir / "config.yaml"
+                name = f"{tier_id.value} Sub-test {subdir.name}"
+                description = f"Sub-test configuration {subdir.name}"
+
+                if config_file.exists():
+                    with open(config_file) as f:
+                        config_data = yaml.safe_load(f) or {}
+                    name = config_data.get("name", name)
+                    description = config_data.get("description", description)
+
+                subtests.append(
+                    SubTestConfig(
+                        id=subdir.name,
+                        name=name,
+                        description=description,
+                        claude_md_path=claude_md if claude_md.exists() else None,
+                        claude_dir_path=claude_dir if claude_dir.exists() else None,
+                        extends_previous=True,
+                    )
+                )
+
+        return subtests
+
+    def prepare_workspace(
+        self,
+        workspace: Path,
+        tier_id: TierID,
+        subtest_id: str,
+        baseline: TierBaseline | None = None,
+    ) -> None:
+        """Prepare a workspace with tier configuration.
+
+        Implements the copy+extend inheritance pattern:
+        1. If baseline provided and sub-test extends_previous, copy baseline
+        2. Overlay the sub-test's specific configuration
+
+        Args:
+            workspace: Path to the workspace directory
+            tier_id: The tier being prepared
+            subtest_id: The sub-test identifier
+            baseline: Previous tier's winning baseline (if any)
+        """
+        # For T0, ensure no CLAUDE.md exists (clean slate)
+        if tier_id == TierID.T0:
+            claude_md = workspace / "CLAUDE.md"
+            claude_dir = workspace / ".claude"
+            if claude_md.exists():
+                claude_md.unlink()
+            if claude_dir.exists():
+                shutil.rmtree(claude_dir)
+            return
+
+        # For T1, use defaults (no changes needed)
+        if tier_id == TierID.T1:
+            return
+
+        # For T2+, apply inheritance and overlay
+        tier_config = self.load_tier_config(tier_id)
+        subtest = next((s for s in tier_config.subtests if s.id == subtest_id), None)
+
+        if not subtest:
+            raise ValueError(f"Sub-test {subtest_id} not found for tier {tier_id.value}")
+
+        # Step 1: Copy baseline if extending from previous tier
+        if baseline and subtest.extends_previous:
+            self._copy_baseline(workspace, baseline)
+
+        # Step 2: Overlay sub-test configuration
+        self._overlay_subtest(workspace, subtest)
+
+    def _copy_baseline(self, workspace: Path, baseline: TierBaseline) -> None:
+        """Copy baseline configuration to workspace.
+
+        Args:
+            workspace: Target workspace directory
+            baseline: Baseline configuration to copy
+        """
+        # Copy CLAUDE.md
+        if baseline.claude_md_path and baseline.claude_md_path.exists():
+            dest = workspace / "CLAUDE.md"
+            shutil.copy(baseline.claude_md_path, dest)
+
+        # Copy .claude directory
+        if baseline.claude_dir_path and baseline.claude_dir_path.exists():
+            dest = workspace / ".claude"
+            if dest.exists():
+                shutil.rmtree(dest)
+            shutil.copytree(baseline.claude_dir_path, dest)
+
+    def _overlay_subtest(self, workspace: Path, subtest: SubTestConfig) -> None:
+        """Overlay sub-test configuration onto workspace.
+
+        This merges the sub-test's CLAUDE.md and .claude directory
+        with any existing configuration from the baseline.
+
+        Args:
+            workspace: Target workspace directory
+            subtest: Sub-test configuration to overlay
+        """
+        # Handle CLAUDE.md
+        if subtest.claude_md_path and subtest.claude_md_path.exists():
+            dest = workspace / "CLAUDE.md"
+            if dest.exists() and subtest.extends_previous:
+                # Merge: append sub-test content to existing
+                existing = dest.read_text()
+                addition = subtest.claude_md_path.read_text()
+                merged = f"{existing}\n\n# Tier {subtest.id} Additions\n\n{addition}"
+                dest.write_text(merged)
+            else:
+                # Replace
+                shutil.copy(subtest.claude_md_path, dest)
+
+        # Handle .claude directory
+        if subtest.claude_dir_path and subtest.claude_dir_path.exists():
+            dest = workspace / ".claude"
+            if dest.exists() and subtest.extends_previous:
+                # Merge: copy files from sub-test, overwriting conflicts
+                self._merge_directories(subtest.claude_dir_path, dest)
+            else:
+                # Replace
+                if dest.exists():
+                    shutil.rmtree(dest)
+                shutil.copytree(subtest.claude_dir_path, dest)
+
+    def _merge_directories(self, src: Path, dest: Path) -> None:
+        """Recursively merge source directory into destination.
+
+        Files from source overwrite destination files on conflict.
+        Directories are merged recursively.
+
+        Args:
+            src: Source directory
+            dest: Destination directory
+        """
+        dest.mkdir(parents=True, exist_ok=True)
+
+        for item in src.iterdir():
+            dest_item = dest / item.name
+            if item.is_dir():
+                self._merge_directories(item, dest_item)
+            else:
+                shutil.copy(item, dest_item)
+
+    def get_baseline_for_subtest(
+        self,
+        tier_id: TierID,
+        subtest_id: str,
+        results_dir: Path,
+    ) -> TierBaseline:
+        """Create a baseline reference from a completed sub-test.
+
+        Args:
+            tier_id: The tier of the winning sub-test
+            subtest_id: The winning sub-test ID
+            results_dir: Directory containing the sub-test's results
+
+        Returns:
+            TierBaseline that can be passed to the next tier.
+        """
+        config_dir = results_dir / "config"
+
+        return TierBaseline(
+            tier_id=tier_id,
+            subtest_id=subtest_id,
+            claude_md_path=config_dir / "CLAUDE.md" if (config_dir / "CLAUDE.md").exists() else None,
+            claude_dir_path=config_dir / ".claude" if (config_dir / ".claude").exists() else None,
+        )
+
+    def save_subtest_config(
+        self,
+        workspace: Path,
+        results_dir: Path,
+    ) -> None:
+        """Save the workspace configuration to results directory.
+
+        Preserves the CLAUDE.md and .claude directory used for this
+        sub-test so it can be used as a baseline for the next tier.
+
+        Args:
+            workspace: Workspace with the configuration
+            results_dir: Results directory to save to
+        """
+        config_dir = results_dir / "config"
+        config_dir.mkdir(parents=True, exist_ok=True)
+
+        # Save CLAUDE.md
+        claude_md = workspace / "CLAUDE.md"
+        if claude_md.exists():
+            shutil.copy(claude_md, config_dir / "CLAUDE.md")
+
+        # Save .claude directory
+        claude_dir = workspace / ".claude"
+        if claude_dir.exists():
+            dest = config_dir / ".claude"
+            if dest.exists():
+                shutil.rmtree(dest)
+            shutil.copytree(claude_dir, dest)

--- a/tests/unit/e2e/__init__.py
+++ b/tests/unit/e2e/__init__.py
@@ -1,0 +1,1 @@
+"""Unit tests for E2E testing framework."""

--- a/tests/unit/e2e/test_command_logger.py
+++ b/tests/unit/e2e/test_command_logger.py
@@ -1,0 +1,180 @@
+"""Unit tests for command logger."""
+
+from __future__ import annotations
+
+import json
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from scylla.e2e.command_logger import CommandLog, CommandLogger
+
+
+class TestCommandLog:
+    """Tests for CommandLog."""
+
+    def test_to_dict(self) -> None:
+        """Test conversion to dictionary."""
+        log = CommandLog(
+            timestamp="2026-01-01T12:00:00Z",
+            command=["claude", "--print", "hello"],
+            cwd="/workspace",
+            env_vars={"PATH": "/usr/bin"},
+            exit_code=0,
+            stdout_file="cmd_0000_stdout.log",
+            stderr_file="cmd_0000_stderr.log",
+            duration_seconds=1.5,
+        )
+
+        d = log.to_dict()
+
+        assert d["command"] == ["claude", "--print", "hello"]
+        assert d["exit_code"] == 0
+        assert d["duration_seconds"] == 1.5
+
+    def test_from_dict(self) -> None:
+        """Test creation from dictionary."""
+        data = {
+            "timestamp": "2026-01-01T12:00:00Z",
+            "command": ["git", "status"],
+            "cwd": "/repo",
+            "env_vars": {},
+            "exit_code": 0,
+            "stdout_file": "stdout.log",
+            "stderr_file": "stderr.log",
+            "duration_seconds": 0.5,
+        }
+
+        log = CommandLog.from_dict(data)
+
+        assert log.command == ["git", "status"]
+        assert log.exit_code == 0
+
+
+class TestCommandLogger:
+    """Tests for CommandLogger."""
+
+    def test_log_command(self) -> None:
+        """Test logging a command."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            logger = CommandLogger(Path(tmpdir))
+
+            log = logger.log_command(
+                cmd=["echo", "hello"],
+                stdout="hello\n",
+                stderr="",
+                exit_code=0,
+                duration=0.1,
+            )
+
+            assert log.command == ["echo", "hello"]
+            assert log.exit_code == 0
+            assert len(logger.commands) == 1
+
+            # Check stdout file was written
+            stdout_file = Path(tmpdir) / log.stdout_file
+            assert stdout_file.exists()
+            assert stdout_file.read_text() == "hello\n"
+
+    def test_save(self) -> None:
+        """Test saving command log to JSON."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            logger = CommandLogger(Path(tmpdir))
+
+            logger.log_command(
+                cmd=["cmd1"],
+                stdout="out1",
+                stderr="",
+                exit_code=0,
+                duration=1.0,
+            )
+            logger.log_command(
+                cmd=["cmd2"],
+                stdout="out2",
+                stderr="err2",
+                exit_code=1,
+                duration=2.0,
+            )
+
+            log_path = logger.save()
+
+            assert log_path.exists()
+
+            with open(log_path) as f:
+                data = json.load(f)
+
+            assert data["total_commands"] == 2
+            assert len(data["commands"]) == 2
+
+    def test_save_replay_script(self) -> None:
+        """Test generating replay script."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            logger = CommandLogger(Path(tmpdir))
+
+            logger.log_command(
+                cmd=["echo", "hello world"],
+                stdout="hello world\n",
+                stderr="",
+                exit_code=0,
+                duration=0.1,
+                cwd="/test/dir",
+            )
+
+            script_path = logger.save_replay_script()
+
+            assert script_path.exists()
+            assert script_path.stat().st_mode & 0o100  # Executable
+
+            content = script_path.read_text()
+            assert "#!/bin/bash" in content
+            assert "cd /test/dir" in content  # Path without spaces doesn't need quotes
+            assert "echo 'hello world'" in content
+
+    def test_load(self) -> None:
+        """Test loading saved command log."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            # Create and save logger
+            logger1 = CommandLogger(Path(tmpdir))
+            logger1.log_command(
+                cmd=["test", "cmd"],
+                stdout="output",
+                stderr="",
+                exit_code=0,
+                duration=1.0,
+            )
+            logger1.save()
+
+            # Load into new logger
+            logger2 = CommandLogger.load(Path(tmpdir))
+
+            assert len(logger2.commands) == 1
+            assert logger2.commands[0].command == ["test", "cmd"]
+
+    def test_env_var_redaction(self) -> None:
+        """Test that sensitive env vars are redacted."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            import os
+
+            # Temporarily set an API key
+            original = os.environ.get("ANTHROPIC_API_KEY")
+            os.environ["ANTHROPIC_API_KEY"] = "secret-key-12345"
+
+            try:
+                logger = CommandLogger(Path(tmpdir))
+                log = logger.log_command(
+                    cmd=["test"],
+                    stdout="",
+                    stderr="",
+                    exit_code=0,
+                    duration=0.1,
+                )
+
+                # API key should be redacted
+                assert log.env_vars.get("ANTHROPIC_API_KEY") == "[REDACTED]"
+
+            finally:
+                if original:
+                    os.environ["ANTHROPIC_API_KEY"] = original
+                else:
+                    os.environ.pop("ANTHROPIC_API_KEY", None)

--- a/tests/unit/e2e/test_judge_selection.py
+++ b/tests/unit/e2e/test_judge_selection.py
@@ -1,0 +1,192 @@
+"""Unit tests for judge selection."""
+
+from __future__ import annotations
+
+import pytest
+
+from scylla.e2e.judge_selection import (
+    JudgeSelection,
+    JudgeVote,
+    _calculate_composite_score,
+    select_best_subtest,
+)
+from scylla.e2e.models import SubTestResult, TierID
+
+
+class TestJudgeVote:
+    """Tests for JudgeVote."""
+
+    def test_to_dict(self) -> None:
+        """Test conversion to dictionary."""
+        vote = JudgeVote(
+            subtest_id="01",
+            score=0.85,
+            confidence=0.9,
+            reasoning="Good performance",
+        )
+
+        d = vote.to_dict()
+
+        assert d["subtest_id"] == "01"
+        assert d["score"] == 0.85
+        assert d["confidence"] == 0.9
+
+
+class TestJudgeSelection:
+    """Tests for JudgeSelection."""
+
+    def test_to_dict(self) -> None:
+        """Test conversion to dictionary."""
+        selection = JudgeSelection(
+            winning_subtest="01",
+            winning_score=0.85,
+            votes=[
+                JudgeVote("01", 0.85, 0.9, "Good"),
+                JudgeVote("02", 0.80, 0.8, "Okay"),
+            ],
+            margin=0.05,
+            tiebreaker_needed=False,
+        )
+
+        d = selection.to_dict()
+
+        assert d["winning_subtest"] == "01"
+        assert d["margin"] == 0.05
+        assert len(d["votes"]) == 2
+
+
+class TestSelectBestSubtest:
+    """Tests for select_best_subtest function."""
+
+    def test_single_subtest(self) -> None:
+        """Test selection with single subtest."""
+        results = {
+            "baseline": SubTestResult(
+                subtest_id="baseline",
+                tier_id=TierID.T0,
+                runs=[],
+                median_score=0.75,
+            ),
+        }
+
+        selection = select_best_subtest(results)
+
+        assert selection.winning_subtest == "baseline"
+        assert selection.margin == 1.0
+        assert not selection.tiebreaker_needed
+
+    def test_clear_winner(self) -> None:
+        """Test selection with clear winner."""
+        results = {
+            "01": SubTestResult(
+                subtest_id="01",
+                tier_id=TierID.T2,
+                runs=[],
+                median_score=0.90,
+                consistency=0.9,
+            ),
+            "02": SubTestResult(
+                subtest_id="02",
+                tier_id=TierID.T2,
+                runs=[],
+                median_score=0.70,
+                consistency=0.8,
+            ),
+        }
+
+        selection = select_best_subtest(results)
+
+        assert selection.winning_subtest == "01"
+        assert abs(selection.margin - 0.20) < 0.001  # Float comparison
+        assert not selection.tiebreaker_needed
+
+    def test_tiebreaker_triggered(self) -> None:
+        """Test that tiebreaker is triggered for close scores."""
+        results = {
+            "01": SubTestResult(
+                subtest_id="01",
+                tier_id=TierID.T2,
+                runs=[],
+                median_score=0.82,
+                mean_score=0.82,
+                pass_rate=0.8,
+                consistency=0.9,
+                mean_cost=0.10,
+            ),
+            "02": SubTestResult(
+                subtest_id="02",
+                tier_id=TierID.T2,
+                runs=[],
+                median_score=0.80,
+                mean_score=0.80,
+                pass_rate=0.9,  # Higher pass rate
+                consistency=0.95,  # Higher consistency
+                mean_cost=0.08,  # Lower cost
+            ),
+        }
+
+        selection = select_best_subtest(results, tie_threshold=0.05)
+
+        assert selection.tiebreaker_needed
+        assert selection.tiebreaker_result is not None
+        # With higher pass rate, consistency, and lower cost, 02 might win
+
+    def test_empty_results(self) -> None:
+        """Test that empty results raise error."""
+        with pytest.raises(ValueError, match="No sub-test results"):
+            select_best_subtest({})
+
+
+class TestCompositeScore:
+    """Tests for composite score calculation."""
+
+    def test_high_score_result(self) -> None:
+        """Test composite score for high-performing result."""
+        result = SubTestResult(
+            subtest_id="01",
+            tier_id=TierID.T2,
+            runs=[],
+            median_score=0.95,
+            pass_rate=0.9,
+            consistency=0.85,
+            mean_cost=0.05,
+        )
+
+        score = _calculate_composite_score(result)
+
+        # Should be high (close to 1.0)
+        assert score > 0.8
+
+    def test_low_score_result(self) -> None:
+        """Test composite score for low-performing result."""
+        result = SubTestResult(
+            subtest_id="01",
+            tier_id=TierID.T2,
+            runs=[],
+            median_score=0.2,
+            pass_rate=0.1,
+            consistency=0.3,
+            mean_cost=0.80,
+        )
+
+        score = _calculate_composite_score(result)
+
+        # Should be low
+        assert score < 0.3
+
+    def test_balanced_result(self) -> None:
+        """Test composite score for balanced result."""
+        result = SubTestResult(
+            subtest_id="01",
+            tier_id=TierID.T2,
+            runs=[],
+            median_score=0.5,
+            pass_rate=0.5,
+            consistency=0.5,
+            mean_cost=0.50,
+        )
+
+        score = _calculate_composite_score(result)
+
+        # Should be around 0.5
+        assert 0.4 < score < 0.6

--- a/tests/unit/e2e/test_models.py
+++ b/tests/unit/e2e/test_models.py
@@ -1,0 +1,208 @@
+"""Unit tests for E2E data models."""
+
+from __future__ import annotations
+
+import json
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from scylla.e2e.models import (
+    ExperimentConfig,
+    RunResult,
+    SubTestConfig,
+    SubTestResult,
+    TierBaseline,
+    TierConfig,
+    TierID,
+    TierResult,
+)
+
+
+class TestTierID:
+    """Tests for TierID enum."""
+
+    def test_from_string_uppercase(self) -> None:
+        """Test creating TierID from uppercase string."""
+        assert TierID.from_string("T0") == TierID.T0
+        assert TierID.from_string("T3") == TierID.T3
+
+    def test_from_string_lowercase(self) -> None:
+        """Test creating TierID from lowercase string."""
+        assert TierID.from_string("t0") == TierID.T0
+        assert TierID.from_string("t6") == TierID.T6
+
+    def test_tier_ordering(self) -> None:
+        """Test that tiers can be sorted."""
+        assert TierID.T0 < TierID.T1
+        assert TierID.T1 < TierID.T6
+        assert not TierID.T3 < TierID.T2
+
+
+class TestSubTestConfig:
+    """Tests for SubTestConfig."""
+
+    def test_to_dict(self) -> None:
+        """Test conversion to dictionary."""
+        config = SubTestConfig(
+            id="01",
+            name="Minimal",
+            description="Minimal CLAUDE.md",
+            claude_md_path=Path("/path/to/CLAUDE.md"),
+        )
+
+        result = config.to_dict()
+
+        assert result["id"] == "01"
+        assert result["name"] == "Minimal"
+        assert result["claude_md_path"] == "/path/to/CLAUDE.md"
+        assert result["extends_previous"] is True
+
+    def test_to_dict_with_none_paths(self) -> None:
+        """Test conversion with None paths."""
+        config = SubTestConfig(
+            id="baseline",
+            name="Baseline",
+            description="No customization",
+        )
+
+        result = config.to_dict()
+
+        assert result["claude_md_path"] is None
+        assert result["claude_dir_path"] is None
+
+
+class TestTierConfig:
+    """Tests for TierConfig."""
+
+    def test_to_dict(self) -> None:
+        """Test conversion to dictionary."""
+        config = TierConfig(
+            tier_id=TierID.T2,
+            subtests=[
+                SubTestConfig(id="01", name="First", description="First subtest"),
+                SubTestConfig(id="02", name="Second", description="Second subtest"),
+            ],
+            system_prompt_mode="custom",
+        )
+
+        result = config.to_dict()
+
+        assert result["tier_id"] == "T2"
+        assert len(result["subtests"]) == 2
+        assert result["system_prompt_mode"] == "custom"
+
+
+class TestRunResult:
+    """Tests for RunResult."""
+
+    def test_to_dict(self) -> None:
+        """Test conversion to dictionary."""
+        result = RunResult(
+            run_number=1,
+            exit_code=0,
+            tokens_input=1000,
+            tokens_output=200,
+            cost_usd=0.05,
+            duration_seconds=15.5,
+            judge_score=0.8,
+            judge_passed=True,
+            judge_grade="B",
+            judge_reasoning="Good work",
+            workspace_path=Path("/workspace"),
+            logs_path=Path("/logs"),
+        )
+
+        d = result.to_dict()
+
+        assert d["run_number"] == 1
+        assert d["exit_code"] == 0
+        assert d["cost_usd"] == 0.05
+        assert d["judge_score"] == 0.8
+        assert d["workspace_path"] == "/workspace"
+
+
+class TestSubTestResult:
+    """Tests for SubTestResult."""
+
+    def test_aggregated_metrics(self) -> None:
+        """Test that aggregated metrics work."""
+        result = SubTestResult(
+            subtest_id="01",
+            tier_id=TierID.T2,
+            runs=[],
+            pass_rate=0.8,
+            mean_score=0.75,
+            median_score=0.77,
+            std_dev_score=0.05,
+            mean_cost=0.10,
+            total_cost=1.00,
+            consistency=0.93,
+        )
+
+        d = result.to_dict()
+
+        assert d["pass_rate"] == 0.8
+        assert d["median_score"] == 0.77
+        assert d["consistency"] == 0.93
+
+
+class TestTierBaseline:
+    """Tests for TierBaseline."""
+
+    def test_to_dict(self) -> None:
+        """Test conversion to dictionary."""
+        baseline = TierBaseline(
+            tier_id=TierID.T2,
+            subtest_id="01",
+            claude_md_path=Path("/config/CLAUDE.md"),
+            claude_dir_path=Path("/config/.claude"),
+        )
+
+        d = baseline.to_dict()
+
+        assert d["tier_id"] == "T2"
+        assert d["subtest_id"] == "01"
+        assert d["claude_md_path"] == "/config/CLAUDE.md"
+
+
+class TestExperimentConfig:
+    """Tests for ExperimentConfig."""
+
+    def test_to_dict(self) -> None:
+        """Test conversion to dictionary."""
+        config = ExperimentConfig(
+            experiment_id="test-001",
+            task_repo="https://github.com/test/repo",
+            task_commit="abc123",
+            task_prompt_file=Path("prompt.md"),
+            tiers_to_run=[TierID.T0, TierID.T1],
+        )
+
+        d = config.to_dict()
+
+        assert d["experiment_id"] == "test-001"
+        assert d["task_repo"] == "https://github.com/test/repo"
+        assert d["tiers_to_run"] == ["T0", "T1"]
+
+    def test_save_and_load(self) -> None:
+        """Test saving and loading configuration."""
+        config = ExperimentConfig(
+            experiment_id="test-002",
+            task_repo="https://github.com/test/repo",
+            task_commit="def456",
+            task_prompt_file=Path("prompt.md"),
+            runs_per_subtest=5,
+            tiers_to_run=[TierID.T0, TierID.T1, TierID.T2],
+        )
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = Path(tmpdir) / "config.json"
+            config.save(path)
+
+            loaded = ExperimentConfig.load(path)
+
+            assert loaded.experiment_id == "test-002"
+            assert loaded.runs_per_subtest == 5
+            assert loaded.tiers_to_run == [TierID.T0, TierID.T1, TierID.T2]


### PR DESCRIPTION
## Summary

Redesigns the E2E testing framework to implement a progressive optimization system where:
- Each tier (T0-T6) can have multiple numbered sub-tests
- Sub-tests run in parallel within each tier
- LLM judge selects the best sub-test (with tie-breaker using alternate model)
- Best sub-test becomes the baseline for the next tier (copy+extend inheritance)

## Key Features

### Tier Structure
- **T0**: Claude CLI with NO system prompt (`--system-prompt ""`)
- **T1**: Claude CLI with DEFAULT system prompt (no flag)
- **T2+**: Multiple numbered sub-tests (01, 02, 03...) with different CLAUDE.md/.claude configs

### Execution Flow
1. Clone repo to temp directory at specified commit
2. For each tier (T0 → T6):
   - Run all sub-tests in parallel (10 runs each)
   - Inject sub-test's CLAUDE.md/.claude into workspace
   - LLM judge scores each run
   - Select best sub-test (tie-breaker if scores within 5%)
   - Copy best config as baseline for next tier
3. Generate cross-tier analysis and report

### Reproducibility
- All commands logged to `command_log.json`
- Executable `replay.sh` generated for each run
- Full stdout/stderr captured

## Files Added

| File | Purpose |
|------|---------|
| `src/scylla/e2e/models.py` | Data models (ExperimentConfig, TierConfig, RunResult, etc.) |
| `src/scylla/e2e/command_logger.py` | Command logging + replay.sh generation |
| `src/scylla/e2e/tier_manager.py` | Tier config loading and inheritance |
| `src/scylla/e2e/subtest_executor.py` | Sub-test execution with parallel runs |
| `src/scylla/e2e/judge_selection.py` | LLM judge and tie-breaker |
| `src/scylla/e2e/runner.py` | Main experiment orchestration |
| `scripts/run_e2e_experiment.py` | CLI entry point |

## Files Modified

| File | Change |
|------|--------|
| `src/scylla/adapters/claude_code.py` | Add `--system-prompt` flag support for T0 |

## Usage

```bash
python scripts/run_e2e_experiment.py \
  --repo https://github.com/octocat/Hello-World \
  --commit 7fd1a60 \
  --prompt tests/fixtures/tests/test-001/prompt.md \
  --tiers T0 T1 T2 \
  --runs 10
```

## Test plan

- [x] Unit tests pass (27 new tests)
- [ ] Integration test with T0/T1 tiers
- [ ] Full experiment run with T0-T2

🤖 Generated with [Claude Code](https://claude.com/claude-code)