### PR TITLE
feat(e2e): add git worktrees and per-run markdown reports

### DIFF
--- a/config/judge/system_prompt.md
+++ b/config/judge/system_prompt.md
@@ -84,8 +84,10 @@ You are an expert evaluator for AI agent task completion. Your job is to objecti
 Respond with a JSON object containing:
 - "score": Weighted average (0.0-1.0) using weights above
 - "passed": true if score >= 0.7 AND correctness >= 0.8
-- "reasoning": Brief explanation (2-3 sentences) of judgment
-- "criteria_scores": Object with all criterion scores (0.0-1.0):
+- "reasoning": Overall summary (2-3 sentences) of judgment
+- "criteria_scores": Object with all criterion evaluations, each containing:
+  - "score": Numeric score (0.0-1.0)
+  - "explanation": Paragraph explaining why this score was given, with specific examples from the code
 
 ```json
 {
@@ -93,16 +95,46 @@ Respond with a JSON object containing:
   "passed": true,
   "reasoning": "The agent created a working solution that handles normal cases correctly. Edge case handling is incomplete and documentation is minimal, but the core functionality works as specified.",
   "criteria_scores": {
-    "correctness": 0.9,
-    "completeness": 0.85,
-    "edge_case_handling": 0.6,
-    "following_instructions": 0.9,
-    "code_structure": 0.8,
-    "documentation": 0.5,
-    "linting_compliance": 0.75,
-    "testability": 0.7,
-    "security": 1.0,
-    "error_handling": 0.7
+    "correctness": {
+      "score": 0.9,
+      "explanation": "The implementation produces correct output for the specified requirements. The hello.py script prints exactly 'Hello, World!' as requested and exits cleanly with code 0. Minor deduction for not including a main guard, though this doesn't affect functionality for this simple script."
+    },
+    "completeness": {
+      "score": 0.85,
+      "explanation": "All primary requirements were satisfied: the file was created with the correct name, produces the expected output, and exits properly. The solution could be more complete with a shebang line for direct execution."
+    },
+    "edge_case_handling": {
+      "score": 0.6,
+      "explanation": "For this simple task, edge cases are minimal. However, the script doesn't handle potential encoding issues or verify stdout availability. Given the task simplicity, this is acceptable but noted."
+    },
+    "following_instructions": {
+      "score": 0.9,
+      "explanation": "The agent followed instructions well, creating the file in the current working directory using a relative path as specified. The output matches the exact format requested."
+    },
+    "code_structure": {
+      "score": 0.8,
+      "explanation": "The code is appropriately simple for the task. A single print statement is the right approach here. Structure is minimal but appropriate - no over-engineering."
+    },
+    "documentation": {
+      "score": 0.5,
+      "explanation": "No docstring or comments were provided. While the code is self-explanatory for this trivial case, a brief module docstring would improve clarity for any reader."
+    },
+    "linting_compliance": {
+      "score": 0.75,
+      "explanation": "The code follows basic Python style guidelines. No unused imports or variables. Could benefit from a trailing newline at end of file per PEP8."
+    },
+    "testability": {
+      "score": 0.7,
+      "explanation": "The script is testable via subprocess execution. However, wrapping the print in a function would make unit testing easier without subprocess overhead."
+    },
+    "security": {
+      "score": 1.0,
+      "explanation": "No security concerns for this simple script. No user input handling, no file operations beyond stdout, no network calls, no secrets or credentials."
+    },
+    "error_handling": {
+      "score": 0.7,
+      "explanation": "The script has no explicit error handling, but for a simple print statement, none is strictly required. The implicit behavior (Python's default exception handling) is acceptable here."
+    }
   }
 }
 ```

