### PR TITLE
feat(e2e): add LLM judge and T2+ sub-test configurations

### DIFF
--- a/config/tiers/t2/01/CLAUDE.md
+++ b/config/tiers/t2/01/CLAUDE.md
@@ -1,0 +1,9 @@
+# CLAUDE.md
+
+Focus on completing the task correctly and efficiently.
+
+## Guidelines
+
+- Read the task requirements carefully before starting
+- Complete all required steps
+- Verify your work meets the success criteria

--- a/config/tiers/t2/01/config.yaml
+++ b/config/tiers/t2/01/config.yaml
@@ -1,0 +1,2 @@
+name: "Minimal CLAUDE.md"
+description: "Basic task focus with minimal guidance - tests baseline CLAUDE.md effectiveness"

--- a/config/tiers/t2/02/CLAUDE.md
+++ b/config/tiers/t2/02/CLAUDE.md
@@ -1,0 +1,23 @@
+# CLAUDE.md
+
+You are an expert software developer. Complete tasks systematically and verify your work.
+
+## Workflow
+
+1. **Understand**: Read the task requirements completely before starting
+2. **Plan**: Break down the task into clear steps
+3. **Execute**: Implement each step carefully
+4. **Verify**: Check that all requirements are satisfied
+
+## Best Practices
+
+- Write clean, readable code
+- Follow language conventions and idioms
+- Handle edge cases appropriately
+- Test your implementation before declaring completion
+
+## Quality Standards
+
+- All code should run without errors
+- Output should match expected format exactly
+- Files should be created in the correct locations

--- a/config/tiers/t2/02/config.yaml
+++ b/config/tiers/t2/02/config.yaml
@@ -1,0 +1,2 @@
+name: "Structured Workflow"
+description: "Systematic approach with clear workflow steps and best practices"

--- a/config/tiers/t2/03/CLAUDE.md
+++ b/config/tiers/t2/03/CLAUDE.md
@@ -1,0 +1,54 @@
+# CLAUDE.md
+
+You are a senior software engineer with expertise in clean code practices, testing, and systematic problem-solving.
+
+## Task Execution Framework
+
+### Phase 1: Analysis
+- Read the complete task specification
+- Identify all requirements (explicit and implicit)
+- Note success criteria and expected outputs
+- Identify potential edge cases or challenges
+
+### Phase 2: Planning
+- Break the task into atomic, verifiable steps
+- Order steps by dependencies
+- Identify which files need to be created or modified
+- Plan verification approach for each step
+
+### Phase 3: Implementation
+- Execute each step methodically
+- Follow language-specific best practices and idioms
+- Write self-documenting code with clear variable names
+- Handle errors gracefully where appropriate
+
+### Phase 4: Verification
+- Run the implementation to verify it works
+- Check output matches expected format exactly
+- Verify all files are in correct locations
+- Confirm all success criteria are met
+
+## Code Quality Standards
+
+### General
+- Prefer simplicity over cleverness
+- Keep functions small and focused
+- Use meaningful names for variables and functions
+- Follow the principle of least surprise
+
+### Error Handling
+- Anticipate common failure modes
+- Provide clear error messages when appropriate
+- Fail fast on invalid input
+
+### Output
+- Match expected output format exactly
+- Include required newlines and formatting
+- Verify file encoding (use UTF-8)
+
+## Common Pitfalls to Avoid
+
+- Starting implementation before fully understanding requirements
+- Missing implicit requirements (file locations, exact output format)
+- Not testing the implementation before declaring completion
+- Overcomplicating simple tasks

--- a/config/tiers/t2/03/config.yaml
+++ b/config/tiers/t2/03/config.yaml
@@ -1,0 +1,2 @@
+name: "Comprehensive Framework"
+description: "Full task execution framework with analysis, planning, implementation, and verification phases"

