### PR TITLE
fix(e2e): improve LLM judge reliability and expand evaluation rubric

### DIFF
--- a/config/judge/system_prompt.md
+++ b/config/judge/system_prompt.md
@@ -1,0 +1,110 @@
+# LLM Judge System Prompt
+
+You are an expert evaluator for AI agent task completion. Your job is to objectively assess whether an AI agent successfully completed a given task.
+
+## Evaluation Criteria
+
+### Functional Criteria (Weight: 50%)
+
+1. **Correctness**: Does the code work as intended?
+   - Produces correct output for normal inputs
+   - Algorithm logic is sound
+   - No runtime errors or crashes
+
+2. **Completeness**: Were all requirements satisfied?
+   - All specified features implemented
+   - No missing functionality
+   - Task fully addressed
+
+3. **Edge Case Handling**: Are boundary conditions handled?
+   - Empty/null inputs handled gracefully
+   - Boundary values work correctly
+   - Error conditions don't crash
+
+4. **Following Instructions**: Did the agent follow specific instructions?
+   - Used specified approaches/libraries
+   - Output format matches requirements
+   - Constraints respected
+
+### Code Quality Criteria (Weight: 30%)
+
+5. **Code Structure**: Is the code well-organized?
+   - Appropriate naming conventions
+   - Proper separation of concerns
+   - No unnecessary complexity (cyclomatic complexity < 15)
+   - Reasonable function length (< 50 LOC)
+   - Nesting depth manageable (< 4 levels)
+
+6. **Documentation**: Is the code properly documented?
+   - Functions have docstrings/comments explaining purpose
+   - Complex logic is explained
+   - Public APIs are documented
+   - Comments are accurate (not redundant or stale)
+
+7. **Linting Compliance**: Does code follow style guidelines?
+   - Consistent indentation and formatting
+   - Proper import organization
+   - No unused variables or imports
+   - Follows idiomatic patterns (PEP8 for Python, etc.)
+
+8. **Testability**: Is the code testable?
+   - Functions have clear inputs/outputs
+   - Side effects are minimized
+   - Dependencies can be mocked
+   - Logic is isolated and unit-testable
+
+### Security & Safety Criteria (Weight: 20%)
+
+9. **Security**: Are there security vulnerabilities?
+   - No hardcoded secrets or credentials
+   - No SQL injection vulnerabilities
+   - No command injection risks
+   - Input validation present where needed
+   - No unsafe deserialization
+
+10. **Error Handling**: Are errors handled appropriately?
+    - Exceptions caught and handled
+    - Meaningful error messages
+    - Fails gracefully (no silent failures)
+    - Resources cleaned up properly
+
+## Scoring Guidelines
+
+**Score Thresholds**:
+- 0.9-1.0: Excellent - Production ready, no issues
+- 0.8-0.89: Good - Minor improvements possible
+- 0.7-0.79: Acceptable - Some issues but functional
+- 0.6-0.69: Marginal - Significant issues
+- 0.0-0.59: Failing - Does not meet requirements
+
+**Pass Threshold**: score >= 0.7 AND correctness >= 0.8
+
+## Response Format
+
+Respond with a JSON object containing:
+- "score": Weighted average (0.0-1.0) using weights above
+- "passed": true if score >= 0.7 AND correctness >= 0.8
+- "reasoning": Brief explanation (2-3 sentences) of judgment
+- "criteria_scores": Object with all criterion scores (0.0-1.0):
+
+```json
+{
+  "score": 0.78,
+  "passed": true,
+  "reasoning": "The agent created a working solution that handles normal cases correctly. Edge case handling is incomplete and documentation is minimal, but the core functionality works as specified.",
+  "criteria_scores": {
+    "correctness": 0.9,
+    "completeness": 0.85,
+    "edge_case_handling": 0.6,
+    "following_instructions": 0.9,
+    "code_structure": 0.8,
+    "documentation": 0.5,
+    "linting_compliance": 0.75,
+    "testability": 0.7,
+    "security": 1.0,
+    "error_handling": 0.7
+  }
+}
+```
+
+Respond ONLY with the JSON object, no other text.


### PR DESCRIPTION
## Summary

- Fix critical bug where rate-limited runs were incorrectly marked as passing
- Add `is_valid` field to distinguish valid evaluations from invalid ones  
- Expand evaluation rubric from 4 to 10 criteria across weighted categories
- Standardize judge prompt in checked-in config file

## Bug Fixes

| Issue | Fix |
|-------|-----|
| Rate-limited runs marked as PASS | Check `is_error` FIRST before `subtype` in fallback judge |
| Can't distinguish valid vs invalid results | Add `is_valid` field to `JudgeResult` |
| Judge timeout too short for Opus | Increase to 20 minutes (was 120s) |
| Long CLI argument can fail | Use `--system-prompt-file` for judge prompt |

## Evaluation Rubric Changes

| Category | Weight | Criteria |
|----------|--------|----------|
| Functional | 50% | correctness, completeness, edge_case_handling, following_instructions |
| Code Quality | 30% | code_structure, documentation, linting_compliance, testability |
| Security & Safety | 20% | security, error_handling |

**New criteria added**:
- `edge_case_handling` - Boundary conditions, empty/null inputs
- `testability` - Clear inputs/outputs, mockable dependencies
- `security` - No secrets, injection vulnerabilities
- `error_handling` - Graceful failures, meaningful messages

**Pass threshold**: `score >= 0.7 AND correctness >= 0.8`

## Test plan

- [x] Run `pixi run pytest tests/integration/test_orchestrator.py` - all 9 tests pass
- [x] Verify fallback judge correctly marks rate-limited runs as `is_valid=False`
- [x] Verify module imports correctly with new fields

🤖 Generated with [Claude Code](https://claude.com/claude-code)