--- a/src/scylla/e2e/judge_selection.py
+++ b/src/scylla/e2e/judge_selection.py
@@ -78,7 +78,7 @@ class JudgeSelection:
 def select_best_subtest(
     subtest_results: dict[str, SubTestResult],
     primary_judge_model: str = "claude-opus-4-5-20251101",
-    tiebreaker_model: str = "gpt-4",
+    tiebreaker_model: str = "claude-opus-4-5-20251101",
     tie_threshold: float = 0.05,
 ) -> JudgeSelection:
     """Select the best sub-test using LLM judge with tie-breaker.

--- a/src/scylla/e2e/llm_judge.py
+++ b/src/scylla/e2e/llm_judge.py
@@ -33,7 +33,8 @@ class JudgeResult:
         grade: Letter grade (A, B, C, D, F, or N/A for invalid)
         reasoning: Detailed explanation of the judgment
         is_valid: Whether the evaluation was successfully completed (False if agent errored)
-        criteria_scores: Individual scores for each criterion
+        criteria_scores: Individual evaluations for each criterion, each containing
+            'score' (float) and 'explanation' (str)
         raw_response: Raw LLM response for debugging
     """
 
@@ -42,7 +43,7 @@ class JudgeResult:
     grade: str
     reasoning: str
     is_valid: bool = True  # False if evaluation couldn't be completed (e.g., agent error)
-    criteria_scores: dict[str, float] | None = None
+    criteria_scores: dict[str, dict[str, Any]] | None = None
     raw_response: str | None = None
 
     def to_dict(self) -> dict[str, Any]:
@@ -206,8 +207,6 @@ def _call_claude_judge(evaluation_context: str, model: str) -> str:
         "--output-format",
         "text",
         "--dangerously-skip-permissions",
-        "--max-turns",
-        "1",
         "--system-prompt-file",
         str(JUDGE_SYSTEM_PROMPT_FILE),
         evaluation_context,

--- a/src/scylla/e2e/models.py
+++ b/src/scylla/e2e/models.py
@@ -315,7 +315,7 @@ class ExperimentConfig:
     runs_per_subtest: int = 10
     tiers_to_run: list[TierID] = field(default_factory=lambda: list(TierID))
     judge_model: str = "claude-opus-4-5-20251101"
-    tiebreaker_model: str = "gpt-4"
+    tiebreaker_model: str = "claude-opus-4-5-20251101"
     parallel_subtests: int = 4
     timeout_seconds: int = 3600
 
@@ -355,7 +355,7 @@ class ExperimentConfig:
             runs_per_subtest=data.get("runs_per_subtest", 10),
             tiers_to_run=[TierID.from_string(t) for t in data.get("tiers_to_run", [])],
             judge_model=data.get("judge_model", "claude-opus-4-5-20251101"),
-            tiebreaker_model=data.get("tiebreaker_model", "gpt-4"),
+            tiebreaker_model=data.get("tiebreaker_model", "claude-opus-4-5-20251101"),
             parallel_subtests=data.get("parallel_subtests", 4),
             timeout_seconds=data.get("timeout_seconds", 3600),
         )