--- a/config/tiers/t3/01/CLAUDE.md
+++ b/config/tiers/t3/01/CLAUDE.md
@@ -1,0 +1,16 @@
+# CLAUDE.md
+
+You have access to tools for executing commands and interacting with the filesystem.
+
+## Tool Usage
+
+- Use tools to accomplish tasks rather than just describing what to do
+- Execute commands to verify your work
+- Check file contents after creation to confirm correctness
+
+## Workflow
+
+1. Understand the task requirements
+2. Use appropriate tools to implement the solution
+3. Verify the implementation by running/testing it
+4. Confirm all success criteria are met

--- a/config/tiers/t3/01/config.yaml
+++ b/config/tiers/t3/01/config.yaml
@@ -1,0 +1,2 @@
+name: "Basic Tool Usage"
+description: "Introduction to tool-based task execution with verification"

--- a/config/tiers/t3/02/CLAUDE.md
+++ b/config/tiers/t3/02/CLAUDE.md
@@ -1,0 +1,34 @@
+# CLAUDE.md
+
+You are an expert at using tools to accomplish software development tasks.
+
+## Tool Strategy
+
+### Before Starting
+- Identify which tools will be needed
+- Plan the sequence of tool operations
+- Consider dependencies between operations
+
+### During Execution
+- Use the right tool for each task
+- Chain tool operations efficiently
+- Capture and use output from previous commands
+- Handle tool errors gracefully
+
+### After Completion
+- Verify results using appropriate tools
+- Test implementations by running them
+- Check file contents match expectations
+
+## Best Practices
+
+- Prefer atomic operations that can be verified
+- Use read operations before write when modifying files
+- Run tests or verification commands after implementation
+- Check command exit codes and output for errors
+
+## Quality Verification
+
+- Execute the code to verify it runs correctly
+- Compare actual output to expected output
+- Ensure all artifacts are created in correct locations

--- a/config/tiers/t3/02/config.yaml
+++ b/config/tiers/t3/02/config.yaml
@@ -1,0 +1,2 @@
+name: "Advanced Tool Strategy"
+description: "Sophisticated tool usage with planning, chaining, and comprehensive verification"