--- a/src/scylla/e2e/run_report.py
+++ b/src/scylla/e2e/run_report.py
@@ -1,0 +1,255 @@
+"""Per-run markdown report generation for E2E experiments.
+
+Python Justification: Required for file I/O and string formatting.
+
+This module generates detailed markdown reports for each test run,
+providing human-readable analysis of agent performance.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+
+def generate_run_report(
+    tier_id: str,
+    subtest_id: str,
+    run_number: int,
+    score: float,
+    grade: str,
+    passed: bool,
+    reasoning: str,
+    cost_usd: float,
+    duration_seconds: float,
+    tokens_input: int,
+    tokens_output: int,
+    exit_code: int,
+    task_prompt: str,
+    workspace_path: Path,
+    criteria_scores: dict[str, dict[str, Any]] | None = None,
+    agent_output: str | None = None,
+) -> str:
+    """Generate markdown report content for a single run.
+
+    Args:
+        tier_id: Tier identifier (e.g., "T0", "T1")
+        subtest_id: Sub-test identifier (e.g., "baseline", "01")
+        run_number: Run number (1-indexed)
+        score: Overall judge score (0.0-1.0)
+        grade: Letter grade (A-F)
+        passed: Whether the run passed
+        reasoning: Judge's overall reasoning
+        cost_usd: Total cost in USD
+        duration_seconds: Execution duration
+        tokens_input: Number of input tokens
+        tokens_output: Number of output tokens
+        exit_code: Process exit code
+        task_prompt: The task prompt given to the agent
+        workspace_path: Path to the workspace directory
+        criteria_scores: Optional detailed criteria evaluations
+        agent_output: Optional truncated agent output
+
+    Returns:
+        Formatted markdown report string.
+    """
+    timestamp = datetime.now(timezone.utc).isoformat()
+    pass_status = "\u2713 PASS" if passed else "\u2717 FAIL"
+
+    lines = [
+        f"# Run Report: {tier_id}/{subtest_id}/run_{run_number:02d}",
+        "",
+        f"**Generated**: {timestamp}",
+        "",
+        "## Summary",
+        "",
+        "| Metric | Value |",
+        "|--------|-------|",
+        f"| Score | {score:.3f} |",
+        f"| Grade | {grade} |",
+        f"| Status | {pass_status} |",
+        f"| Cost | ${cost_usd:.4f} |",
+        f"| Duration | {duration_seconds:.2f}s |",
+        f"| Tokens | {tokens_input:,} in / {tokens_output:,} out |",
+        f"| Exit Code | {exit_code} |",
+        "",
+        "---",
+        "",
+        "## Task",
+        "",
+        task_prompt,
+        "",
+        "---",
+        "",
+        "## Judge Evaluation",
+        "",
+        "### Overall Assessment",
+        "",
+        reasoning,
+        "",
+    ]
+
+    # Add criteria scores if available
+    if criteria_scores:
+        lines.extend([
+            "### Criteria Scores",
+            "",
+            "| Criterion | Score | Explanation |",
+            "|-----------|-------|-------------|",
+        ])
+
+        for criterion, data in criteria_scores.items():
+            if isinstance(data, dict):
+                crit_score = data.get("score", "N/A")
+                explanation = data.get("explanation", "No explanation provided")
+                # Truncate long explanations for table, escape pipes
+                explanation_short = explanation[:100].replace("|", "\\|")
+                if len(explanation) > 100:
+                    explanation_short += "..."
+                if isinstance(crit_score, (int, float)):
+                    lines.append(f"| {criterion} | {crit_score:.2f} | {explanation_short} |")
+                else:
+                    lines.append(f"| {criterion} | {crit_score} | {explanation_short} |")
+            else:
+                # Legacy format: just a number
+                lines.append(f"| {criterion} | {data:.2f} | - |")
+
+        lines.append("")
+
+        # Add full explanations section
+        lines.extend([
+            "### Detailed Explanations",
+            "",
+        ])
+
+        for criterion, data in criteria_scores.items():
+            if isinstance(data, dict):
+                crit_score = data.get("score", "N/A")
+                explanation = data.get("explanation", "No explanation provided")
+                score_str = f"{crit_score:.2f}" if isinstance(crit_score, (int, float)) else str(crit_score)
+                lines.extend([
+                    f"#### {criterion.replace('_', ' ').title()} ({score_str})",
+                    "",
+                    explanation,
+                    "",
+                ])
+
+    # Add workspace state
+    lines.extend([
+        "---",
+        "",
+        "## Workspace State",
+        "",
+    ])
+
+    workspace_files = _get_workspace_files(workspace_path)
+    if workspace_files:
+        lines.append("Files created/modified:")
+        lines.append("")
+        for file_path in workspace_files:
+            lines.append(f"- `{file_path}`")
+        lines.append("")
+    else:
+        lines.append("No files created in workspace.")
+        lines.append("")
+
+    # Add agent output if available
+    if agent_output:
+        lines.extend([
+            "---",
+            "",
+            "## Agent Output",
+            "",
+            "```",
+            agent_output[:2000] if len(agent_output) > 2000 else agent_output,
+        ])
+        if len(agent_output) > 2000:
+            lines.append("... (truncated)")
+        lines.extend([
+            "```",
+            "",
+        ])
+
+    lines.extend([
+        "---",
+        "",
+        "*Generated by ProjectScylla E2E Framework*",
+    ])
+
+    return "\n".join(lines)
+
+
+def _get_workspace_files(workspace_path: Path) -> list[str]:
+    """Get list of files in workspace (excluding .git).
+
+    Args:
+        workspace_path: Path to workspace directory
+
+    Returns:
+        List of relative file paths.
+    """
+    files = []
+    if not workspace_path.exists():
+        return files
+
+    for item in sorted(workspace_path.rglob("*")):
+        if ".git" in item.parts:
+            continue
+        if item.is_file():
+            try:
+                rel_path = item.relative_to(workspace_path)
+                files.append(str(rel_path))
+            except ValueError:
+                pass
+
+    return files
+
+
+def save_run_report(
+    output_path: Path,
+    tier_id: str,
+    subtest_id: str,
+    run_number: int,
+    score: float,
+    grade: str,
+    passed: bool,
+    reasoning: str,
+    cost_usd: float,
+    duration_seconds: float,
+    tokens_input: int,
+    tokens_output: int,
+    exit_code: int,
+    task_prompt: str,
+    workspace_path: Path,
+    criteria_scores: dict[str, dict[str, Any]] | None = None,
+    agent_output: str | None = None,
+) -> None:
+    """Generate and save markdown report for a single run.
+
+    Args:
+        output_path: Path to save the report (e.g., logs/report.md)
+        ... (same as generate_run_report)
+    """
+    report = generate_run_report(
+        tier_id=tier_id,
+        subtest_id=subtest_id,
+        run_number=run_number,
+        score=score,
+        grade=grade,
+        passed=passed,
+        reasoning=reasoning,
+        cost_usd=cost_usd,
+        duration_seconds=duration_seconds,
+        tokens_input=tokens_input,
+        tokens_output=tokens_output,
+        exit_code=exit_code,
+        task_prompt=task_prompt,
+        workspace_path=workspace_path,
+        criteria_scores=criteria_scores,
+        agent_output=agent_output,
+    )
+
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(report)

--- a/src/scylla/e2e/runner.py
+++ b/src/scylla/e2e/runner.py
@@ -25,6 +25,7 @@ from scylla.e2e.models import (
 )
 from scylla.e2e.subtest_executor import run_tier_subtests_parallel
 from scylla.e2e.tier_manager import TierManager
+from scylla.e2e.workspace_manager import WorkspaceManager
 
 if TYPE_CHECKING:
     pass
@@ -73,6 +74,7 @@ class E2ERunner:
         self.tier_manager = TierManager(tiers_dir)
         self.results_base_dir = results_base_dir
         self.experiment_dir: Path | None = None
+        self.workspace_manager: WorkspaceManager | None = None
 
     def run(self) -> ExperimentResult:
         """Run the complete E2E experiment.
@@ -87,6 +89,14 @@ class E2ERunner:
 
         # Save configuration
         self._save_config()
+
+        # Create workspace manager and setup base repo
+        self.workspace_manager = WorkspaceManager(
+            experiment_dir=self.experiment_dir,
+            repo_url=self.config.task_repo,
+            commit=self.config.task_commit,
+        )
+        self.workspace_manager.setup_base_repo()
 
         # Run tiers
         tier_results: dict[TierID, TierResult] = {}
@@ -208,6 +218,7 @@ class E2ERunner:
             tier_id=tier_id,
             tier_config=tier_config,
             tier_manager=self.tier_manager,
+            workspace_manager=self.workspace_manager,
             baseline=baseline,
             results_dir=tier_dir,
         )

--- a/src/scylla/e2e/workspace_manager.py
+++ b/src/scylla/e2e/workspace_manager.py
@@ -1,0 +1,231 @@
+"""Workspace manager for E2E experiments using git worktrees.
+
+Python Justification: Required for subprocess orchestration and git operations.
+
+This module provides efficient workspace management by cloning a repository once
+and using git worktrees for each test run, reducing storage and network overhead.
+"""
+
+from __future__ import annotations
+
+import logging
+import subprocess
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+
+class WorkspaceManager:
+    """Manages git worktrees for experiment runs.
+
+    Instead of cloning the repository for each test run, this manager:
+    1. Clones the repo once at experiment start
+    2. Creates lightweight worktrees for each run
+    3. Shares the .git directory across all worktrees
+
+    This reduces storage by ~99% and speeds up workspace setup significantly.
+    """
+
+    def __init__(
+        self,
+        experiment_dir: Path,
+        repo_url: str,
+        commit: str | None = None,
+    ) -> None:
+        """Initialize workspace manager.
+
+        Args:
+            experiment_dir: Root directory for the experiment
+            repo_url: Git repository URL to clone
+            commit: Specific commit to checkout (optional)
+        """
+        self.experiment_dir = experiment_dir
+        self.repo_url = repo_url
+        self.commit = commit
+        self.base_repo = experiment_dir / "repo"
+        self._is_setup = False
+        self._worktree_count = 0
+
+    def setup_base_repo(self) -> None:
+        """Clone repository once at experiment start.
+
+        Creates a shallow clone with the specified commit checked out.
+        This is the single source for all worktrees.
+        """
+        if self._is_setup:
+            logger.debug("Base repo already set up")
+            return
+
+        logger.info(f"Cloning base repo to {self.base_repo}")
+
+        # Create experiment directory if needed
+        self.experiment_dir.mkdir(parents=True, exist_ok=True)
+
+        # Clone with depth=1 for efficiency
+        clone_cmd = [
+            "git",
+            "clone",
+            "--depth=1",
+            self.repo_url,
+            str(self.base_repo),
+        ]
+
+        result = subprocess.run(
+            clone_cmd,
+            capture_output=True,
+            text=True,
+        )
+
+        if result.returncode != 0:
+            raise RuntimeError(
+                f"Failed to clone repository: {result.stderr}"
+            )
+
+        # If specific commit requested, fetch and checkout
+        if self.commit:
+            self._checkout_commit()
+
+        self._is_setup = True
+        logger.info("Base repo setup complete")
+
+    def _checkout_commit(self) -> None:
+        """Fetch and checkout specific commit in base repo."""
+        # Try to fetch the specific commit
+        fetch_cmd = [
+            "git",
+            "-C",
+            str(self.base_repo),
+            "fetch",
+            "--depth=1",
+            "origin",
+            self.commit,
+        ]
+
+        result = subprocess.run(
+            fetch_cmd,
+            capture_output=True,
+            text=True,
+        )
+
+        # Fetch may fail if commit is already in shallow clone, that's ok
+        if result.returncode != 0:
+            logger.debug(f"Fetch returned non-zero (may be ok): {result.stderr}")
+
+        # Checkout the commit
+        checkout_cmd = [
+            "git",
+            "-C",
+            str(self.base_repo),
+            "checkout",
+            self.commit,
+        ]
+
+        result = subprocess.run(
+            checkout_cmd,
+            capture_output=True,
+            text=True,
+        )
+
+        if result.returncode != 0:
+            raise RuntimeError(
+                f"Failed to checkout commit {self.commit}: {result.stderr}"
+            )
+
+    def create_worktree(self, workspace_path: Path) -> None:
+        """Create a worktree for a single run.
+
+        Args:
+            workspace_path: Path where the worktree should be created
+
+        Raises:
+            RuntimeError: If base repo not set up or worktree creation fails
+        """
+        if not self._is_setup:
+            raise RuntimeError("Base repo not set up. Call setup_base_repo() first.")
+
+        # Ensure parent directory exists
+        workspace_path.parent.mkdir(parents=True, exist_ok=True)
+
+        # Generate unique branch name for this worktree
+        self._worktree_count += 1
+        branch_name = f"worktree-{self._worktree_count}"
+
+        # Create worktree with detached HEAD at the commit
+        # Using --detach to avoid branch management
+        worktree_cmd = [
+            "git",
+            "-C",
+            str(self.base_repo),
+            "worktree",
+            "add",
+            "--detach",
+            str(workspace_path),
+        ]
+
+        # Add commit reference if specified
+        if self.commit:
+            worktree_cmd.append(self.commit)
+
+        result = subprocess.run(
+            worktree_cmd,
+            capture_output=True,
+            text=True,
+        )
+
+        if result.returncode != 0:
+            raise RuntimeError(
+                f"Failed to create worktree at {workspace_path}: {result.stderr}"
+            )
+
+        logger.debug(f"Created worktree at {workspace_path}")
+
+    def cleanup_worktree(self, workspace_path: Path) -> None:
+        """Remove a worktree after run completion.
+
+        Args:
+            workspace_path: Path to the worktree to remove
+        """
+        if not workspace_path.exists():
+            return
+
+        # Remove the worktree
+        remove_cmd = [
+            "git",
+            "-C",
+            str(self.base_repo),
+            "worktree",
+            "remove",
+            "--force",
+            str(workspace_path),
+        ]
+
+        result = subprocess.run(
+            remove_cmd,
+            capture_output=True,
+            text=True,
+        )
+
+        if result.returncode != 0:
+            logger.warning(f"Failed to remove worktree: {result.stderr}")
+
+    def cleanup_all(self) -> None:
+        """Cleanup all worktrees and prune stale entries."""
+        if not self.base_repo.exists():
+            return
+
+        # Prune worktrees that no longer exist
+        prune_cmd = [
+            "git",
+            "-C",
+            str(self.base_repo),
+            "worktree",
+            "prune",
+        ]
+
+        subprocess.run(prune_cmd, capture_output=True, text=True)
+        logger.debug("Pruned stale worktrees")
+
+    @property
+    def is_setup(self) -> bool:
+        """Check if base repo is set up."""
+        return self._is_setup