--- a/src/scylla/e2e/__init__.py
+++ b/src/scylla/e2e/__init__.py
@@ -9,6 +9,7 @@ Python Justification: Required for subprocess execution, parallel processing,
 and LLM API calls for judging.
 """
 
+from scylla.e2e.llm_judge import JudgeResult, run_llm_judge
 from scylla.e2e.models import (
     ExperimentConfig,
     ExperimentResult,
@@ -23,10 +24,12 @@ from scylla.e2e.models import (
 __all__ = [
     "ExperimentConfig",
     "ExperimentResult",
+    "JudgeResult",
     "RunResult",
     "SubTestConfig",
     "SubTestResult",
     "TierConfig",
     "TierID",
     "TierResult",
+    "run_llm_judge",
 ]

--- a/src/scylla/e2e/llm_judge.py
+++ b/src/scylla/e2e/llm_judge.py
@@ -1,0 +1,380 @@
+"""LLM-based judge for evaluating E2E task completion.
+
+This module provides LLM-based evaluation of agent task completion,
+using structured prompts and rubrics for consistent scoring.
+
+Python Justification: Required for Anthropic API interaction.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class JudgeResult:
+    """Result from LLM judge evaluation.
+
+    Attributes:
+        score: Numeric score from 0.0 to 1.0
+        passed: Whether the task was successfully completed
+        grade: Letter grade (A, B, C, D, F)
+        reasoning: Detailed explanation of the judgment
+        criteria_scores: Individual scores for each criterion
+        raw_response: Raw LLM response for debugging
+    """
+
+    score: float
+    passed: bool
+    grade: str
+    reasoning: str
+    criteria_scores: dict[str, float] | None = None
+    raw_response: str | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        """Convert to dictionary."""
+        return {
+            "score": self.score,
+            "passed": self.passed,
+            "grade": self.grade,
+            "reasoning": self.reasoning,
+            "criteria_scores": self.criteria_scores,
+        }
+
+
+def _score_to_grade(score: float) -> str:
+    """Convert numeric score to letter grade."""
+    if score >= 0.9:
+        return "A"
+    elif score >= 0.8:
+        return "B"
+    elif score >= 0.7:
+        return "C"
+    elif score >= 0.6:
+        return "D"
+    return "F"
+
+
+def _build_judge_prompt(
+    task_prompt: str,
+    agent_output: str,
+    workspace_state: str,
+) -> str:
+    """Build the evaluation prompt for the LLM judge.
+
+    Args:
+        task_prompt: The original task prompt
+        agent_output: The agent's stdout/conversation output
+        workspace_state: Description of files created/modified
+
+    Returns:
+        Formatted prompt for the judge LLM.
+    """
+    return f"""You are an expert evaluator for AI agent task completion. Your job is to objectively assess whether an AI agent successfully completed a given task.
+
+## Task Given to Agent
+
+{task_prompt}
+
+## Agent's Output
+
+{agent_output}
+
+## Workspace State After Agent Execution
+
+{workspace_state}
+
+## Evaluation Instructions
+
+Evaluate the agent's work against the task requirements. Consider:
+
+1. **Correctness**: Did the agent produce the correct output/files as specified?
+2. **Completeness**: Were all requirements satisfied?
+3. **Quality**: Is the solution well-structured and following best practices?
+4. **Following Instructions**: Did the agent follow the specific instructions given?
+
+## Response Format
+
+Respond with a JSON object containing:
+- "score": A number from 0.0 to 1.0 (0.0 = complete failure, 1.0 = perfect completion)
+- "passed": true if the task was successfully completed, false otherwise
+- "reasoning": A brief explanation (2-3 sentences) of your judgment
+- "criteria_scores": An object with scores for each criterion:
+  - "correctness": 0.0-1.0
+  - "completeness": 0.0-1.0
+  - "quality": 0.0-1.0
+  - "following_instructions": 0.0-1.0
+
+Example response:
+```json
+{{
+  "score": 0.85,
+  "passed": true,
+  "reasoning": "The agent successfully created the required file with correct output. Minor improvements possible in code structure.",
+  "criteria_scores": {{
+    "correctness": 0.9,
+    "completeness": 1.0,
+    "quality": 0.7,
+    "following_instructions": 0.8
+  }}
+}}
+```
+
+Respond ONLY with the JSON object, no other text."""
+
+
+def _get_workspace_state(workspace: Path) -> str:
+    """Get a description of the workspace state.
+
+    Args:
+        workspace: Path to the workspace directory
+
+    Returns:
+        String describing files and their contents.
+    """
+    lines = ["Files in workspace:"]
+
+    # List all files (excluding .git)
+    for item in sorted(workspace.rglob("*")):
+        if ".git" in item.parts:
+            continue
+        if item.is_file():
+            rel_path = item.relative_to(workspace)
+            try:
+                content = item.read_text()
+                if len(content) > 1000:
+                    content = content[:1000] + "\n... (truncated)"
+                lines.append(f"\n### {rel_path}\n```\n{content}\n```")
+            except (UnicodeDecodeError, PermissionError):
+                lines.append(f"\n### {rel_path}\n(binary file)")
+
+    if len(lines) == 1:
+        lines.append("(no files created)")
+
+    return "\n".join(lines)
+
+
+def run_llm_judge(
+    workspace: Path,
+    task_prompt: str,
+    agent_output: str,
+    model: str = "claude-sonnet-4-20250514",
+    logs_dir: Path | None = None,
+) -> JudgeResult:
+    """Run LLM judge evaluation on agent's work.
+
+    Uses the Claude CLI to evaluate task completion with an LLM judge.
+    Falls back to heuristic evaluation if the LLM call fails.
+
+    Args:
+        workspace: Path to the workspace with agent's output
+        task_prompt: The original task prompt
+        agent_output: The agent's stdout output
+        model: Model to use for judging
+        logs_dir: Optional directory to save judge logs
+
+    Returns:
+        JudgeResult with evaluation details.
+    """
+    # Get workspace state
+    workspace_state = _get_workspace_state(workspace)
+
+    # Build the judge prompt
+    judge_prompt = _build_judge_prompt(task_prompt, agent_output, workspace_state)
+
+    # Call Claude CLI for judgment
+    try:
+        result = _call_claude_judge(judge_prompt, model)
+
+        # Parse the response
+        judge_result = _parse_judge_response(result)
+
+        # Save judge logs if directory provided
+        if logs_dir:
+            _save_judge_logs(logs_dir, judge_prompt, result, judge_result)
+
+        return judge_result
+
+    except Exception as e:
+        logger.warning(f"LLM judge failed, using fallback: {e}")
+        return _fallback_judge(agent_output)
+
+
+def _call_claude_judge(prompt: str, model: str) -> str:
+    """Call Claude CLI to get judgment.
+
+    Args:
+        prompt: The judge prompt
+        model: Model to use
+
+    Returns:
+        Raw response from Claude.
+    """
+    cmd = [
+        "claude",
+        "--model",
+        model,
+        "--print",
+        "--output-format",
+        "text",
+        "--dangerously-skip-permissions",
+        "--max-turns",
+        "1",
+        prompt,
+    ]
+
+    result = subprocess.run(
+        cmd,
+        capture_output=True,
+        text=True,
+        timeout=120,
+        env={**os.environ, "ANTHROPIC_API_KEY": os.environ.get("ANTHROPIC_API_KEY", "")},
+    )
+
+    if result.returncode != 0:
+        raise RuntimeError(f"Claude CLI failed: {result.stderr}")
+
+    return result.stdout
+
+
+def _parse_judge_response(response: str) -> JudgeResult:
+    """Parse the judge's JSON response.
+
+    Args:
+        response: Raw response from the LLM
+
+    Returns:
+        JudgeResult parsed from response.
+    """
+    # Try to extract JSON from response
+    response = response.strip()
+
+    # Handle markdown code blocks
+    if "```json" in response:
+        start = response.find("```json") + 7
+        end = response.find("```", start)
+        response = response[start:end].strip()
+    elif "```" in response:
+        start = response.find("```") + 3
+        end = response.find("```", start)
+        response = response[start:end].strip()
+
+    try:
+        data = json.loads(response)
+
+        score = float(data.get("score", 0.0))
+        passed = bool(data.get("passed", False))
+        reasoning = str(data.get("reasoning", "No reasoning provided"))
+        criteria_scores = data.get("criteria_scores")
+
+        # Validate score range
+        score = max(0.0, min(1.0, score))
+
+        return JudgeResult(
+            score=score,
+            passed=passed,
+            grade=_score_to_grade(score),
+            reasoning=reasoning,
+            criteria_scores=criteria_scores,
+            raw_response=response,
+        )
+
+    except json.JSONDecodeError as e:
+        logger.warning(f"Failed to parse judge response as JSON: {e}")
+        # Try to extract a pass/fail from the text
+        response_lower = response.lower()
+        if "passed" in response_lower or "success" in response_lower:
+            return JudgeResult(
+                score=0.7,
+                passed=True,
+                grade="C",
+                reasoning=f"Extracted from text: {response[:200]}",
+                raw_response=response,
+            )
+        return JudgeResult(
+            score=0.3,
+            passed=False,
+            grade="F",
+            reasoning=f"Could not parse judge response: {response[:200]}",
+            raw_response=response,
+        )
+
+
+def _fallback_judge(agent_output: str) -> JudgeResult:
+    """Fallback heuristic judge when LLM fails.
+
+    Args:
+        agent_output: The agent's stdout output
+
+    Returns:
+        JudgeResult from heuristic evaluation.
+    """
+    try:
+        data = json.loads(agent_output.strip())
+        if data.get("subtype") == "success":
+            return JudgeResult(
+                score=0.7,
+                passed=True,
+                grade="C",
+                reasoning="Fallback: Agent reported success",
+            )
+        elif data.get("is_error"):
+            return JudgeResult(
+                score=0.0,
+                passed=False,
+                grade="F",
+                reasoning=f"Fallback: Agent error - {data.get('error', 'Unknown')}",
+            )
+    except (json.JSONDecodeError, AttributeError):
+        pass
+
+    # Default fallback
+    if len(agent_output) > 100:
+        return JudgeResult(
+            score=0.3,
+            passed=False,
+            grade="F",
+            reasoning="Fallback: Agent produced output but unclear if successful",
+        )
+
+    return JudgeResult(
+        score=0.0,
+        passed=False,
+        grade="F",
+        reasoning="Fallback: Unable to evaluate agent output",
+    )
+
+
+def _save_judge_logs(
+    logs_dir: Path,
+    prompt: str,
+    response: str,
+    result: JudgeResult,
+) -> None:
+    """Save judge evaluation logs.
+
+    Args:
+        logs_dir: Directory to save logs
+        prompt: The judge prompt
+        response: Raw LLM response
+        result: Parsed judge result
+    """
+    logs_dir.mkdir(parents=True, exist_ok=True)
+
+    # Save the prompt
+    (logs_dir / "judge_prompt.md").write_text(prompt)
+
+    # Save raw response
+    (logs_dir / "judge_response.txt").write_text(response)
+
+    # Save structured result
+    with open(logs_dir / "judgment.json", "w") as f:
+        json.dump(result.to_dict(), f, indent=2)