--- a/tests/fixtures/tests/test-001/prompt.md
+++ b/tests/fixtures/tests/test-001/prompt.md
@@ -4,7 +4,7 @@ Create a simple Python script called `hello.py` that prints "Hello, World!" to s
 
 ## Requirements
 
-1. Create a file named `hello.py` in the current directory
+1. Create a file named `hello.py` in the current working directory (use relative path `./hello.py`, NOT an absolute path)
 2. The script should print exactly: `Hello, World!`
 3. The script should exit with code 0
 
@@ -17,6 +17,8 @@ Hello, World!
 
 ## Success Criteria
 
-- File `hello.py` exists
-- Running `python hello.py` prints "Hello, World!"
+- File `hello.py` exists in the current working directory (created with relative path)
+- Running `python hello.py` from the current directory prints "Hello, World!"
 - Exit code is 0
+
+**IMPORTANT**: Use relative paths only. Do NOT use absolute paths like `/home/...`.


### PR DESCRIPTION
## Summary

Major improvements to the E2E experiment runner for efficiency and observability.

### Git Worktrees (Single Clone)
- Clone repo once at experiment start to `repo/` directory
- Use lightweight worktrees for each run instead of full clones
- Reduces storage by ~99% (worktrees share .git directory)
- Significantly faster workspace setup

### Per-Run Markdown Reports
- New `run_report.py` generates detailed markdown reports per run
- Reports include:
  - Summary metrics table
  - Task prompt
  - Judge evaluation with overall assessment
  - Criteria scores table with explanations
  - Detailed explanations per criterion
  - Workspace file list
  - Agent output (truncated)
- Saved to `logs/report.md` for each run

### Enhanced Judge Output
- Criteria scores now include explanatory paragraphs (not just numbers)
- Removed `--max-turns 1` limit on judge for reliable evaluation
- Changed tiebreaker model from gpt-4 to claude-opus-4-5-20251101

### Test Prompt Fix
- Explicit instruction to use relative paths in test-001 prompt
- Prevents agents from creating files in wrong directory

## New Directory Structure

```
results/<timestamp>-<experiment>/
├── repo/                          # Single base clone with .git/
├── tiers/
│   └── T0/baseline/run_01/
│       ├── workspace/             # Worktree (has .git file, not directory)
│       │   └── hello.py
│       └── logs/
│           ├── report.md          # NEW: Per-run markdown report
│           ├── judgment.json
│           └── command_log.json
```

## Test Plan

- [x] Run E2E experiment with T0 and T1 tiers
- [x] Verify base repo cloned once to `repo/` directory
- [x] Verify workspaces are worktrees (have `.git` file, not directory)
- [x] Verify per-run markdown reports generated in `logs/report.md`
- [x] Verify criteria scores include explanations in judgment.json

🤖 Generated with [Claude Code](https://claude.com/claude-code)