### PR DESCRIPTION
## Summary

- Add real LLM-based judge for task evaluation (replaces heuristics)
- Create T2 and T3 sub-test configurations with numbered directories

## Changes

### LLM Judge (`src/scylla/e2e/llm_judge.py`)
- Uses Claude CLI to evaluate task completion against requirements
- Returns structured judgments with:
  - Overall score (0.0-1.0)
  - Pass/fail determination
  - Letter grade (A-F)
  - Detailed reasoning
  - Criteria scores (correctness, completeness, quality, following_instructions)
- Falls back to heuristic evaluation if LLM call fails
- Saves judge prompt, response, and result for debugging

### T2 Sub-tests (`config/tiers/t2/`)
| Sub-test | Name | Description |
|----------|------|-------------|
| 01 | Minimal CLAUDE.md | Basic task focus with minimal guidance |
| 02 | Structured Workflow | Systematic approach with workflow steps |
| 03 | Comprehensive Framework | Full analysis/planning/verification phases |

### T3 Sub-tests (`config/tiers/t3/`)
| Sub-test | Name | Description |
|----------|------|-------------|
| 01 | Basic Tool Usage | Introduction to tool-based execution |
| 02 | Advanced Tool Strategy | Sophisticated tool usage with verification |

## Test Results

Ran smoke test with T0, T1, T2 (1 run each):

| Tier | Best Sub-test | Score | Cost | Frontier CoP |
|------|---------------|-------|------|--------------|
| T0 | baseline | 1.000 | $0.23 | $0.23 |
| T1 | baseline | 1.000 | $0.11 | **$0.11** |
| T2 | 01 | 1.000 | $0.51 | $0.17 |

T1 selected as best tier with lowest Cost-of-Pass.

## Test plan

- [x] Unit tests pass (27 tests)
- [x] E2E smoke test with LLM judge works
- [x] T2 sub-tests discovered and executed correctly
- [x] Judge outputs structured JSON with reasoning

🤖 Generated with [Claude Code](https://claude.com/claude-code)