### PR TITLE
feat(e2e): add T2+ dtype migration test case with patchfile comparison

### DIFF
--- a/config/judge/system_prompt.md
+++ b/config/judge/system_prompt.md
@@ -68,6 +68,29 @@ You are an expert evaluator for AI agent task completion. Your job is to objecti
     - Fails gracefully (no silent failures)
     - Resources cleaned up properly
 
+### Patchfile Quality Criteria (When Reference Provided)
+
+If a reference solution patch is provided, also evaluate:
+
+11. **Semantic Alignment**: Does the solution achieve the same result as the reference?
+    - Same files created/modified/deleted
+    - Similar architectural approach
+    - Equivalent functionality (not necessarily identical code)
+
+12. **Change Minimality**: Are changes focused and minimal?
+    - No unrelated modifications
+    - No scope creep
+    - Changes directly address the requirements
+
+13. **Completeness vs Reference**: How complete is the solution compared to reference?
+    - All key transformations implemented
+    - No critical files missed
+    - Edge cases covered
+
+Note: The agent's solution does NOT need to be identical to the reference. Evaluate
+whether it achieves the same semantic result. Different approaches that accomplish
+the same goal should score well if they work correctly.
+
 ## Scoring Guidelines
 
 **Score Thresholds**:

--- a/src/scylla/e2e/models.py
+++ b/src/scylla/e2e/models.py
@@ -305,6 +305,7 @@ class ExperimentConfig:
         tiebreaker_model: Model to use for tie-breaking
         parallel_subtests: Max parallel sub-tests (default: 4)
         timeout_seconds: Timeout per run in seconds
+        max_turns: Maximum conversation turns for agent (None = unlimited)
     """
 
     experiment_id: str
@@ -318,6 +319,7 @@ class ExperimentConfig:
     tiebreaker_model: str = "claude-opus-4-5-20251101"
     parallel_subtests: int = 4
     timeout_seconds: int = 3600
+    max_turns: int | None = None  # Max conversation turns for agent (None = unlimited)
 
     def to_dict(self) -> dict[str, Any]:
         """Convert to dictionary for JSON serialization."""
@@ -333,6 +335,7 @@ class ExperimentConfig:
             "tiebreaker_model": self.tiebreaker_model,
             "parallel_subtests": self.parallel_subtests,
             "timeout_seconds": self.timeout_seconds,
+            "max_turns": self.max_turns,
         }
 
     def save(self, path: Path) -> None:
@@ -358,6 +361,7 @@ class ExperimentConfig:
             tiebreaker_model=data.get("tiebreaker_model", "claude-opus-4-5-20251101"),
             parallel_subtests=data.get("parallel_subtests", 4),
             timeout_seconds=data.get("timeout_seconds", 3600),
+            max_turns=data.get("max_turns"),
         )
 
 

--- a/src/scylla/e2e/subtest_executor.py
+++ b/src/scylla/e2e/subtest_executor.py
@@ -176,12 +176,18 @@ class SubTestExecutor:
         prompt_file = logs_dir / "task_prompt.md"
         prompt_file.write_text(task_prompt)
 
+        # Build extra args for adapter
+        extra_args: list[str] = []
+        if self.config.max_turns is not None:
+            extra_args.extend(["--max-turns", str(self.config.max_turns)])
+
         adapter_config = AdapterConfig(
             model=self.config.models[0],
             prompt_file=prompt_file,
             workspace=workspace,
             output_dir=logs_dir,
             timeout=self.config.timeout_seconds,
+            extra_args=extra_args,
         )
 
         # Execute agent

--- a/tests/002-dtype-native-migration/constraints/forbidden.md
+++ b/tests/002-dtype-native-migration/constraints/forbidden.md
@@ -1,0 +1,103 @@
+# Forbidden Actions
+
+The following actions are explicitly PROHIBITED during this evaluation task.
+Violation of these constraints will result in evaluation failure.
+
+## Git History Access (FORBIDDEN)
+
+You CANNOT access the git history in any way:
+
+- `git log` - View commit history
+- `git show <commit>` - Show commit details
+- `git diff <commit>..<commit>` - Compare commits
+- `git blame` - View line-by-line history
+- `git reflog` - View reference logs
+- Any command that reveals previous commits or changes
+
+**Rationale**: The evaluation tests your ability to understand the codebase from
+its current state and implement the migration based on the provided requirements,
+not by copying the existing solution.
+
+## GitHub API Access (FORBIDDEN)
+
+You CANNOT access GitHub resources via API or CLI:
+
+- `gh issue view` - View issues
+- `gh pr view` - View pull requests
+- `gh pr diff` - Get PR diffs
+- `gh api` - Direct API calls
+- Any curl/wget to GitHub API endpoints
+- Any web searches for the solution
+
+**Rationale**: The issue and PR contain the exact solution. Accessing them would
+bypass the evaluation entirely.
+
+## Remote Git Operations (FORBIDDEN)
+
+You CANNOT perform remote git operations:
+
+- `git push` - Push to remote
+- `git branch -r` - List remote branches
+- `git fetch` (after initial clone) - Fetch remote changes
+- `gh pr create` - Create pull requests
+- Any operation that modifies the remote repository
+
+**Rationale**: Your solution must be local changes only. The evaluation system
+captures your work via `git diff HEAD`.
+
+## Commit Modification (FORBIDDEN)
+
+You CANNOT modify the initial commit state:
+
+- `git commit --amend` - Amend commits
+- `git reset` - Reset HEAD
+- `git rebase` - Rebase commits
+- `git checkout <commit>` - Checkout different commits
+
+**Rationale**: The evaluation compares your changes against the fixed base commit.
+
+## External Solution Access (FORBIDDEN)
+
+You CANNOT access external resources that contain the solution:
+
+- Web searches for "ProjectOdyssey dtype migration"
+- Stack Overflow or forum posts about this specific task
+- Any documentation that reveals the implementation details
+
+**Rationale**: This evaluation tests your ability to solve the problem, not
+find existing solutions.
+
+## Allowed Actions
+
+You CAN and SHOULD:
+
+- Read any file in the current workspace
+- Modify any file in the workspace
+- Create new files
+- Delete files
+- Run `pixi run mojo build src/` to verify compilation
+- Run `pixi run mojo test tests/` to verify tests pass
+- Run `pixi run mojo format src/` to format code
+- Use `git status` to see your changes
+- Use `git diff` (without commit args) to see unstaged changes
+- Use `git add` to stage changes (but not commit)
+
+## Enforcement
+
+The evaluation system monitors for forbidden commands. If detected:
+1. The run will be flagged as invalid
+2. The agent output will be marked as "violated constraints"
+3. No score will be assigned
+
+## Summary
+
+| Action | Status |
+|--------|--------|
+| Read/modify workspace files | ALLOWED |
+| Run mojo build/test/format | ALLOWED |
+| git status, git diff | ALLOWED |
+| git log, git show, git blame | FORBIDDEN |
+| gh issue, gh pr, gh api | FORBIDDEN |
+| git push, gh pr create | FORBIDDEN |
+| git commit, git reset | FORBIDDEN |
+| Web search for solution | FORBIDDEN |

--- a/tests/002-dtype-native-migration/expected/criteria.md
+++ b/tests/002-dtype-native-migration/expected/criteria.md
@@ -1,0 +1,122 @@
+# Success Criteria: DType Native Migration
+
+## File Requirements
+
+### New File: `shared/core/types/dtype_aliases.mojo`
+
+This file MUST exist and contain type aliases for all custom dtypes.
+
+**Required content**:
+```mojo
+# Use comptime (not alias) per Mojo best practices
+comptime BF16 = DType.bfloat16
+comptime FP8 = DType.float8_e4m3fn
+comptime BF8 = DType.float8_e5m2
+comptime FP4 = DType.float4_e2m1fn
+comptime E8M0 = DType.float8_e8m0fnu
+```
+
+### E8M0 Conversion Helpers
+
+The E8M0 format is exponent-only (8 exponent bits, 0 mantissa bits). Native Mojo
+conversion DOES NOT work correctly for this format. Manual helpers MUST be provided.
+
+**Required functions**:
+- `_e8m0_from_float32(scale: Float32) -> Scalar[E8M0]`
+- `_e8m0_to_float32(e8m0_val: Scalar[E8M0]) -> Float32`
+
+**Key implementation details**:
+- Use `bitcast` for raw bit manipulation
+- Extract exponent from Float32 bits: `((bits >> 23) & 0xFF)`
+- Round to nearest power of 2 based on mantissa
+- Handle special cases: zero, infinity, NaN
+
+### Deleted Files
+
+The following files should be DELETED:
+- Custom dtype struct implementations in `shared/core/types/`
+- Obsolete test files for old implementations
+- Any file that only existed to support the custom structs
+
+### Modified Files
+
+The following should be UPDATED:
+- `shared/core/__init__.mojo` - Export from dtype_aliases instead of individual files
+- `shared/core/types/mxfp4.mojo` - Use native types
+- `shared/core/types/nvfp4.mojo` - Use native types
+- `shared/training/dtype_utils.mojo` - Update bfloat16_dtype alias
+- CI workflow files - Remove deleted test patterns
+
+## Functional Validation
+
+### Code Compiles
+
+```bash
+pixi run mojo build src/
+# Exit code: 0
+```
+
+### All Tests Pass
+
+```bash
+pixi run mojo test tests/
+# Exit code: 0
+# All test groups pass
+```
+
+## Type Mapping Reference
+
+| Custom Type | Mojo Native DType | Purpose |
+|-------------|------------------|---------|
+| `BF16` | `DType.bfloat16` | Brain floating point (8 exp, 7 mantissa) |
+| `FP8` | `DType.float8_e4m3fn` | 8-bit float (4 exp, 3 mantissa) |
+| `BF8` | `DType.float8_e5m2` | 8-bit float (5 exp, 2 mantissa) |
+| `FP4` | `DType.float4_e2m1fn` | 4-bit float (2 exp, 1 mantissa) |
+| `E8M0` | `DType.float8_e8m0fnu` | Exponent-only scaling format |
+
+## Code Quality Checks
+
+### Use `comptime` Not `alias`
+
+```mojo
+# CORRECT
+comptime BF16 = DType.bfloat16
+
+# INCORRECT (deprecated)
+alias BF16 = DType.bfloat16
+```
+
+### Bitcast Patterns
+
+```mojo
+# Reading raw bits from native dtype
+var raw_byte = bitcast[DType.uint8, 1](scalar_val)[0]
+
+# Creating native dtype from raw bits
+var scalar_val = bitcast[FP8, 1](SIMD[DType.uint8, 1](raw_byte))
+```
+
+### Import Updates
+
+```mojo
+# shared/core/__init__.mojo should export from dtype_aliases
+from .types.dtype_aliases import BF16, FP8, BF8, FP4, E8M0
+```
+
+## Scoring Summary
+
+| Score | Criteria |
+|-------|----------|
+| 1.0 | Full migration complete, all tests pass, code quality excellent |
+| 0.8 | Migration complete with minor issues, tests pass |
+| 0.6 | Most types migrated, some tests may fail |
+| 0.4 | Partial migration, significant issues |
+| 0.0 | No meaningful progress on migration |
+
+## Forbidden Actions Reminder
+
+- NO access to git history, commits, or logs
+- NO access to GitHub issues, PRs, or API
+- NO remote git operations (push, branch, PR)
+- NO modification of the initial commit
+- Local file changes ONLY

--- a/tests/002-dtype-native-migration/expected/reference/METADATA.yaml
+++ b/tests/002-dtype-native-migration/expected/reference/METADATA.yaml
@@ -1,0 +1,78 @@
+# Reference Solution Metadata
+
+source:
+  repository: "https://github.com/mvillmow/ProjectOdyssey"
+  pull_request: 3017
+  issue: 3012
+  title: "refactor(types)!: migrate custom dtypes to Mojo built-in types"
+
+commits:
+  base: "68a608896097f0b519ac2a410c7d6d645f921439"
+  head: "HEAD of PR #3017"
+
+summary: |
+  Migrates all custom dtype struct implementations to Mojo's native built-in types.
+  This is a breaking change that replaces ~5000 lines of custom code with native types
+  while maintaining backward compatibility through type aliases.
+
+type_mappings:
+  - old: "BF16 struct"
+    new: "DType.bfloat16"
+    alias: "BF16"
+
+  - old: "FP8 struct"
+    new: "DType.float8_e4m3fn"
+    alias: "FP8"
+
+  - old: "BF8 struct"
+    new: "DType.float8_e5m2"
+    alias: "BF8"
+
+  - old: "FP4_E2M1 struct"
+    new: "DType.float4_e2m1fn"
+    alias: "FP4"
+
+  - old: "E8M0Scale struct"
+    new: "DType.float8_e8m0fnu"
+    alias: "E8M0"
+
+key_changes:
+  new_files:
+    - "shared/core/types/dtype_aliases.mojo"
+
+  deleted_files:
+    - "shared/core/types/bf16.mojo"
+    - "shared/core/types/fp8.mojo"
+    - "shared/core/types/bf8.mojo"
+    - "shared/core/types/fp4.mojo"
+    - "tests/shared/core/types/test_bf16.mojo"
+    - "tests/shared/core/types/test_fp8.mojo"
+    - "tests/shared/core/types/test_bf8.mojo"
+    - "tests/shared/core/types/test_fp4.mojo"
+
+  modified_files:
+    - "shared/core/__init__.mojo"
+    - "shared/core/types/mxfp4.mojo"
+    - "shared/core/types/nvfp4.mojo"
+    - "shared/training/dtype_utils.mojo"
+    - ".github/workflows/comprehensive-tests.yml"
+
+critical_patterns:
+  - pattern: "Use comptime not alias"
+    example: "comptime BF16 = DType.bfloat16"
+
+  - pattern: "E8M0 requires manual conversion"
+    reason: "Exponent-only format not handled by native conversion"
+
+  - pattern: "Bitcast for raw byte access"
+    example: "bitcast[DType.uint8, 1](scalar_val)[0]"
+
+test_results:
+  passed: true
+  total_groups: 33
+  duration_seconds: 1034
+
+lines_changed:
+  added: 750
+  removed: 5000
+  net: -4250

--- a/tests/002-dtype-native-migration/expected/reference/reference.patch
+++ b/tests/002-dtype-native-migration/expected/reference/reference.patch
@@ -1,0 +1,8211 @@
+diff --git a/.github/workflows/comprehensive-tests.yml b/.github/workflows/comprehensive-tests.yml
+index bcf08a223..f371db086 100644
+--- a/.github/workflows/comprehensive-tests.yml
++++ b/.github/workflows/comprehensive-tests.yml
+@@ -198,7 +198,7 @@ jobs:
+             pattern: "test_losses.mojo test_loss_funcs.mojo test_loss_utils.mojo"
+           - name: "Core DTypes"
+             path: "tests/shared/core"
+-            pattern: "test_bf8.mojo test_bfloat16.mojo test_fp4.mojo test_fp8.mojo test_mxfp4.mojo test_nvfp4.mojo test_unsigned.mojo test_dtype_dispatch.mojo test_dtype_ordinal.mojo"
++            pattern: "test_unsigned.mojo test_dtype_dispatch.mojo test_dtype_ordinal.mojo"
+           - name: "Core Gradient"
+             path: "tests/shared/core"
+             pattern: "test_backward.mojo test_backward_compat_aliases.mojo test_gradient_checking.mojo test_gradient_numerical_stability.mojo test_gradient_validation.mojo test_variable_backward.mojo"
+diff --git a/examples/alexnet-cifar10/train.mojo b/examples/alexnet-cifar10/train.mojo
+index 4d39196bc..7cf02d913 100644
+--- a/examples/alexnet-cifar10/train.mojo
++++ b/examples/alexnet-cifar10/train.mojo
+@@ -431,12 +431,12 @@ fn evaluate(
+ 
+     print("Evaluating...")
+ 
+-    # Tensor slicing is now implemented (Issue #3013)
+-    # Process in batches for better efficiency
++    # TODO(#3013): Process in batches when slicing is implemented
++    # For now, evaluate on first 100 samples
+     var eval_samples = min(100, num_samples)
+ 
+     for i in range(eval_samples):
+-        # Tensor slicing works via slice() or __getitem__()
++        # TODO(#3013): Extract single sample when slicing works
+         # For demonstration, we'll use the first image repeatedly
+         var pred_class = model.predict(test_images)
+         var true_label = Int(test_labels[i])
+diff --git a/shared/__init__.mojo b/shared/__init__.mojo
+index 42515e19d..0a6529d8f 100644
+--- a/shared/__init__.mojo
++++ b/shared/__init__.mojo
+@@ -38,20 +38,20 @@ Example:
+         print("Epoch", epoch, "Loss:", loss)
+     ```
+ 
+-RESOLVED(#3010): All packaging integration tests in tests/shared/integration/test_packaging.mojo
+-now use actual implemented imports and verify real functionality:
+-- test_subpackage_accessibility: Verified all subpackages (core, training, data, utils) importable
+-- test_root_level_imports: ExTensor, SGD, Logger imports work
+-- test_module_level_imports: Verified core, training, data module imports work
+-- test_nested_imports: Verified nested operation imports (linear, conv2d, etc.)
+-- test_core_training_integration: Verified core ExTensor works with SGD optimizer
+-- test_core_data_integration: Verified ExTensor works with ExTensorDataset
+-- test_training_data_integration: Verified training components work with datasets
+-- test_complete_training_workflow: Verified complete workflow with all modules
+-- test_paper_implementation_pattern: Verified typical paper implementation pattern
+-- test_no_private_exports: Updated for Mojo v0.26.1 limitations
+-- test_deprecated_imports: No deprecated APIs yet
+-See Issue #3010 for implementation details
++FIXME(#3010): Placeholder tests in tests/shared/integration/test_packaging.mojo require:
++- test_subpackage_accessibility (line 28)
++- test_root_level_imports (line 49)
++- test_module_level_imports (line 65)
++- test_nested_imports (line 74)
++- test_core_training_integration (line 88)
++- test_core_data_integration (line 108)
++- test_training_data_integration (line 124)
++- test_complete_training_workflow (line 145)
++- test_paper_implementation_pattern (line 181)
++- test_public_api_exports (line 218)
++- test_no_private_exports (line 237)
++- test_deprecated_imports (line 254)
++See Issue #49 for details
+ """
+ 
+ # Package version
+diff --git a/shared/autograd/tape.mojo b/shared/autograd/tape.mojo
+index 7764713ba..dd9996788 100644
+--- a/shared/autograd/tape.mojo
++++ b/shared/autograd/tape.mojo
+@@ -338,7 +338,7 @@ struct NoGradContext(Copyable, Movable):
+ 
+     WARNING: This is currently a stub implementation that does not function.
+     The full context manager is blocked by Mojo's UnsafePointer limitation
+-    (parametric mutability not yet supported). See issue #2400.
++    (parametric mutability not yet supported). See issue #3014.
+ 
+     Workaround: Manually manage gradient tracking with requires_grad=False
+     on Variables that shouldn't track gradients. Alternatively, use
+@@ -370,10 +370,10 @@ struct NoGradContext(Copyable, Movable):
+ 
+     fn __enter__(mut self) -> None:
+         """Enter no-grad context (disable gradient tracking)."""
+-        # TODO(#2400): Implement gradient tracking disable
++        # TODO(#3014): Implement gradient tracking disable
+         pass
+ 
+     fn __exit__(mut self) -> None:
+         """Exit no-grad context (restore gradient tracking)."""
+-        # TODO(#2400): Implement gradient tracking restore
++        # TODO(#3014): Implement gradient tracking restore
+         pass
+diff --git a/shared/core/__init__.mojo b/shared/core/__init__.mojo
+index c452e21e6..71110f6b6 100644
+--- a/shared/core/__init__.mojo
++++ b/shared/core/__init__.mojo
+@@ -13,7 +13,7 @@ Architecture:
+ 
+ Modules:
+     extensor: Core tensor type and creation functions
+-    types: Custom data types (FP8 for E4M3, BF8 for E5M2 8-bit floating point)
++    types: Custom data types (type aliases for FP8/BF8/BF16/FP4, MXFP4/NVFP4 blocked formats)
+     arithmetic: Element-wise arithmetic operations (add, subtract, multiply, divide)
+     matrix: Matrix operations (matmul, transpose, dot, outer)
+     activation: Activation functions (relu, sigmoid, tanh, softmax, gelu)
+@@ -52,12 +52,13 @@ Example:
+     var a1 = relu(h1)
+     ```
+ 
+-RESOLVED(#3010): All core import tests in tests/shared/test_imports.mojo now use
+-actual implemented imports from this module:
+-- test_core_imports (line 17-23): ExTensor, zeros, ones, randn, relu, sigmoid, tanh, softmax, gelu
+-- test_core_layers_imports (line 26-31): linear, conv2d, flatten, pool2d_max, pool2d_avg
+-- test_core_activations_imports (line 34-49): All activation functions
+-- test_core_types_imports (line 52-56): ExTensor, FP8, BF8
++FIXME(#3010): Placeholder import tests in tests/shared/test_imports.mojo require:
++- test_core_imports (line 17)
++- test_core_layers_imports (line 31)
++- test_core_activations_imports (line 46)
++- test_core_types_imports (line 60)
++All tests marked as "(placeholder - awaiting implementation)" and require module
++imports to be uncommented as Issue #49 progresses. See Issue #49 for details
+ """
+ 
+ # Package version
+@@ -195,11 +196,10 @@ from shared.core.shape import (
+ )
+ 
+ # ============================================================================
+-# Custom Data Types
++# Custom Data Types (Type Aliases)
+ # ============================================================================
+ 
+-from shared.core.types.fp8 import FP8
+-from shared.core.types.bf8 import BF8
++from shared.core.types.dtype_aliases import BF16, FP8, BF8, FP4, E8M0
+ 
+ # ============================================================================
+ # Gradient Container Types
+diff --git a/shared/core/bfloat16.mojo b/shared/core/bfloat16.mojo
+deleted file mode 100644
+index 104807007..000000000
+--- a/shared/core/bfloat16.mojo
++++ /dev/null
+@@ -1,461 +0,0 @@
+-"""BFloat16 (Brain Floating Point) implementation.
+-
+-Implements BFloat16 data type with uint16 storage and proper IEEE 754-like
+-bit manipulation. BFloat16 uses the same exponent bits as Float32 but with
+-reduced mantissa precision, making it ideal for deep learning workloads.
+-
+-BFloat16 Format (16 bits):
+-- 1 sign bit
+-- 8 exponent bits (same as Float32)
+-- 7 mantissa bits (vs 23 in Float32, 10 in Float16)
+-
+-Benefits:
+-- Same range as Float32 (~1e-38 to 3.4e38)
+-- Half the memory of Float32
+-- Simpler conversion to/from Float32 (truncation)
+-- Better for training than Float16 (wider range, less overflow)
+-
+-Usage:
+-    var bf16 = BFloat16.from_float32(3.14159)
+-    var f32 = bf16.to_float32()
+-    print(bf16)  # BFloat16(3.140625)
+-"""
+-
+-from memory import bitcast
+-from math import isnan, isinf
+-
+-
+-@register_passable("trivial")
+-struct BFloat16:
+-    """BFloat16 (Brain Floating Point) data type.
+-
+-    Stores value as uint16 with proper bit layout:
+-    - Bit 15: Sign
+-    - Bits 14-7: Exponent (8 bits)
+-    - Bits 6-0: Mantissa (7 bits)
+-
+-    This matches Float32 exponent but with truncated mantissa,
+-    enabling simple conversion: truncate Float32's lower 16 bits.
+-
+-    Attributes:
+-        bits: uint16 storage for BF16 representation.
+-    """
+-
+-    var bits: UInt16
+-
+-    # ========================================================================
+-    # Constructors
+-    # ========================================================================
+-
+-    fn __init__(out self):
+-        """Initialize BFloat16 to zero."""
+-        self.bits = 0
+-
+-    fn __init__(out self, bits: UInt16):
+-        """Initialize BFloat16 from raw bits.
+-
+-        Args:
+-            bits: Raw uint16 bit representation.
+-        """
+-        self.bits = bits
+-
+-    # ========================================================================
+-    # Conversion from Float32
+-    # ========================================================================
+-
+-    @staticmethod
+-    @always_inline
+-    fn from_float32(value: Float32) -> BFloat16:
+-        """Convert Float32 to BFloat16 using rounding.
+-
+-        Uses round-to-nearest-even (RNE) for proper IEEE 754 rounding.
+-        This is the recommended conversion method.
+-
+-        Args:
+-            value: Float32 value to convert.
+-
+-        Returns:
+-            BFloat16 representation.
+-
+-        Example:
+-        ```mojo
+-        var bf16 = BFloat16.from_float32(3.14159)
+-        ```
+-        """
+-        # Handle special cases
+-        if isnan(value):
+-            return BFloat16._nan()
+-        if isinf(value):
+-            return BFloat16._inf() if value > 0 else BFloat16._neg_inf()
+-
+-        # Get bit representation of Float32 using SIMD bitcast
+-        var bits32 = bitcast[DType.uint32, 1](SIMD[DType.float32, 1](value))[0]
+-
+-        # Extract components from Float32 (32 bits)
+-        # Float32: [sign:1][exponent:8][mantissa:23]
+-        var sign_bit = (bits32 >> 31) & 0x1
+-        var exponent = (bits32 >> 23) & 0xFF
+-        var mantissa23 = bits32 & 0x7FFFFF
+-
+-        # Round to nearest even (RNE)
+-        # BF16 keeps bits 31-16, so bit 15 is the rounding bit, bits 14-0 are sticky
+-        var rounding_bit = (bits32 >> 15) & 0x1
+-        var sticky_bits = bits32 & 0x7FFF
+-
+-        # Extract top 7 bits of mantissa for BF16
+-        var mantissa7 = (mantissa23 >> 16) & 0x7F
+-
+-        # Apply rounding: round up if rounding bit is 1 AND
+-        # (sticky bits != 0 OR mantissa7 is odd - for round-to-even)
+-        if rounding_bit == 1:
+-            if sticky_bits != 0 or (mantissa7 & 0x1) == 1:
+-                mantissa7 += 1
+-                # Handle mantissa overflow
+-                if mantissa7 > 0x7F:
+-                    mantissa7 = 0
+-                    exponent += 1
+-                    # Handle exponent overflow (infinity)
+-                    if exponent > 0xFF:
+-                        return (
+-                            BFloat16._inf() if sign_bit
+-                            == 0 else BFloat16._neg_inf()
+-                        )
+-
+-        # Combine into BFloat16 format: [sign:1][exponent:8][mantissa:7]
+-        var bits16 = UInt16((sign_bit << 15) | (exponent << 7) | mantissa7)
+-
+-        return BFloat16(bits16)
+-
+-    @staticmethod
+-    @always_inline
+-    fn from_float32_truncate(value: Float32) -> BFloat16:
+-        """Convert Float32 to BFloat16 using simple truncation.
+-
+-        Faster than rounding but less accurate. Use only when performance
+-        is critical and slight accuracy loss is acceptable.
+-
+-        Args:
+-            value: Float32 value to convert.
+-
+-        Returns:
+-            BFloat16 representation.
+-
+-        Example:
+-        ```mojo
+-            var bf16 = BFloat16.from_float32_truncate(3.14159)
+-        ```
+-        """
+-        # Get bit representation using SIMD bitcast
+-        var bits32 = bitcast[DType.uint32, 1](SIMD[DType.float32, 1](value))[0]
+-
+-        # Simply take upper 16 bits (truncate lower 16)
+-        var bits16 = UInt16(bits32 >> 16)
+-
+-        return BFloat16(bits16)
+-
+-    # ========================================================================
+-    # Conversion to Float32
+-    # ========================================================================
+-
+-    @always_inline
+-    fn to_float32(self) -> Float32:
+-        """Convert BFloat16 to Float32.
+-
+-        Conversion is exact (no rounding needed) since we're expanding
+-        mantissa bits (7 -> 23) by zero-padding.
+-
+-        Returns:
+-            Float32 representation.
+-
+-        Example:
+-        ```mojo
+-            var f32 = bf16.to_float32()
+-        ```
+-        """
+-        # BFloat16 to Float32 is simple: extend to 32 bits by shifting left 16
+-        # BF16: [sign:1][exponent:8][mantissa:7]
+-        # FP32: [sign:1][exponent:8][mantissa:23]
+-        #
+-        # We just zero-pad the lower 16 bits of mantissa
+-        var bits32 = UInt32(self.bits) << 16
+-
+-        # Convert bits to Float32 using SIMD bitcast
+-        var result = bitcast[DType.float32, 1](SIMD[DType.uint32, 1](bits32))[0]
+-
+-        return result
+-
+-    fn to_float64(self) -> Float64:
+-        """Convert BFloat16 to Float64.
+-
+-        Goes through Float32 conversion first.
+-
+-        Returns:
+-            Float64 representation.
+-        """
+-        return Float64(self.to_float32())
+-
+-    # ========================================================================
+-    # Special Values
+-    # ========================================================================
+-
+-    @staticmethod
+-    fn _zero() -> BFloat16:
+-        """Create BFloat16 zero."""
+-        return BFloat16(0x0000)
+-
+-    @staticmethod
+-    fn _neg_zero() -> BFloat16:
+-        """Create BFloat16 negative zero."""
+-        return BFloat16(0x8000)
+-
+-    @staticmethod
+-    fn _inf() -> BFloat16:
+-        """Create BFloat16 positive infinity."""
+-        return BFloat16(0x7F80)
+-
+-    @staticmethod
+-    fn _neg_inf() -> BFloat16:
+-        """Create BFloat16 negative infinity."""
+-        return BFloat16(0xFF80)
+-
+-    @staticmethod
+-    fn _nan() -> BFloat16:
+-        """Create BFloat16 NaN."""
+-        return BFloat16(0x7FC0)
+-
+-    fn is_nan(self) -> Bool:
+-        """Check if value is NaN.
+-
+-        Returns:
+-            True if NaN, False otherwise.
+-        """
+-        # NaN: exponent = 0xFF, mantissa != 0
+-        var exponent = (self.bits >> 7) & 0xFF
+-        var mantissa = self.bits & 0x7F
+-        return exponent == 0xFF and mantissa != 0
+-
+-    fn is_inf(self) -> Bool:
+-        """Check if value is infinity (positive or negative).
+-
+-        Returns:
+-            True if infinity, False otherwise.
+-        """
+-        # Inf: exponent = 0xFF, mantissa = 0
+-        var exponent = (self.bits >> 7) & 0xFF
+-        var mantissa = self.bits & 0x7F
+-        return exponent == 0xFF and mantissa == 0
+-
+-    fn is_finite(self) -> Bool:
+-        """Check if value is finite (not NaN or infinity).
+-
+-        Returns:
+-            True if finite, False otherwise.
+-        """
+-        return not (self.is_nan() or self.is_inf())
+-
+-    # ========================================================================
+-    # Arithmetic Operations (via Float32)
+-    # ========================================================================
+-
+-    fn __add__(self, other: BFloat16) -> BFloat16:
+-        """Add two BFloat16 values.
+-
+-        Args:
+-            other: Value to add.
+-
+-        Returns:
+-            Sum as BFloat16.
+-        """
+-        var a = self.to_float32()
+-        var b = other.to_float32()
+-        return BFloat16.from_float32(a + b)
+-
+-    fn __sub__(self, other: BFloat16) -> BFloat16:
+-        """Subtract two BFloat16 values.
+-
+-        Args:
+-            other: Value to subtract.
+-
+-        Returns:
+-            Difference as BFloat16.
+-        """
+-        var a = self.to_float32()
+-        var b = other.to_float32()
+-        return BFloat16.from_float32(a - b)
+-
+-    fn __mul__(self, other: BFloat16) -> BFloat16:
+-        """Multiply two BFloat16 values.
+-
+-        Args:
+-            other: Value to multiply.
+-
+-        Returns:
+-            Product as BFloat16.
+-        """
+-        var a = self.to_float32()
+-        var b = other.to_float32()
+-        return BFloat16.from_float32(a * b)
+-
+-    fn __truediv__(self, other: BFloat16) -> BFloat16:
+-        """Divide two BFloat16 values.
+-
+-        Args:
+-            other: Divisor.
+-
+-        Returns:
+-            Quotient as BFloat16.
+-        """
+-        var a = self.to_float32()
+-        var b = other.to_float32()
+-        return BFloat16.from_float32(a / b)
+-
+-    fn __neg__(self) -> BFloat16:
+-        """Negate BFloat16 value.
+-
+-        Returns:
+-            Negated value.
+-        """
+-        # Flip sign bit
+-        return BFloat16(self.bits ^ 0x8000)
+-
+-    # ========================================================================
+-    # Comparison Operations
+-    # ========================================================================
+-
+-    fn __eq__(self, other: BFloat16) -> Bool:
+-        """Check equality.
+-
+-        Args:
+-            other: Value to compare.
+-
+-        Returns:
+-            True if equal.
+-        """
+-        # NaN != NaN
+-        if self.is_nan() or other.is_nan():
+-            return False
+-        return self.bits == other.bits
+-
+-    fn __ne__(self, other: BFloat16) -> Bool:
+-        """Check inequality.
+-
+-        Args:
+-            other: Value to compare.
+-
+-        Returns:
+-            True if not equal.
+-        """
+-        return not (self == other)
+-
+-    fn __lt__(self, other: BFloat16) -> Bool:
+-        """Check less than.
+-
+-        Args:
+-            other: Value to compare.
+-
+-        Returns:
+-            True if self < other.
+-        """
+-        return self.to_float32() < other.to_float32()
+-
+-    fn __le__(self, other: BFloat16) -> Bool:
+-        """Check less than or equal.
+-
+-        Args:
+-            other: Value to compare.
+-
+-        Returns:
+-            True if self <= other.
+-        """
+-        return self.to_float32() <= other.to_float32()
+-
+-    fn __gt__(self, other: BFloat16) -> Bool:
+-        """Check greater than.
+-
+-        Args:
+-            other: Value to compare.
+-
+-        Returns:
+-            True if self > other.
+-        """
+-        return self.to_float32() > other.to_float32()
+-
+-    fn __ge__(self, other: BFloat16) -> Bool:
+-        """Check greater than or equal.
+-
+-        Args:
+-            other: Value to compare.
+-
+-        Returns:
+-            True if self >= other.
+-        """
+-        return self.to_float32() >= other.to_float32()
+-
+-    # ========================================================================
+-    # String Representation
+-    # ========================================================================
+-
+-    fn __str__(self) -> String:
+-        """Convert to string.
+-
+-        Returns:
+-            String representation.
+-        """
+-        return "BFloat16(" + String(self.to_float32()) + ")"
+-
+-    fn __repr__(self) -> String:
+-        """Get representation string.
+-
+-        Returns:
+-            Representation string.
+-        """
+-        return self.__str__()
+-
+-
+-# ============================================================================
+-# Utility Functions
+-# ============================================================================
+-
+-
+-fn print_bfloat16_bits(value: BFloat16):
+-    """Print BFloat16 value and its bit representation.
+-
+-    Shows sign, exponent, and mantissa bits for debugging.
+-
+-    Args:
+-        value: BFloat16 value to print.
+-
+-    Example:
+-        ```mojo
+-        var bf16 = BFloat16.from_float32(3.14159)
+-        print_bfloat16_bits(bf16)
+-        # Output:
+-        # BFloat16: 3.140625
+-        # Bits: 0100000010010010
+-        # Sign: 0, Exponent: 10000000 (128), Mantissa: 1001001
+-        ```
+-    """
+-    print("BFloat16: " + String(value.to_float32()))
+-
+-    # Print binary representation
+-    var bits = value.bits
+-    var binary = String("")
+-    for i in range(15, -1, -1):
+-        var bit = (bits >> i) & 0x1
+-        binary += String(bit)
+-
+-    print("Bits: " + binary)
+-
+-    # Decode components
+-    var sign = (bits >> 15) & 0x1
+-    var exponent = (bits >> 7) & 0xFF
+-    var mantissa = bits & 0x7F
+-
+-    print(
+-        "Sign: "
+-        + String(sign)
+-        + ", Exponent: "
+-        + String(exponent)
+-        + ", Mantissa: "
+-        + String(mantissa)
+-    )
+diff --git a/shared/core/dtype_cast.mojo b/shared/core/dtype_cast.mojo
+index ffbc5ada0..7e6043bbf 100644
+--- a/shared/core/dtype_cast.mojo
++++ b/shared/core/dtype_cast.mojo
+@@ -5,7 +5,8 @@ for common conversions (FP32 <-> FP16, FP32 <-> BF16).
+ """
+ 
+ from shared.core.extensor import ExTensor
+-from shared.core.bfloat16 import BFloat16
++from shared.core.types.dtype_aliases import BF16
++from memory import bitcast
+ 
+ 
+ fn cast_tensor(tensor: ExTensor, target_dtype: DType) raises -> ExTensor:
+@@ -94,16 +95,16 @@ fn cast_tensor(tensor: ExTensor, target_dtype: DType) raises -> ExTensor:
+ 
+ 
+ fn cast_to_bfloat16(tensor: ExTensor) raises -> ExTensor:
+-    """Convert tensor to BFloat16 storage (stored as uint16).
++    """Convert tensor to BF16 storage (stored as uint16).
+ 
+-    Creates new tensor with BFloat16 values stored as uint16.
++    Creates new tensor with BF16 values stored as uint16.
+     Use this for storing model parameters in BF16 format.
+ 
+     Args:
+         tensor: Source tensor (any floating point dtype).
+ 
+     Returns:
+-        Tensor with uint16 storage containing BFloat16 values.
++        Tensor with uint16 storage containing BF16 values.
+ 
+     Raises:
+         Error: If tensor is empty.
+@@ -116,17 +117,19 @@ fn cast_to_bfloat16(tensor: ExTensor) raises -> ExTensor:
+         ```
+     """
+     if tensor._numel == 0:
+-        raise Error("Cannot convert empty tensor to BFloat16")
++        raise Error("Cannot convert empty tensor to BF16")
+ 
+     # Create uint16 tensor for BF16 storage
+     var result = ExTensor(tensor.shape(), DType.uint16)
+     var size = tensor._numel
+ 
+-    # Convert each element
++    # Convert each element using native SIMD conversion
+     for i in range(size):
+         var f32_val = Float32(tensor._get_float64(i))
+-        var bf16_val = BFloat16.from_float32(f32_val)
+-        result._data.bitcast[UInt16]()[i] = bf16_val.bits
++        # Convert to bfloat16 using native SIMD, then bitcast to uint16 for storage
++        var bf16_val = SIMD[BF16, 1](f32_val)
++        var bf16_bits = bitcast[DType.uint16, 1](bf16_val)[0]
++        result._data.bitcast[UInt16]()[i] = bf16_bits
+ 
+     return result
+ 
+@@ -134,12 +137,12 @@ fn cast_to_bfloat16(tensor: ExTensor) raises -> ExTensor:
+ fn cast_from_bfloat16(
+     tensor: ExTensor, target_dtype: DType = DType.float32
+ ) raises -> ExTensor:
+-    """Convert tensor from BFloat16 storage to floating point.
++    """Convert tensor from BF16 storage to floating point.
+ 
+-    Assumes input tensor stores BFloat16 values as uint16.
++    Assumes input tensor stores BF16 values as uint16.
+ 
+     Args:
+-        tensor: Source tensor with uint16 BFloat16 storage.
++        tensor: Source tensor with uint16 BF16 storage.
+         target_dtype: Target floating point dtype (default: float32).
+ 
+     Returns:
+@@ -156,7 +159,7 @@ fn cast_from_bfloat16(
+     """
+     if tensor.dtype() != DType.uint16:
+         raise Error(
+-            "Expected uint16 tensor for BFloat16 storage, got: "
++            "Expected uint16 tensor for BF16 storage, got: "
+             + String(tensor.dtype())
+         )
+ 
+@@ -170,11 +173,12 @@ fn cast_from_bfloat16(
+     var result = ExTensor(tensor.shape(), target_dtype)
+     var size = tensor._numel
+ 
+-    # Convert each element
++    # Convert each element using native SIMD conversion
+     for i in range(size):
+         var bf16_bits = tensor._data.bitcast[UInt16]()[i]
+-        var bf16_val = BFloat16(bf16_bits)
+-        var f32_val = bf16_val.to_float32()
++        # Bitcast uint16 to bfloat16, then convert to float32
++        var bf16_val = bitcast[BF16, 1](SIMD[DType.uint16, 1](bf16_bits))
++        var f32_val = Float32(bf16_val[0])
+ 
+         if target_dtype == DType.float32:
+             result._data.bitcast[Float32]()[i] = f32_val
+@@ -238,6 +242,7 @@ fn is_floating_dtype(dtype: DType) -> Bool:
+         dtype == DType.float16
+         or dtype == DType.float32
+         or dtype == DType.float64
++        or dtype == DType.bfloat16
+     )
+ 
+ 
+diff --git a/shared/core/dtype_dispatch.mojo b/shared/core/dtype_dispatch.mojo
+index dc6df7bb9..fa1db4737 100644
+--- a/shared/core/dtype_dispatch.mojo
++++ b/shared/core/dtype_dispatch.mojo
+@@ -18,7 +18,7 @@ Supported Dtypes:
+ - Float64 (FP64) ✓ - High precision
+ - Int8, Int16, Int32, Int64 ✓ - Integer types
+ - UInt8, UInt16, UInt32, UInt64 ✓ - Unsigned integer types
+-- BFloat16 (BF16) ⚠ - Not yet available in Mojo (add when supported)
++- BF16 ⚠ - Not yet available in Mojo (add when supported)
+ 
+ Example usage:
+     # Before (40+ lines):
+diff --git a/shared/core/extensor.mojo b/shared/core/extensor.mojo
+index 4500ca94c..6619296c5 100644
+--- a/shared/core/extensor.mojo
++++ b/shared/core/extensor.mojo
+@@ -20,18 +20,18 @@ Array API Categories:
+ - Arithmetic: add, subtract, multiply, divide, floor_divide, modulo, power ✓
+ - Comparison: equal, not_equal, less, less_equal, greater, greater_equal ✓
+ - Reduction: sum, mean, max, min (all-elements only) ✓
+-- Matrix: matmul, transpose, dot, outer, inner, tensordot ✓
+-- Shape manipulation: reshape, squeeze, unsqueeze, concatenate, stack, tile, repeat, broadcast_to, permute ✓
+-- Broadcasting: Full support for different-shape operations ✓
+-- Element-wise math: exp, log, sqrt, sin, cos, tanh, ceil, floor, round, abs, sign ✓
+-- Statistical: var, std, median, percentile ✓
+-- Indexing: slicing, advanced indexing ✓
++- Matrix: matmul, transpose, dot, outer (TODO(#3013))
++- Shape manipulation: reshape, squeeze, unsqueeze, concatenate (TODO(#3013))
++- Broadcasting: Full support for different-shape operations (TODO(#3013))
++- Element-wise math: exp, log, sqrt, sin, cos, tanh (TODO(#3013))
++- Statistical: var, std, median, percentile (TODO(#3013))
++- Indexing: slicing, advanced indexing (TODO(#3013))
+ 
+ Reference: https://data-apis.org/array-api/latest/API_specification/index.html
+ """
+ 
+ from collections import List
+-from memory import UnsafePointer, memset_zero, alloc
++from memory import UnsafePointer, memset_zero, alloc, bitcast
+ from sys.info import simd_width_of
+ from math import ceildiv, sqrt, log, cos, sin
+ from utils.numerics import inf as numeric_inf, neg_inf as numeric_neg_inf
+@@ -1349,7 +1349,8 @@ struct ExTensor(Copyable, ImplicitlyCopyable, Movable, Sized):
+             are clamped. This is useful for memory-efficient training/inference.
+             FP16 inputs are converted to FP32 before quantization.
+         """
+-        from shared.core.types.fp8 import FP8
++        from shared.core.types.dtype_aliases import FP8
++        from memory import bitcast
+ 
+         # Verify source is floating point
+         if not (
+@@ -1381,9 +1382,10 @@ struct ExTensor(Copyable, ImplicitlyCopyable, Movable, Sized):
+                 # Defensive re-validation (fixes DATA-003)
+                 raise Error("Invalid dtype for FP8 conversion")
+ 
+-            # Convert to FP8 and store
+-            var fp8_val = FP8.from_float32(val)
+-            result._data.bitcast[UInt8]()[i] = fp8_val.value
++            # Convert to FP8 using native SIMD and store as uint8
++            var fp8_val = SIMD[FP8, 1](val)
++            var fp8_bits = bitcast[DType.uint8, 1](fp8_val)[0]
++            result._data.bitcast[UInt8]()[i] = fp8_bits
+ 
+         return result^
+ 
+@@ -1407,7 +1409,8 @@ struct ExTensor(Copyable, ImplicitlyCopyable, Movable, Sized):
+             This assumes the uint8 tensor contains valid FP8 E4M3 encoded values.
+             Use this to decode tensors created by to_fp8().
+         """
+-        from shared.core.types.fp8 import FP8
++        from shared.core.types.dtype_aliases import FP8
++        from memory import bitcast
+ 
+         # Verify source is uint8
+         if self._dtype != DType.uint8:
+@@ -1416,11 +1419,12 @@ struct ExTensor(Copyable, ImplicitlyCopyable, Movable, Sized):
+         # Create output tensor with float32 dtype
+         var result = ExTensor(self._shape, DType.float32)
+ 
+-        # Convert each element from FP8 to Float32
++        # Convert each element from FP8 to Float32 using native SIMD
+         for i in range(self._numel):
+             var fp8_bits = self._data.bitcast[UInt8]()[i]
+-            var fp8_val = FP8(fp8_bits)
+-            var float_val = fp8_val.to_float32()
++            # Bitcast uint8 to FP8, then convert to float32
++            var fp8_val = bitcast[FP8, 1](SIMD[DType.uint8, 1](fp8_bits))
++            var float_val = Float32(fp8_val[0])
+             result._data.bitcast[Float32]()[i] = float_val
+ 
+         return result^
+@@ -1900,7 +1904,8 @@ struct ExTensor(Copyable, ImplicitlyCopyable, Movable, Sized):
+             training/inference where range is more important than precision.
+             FP16 inputs are converted to FP32 before quantization.
+         """
+-        from shared.core.types.bf8 import BF8
++        from shared.core.types.dtype_aliases import BF8
++        from memory import bitcast
+ 
+         # Verify source is floating point
+         if not (
+@@ -1928,8 +1933,10 @@ struct ExTensor(Copyable, ImplicitlyCopyable, Movable, Sized):
+             else:
+                 raise Error("Invalid dtype for BF8 conversion")
+ 
+-            var bf8_val = BF8.from_float32(val)
+-            result._data.bitcast[UInt8]()[i] = bf8_val.value
++            # Convert to BF8 using native SIMD and store as uint8
++            var bf8_val = SIMD[BF8, 1](val)
++            var bf8_bits = bitcast[DType.uint8, 1](bf8_val)[0]
++            result._data.bitcast[UInt8]()[i] = bf8_bits
+ 
+         return result^
+ 
+@@ -1953,7 +1960,8 @@ struct ExTensor(Copyable, ImplicitlyCopyable, Movable, Sized):
+             This assumes the uint8 tensor contains valid BF8 E5M2 encoded values.
+             Use this to decode tensors created by to_bf8().
+         """
+-        from shared.core.types.bf8 import BF8
++        from shared.core.types.dtype_aliases import BF8
++        from memory import bitcast
+ 
+         # Verify source is uint8
+         if self._dtype != DType.uint8:
+@@ -1962,11 +1970,12 @@ struct ExTensor(Copyable, ImplicitlyCopyable, Movable, Sized):
+         # Create output tensor with float32 dtype
+         var result = ExTensor(self._shape, DType.float32)
+ 
+-        # Convert each element from BF8 to Float32
++        # Convert each element from BF8 to Float32 using native SIMD
+         for i in range(self._numel):
+             var bf8_bits = self._data.bitcast[UInt8]()[i]
+-            var bf8_val = BF8(bf8_bits)
+-            var float_val = bf8_val.to_float32()
++            # Bitcast uint8 to BF8, then convert to float32
++            var bf8_val = bitcast[BF8, 1](SIMD[DType.uint8, 1](bf8_bits))
++            var float_val = Float32(bf8_val[0])
+             result._data.bitcast[Float32]()[i] = float_val
+ 
+         return result^
+@@ -2097,9 +2106,10 @@ struct ExTensor(Copyable, ImplicitlyCopyable, Movable, Sized):
+             var block_offset = block_idx * 17
+             for i in range(16):
+                 result._data.bitcast[UInt8]()[block_offset + i] = block.data[i]
+-            result._data.bitcast[UInt8]()[
+-                block_offset + 16
+-            ] = block.scale.exponent
++            # Extract exponent bits from E8M0 scale via bitcast
++            result._data.bitcast[UInt8]()[block_offset + 16] = bitcast[
++                DType.uint8, 1
++            ](block.scale)[0]
+ 
+         return result^
+ 
+@@ -2124,7 +2134,8 @@ struct ExTensor(Copyable, ImplicitlyCopyable, Movable, Sized):
+             Use this to decode tensors created by to_mxfp4().
+             Original tensor size is restored from metadata if available.
+         """
+-        from shared.core.types.mxfp4 import MXFP4Block, E8M0Scale
++        from shared.core.types.mxfp4 import MXFP4Block
++        from shared.core.types.dtype_aliases import E8M0
+ 
+         # Verify source is uint8
+         if self._dtype != DType.uint8:
+@@ -2157,9 +2168,9 @@ struct ExTensor(Copyable, ImplicitlyCopyable, Movable, Sized):
+             var data = SIMD[DType.uint8, 16](0)
+             for i in range(16):
+                 data[i] = self._data.bitcast[UInt8]()[block_offset + i]
+-            var scale = E8M0Scale(
+-                self._data.bitcast[UInt8]()[block_offset + 16]
+-            )
++            # Reconstruct E8M0 scale from raw exponent byte
++            var scale_byte = self._data.bitcast[UInt8]()[block_offset + 16]
++            var scale = bitcast[E8M0, 1](SIMD[DType.uint8, 1](scale_byte))
+ 
+             var block = MXFP4Block(data, scale)
+ 
+@@ -2310,7 +2321,10 @@ struct ExTensor(Copyable, ImplicitlyCopyable, Movable, Sized):
+             var block_offset = block_idx * 9
+             for i in range(8):
+                 result._data.bitcast[UInt8]()[block_offset + i] = block.data[i]
+-            result._data.bitcast[UInt8]()[block_offset + 8] = block.scale.value
++            # Extract raw FP8 bits from scale via bitcast
++            result._data.bitcast[UInt8]()[block_offset + 8] = bitcast[
++                DType.uint8, 1
++            ](block.scale)[0]
+ 
+         return result^
+ 
+@@ -2337,7 +2351,8 @@ struct ExTensor(Copyable, ImplicitlyCopyable, Movable, Sized):
+                 Use this to decode tensors created by to_nvfp4().
+                 Original tensor size is restored from metadata if available.
+         """
+-        from shared.core.types.nvfp4 import NVFP4Block, E4M3Scale
++        from shared.core.types.nvfp4 import NVFP4Block
++        from shared.core.types.dtype_aliases import FP8
+ 
+         # Verify source is uint8
+         if self._dtype != DType.uint8:
+@@ -2370,7 +2385,9 @@ struct ExTensor(Copyable, ImplicitlyCopyable, Movable, Sized):
+             var data = SIMD[DType.uint8, 8](0)
+             for i in range(8):
+                 data[i] = self._data.bitcast[UInt8]()[block_offset + i]
+-            var scale = E4M3Scale(self._data.bitcast[UInt8]()[block_offset + 8])
++            # Reconstruct FP8 (E4M3) scale from raw byte
++            var scale_byte = self._data.bitcast[UInt8]()[block_offset + 8]
++            var scale = bitcast[FP8, 1](SIMD[DType.uint8, 1](scale_byte))
+ 
+             var block = NVFP4Block(data, scale)
+ 
+diff --git a/shared/core/traits.mojo b/shared/core/traits.mojo
+index 59847a777..944bd7fe4 100644
+--- a/shared/core/traits.mojo
++++ b/shared/core/traits.mojo
+@@ -280,7 +280,7 @@ trait Composable(Differentiable):
+ 
+         NOTE: Full implementation blocked by Mojo language limitation
+         Generic types F and S require Movable constraint which cannot
+-        be expressed in the current Mojo type system. See issue #2401.
++        be expressed in the current Mojo type system. See issue #3014.
+ 
+         Args:
+             other: The component to compose with this one.
+@@ -311,7 +311,7 @@ trait Composable(Differentiable):
+         )
+ 
+ 
+-# TODO(#2401): ComposedOp struct blocked by Mojo type system limitation
++# TODO(#3014): ComposedOp struct blocked by Mojo type system limitation
+ #
+ # Issue: ComposedOp requires Movable constraint on generic types F and S,
+ # but Mojo does not support trait intersection syntax needed to express:
+@@ -336,7 +336,7 @@ trait Composable(Differentiable):
+ #         return self.first.backward(grad_intermediate)
+ #
+ # See: https://docs.modular.com/mojo/manual/traits/
+-# See: GitHub issue #2401 for limitation details
++# See: GitHub issue #3014 for limitation details
+ 
+ 
+ trait Trainable:
+diff --git a/shared/core/types/__init__.mojo b/shared/core/types/__init__.mojo
+index 0f9035f49..99556fe7c 100644
+--- a/shared/core/types/__init__.mojo
++++ b/shared/core/types/__init__.mojo
+@@ -1,30 +1,38 @@
+ """
+ Types and Data Structures Module.
+ 
+-This module contains custom types and data structures optimized for ML workloads
++This module contains custom types and data structures optimized for ML workloads.
+ All types are implemented using Mojo's struct system for memory safety and performance.
+ 
+ Components:
+-    - FP8: 8-bit floating point type (E4M3 format)
+-    - BF8: 8-bit floating point type (E5M2 format)
+-    - FP4_E2M1: 4-bit floating point base type (E2M1 format)
++    - BF16: Type alias for DType.bfloat16
++    - FP8: Type alias for DType.float8_e4m3fn (E4M3 format)
++    - BF8: Type alias for DType.float8_e5m2 (E5M2 format)
++    - FP4: Type alias for DType.float4_e2m1fn (E2M1 format)
++    - E8M0: Type alias for DType.float8_e8m0fnu (exponent-only scale)
+     - MXFP4: Microscaling FP4 with E8M0 scaling (32-element blocks)
+     - NVFP4: NVIDIA FP4 with E4M3 scaling (16-element blocks)
+ 
+ Note:
+     For integer types, use Mojo's built-in types (Int8, Int16, etc.)
++    The type aliases (BF16, FP8, BF8, FP4, E8M0) are DType values, not structs.
++    Use Scalar[BF16], Scalar[FP8], etc. for scalar values.
+ 
+ Example:
+     ```mojo
+-    from shared.core.types import FP8, BF8, FP4_E2M1, MXFP4, NVFP4
++    from shared.core.types import BF16, FP8, BF8, FP4, MXFP4, NVFP4
+ 
+-    # Work with FP8 values
+-    var fp8_val = FP8.from_float32(3.14159)
+-    var float_val = fp8_val.to_float32()
++    # Work with FP8 values using native SIMD
++    var fp8_val = Scalar[FP8](3.14159)
++    var float_val = Float32(fp8_val)
+ 
+     # Work with BF8 values
+-    var bf8_val = BF8.from_float32(100.0)
+-    var float_val2 = bf8_val.to_float32()
++    var bf8_val = Scalar[BF8](100.0)
++    var float_val2 = Float32(bf8_val)
++
++    # Work with BF16 values (brain floating point)
++    var bf16_val = Scalar[BF16](1e30)
++    var float_val3 = Float32(bf16_val)
+ 
+     # Work with blocked FP4 values
+     var mxfp4_val = MXFP4.from_float32(2.718)
+@@ -33,12 +41,12 @@ Example:
+     ```
+ """
+ 
+-# Type exports
+-from shared.core.types.fp8 import FP8
+-from shared.core.types.bf8 import BF8
+-from shared.core.types.fp4 import FP4_E2M1
+-from shared.core.types.mxfp4 import MXFP4, E8M0Scale
+-from shared.core.types.nvfp4 import NVFP4, E4M3Scale
++# Type alias exports (DType aliases for native Mojo types)
++from shared.core.types.dtype_aliases import BF16, FP8, BF8, FP4, E8M0
++
++# Blocked FP4 format exports (custom structs for microscaling)
++from shared.core.types.mxfp4 import MXFP4, MXFP4Block
++from shared.core.types.nvfp4 import NVFP4, NVFP4Block
+ 
+ # FP type constants
+ from shared.core.types.fp_constants import (
+diff --git a/shared/core/types/bf8.mojo b/shared/core/types/bf8.mojo
+deleted file mode 100644
+index 8ccc55968..000000000
+--- a/shared/core/types/bf8.mojo
++++ /dev/null
+@@ -1,238 +0,0 @@
+-"""BF8 (8-bit floating point) data type implementation.
+-
+-This module implements BF8 E5M2 format:
+-- 1 sign bit
+-- 5 exponent bits (bias = 15)
+-- 2 mantissa bits
+-
+-BF8 E5M2 provides a larger range than FP8 E4M3 but with less precision
+-It is used for memory-efficient training and inference in modern ML workloads.
+-Supported range: approximately ±57,344 with reduced precision.
+-
+-Example:
+-    ```mojo
+-    from shared.core.types.bf8 import BF8
+-
+-    var x = BF8.from_float32(3.14159)
+-    var y = x.to_float32()
+-    ```
+-"""
+-
+-from math import isnan, isinf
+-
+-
+-struct BF8(Copyable, Movable, Representable, Stringable):
+-    """8-bit floating point number in E5M2 format.
+-
+-    Memory layout (1 byte):
+-    - Bit 7: Sign bit
+-    - Bits 6-2: Exponent (5 bits, bias = 15)
+-    - Bits 1-0: Mantissa (2 bits)
+-
+-    Special values:
+-    - Zero: exp=0, mantissa=0
+-    - NaN: exp=31, mantissa!=0
+-    - Inf: exp=31, mantissa=0
+-    """
+-
+-    var value: UInt8
+-
+-    fn __init__(out self, value: UInt8 = 0):
+-        """Initialize BF8 from raw UInt8 bits.
+-
+-        Args:
+-            value: Raw 8-bit representation.
+-        """
+-        self.value = value
+-
+-    @staticmethod
+-    fn from_float32(x: Float32) -> Self:
+-        """Convert Float32 to BF8 E5M2 format.
+-
+-        Args:
+-            x: Float32 value to convert.
+-
+-        Returns:
+-            BF8 representation (with potential precision loss).
+-
+-        Note:
+-            Values outside BF8 range are clamped to max/min representable values.
+-        """
+-        # Handle special cases
+-        if isnan(x):
+-            return BF8(0b01111101)  # NaN: exp=31, mantissa!=0
+-
+-        if isinf(x):
+-            if x > 0:
+-                return BF8(0b01111100)  # +Inf: sign=0, exp=31, mantissa=0
+-            else:
+-                return BF8(0b11111100)  # -Inf: sign=1, exp=31, mantissa=0
+-
+-        if x == 0.0:
+-            return BF8(0)  # +0
+-
+-        # Extract sign
+-        var sign: UInt8 = 0
+-        var abs_x = x
+-        if x < 0:
+-            sign = 1
+-            abs_x = -x
+-
+-        # BF8 E5M2 max value is approximately 57344 (2^(31-15) * (1.75))
+-        # Clamp to representable range
+-        if abs_x >= 57344.0:
+-            # Return max BF8 value
+-            var bits = (sign << 7) | 0b01111011  # exp=30, mantissa=3
+-            return BF8(bits)
+-
+-        # BF8 E5M2 min normal value is 2^-14 = 0.00006103515625
+-        if abs_x < 0.00006103515625:
+-            # Return min normal value or zero
+-            if abs_x < 0.000030517578125:  # Below subnormal range
+-                return BF8(sign << 7)  # Zero
+-            # Subnormal handling: exp=0, encode in mantissa
+-            var mantissa = Int(abs_x * 16384.0)  # Scale to 2-bit range
+-            if mantissa > 3:
+-                mantissa = 3
+-            var bits = (sign << 7) | UInt8(mantissa)
+-            return BF8(bits)
+-
+-        # Normal number encoding
+-        # Find exponent (log2 of abs_x)
+-        var exp_val = 0
+-        var scaled = abs_x
+-
+-        # Scale to range [1, 2)
+-        while scaled >= 2.0:
+-            scaled /= 2.0
+-            exp_val += 1
+-
+-        while scaled < 1.0:
+-            scaled *= 2.0
+-            exp_val -= 1
+-
+-        # Apply bias (15 for E5M2)
+-        var biased_exp = exp_val + 15
+-
+-        # Clamp exponent to valid range [1, 30]
+-        if biased_exp <= 0:
+-            biased_exp = 0
+-            # Subnormal
+-        elif biased_exp >= 31:
+-            biased_exp = 30
+-
+-        # Extract mantissa (2 bits)
+-        # scaled is in [1, 2), we want the fractional part
+-        var mantissa_val = scaled - 1.0  # Now in [0, 1)
+-        var mantissa = Int(mantissa_val * 4.0)  # Scale to 2-bit range [0, 3]
+-        if mantissa > 3:
+-            mantissa = 3
+-
+-        # Combine: sign(1) | exponent(5) | mantissa(2)
+-        var bits = (sign << 7) | (UInt8(biased_exp) << 2) | UInt8(mantissa)
+-        return BF8(bits)
+-
+-    fn to_float32(self) -> Float32:
+-        """Convert BF8 E5M2 to Float32.
+-
+-        Returns:
+-            Float32 representation of the BF8 value.
+-        """
+-        # Extract components
+-        var sign = (self.value >> 7) & 0x1
+-        var exp = (self.value >> 2) & 0x1F  # 5 bits
+-        var mantissa = self.value & 0x3  # 2 bits
+-
+-        # Handle special cases
+-        if exp == 31:
+-            if mantissa != 0:
+-                return Float32(0.0) / Float32(0.0)  # NaN
+-            else:
+-                if sign == 1:
+-                    return -Float32(1.0) / Float32(0.0)  # -Inf
+-                else:
+-                    return Float32(1.0) / Float32(0.0)  # +Inf.
+-
+-        # Handle zero
+-        if exp == 0 and mantissa == 0:
+-            if sign == 1:
+-                return -0.0
+-            else:
+-                return 0.0
+-
+-        # Compute value
+-        var result: Float32
+-
+-        if exp == 0:
+-            # Subnormal number
+-            # value = (-1)^sign * 2^(-14) * (mantissa / 4)
+-            result = Float32(mantissa.cast[DType.float32]()) / 4.0
+-            result *= 0.00006103515625  # 2^-14
+-        else:
+-            # Normal number
+-            # value = (-1)^sign * 2^(exp - 15) * (1 + mantissa / 4)
+-            var exponent = exp.cast[DType.int32]() - 15
+-            var base = Float32(1.0) + (
+-                Float32(mantissa.cast[DType.float32]()) / 4.0
+-            )
+-
+-            # Compute 2^exponent
+-            var scale = Float32(1.0)
+-            if exponent > 0:
+-                for _ in range(exponent):
+-                    scale *= 2.0
+-            elif exponent < 0:
+-                for _ in range(-exponent):
+-                    scale /= 2.0
+-
+-            result = base * scale
+-
+-        # Apply sign
+-        if sign == 1:
+-            result = -result
+-
+-        return result
+-
+-    fn __str__(self) -> String:
+-        """String representation showing BF8 value as Float32.
+-
+-        Returns:
+-            String representation.
+-        """
+-        return "BF8(" + String(self.to_float32()) + ")"
+-
+-    fn __repr__(self) -> String:
+-        """Detailed representation showing both bits and value.
+-
+-        Returns:
+-            Detailed string representation.
+-        """
+-        return (
+-            "BF8(bits=0x"
+-            + hex(self.value)
+-            + ", value="
+-            + String(self.to_float32())
+-            + ")"
+-        )
+-
+-    fn __eq__(self, other: Self) -> Bool:
+-        """Check equality by comparing raw bits.
+-
+-        Args:
+-            other: Other BF8 value.
+-
+-        Returns:
+-            True if bit patterns match.
+-        """
+-        return self.value == other.value
+-
+-    fn __ne__(self, other: Self) -> Bool:
+-        """Check inequality.
+-
+-        Args:
+-            other: Other BF8 value.
+-
+-        Returns:
+-            True if bit patterns differ.
+-        """
+-        return self.value != other.value
+diff --git a/shared/core/types/dtype_aliases.mojo b/shared/core/types/dtype_aliases.mojo
+new file mode 100644
+index 000000000..e6eadf321
+--- /dev/null
++++ b/shared/core/types/dtype_aliases.mojo
+@@ -0,0 +1,47 @@
++"""Type aliases for Mojo built-in dtypes.
++
++Provides short aliases for common dtypes used in ML training.
++These aliases use Mojo's built-in DType constants for reduced precision types.
++
++Aliases:
++    BF16: BFloat16 (1 sign + 8 exponent + 7 mantissa)
++    FP8: Float8 E4M3 (1 sign + 4 exponent + 3 mantissa)
++    BF8: Float8 E5M2 (1 sign + 5 exponent + 2 mantissa)
++    FP4: Float4 E2M1 (1 sign + 2 exponent + 1 mantissa)
++    E8M0: Float8 E8M0 (8 exponent bits only, used for MXFP4 scale)
++
++Example:
++    ```mojo
++    from shared.core.types.dtype_aliases import BF16, FP8
++
++    # Use with Scalar
++    var bf16_val = Scalar[BF16](3.14)
++    var fp8_val = Scalar[FP8](2.5)
++
++    # Use with SIMD
++    var bf16_vec = SIMD[BF16, 4](1.0, 2.0, 3.0, 4.0)
++    ```
++
++Platform Note:
++    DType.bfloat16 is not supported on Apple Silicon.
++"""
++
++# BFloat16 - Brain Floating Point (16-bit)
++# Same exponent range as Float32, ideal for training
++comptime BF16 = DType.bfloat16
++
++# FP8 E4M3 - 8-bit float with 4 exponent + 3 mantissa bits
++# NVIDIA/AMD standard for inference
++comptime FP8 = DType.float8_e4m3fn
++
++# BF8 E5M2 - 8-bit float with 5 exponent + 2 mantissa bits
++# Wider range than FP8, less precision
++comptime BF8 = DType.float8_e5m2
++
++# FP4 E2M1 - 4-bit float with 2 exponent + 1 mantissa bit
++# Used in blocked formats (MXFP4, NVFP4)
++comptime FP4 = DType.float4_e2m1fn
++
++# E8M0 - 8-bit exponent-only format (no mantissa, no sign)
++# Used as scale factor in MXFP4 blocked format
++comptime E8M0 = DType.float8_e8m0fnu
+diff --git a/shared/core/types/fp4.mojo b/shared/core/types/fp4.mojo
+deleted file mode 100644
+index 975962732..000000000
+--- a/shared/core/types/fp4.mojo
++++ /dev/null
+@@ -1,242 +0,0 @@
+-"""FP4 E2M1 (4-bit floating point) base format implementation.
+-
+-This module implements the E2M1 format used in blocked FP4 formats (MXFP4, NVFP4):
+-- 1 sign bit
+-- 2 exponent bits (bias = 1)
+-- 1 mantissa bit
+-
+-E2M1 is NOT used standalone - it requires a block-level scale factor
+-This module provides the base encoding/decoding for MXFP4 and NVFP4.
+-
+-Key characteristics:
+-- 4 bits per value
+-- Limited precision (1-bit mantissa)
+-- Limited range (2-bit exponent)
+-- Requires external scale factor for proper representation
+-
+-Example:
+-    ```mojo
+-    from shared.core.types.fp4 import FP4_E2M1
+-
+-    # E2M1 is typically used within block structures
+-    var fp4_val = FP4_E2M1.from_float32(1.5, scale=1.0)
+-    var reconstructed = fp4_val.to_float32(scale=1.0)
+-    ```
+-"""
+-
+-from math import isnan, isinf
+-
+-# TEST-010 RESOLVED: FP4_E2M1 base type fully tested
+-# Coverage verified in:
+-#   - tests/shared/core/test_fp4.mojo (25+ test functions)
+-#   - tests/core/types/test_fp4_base.mojo (15+ test functions)
+-#
+-# Functions tested:
+-#   - from_float32() (E2M1 encoding algorithm)
+-#   - to_float32() (E2M1 decoding algorithm)
+-#   - String representations (__str__, __repr__)
+-#   - Equality operators (__eq__, __ne__)
+-#   - All 16 possible bit patterns (0x0 to 0xF)
+-#   - Special values (NaN, Infinity, Zero)
+-#   - Edge cases (quantization, clamping, scale factors)
+-#
+-# See: Issue #3008 for verification details
+-
+-
+-struct FP4_E2M1(Copyable, Movable, Representable, Stringable):
+-    """4-bit floating point number in E2M1 format.
+-
+-    Memory layout (4 bits stored in UInt8):
+-    - Bit 3: Sign bit
+-    - Bits 2-1: Exponent (2 bits, bias = 1)
+-    - Bit 0: Mantissa (1 bit)
+-
+-    Special values:
+-    - Zero: exp=0, mantissa=0
+-    - Max normal: exp=2, mantissa=1 (value = 6.0 before scaling)
+-    - Min normal: exp=1, mantissa=0 (value = 1.0 before scaling)
+-
+-    Note:
+-        E2M1 values are meaningless without a block-level scale factor.
+-        Use MXFP4 or NVFP4 for complete block-based representations.
+-    """
+-
+-    var value: UInt8  # Only lower 4 bits are used
+-
+-    fn __init__(out self, value: UInt8 = 0):
+-        """Initialize FP4_E2M1 from raw 4-bit value.
+-
+-        Args:
+-            value: Raw 4-bit representation (only lower 4 bits used).
+-        """
+-        self.value = value & 0xF  # Mask to 4 bits
+-
+-    @staticmethod
+-    fn from_float32(x: Float32, scale: Float32 = 1.0) -> Self:
+-        """Convert Float32 to FP4 E2M1 format with given scale.
+-
+-        Args:
+-            x: Float32 value to convert.
+-            scale: Block-level scale factor.
+-
+-        Returns:
+-            FP4_E2M1 representation.
+-
+-        Note:
+-            The value is divided by scale before encoding.
+-            Values outside representable range are clamped.
+-        """
+-        # Handle special cases
+-        if isnan(x):
+-            return FP4_E2M1(0b0111)  # Max value as NaN representation
+-
+-        if isinf(x):
+-            if x > 0:
+-                return FP4_E2M1(0b0111)  # Max positive value
+-            else:
+-                return FP4_E2M1(0b1111)  # Max negative value
+-
+-        # Scale the input
+-        var scaled = x / scale
+-
+-        if scaled == 0.0:
+-            return FP4_E2M1(0)  # +0
+-
+-        # Extract sign
+-        var sign: UInt8 = 0
+-        var abs_scaled = scaled
+-        if scaled < 0:
+-            sign = 1
+-            abs_scaled = -scaled
+-
+-        # E2M1 representable values (before scaling):
+-        # exp=0, mantissa=0: 0
+-        # exp=1, mantissa=0: 1.0
+-        # exp=1, mantissa=1: 1.5
+-        # exp=2, mantissa=0: 2.0
+-        # exp=2, mantissa=1: 3.0
+-        # exp=3, mantissa=0: 4.0
+-        # exp=3, mantissa=1: 6.0 (max)
+-
+-        # Clamp to representable range [0, 6.0]
+-        if abs_scaled >= 6.0:
+-            # Return max value: sign=s, exp=3, mantissa=1
+-            return FP4_E2M1((sign << 3) | 0b111)
+-
+-        if abs_scaled < 0.5:
+-            # Return zero (subnormals not well-defined for E2M1)
+-            return FP4_E2M1(sign << 3)
+-
+-        # Find best representation
+-        # Quantize to nearest representable value
+-        # Representable values: 0, 1.0, 1.5, 2.0, 3.0, 4.0, 6.0
+-        var exp: UInt8
+-        var mantissa: UInt8
+-        if abs_scaled < 1.25:
+-            exp = 1
+-            mantissa = 0  # 1.0
+-        elif abs_scaled < 1.75:
+-            exp = 1
+-            mantissa = 1  # 1.5
+-        elif abs_scaled < 2.5:
+-            exp = 2
+-            mantissa = 0  # 2.0
+-        elif abs_scaled < 3.5:
+-            exp = 2
+-            mantissa = 1  # 3.0
+-        elif abs_scaled < 5.0:
+-            exp = 3
+-            mantissa = 0  # 4.0
+-        else:
+-            exp = 3
+-            mantissa = 1  # 6.0
+-
+-        # Combine: sign(1) | exponent(2) | mantissa(1)
+-        var bits = (sign << 3) | (exp << 1) | mantissa
+-        return FP4_E2M1(bits)
+-
+-    fn to_float32(self, scale: Float32 = 1.0) -> Float32:
+-        """Convert FP4 E2M1 to Float32 with given scale.
+-
+-        Args:
+-            scale: Block-level scale factor.
+-
+-        Returns:
+-            Float32 representation of the scaled E2M1 value.
+-        """
+-        # Extract components (4 bits total)
+-        var sign = (self.value >> 3) & 0x1
+-        var exp = (self.value >> 1) & 0x3  # 2 bits
+-        var mantissa = self.value & 0x1  # 1 bit
+-
+-        # Handle zero
+-        if exp == 0:
+-            return Float32(0.0) if sign == 0 else Float32(-0.0)
+-
+-        # Compute unscaled value
+-        # E2M1: value = 2^(exp-1) * (1 + mantissa/2)
+-        # With 1-bit mantissa, the fractional part is mantissa * 0.5
+-        var exponent = exp.cast[DType.int32]() - 1
+-        var base = Float32(1.0) + Float32(
+-            mantissa.cast[DType.float32]()
+-        ) * Float32(0.5)
+-
+-        # Compute 2^exponent
+-        var unscaled = base
+-        if exponent > 0:
+-            for _ in range(exponent):
+-                unscaled *= 2.0
+-        elif exponent < 0:
+-            for _ in range(-exponent):
+-                unscaled /= 2.0
+-
+-        # Apply sign and scale
+-        var result = unscaled * scale
+-        if sign == 1:
+-            result = -result
+-
+-        return result
+-
+-    fn __str__(self) -> String:
+-        """String representation showing FP4 value as Float32 (unscaled).
+-
+-        Returns:
+-            String representation.
+-        """
+-        return "FP4_E2M1(" + String(self.to_float32(scale=1.0)) + ")"
+-
+-    fn __repr__(self) -> String:
+-        """Detailed representation showing bits and value.
+-
+-        Returns:
+-            Detailed string representation.
+-        """
+-        return (
+-            "FP4_E2M1(bits=0x"
+-            + hex(self.value)
+-            + ", value="
+-            + String(self.to_float32(scale=1.0))
+-            + ")"
+-        )
+-
+-    fn __eq__(self, other: Self) -> Bool:
+-        """Check equality by comparing raw bits.
+-
+-        Args:
+-            other: Other FP4_E2M1 value.
+-
+-        Returns:
+-            True if bit patterns match.
+-        """
+-        return self.value == other.value
+-
+-    fn __ne__(self, other: Self) -> Bool:
+-        """Check inequality.
+-
+-        Args:
+-            other: Other FP4_E2M1 value.
+-
+-        Returns:
+-            True if bit patterns differ.
+-        """
+-        return self.value != other.value
+diff --git a/shared/core/types/fp8.mojo b/shared/core/types/fp8.mojo
+deleted file mode 100644
+index 9e61163f7..000000000
+--- a/shared/core/types/fp8.mojo
++++ /dev/null
+@@ -1,237 +0,0 @@
+-"""FP8 (8-bit floating point) data type implementation.
+-
+-This module implements FP8 E4M3 format:
+-- 1 sign bit
+-- 4 exponent bits (bias = 7)
+-- 3 mantissa bits
+-
+-FP8 is used for memory-efficient training and inference in modern ML workloads
+-Supported range: approximately ±240 with reduced precision.
+-
+-Example:
+-    ```mojo
+-    from shared.core.types.fp8 import FP8
+-
+-    var x = FP8.from_float32(3.14159)
+-    var y = x.to_float32()
+-    ```
+-"""
+-
+-from math import isnan, isinf
+-
+-
+-struct FP8(Copyable, Movable, Representable, Stringable):
+-    """8-bit floating point number in E4M3 format.
+-
+-    Memory layout (1 byte):
+-    - Bit 7: Sign bit
+-    - Bits 6-3: Exponent (4 bits, bias = 7)
+-    - Bits 2-0: Mantissa (3 bits)
+-
+-    Special values:
+-    - Zero: exp=0, mantissa=0
+-    - NaN: exp=15, mantissa!=0
+-    - Inf: exp=15, mantissa=0
+-    """
+-
+-    var value: UInt8
+-
+-    fn __init__(out self, value: UInt8 = 0):
+-        """Initialize FP8 from raw UInt8 bits.
+-
+-        Args:
+-            value: Raw 8-bit representation.
+-        """
+-        self.value = value
+-
+-    @staticmethod
+-    fn from_float32(x: Float32) -> Self:
+-        """Convert Float32 to FP8 E4M3 format.
+-
+-        Args:
+-            x: Float32 value to convert.
+-
+-        Returns:
+-            FP8 representation (with potential precision loss).
+-
+-        Note:
+-            Values outside FP8 range are clamped to max/min representable values.
+-        """
+-        # Handle special cases
+-        if isnan(x):
+-            return FP8(0b01111111)  # NaN: exp=15, mantissa!=0
+-
+-        if isinf(x):
+-            if x > 0:
+-                return FP8(0b01111000)  # +Inf: sign=0, exp=15, mantissa=0
+-            else:
+-                return FP8(0b11111000)  # -Inf: sign=1, exp=15, mantissa=0
+-
+-        if x == 0.0:
+-            return FP8(0)  # +0
+-
+-        # Extract sign
+-        var sign: UInt8 = 0
+-        var abs_x = x
+-        if x < 0:
+-            sign = 1
+-            abs_x = -x
+-
+-        # FP8 E4M3 max value is approximately 240
+-        # Clamp to representable range
+-        if abs_x >= 240.0:
+-            # Return max FP8 value
+-            var bits = (sign << 7) | 0b01110111  # exp=14, mantissa=7
+-            return FP8(bits)
+-
+-        # FP8 E4M3 min normal value is 2^-6 = 0.015625
+-        if abs_x < 0.015625:
+-            # Return min normal value or zero
+-            if abs_x < 0.0078125:  # Below subnormal range
+-                return FP8(sign << 7)  # Zero
+-            # Subnormal handling: exp=0, encode in mantissa
+-            var mantissa = Int(abs_x * 128.0)  # Scale to 3-bit range
+-            if mantissa > 7:
+-                mantissa = 7
+-            var bits = (sign << 7) | UInt8(mantissa)
+-            return FP8(bits)
+-
+-        # Normal number encoding
+-        # Find exponent (log2 of abs_x)
+-        var exp_val = 0
+-        var scaled = abs_x
+-
+-        # Scale to range [1, 2)
+-        while scaled >= 2.0:
+-            scaled /= 2.0
+-            exp_val += 1
+-
+-        while scaled < 1.0:
+-            scaled *= 2.0
+-            exp_val -= 1
+-
+-        # Apply bias (7 for E4M3)
+-        var biased_exp = exp_val + 7
+-
+-        # Clamp exponent to valid range [1, 14]
+-        if biased_exp <= 0:
+-            biased_exp = 0
+-            # Subnormal
+-        elif biased_exp >= 15:
+-            biased_exp = 14
+-
+-        # Extract mantissa (3 bits)
+-        # scaled is in [1, 2), we want the fractional part
+-        var mantissa_val = scaled - 1.0  # Now in [0, 1)
+-        var mantissa = Int(mantissa_val * 8.0)  # Scale to 3-bit range [0, 7]
+-        if mantissa > 7:
+-            mantissa = 7
+-
+-        # Combine: sign(1) | exponent(4) | mantissa(3)
+-        var bits = (sign << 7) | (UInt8(biased_exp) << 3) | UInt8(mantissa)
+-        return FP8(bits)
+-
+-    fn to_float32(self) -> Float32:
+-        """Convert FP8 E4M3 to Float32.
+-
+-        Returns:
+-            Float32 representation of the FP8 value.
+-        """
+-        # Extract components
+-        var sign = (self.value >> 7) & 0x1
+-        var exp = (self.value >> 3) & 0xF  # 4 bits
+-        var mantissa = self.value & 0x7  # 3 bits
+-
+-        # Handle special cases
+-        if exp == 15:
+-            if mantissa != 0:
+-                return Float32(0.0) / Float32(0.0)  # NaN
+-            else:
+-                if sign == 1:
+-                    return -Float32(1.0) / Float32(0.0)  # -Inf
+-                else:
+-                    return Float32(1.0) / Float32(0.0)  # +Inf.
+-
+-        # Handle zero
+-        if exp == 0 and mantissa == 0:
+-            if sign == 1:
+-                return -0.0
+-            else:
+-                return 0.0
+-
+-        # Compute value
+-        var result: Float32
+-
+-        if exp == 0:
+-            # Subnormal number
+-            # value = (-1)^sign * 2^(-6) * (mantissa / 8)
+-            result = Float32(mantissa.cast[DType.float32]()) / 8.0
+-            result *= 0.015625  # 2^-6
+-        else:
+-            # Normal number
+-            # value = (-1)^sign * 2^(exp - 7) * (1 + mantissa / 8)
+-            var exponent = exp.cast[DType.int32]() - 7
+-            var base = Float32(1.0) + (
+-                Float32(mantissa.cast[DType.float32]()) / 8.0
+-            )
+-
+-            # Compute 2^exponent
+-            var scale = Float32(1.0)
+-            if exponent > 0:
+-                for _ in range(exponent):
+-                    scale *= 2.0
+-            elif exponent < 0:
+-                for _ in range(-exponent):
+-                    scale /= 2.0
+-
+-            result = base * scale
+-
+-        # Apply sign
+-        if sign == 1:
+-            result = -result
+-
+-        return result
+-
+-    fn __str__(self) -> String:
+-        """String representation showing FP8 value as Float32.
+-
+-        Returns:
+-            String representation.
+-        """
+-        return "FP8(" + String(self.to_float32()) + ")"
+-
+-    fn __repr__(self) -> String:
+-        """Detailed representation showing both bits and value.
+-
+-        Returns:
+-            Detailed string representation.
+-        """
+-        return (
+-            "FP8(bits=0x"
+-            + hex(self.value)
+-            + ", value="
+-            + String(self.to_float32())
+-            + ")"
+-        )
+-
+-    fn __eq__(self, other: Self) -> Bool:
+-        """Check equality by comparing raw bits.
+-
+-        Args:
+-            other: Other FP8 value.
+-
+-        Returns:
+-            True if bit patterns match.
+-        """
+-        return self.value == other.value
+-
+-    fn __ne__(self, other: Self) -> Bool:
+-        """Check inequality.
+-
+-        Args:
+-            other: Other FP8 value.
+-
+-        Returns:
+-            True if bit patterns differ.
+-        """
+-        return self.value != other.value
+diff --git a/shared/core/types/mxfp4.mojo b/shared/core/types/mxfp4.mojo
+index f85261764..69a72b9c4 100644
+--- a/shared/core/types/mxfp4.mojo
++++ b/shared/core/types/mxfp4.mojo
+@@ -39,116 +39,233 @@ Reference:
+ """
+ 
+ from math import isnan, isinf
+-from shared.core.types.fp4 import FP4_E2M1
++from memory import bitcast
++from shared.core.types.dtype_aliases import FP4, E8M0
+ 
+ 
+-struct E8M0Scale(Copyable, Movable, Representable, Stringable):
+-    """8-bit exponent-only scale factor for MXFP4 blocks.
++# ============================================================================
++# E8M0 Scale Helper Functions (using native Scalar[E8M0])
++# ============================================================================
+ 
+-    Memory layout (1 byte):
+-    - Bits 7-0: Exponent (8 bits, bias = 127, same as Float32)
+-    - No sign bit (always positive)
+-    - No mantissa bits (implicit mantissa = 1.0)
+ 
+-    Represents: 2^(exponent - 127).
++fn _e8m0_from_float32(scale: Float32) -> Scalar[E8M0]:
++    """Convert Float32 scale to E8M0 format using manual exponent extraction.
+ 
+-    Valid range: 2^-127 to 2^128.
++    Args:
++        scale: Positive Float32 scale value.
++
++    Returns:
++        Scalar[E8M0] representation (power of 2 closest to scale).
++
++    Note:
++        E8M0 is exponent-only (no mantissa), so it can only represent powers of 2.
++        The conversion extracts the Float32 exponent and rounds to nearest power of 2.
++        Scale must be positive. Negative or zero values return minimum scale.
+     """
++    if scale <= 0.0 or isnan(scale):
++        # Return minimum scale by bitcasting exponent 0
++        return bitcast[E8M0, 1](SIMD[DType.uint8, 1](0))
+ 
+-    var exponent: UInt8
+-    """8-bit exponent with bias of 127."""
++    if isinf(scale):
++        # Return maximum scale by bitcasting exponent 255
++        return bitcast[E8M0, 1](SIMD[DType.uint8, 1](255))
+ 
+-    fn __init__(out self, exponent: UInt8 = 127):
+-        """Initialize E8M0 scale from raw exponent.
++    # E8M0 can only represent powers of 2, so we extract the exponent from Float32
++    # Float32 format: 1 sign + 8 exponent + 23 mantissa, exponent bias = 127
++    var bits = bitcast[DType.uint32, 1](SIMD[DType.float32, 1](scale))
++    var float_exp = ((bits[0] >> 23) & 0xFF).cast[DType.uint8]()
+ 
+-        Args:
+-            exponent: 8-bit exponent value (bias = 127).
+-        """
+-        self.exponent = exponent
++    # Adjust for mantissa: if mantissa >= 0.5, round exponent up
++    var mantissa = bits[0] & 0x7FFFFF  # 23-bit mantissa
++    if mantissa >= 0x400000:  # >= 0.5 in binary fraction
++        if float_exp < 255:
++            float_exp += 1
+ 
+-    @staticmethod
+-    fn from_float32(scale: Float32) -> Self:
+-        """Compute E8M0 scale from Float32 value.
++    return bitcast[E8M0, 1](SIMD[DType.uint8, 1](float_exp))
+ 
+-        Args:
+-            scale: Positive Float32 scale value.
+ 
+-        Returns:
+-            E8M0 representation.
++fn _e8m0_to_float32(e8m0_val: Scalar[E8M0]) -> Float32:
++    """Convert E8M0 to Float32 using manual exponent reconstruction.
+ 
+-        Note:
+-            Scale must be positive. Negative or zero values return minimum scale.
+-        """
+-        if scale <= 0.0 or isnan(scale):
+-            return E8M0Scale(0)  # Minimum scale (2^-127)
++    Args:
++        e8m0_val: E8M0 scale value.
+ 
+-        if isinf(scale):
+-            return E8M0Scale(255)  # Maximum scale (2^128)
++    Returns:
++        Float32 representation (power of 2).
+ 
+-        # Find exponent: scale = 2^exp
+-        var exp_val = 0
+-        var s = scale
++    Note:
++        E8M0 is exponent-only, so the result is always a power of 2.
++        Constructs Float32 with the E8M0 exponent and zero mantissa.
++    """
++    # Get the 8-bit exponent from E8M0
++    var exp = bitcast[DType.uint8, 1](e8m0_val)[0]
+ 
+-        # Scale to find the exponent
+-        while s >= 2.0 and exp_val < 128:
+-            s /= 2.0
+-            exp_val += 1
++    # Handle special cases
++    if exp == 0:
++        return Float32(0.0)  # Minimum scale (or could return subnormal)
++    if exp == 255:
++        return Float32(1.0) / Float32(0.0)  # Infinity
+ 
+-        while s < 1.0 and exp_val > -127:
+-            s *= 2.0
+-            exp_val -= 1
++    # Construct Float32: sign=0, exponent=exp, mantissa=0
++    # Float32 bits: 0 (sign) | exp (8 bits) | 0...0 (23 bits mantissa)
++    var float_bits = exp.cast[DType.uint32]() << 23
++    return bitcast[DType.float32, 1](SIMD[DType.uint32, 1](float_bits))[0]
+ 
+-        # Apply bias (127)
+-        var biased_exp = exp_val + 127
+ 
+-        # Clamp to [0, 255]
+-        if biased_exp < 0:
+-            biased_exp = 0
+-        elif biased_exp > 255:
+-            biased_exp = 255
++fn _e8m0_get_exponent(e8m0_val: Scalar[E8M0]) -> UInt8:
++    """Get raw exponent bits from E8M0 value.
+ 
+-        return E8M0Scale(UInt8(biased_exp))
++    Args:
++        e8m0_val: E8M0 scale value.
+ 
+-    fn to_float32(self) -> Float32:
+-        """Convert E8M0 scale to Float32.
++    Returns:
++        8-bit exponent value.
++    """
++    return bitcast[DType.uint8, 1](e8m0_val)[0]
+ 
+-        Returns:
+-            Float32 representation: 2^(exponent - 127).
+-        """
+-        var exponent = self.exponent.cast[DType.int32]() - 127
+ 
+-        # Compute 2^exponent
+-        var result = Float32(1.0)
+-        if exponent > 0:
+-            for _ in range(exponent):
+-                result *= 2.0
+-        elif exponent < 0:
+-            for _ in range(-exponent):
+-                result /= 2.0
++fn _e8m0_from_exponent(exponent: UInt8) -> Scalar[E8M0]:
++    """Create E8M0 from raw exponent bits.
+ 
+-        return result
++    Args:
++        exponent: 8-bit exponent value (bias = 127).
+ 
+-    fn __str__(self) -> String:
+-        """String representation showing scale value.
++    Returns:
++        Scalar[E8M0] value.
++    """
++    return bitcast[E8M0, 1](SIMD[DType.uint8, 1](exponent))
+ 
+-        Returns:
+-            String representation.
+-        """
+-        return (
+-            "E8M0(exp="
+-            + String(self.exponent)
+-            + ", scale="
+-            + String(self.to_float32())
+-            + ")"
+-        )
+ 
+-    fn __repr__(self) -> String:
+-        """Detailed representation.
++# ============================================================================
++# FP4 E2M1 Helper Functions (using native Scalar[FP4])
++# ============================================================================
+ 
+-        Returns:
+-            Detailed string representation.
+-        """
+-        return self.__str__()
++
++fn _fp4_from_float32(x: Float32, scale: Float32) -> UInt8:
++    """Convert Float32 to FP4 E2M1 format with given scale.
++
++    Args:
++        x: Float32 value to convert.
++        scale: Block-level scale factor.
++
++    Returns:
++        4-bit FP4 value stored in lower 4 bits of UInt8.
++
++    Note:
++        The value is divided by scale before encoding.
++        Values outside representable range are clamped.
++    """
++    # Handle special cases
++    if isnan(x):
++        return 0b0111  # Max value as NaN representation
++
++    if isinf(x):
++        if x > 0:
++            return 0b0111  # Max positive value
++        else:
++            return 0b1111  # Max negative value
++
++    # Scale the input
++    var scaled = x / scale
++
++    if scaled == 0.0:
++        return 0  # +0
++
++    # Extract sign
++    var sign: UInt8 = 0
++    var abs_scaled = scaled
++    if scaled < 0:
++        sign = 1
++        abs_scaled = -scaled
++
++    # E2M1 representable values (before scaling):
++    # exp=0, mantissa=0: 0
++    # exp=1, mantissa=0: 1.0
++    # exp=1, mantissa=1: 1.5
++    # exp=2, mantissa=0: 2.0
++    # exp=2, mantissa=1: 3.0
++    # exp=3, mantissa=0: 4.0
++    # exp=3, mantissa=1: 6.0 (max)
++
++    # Clamp to representable range [0, 6.0]
++    if abs_scaled >= 6.0:
++        # Return max value: sign=s, exp=3, mantissa=1
++        return (sign << 3) | 0b111
++
++    if abs_scaled < 0.5:
++        # Return zero (subnormals not well-defined for E2M1)
++        return sign << 3
++
++    # Find best representation
++    # Quantize to nearest representable value
++    # Representable values: 0, 1.0, 1.5, 2.0, 3.0, 4.0, 6.0
++    var exp: UInt8
++    var mantissa: UInt8
++    if abs_scaled < 1.25:
++        exp = 1
++        mantissa = 0  # 1.0
++    elif abs_scaled < 1.75:
++        exp = 1
++        mantissa = 1  # 1.5
++    elif abs_scaled < 2.5:
++        exp = 2
++        mantissa = 0  # 2.0
++    elif abs_scaled < 3.5:
++        exp = 2
++        mantissa = 1  # 3.0
++    elif abs_scaled < 5.0:
++        exp = 3
++        mantissa = 0  # 4.0
++    else:
++        exp = 3
++        mantissa = 1  # 6.0
++
++    # Combine: sign(1) | exponent(2) | mantissa(1)
++    return (sign << 3) | (exp << 1) | mantissa
++
++
++fn _fp4_to_float32(fp4_bits: UInt8, scale: Float32) -> Float32:
++    """Convert FP4 E2M1 bits to Float32 with given scale.
++
++    Args:
++        fp4_bits: 4-bit FP4 value in lower 4 bits.
++        scale: Block-level scale factor.
++
++    Returns:
++        Float32 representation of the scaled E2M1 value.
++    """
++    # Extract components (4 bits total)
++    var sign = (fp4_bits >> 3) & 0x1
++    var exp = (fp4_bits >> 1) & 0x3  # 2 bits
++    var mantissa = fp4_bits & 0x1  # 1 bit
++
++    # Handle zero
++    if exp == 0:
++        return Float32(0.0) if sign == 0 else Float32(-0.0)
++
++    # Compute unscaled value
++    # E2M1: value = 2^(exp-1) * (1 + mantissa/2)
++    # With 1-bit mantissa, the fractional part is mantissa * 0.5
++    var exponent = exp.cast[DType.int32]() - 1
++    var base = Float32(1.0) + Float32(mantissa.cast[DType.float32]()) * Float32(
++        0.5
++    )
++
++    # Compute 2^exponent
++    var unscaled = base
++    if exponent > 0:
++        for _ in range(exponent):
++            unscaled *= 2.0
++    elif exponent < 0:
++        for _ in range(-exponent):
++            unscaled /= 2.0
++
++    # Apply sign and scale
++    var result = unscaled * scale
++    if sign == 1:
++        result = -result
++
++    return result
+ 
+ 
+ struct MXFP4(Copyable, Movable, Representable, Stringable):
+@@ -160,26 +277,26 @@ struct MXFP4(Copyable, Movable, Representable, Stringable):
+     For efficient storage, use MXFP4Block which amortizes the scale across 32 values.
+ 
+     Attributes:
+-        value: 4-bit E2M1 encoded value.
+-        scale: 8-bit E8M0 scale factor.
++        value: 4-bit E2M1 encoded value (stored in lower 4 bits of UInt8).
++        scale: 8-bit E8M0 scale factor (native Scalar[E8M0]).
+     """
+ 
+-    var value: FP4_E2M1
+-    """4-bit E2M1 encoded value."""
+-    var scale: E8M0Scale
++    var value: UInt8
++    """4-bit E2M1 encoded value (lower 4 bits)."""
++    var scale: Scalar[E8M0]
+     """8-bit E8M0 scale factor."""
+ 
+     fn __init__(
+-        out self, value: FP4_E2M1 = FP4_E2M1(), scale: E8M0Scale = E8M0Scale()
++        out self, value: UInt8 = 0, scale: Scalar[E8M0] = Scalar[E8M0](1.0)
+     ):
+         """Initialize MXFP4 from E2M1 value and E8M0 scale.
+ 
+         Args:
+-            value: E2M1 encoded value.
++            value: E2M1 encoded value (4-bit value in lower bits).
+             scale: E8M0 scale factor.
+         """
+-        self.value = value.copy()
+-        self.scale = scale.copy()
++        self.value = value & 0xF  # Mask to 4 bits
++        self.scale = scale
+ 
+     @staticmethod
+     fn from_float32(x: Float32) -> Self:
+@@ -195,10 +312,10 @@ struct MXFP4(Copyable, Movable, Representable, Stringable):
+         """
+         # Handle special cases
+         if isnan(x) or isinf(x):
+-            return MXFP4(FP4_E2M1.from_float32(x, scale=1.0), E8M0Scale(127))
++            return MXFP4(_fp4_from_float32(x, 1.0), _e8m0_from_exponent(127))
+ 
+         if x == 0.0:
+-            return MXFP4(FP4_E2M1(0), E8M0Scale(127))
++            return MXFP4(0, _e8m0_from_exponent(127))
+ 
+         # Compute scale: find 2^k such that |x| / 2^k is in E2M1 range [0, 6]
+         var abs_x = x if x > 0 else -x
+@@ -215,10 +332,10 @@ struct MXFP4(Copyable, Movable, Representable, Stringable):
+             exp_val -= 1
+ 
+         # Create E8M0 scale
+-        var scale = E8M0Scale.from_float32(scale_val)
++        var scale = _e8m0_from_float32(scale_val)
+ 
+         # Encode E2M1 value
+-        var value = FP4_E2M1.from_float32(x, scale=scale.to_float32())
++        var value = _fp4_from_float32(x, _e8m0_to_float32(scale))
+ 
+         return MXFP4(value, scale)
+ 
+@@ -250,10 +367,10 @@ struct MXFP4(Copyable, Movable, Representable, Stringable):
+         """
+         # Handle special cases
+         if isnan(x) or isinf(x):
+-            return MXFP4(FP4_E2M1.from_float32(x, scale=1.0), E8M0Scale(127))
++            return MXFP4(_fp4_from_float32(x, 1.0), _e8m0_from_exponent(127))
+ 
+         if x == 0.0:
+-            return MXFP4(FP4_E2M1(0), E8M0Scale(127))
++            return MXFP4(0, _e8m0_from_exponent(127))
+ 
+         # Compute scale same as deterministic version
+         var abs_x = x if x > 0 else -x
+@@ -268,8 +385,8 @@ struct MXFP4(Copyable, Movable, Representable, Stringable):
+             scale_val /= 2.0
+             exp_val -= 1
+ 
+-        var scale = E8M0Scale.from_float32(scale_val)
+-        var scale_f32 = scale.to_float32()
++        var scale = _e8m0_from_float32(scale_val)
++        var scale_f32 = _e8m0_to_float32(scale)
+ 
+         # Stochastic rounding for E2M1 encoding
+         var value = MXFP4._fp4_stochastic_round(x, scale_f32, seed)
+@@ -277,9 +394,7 @@ struct MXFP4(Copyable, Movable, Representable, Stringable):
+         return MXFP4(value, scale)
+ 
+     @staticmethod
+-    fn _fp4_stochastic_round(
+-        x: Float32, scale: Float32, seed: UInt64
+-    ) -> FP4_E2M1:
++    fn _fp4_stochastic_round(x: Float32, scale: Float32, seed: UInt64) -> UInt8:
+         """Internal: Stochastic rounding helper using simple LCG.
+ 
+         Args:
+@@ -288,7 +403,7 @@ struct MXFP4(Copyable, Movable, Representable, Stringable):
+             seed: Random seed.
+ 
+         Returns:
+-            FP4_E2M1 value with stochastic rounding.
++            4-bit FP4 value with stochastic rounding (stored in lower 4 bits of UInt8).
+         """
+         var scaled = x / scale
+         var sign: UInt8 = 0
+@@ -309,7 +424,7 @@ struct MXFP4(Copyable, Movable, Representable, Stringable):
+         # Boundaries use actual representable values to determine bucket
+         if abs_scaled < 0.5:
+             # Close to zero - round to 0
+-            return FP4_E2M1(sign << 3)
++            return sign << 3
+         elif abs_scaled < 1.0:
+             # Between 0 and 1.0 - stochastic round between them
+             lower = 0.0
+@@ -343,7 +458,7 @@ struct MXFP4(Copyable, Movable, Representable, Stringable):
+             upper_bits = 0b111  # exp=3, mantissa=1
+         else:
+             # At or above max
+-            return FP4_E2M1((sign << 3) | 0b111)
++            return (sign << 3) | 0b111
+ 
+         # Compute probability of rounding up
+         var distance = abs_scaled - lower
+@@ -362,7 +477,7 @@ struct MXFP4(Copyable, Movable, Representable, Stringable):
+         else:
+             result_bits = lower_bits
+ 
+-        return FP4_E2M1((sign << 3) | result_bits)
++        return (sign << 3) | result_bits
+ 
+     fn to_float32(self) -> Float32:
+         """Convert MXFP4 to Float32.
+@@ -370,7 +485,7 @@ struct MXFP4(Copyable, Movable, Representable, Stringable):
+         Returns:
+             Float32 representation.
+         """
+-        return self.value.to_float32(scale=self.scale.to_float32())
++        return _fp4_to_float32(self.value, _e8m0_to_float32(self.scale))
+ 
+     fn __add__(self, other: MXFP4) -> MXFP4:
+         """Add two MXFP4 values (via Float32).
+@@ -423,7 +538,7 @@ struct MXFP4(Copyable, Movable, Representable, Stringable):
+             Negated value.
+         """
+         # Flip sign bit in E2M1 value
+-        var neg_value = FP4_E2M1(self.value.value ^ 0b1000)
++        var neg_value = self.value ^ 0b1000
+         return MXFP4(neg_value, self.scale)
+ 
+     fn __eq__(self, other: MXFP4) -> Bool:
+@@ -435,10 +550,9 @@ struct MXFP4(Copyable, Movable, Representable, Stringable):
+         Returns:
+             True if equal.
+         """
+-        return (
+-            self.value == other.value
+-            and self.scale.exponent == other.scale.exponent
+-        )
++        return self.value == other.value and _e8m0_get_exponent(
++            self.scale
++        ) == _e8m0_get_exponent(other.scale)
+ 
+     fn __ne__(self, other: MXFP4) -> Bool:
+         """Check inequality.
+@@ -510,10 +624,10 @@ struct MXFP4(Copyable, Movable, Representable, Stringable):
+             Representation string.
+         """
+         return (
+-            "MXFP4(value="
+-            + repr(self.value)
++            "MXFP4(value=0x"
++            + hex(self.value)
+             + ", scale="
+-            + repr(self.scale)
++            + String(_e8m0_to_float32(self.scale))
+             + ")"
+         )
+ 
+@@ -548,15 +662,15 @@ struct MXFP4Block(Copyable, Movable, Representable, Stringable):
+ 
+     var data: SIMD[DType.uint8, 16]
+     """16 bytes containing 32 packed E2M1 values (2 per byte)."""
+-    var scale: E8M0Scale
++    var scale: Scalar[E8M0]
+     """Shared E8M0 scale factor for all 32 values."""
+ 
+     fn __init__(out self):
+         """Initialize MXFP4Block with zeros."""
+         self.data = SIMD[DType.uint8, 16](0)
+-        self.scale = E8M0Scale(127)  # Scale = 1.0
++        self.scale = _e8m0_from_exponent(127)  # Scale = 1.0
+ 
+-    fn __init__(out self, data: SIMD[DType.uint8, 16], scale: E8M0Scale):
++    fn __init__(out self, data: SIMD[DType.uint8, 16], scale: Scalar[E8M0]):
+         """Initialize MXFP4Block from packed data and scale.
+ 
+         Args:
+@@ -564,7 +678,7 @@ struct MXFP4Block(Copyable, Movable, Representable, Stringable):
+             scale: E8M0 scale factor for the block.
+         """
+         self.data = data
+-        self.scale = scale.copy()
++        self.scale = scale
+ 
+     @staticmethod
+     fn from_float32_array(values: List[Float32]) raises -> Self:
+@@ -599,39 +713,33 @@ struct MXFP4Block(Copyable, Movable, Representable, Stringable):
+                 max_abs = abs_val
+ 
+         # Compute scale (avoid division by zero)
+-        # TEST-002 RESOLVED: Scale = 0 edge case fully tested
+-        # Coverage verified in:
+-        #   - tests/shared/core/test_mxfp4.mojo (8 edge case tests at lines 320-519)
+-        #   - tests/core/types/test_mxfp4_block.mojo (TEST-002 section at lines 364-412)
+-        #
+-        # Test cases covered:
+-        #   1. Block with all zeros
+-        #   2. Block with values < 1e-10
+-        #   3. E8M0Scale.from_float32(0.0) direct behavior
+-        #   4. Round-trip conversion: zeros -> MXFP4 -> zeros
+-        #   5. Near-threshold values (around 1e-10)
+-        #   6. Mixed zeros and tiny values
+-        #   7. Zero fallback behavior (scale_val = 1.0)
+-        #   8. No division by zero or NaN production
+-        #
+-        # See: Issue #3008 for verification details
++        # **FIXME (#3008 - TEST-002 - P0 CRITICAL)**: Scale = 0 edge case untested
++        # When all values in block are zero or near-zero (< 1e-10), we fallback to scale=1.0
++        # This behavior is COMPLETELY UNTESTED. Missing test cases:
++        #   1. Block with all zeros (should encode as scale=1.0, all E2M1 values = 0)
++        #   2. Block with values < 1e-10 (should trigger fallback)
++        #   3. _e8m0_from_float32(0.0) direct behavior
++        #   4. Round-trip conversion: zeros -> MXFP4 -> zeros (verify lossless)
++        # Impact: Zero blocks are common in ML (dead neurons, zero gradients)
++        # Severity: BLOCKING - edge case must be tested before production use
++        # See: COMPREHENSIVE_REVIEW_FINDINGS.md (TEST-002)
+         var scale_val = max_abs / 6.0
+         if scale_val < 1e-10:
+             scale_val = 1.0
+ 
+-        var scale = E8M0Scale.from_float32(scale_val)
+-        var scale_f32 = scale.to_float32()
++        var scale = _e8m0_from_float32(scale_val)
++        var scale_f32 = _e8m0_to_float32(scale)
+ 
+         # Pack E2M1 values (2 per byte)
+         var data = SIMD[DType.uint8, 16](0)
+         for i in range(16):
+             # First value (upper 4 bits)
+-            var val1 = FP4_E2M1.from_float32(values[i * 2], scale=scale_f32)
++            var val1 = _fp4_from_float32(values[i * 2], scale_f32)
+             # Second value (lower 4 bits)
+-            var val2 = FP4_E2M1.from_float32(values[i * 2 + 1], scale=scale_f32)
++            var val2 = _fp4_from_float32(values[i * 2 + 1], scale_f32)
+ 
+             # Pack: upper 4 bits = val1, lower 4 bits = val2
+-            data[i] = ((val1.value & 0xF) << 4) | (val2.value & 0xF)
++            data[i] = ((val1 & 0xF) << 4) | (val2 & 0xF)
+ 
+         return MXFP4Block(data, scale)
+ 
+@@ -645,17 +753,17 @@ struct MXFP4Block(Copyable, Movable, Representable, Stringable):
+             Decoding is lossless given the quantization that occurred during encoding.
+         """
+         var result = List[Float32]()
+-        var scale_f32 = self.scale.to_float32()
++        var scale_f32 = _e8m0_to_float32(self.scale)
+ 
+         for i in range(16):
+             var byte = self.data[i]
+             # Extract upper 4 bits (first value)
+-            var val1 = FP4_E2M1((byte >> 4) & 0xF)
+-            result.append(val1.to_float32(scale=scale_f32))
++            var val1_bits = (byte >> 4) & 0xF
++            result.append(_fp4_to_float32(val1_bits, scale_f32))
+ 
+             # Extract lower 4 bits (second value)
+-            var val2 = FP4_E2M1(byte & 0xF)
+-            result.append(val2.to_float32(scale=scale_f32))
++            var val2_bits = byte & 0xF
++            result.append(_fp4_to_float32(val2_bits, scale_f32))
+ 
+         return result^
+ 
+@@ -678,13 +786,13 @@ struct MXFP4Block(Copyable, Movable, Representable, Stringable):
+         var is_upper = (index % 2) == 0
+ 
+         var byte = self.data[byte_idx]
+-        var fp4_val: FP4_E2M1
++        var fp4_bits: UInt8
+         if is_upper:
+-            fp4_val = FP4_E2M1((byte >> 4) & 0xF)
++            fp4_bits = (byte >> 4) & 0xF
+         else:
+-            fp4_val = FP4_E2M1(byte & 0xF)
++            fp4_bits = byte & 0xF
+ 
+-        return MXFP4(fp4_val, self.scale)
++        return MXFP4(fp4_bits, self.scale)
+ 
+     fn set(mut self, index: Int, value: MXFP4) raises -> None:
+         """Set MXFP4 value at index (0-31).
+@@ -705,8 +813,8 @@ struct MXFP4Block(Copyable, Movable, Representable, Stringable):
+ 
+         # Re-encode value with block's scale
+         var float_val = value.to_float32()
+-        var fp4_val = FP4_E2M1.from_float32(
+-            float_val, scale=self.scale.to_float32()
++        var fp4_bits = _fp4_from_float32(
++            float_val, _e8m0_to_float32(self.scale)
+         )
+ 
+         var byte_idx = index // 2
+@@ -715,10 +823,10 @@ struct MXFP4Block(Copyable, Movable, Representable, Stringable):
+         var byte = self.data[byte_idx]
+         if is_upper:
+             # Update upper 4 bits
+-            byte = (byte & 0x0F) | ((fp4_val.value & 0xF) << 4)
++            byte = (byte & 0x0F) | ((fp4_bits & 0xF) << 4)
+         else:
+             # Update lower 4 bits
+-            byte = (byte & 0xF0) | (fp4_val.value & 0xF)
++            byte = (byte & 0xF0) | (fp4_bits & 0xF)
+ 
+         self.data[byte_idx] = byte
+ 
+@@ -730,7 +838,7 @@ struct MXFP4Block(Copyable, Movable, Representable, Stringable):
+         """
+         return (
+             "MXFP4Block(32 values, scale="
+-            + String(self.scale.to_float32())
++            + String(_e8m0_to_float32(self.scale))
+             + ")"
+         )
+ 
+@@ -740,4 +848,8 @@ struct MXFP4Block(Copyable, Movable, Representable, Stringable):
+         Returns:
+             Detailed string representation.
+         """
+-        return "MXFP4Block(scale=" + repr(self.scale) + ", data=16 bytes)"
++        return (
++            "MXFP4Block(scale="
++            + String(_e8m0_to_float32(self.scale))
++            + ", data=16 bytes)"
++        )
+diff --git a/shared/core/types/nvfp4.mojo b/shared/core/types/nvfp4.mojo
+index c8cf685b8..c4bde0227 100644
+--- a/shared/core/types/nvfp4.mojo
++++ b/shared/core/types/nvfp4.mojo
+@@ -45,196 +45,239 @@ Reference:
+ """
+ 
+ from math import isnan, isinf
+-from shared.core.types.fp4 import FP4_E2M1
++from memory import bitcast
++from shared.core.types.dtype_aliases import FP4, FP8
+ 
+ 
+-struct E4M3Scale(Copyable, Movable, Representable, Stringable):
+-    """4-bit exponent + 3-bit mantissa scale factor for NVFP4 blocks.
++# ============================================================================
++# E4M3 Scale Helper Functions (using native Scalar[FP8])
++# ============================================================================
+ 
+-    Memory layout (7 bits stored in UInt8):
+-    - Bits 6-3: Exponent (4 bits, bias = 7, same as FP8 E4M3)
+-    - Bits 2-0: Mantissa (3 bits)
+-    - No sign bit (always positive)
+ 
+-    Special values:
+-    - Zero: exp=0, mantissa=0
+-    - Max: exp=15, mantissa=7
+-    - No NaN/Inf (all patterns represent finite positive values)
++fn _e4m3_from_float32(scale: Float32) -> Scalar[FP8]:
++    """Convert Float32 scale to E4M3 format using native FP8 type.
+ 
+-    Valid range: Similar to FP8 E4M3 format.
++    Args:
++        scale: Positive Float32 scale value.
++
++    Returns:
++        Scalar[FP8] representation.
++
++    Note:
++        Scale must be positive. Negative values will be converted to positive.
+     """
++    if scale <= 0.0 or isnan(scale):
++        # Return zero scale
++        return bitcast[FP8, 1](SIMD[DType.uint8, 1](0))
+ 
+-    var value: UInt8
+-    """7-bit E4M3 scale value."""
++    if isinf(scale) or scale >= 240.0:
++        # Return maximum positive FP8 value
++        return bitcast[FP8, 1](
++            SIMD[DType.uint8, 1](0x7E)
++        )  # Max finite positive
+ 
+-    fn __init__(out self, value: UInt8 = 0x38):
+-        """Initialize E4M3 scale from raw 7-bit value.
++    # Use native FP8 conversion (always use absolute value for scale)
++    var abs_scale = scale if scale > 0 else -scale
++    return Scalar[FP8](abs_scale)
+ 
+-        Args:
+-            value: 7-bit representation (default = 0x38 = exp:7, mantissa:0 = 1.0).
+-        """
+-        self.value = value & 0x7F  # Mask to 7 bits
+ 
+-    @staticmethod
+-    fn from_float32(scale: Float32) -> Self:
+-        """Compute E4M3 scale from Float32 value.
++fn _e4m3_to_float32(e4m3_val: Scalar[FP8]) -> Float32:
++    """Convert E4M3 (FP8) to Float32 using native type.
+ 
+-        Args:
+-            scale: Positive Float32 scale value.
++    Args:
++        e4m3_val: FP8 scale value.
+ 
+-        Returns:
+-            E4M3 representation.
++    Returns:
++        Float32 representation.
++    """
++    return Float32(e4m3_val)
+ 
+-        Note:
+-            Scale must be positive. Uses FP8 E4M3 encoding logic.
+-        """
+-        if scale <= 0.0 or isnan(scale):
+-            return E4M3Scale(0)  # Zero scale
+-
+-        if isinf(scale) or scale >= 240.0:
+-            return E4M3Scale(0x7F)  # Maximum scale (exp=15, mantissa=7)
+-
+-        # Handle very small scales
+-        if scale < 0.015625:  # Below normal range
+-            if scale < 0.0078125:
+-                return E4M3Scale(0)  # Zero
+-            # Subnormal: exp=0, encode in mantissa
+-            var mantissa = Int(scale * 512.0)
+-            if mantissa > 7:
+-                mantissa = 7
+-            return E4M3Scale(UInt8(mantissa))
+-
+-        # Normal number encoding (same as FP8 E4M3)
+-        var exp_val = 0
+-        var scaled = scale
+ 
+-        # Scale to range [1, 2)
+-        while scaled >= 2.0:
+-            scaled /= 2.0
+-            exp_val += 1
++fn _e4m3_get_bits(e4m3_val: Scalar[FP8]) -> UInt8:
++    """Get raw bits from E4M3 (FP8) value.
+ 
+-        while scaled < 1.0:
+-            scaled *= 2.0
+-            exp_val -= 1
++    Args:
++        e4m3_val: FP8 scale value.
+ 
+-        # Apply bias (7 for E4M3)
+-        var biased_exp = exp_val + 7
++    Returns:
++        8-bit raw value.
++    """
++    return bitcast[DType.uint8, 1](e4m3_val)[0]
+ 
+-        # Clamp exponent to valid range [1, 14]
+-        if biased_exp <= 0:
+-            biased_exp = 0  # Subnormal
+-        elif biased_exp >= 15:
+-            biased_exp = 14  # Avoid overflow
+ 
+-        # Extract mantissa (3 bits)
+-        var mantissa_val = scaled - 1.0  # Now in [0, 1)
+-        var mantissa = Int(mantissa_val * 8.0)  # Scale to 3-bit range [0, 7]
+-        if mantissa > 7:
+-            mantissa = 7
++fn _e4m3_from_bits(bits: UInt8) -> Scalar[FP8]:
++    """Create E4M3 (FP8) from raw bits.
+ 
+-        # Combine: exponent(4) | mantissa(3)
+-        var bits = (UInt8(biased_exp) << 3) | UInt8(mantissa)
+-        return E4M3Scale(bits)
++    Args:
++        bits: 8-bit raw value.
+ 
+-    fn to_float32(self) -> Float32:
+-        """Convert E4M3 scale to Float32.
++    Returns:
++        Scalar[FP8] value.
++    """
++    return bitcast[FP8, 1](SIMD[DType.uint8, 1](bits))
+ 
+-        Returns:
+-            Float32 representation.
+-        """
+-        # Extract components (7 bits total)
+-        var exp = (self.value >> 3) & 0xF  # 4 bits
+-        var mantissa = self.value & 0x7  # 3 bits
+-
+-        # Handle zero
+-        if exp == 0 and mantissa == 0:
+-            return 0.0
+-
+-        # Compute value (same logic as FP8 E4M3)
+-        var result: Float32
+-
+-        if exp == 0:
+-            # Subnormal number
+-            # value = 2^(-6) * (mantissa / 8)
+-            result = Float32(mantissa.cast[DType.float32]()) / 8.0
+-            result *= 0.015625  # 2^-6
+-        else:
+-            # Normal number
+-            # value = 2^(exp - 7) * (1 + mantissa / 8)
+-            var exponent = exp.cast[DType.int32]() - 7
+-            var base = Float32(1.0) + (
+-                Float32(mantissa.cast[DType.float32]()) / 8.0
+-            )
+ 
+-            # Compute 2^exponent
+-            var scale_factor = Float32(1.0)
+-            if exponent > 0:
+-                for _ in range(exponent):
+-                    scale_factor *= 2.0
+-            elif exponent < 0:
+-                for _ in range(-exponent):
+-                    scale_factor /= 2.0
++# ============================================================================
++# FP4 E2M1 Helper Functions (using native types)
++# ============================================================================
+ 
+-            result = base * scale_factor
+ 
+-        return result
++fn _fp4_from_float32(x: Float32, scale: Float32) -> UInt8:
++    """Convert Float32 to FP4 E2M1 format with given scale.
+ 
+-    fn __str__(self) -> String:
+-        """String representation showing scale value.
++    Args:
++        x: Float32 value to convert.
++        scale: Block-level scale factor.
+ 
+-        Returns:
+-            String representation.
+-        """
+-        var exp = (self.value >> 3) & 0xF
+-        var mantissa = self.value & 0x7
+-        return (
+-            "E4M3(exp="
+-            + String(exp)
+-            + ", mantissa="
+-            + String(mantissa)
+-            + ", scale="
+-            + String(self.to_float32())
+-            + ")"
+-        )
++    Returns:
++        4-bit FP4 value stored in lower 4 bits of UInt8.
+ 
+-    fn __repr__(self) -> String:
+-        """Detailed representation.
++    Note:
++        The value is divided by scale before encoding.
++        Values outside representable range are clamped.
++    """
++    # Handle special cases
++    if isnan(x):
++        return 0b0111  # Max value as NaN representation
+ 
+-        Returns:
+-            Detailed string representation.
+-        """
+-        return self.__str__()
++    if isinf(x):
++        if x > 0:
++            return 0b0111  # Max positive value
++        else:
++            return 0b1111  # Max negative value
++
++    # Scale the input
++    var scaled = x / scale
++
++    if scaled == 0.0:
++        return 0  # +0
++
++    # Extract sign
++    var sign: UInt8 = 0
++    var abs_scaled = scaled
++    if scaled < 0:
++        sign = 1
++        abs_scaled = -scaled
++
++    # E2M1 representable values (before scaling):
++    # exp=0, mantissa=0: 0
++    # exp=1, mantissa=0: 1.0
++    # exp=1, mantissa=1: 1.5
++    # exp=2, mantissa=0: 2.0
++    # exp=2, mantissa=1: 3.0
++    # exp=3, mantissa=0: 4.0
++    # exp=3, mantissa=1: 6.0 (max)
++
++    # Clamp to representable range [0, 6.0]
++    if abs_scaled >= 6.0:
++        # Return max value: sign=s, exp=3, mantissa=1
++        return (sign << 3) | 0b111
++
++    if abs_scaled < 0.5:
++        # Return zero (subnormals not well-defined for E2M1)
++        return sign << 3
++
++    # Find best representation
++    # Quantize to nearest representable value
++    # Representable values: 0, 1.0, 1.5, 2.0, 3.0, 4.0, 6.0
++    var exp: UInt8
++    var mantissa: UInt8
++    if abs_scaled < 1.25:
++        exp = 1
++        mantissa = 0  # 1.0
++    elif abs_scaled < 1.75:
++        exp = 1
++        mantissa = 1  # 1.5
++    elif abs_scaled < 2.5:
++        exp = 2
++        mantissa = 0  # 2.0
++    elif abs_scaled < 3.5:
++        exp = 2
++        mantissa = 1  # 3.0
++    elif abs_scaled < 5.0:
++        exp = 3
++        mantissa = 0  # 4.0
++    else:
++        exp = 3
++        mantissa = 1  # 6.0
++
++    # Combine: sign(1) | exponent(2) | mantissa(1)
++    return (sign << 3) | (exp << 1) | mantissa
++
++
++fn _fp4_to_float32(fp4_bits: UInt8, scale: Float32) -> Float32:
++    """Convert FP4 E2M1 bits to Float32 with given scale.
++
++    Args:
++        fp4_bits: 4-bit FP4 value in lower 4 bits.
++        scale: Block-level scale factor.
++
++    Returns:
++        Float32 representation of the scaled E2M1 value.
++    """
++    # Extract components (4 bits total)
++    var sign = (fp4_bits >> 3) & 0x1
++    var exp = (fp4_bits >> 1) & 0x3  # 2 bits
++    var mantissa = fp4_bits & 0x1  # 1 bit
++
++    # Handle zero
++    if exp == 0:
++        return Float32(0.0) if sign == 0 else Float32(-0.0)
++
++    # Compute unscaled value
++    # E2M1: value = 2^(exp-1) * (1 + mantissa/2)
++    # With 1-bit mantissa, the fractional part is mantissa * 0.5
++    var exponent = exp.cast[DType.int32]() - 1
++    var base = Float32(1.0) + Float32(mantissa.cast[DType.float32]()) * Float32(
++        0.5
++    )
++
++    # Compute 2^exponent
++    var unscaled = base
++    if exponent > 0:
++        for _ in range(exponent):
++            unscaled *= 2.0
++    elif exponent < 0:
++        for _ in range(-exponent):
++            unscaled /= 2.0
++
++    # Apply sign and scale
++    var result = unscaled * scale
++    if sign == 1:
++        result = -result
++
++    return result
+ 
+ 
+ struct NVFP4(Copyable, Movable, Representable, Stringable):
+     """NVFP4 individual value (E2M1 + E4M3 scale).
+ 
+-    Acts like FP16 but stores internally as 4-bit E2M1 value plus 7-bit E4M3 scale.
+-    This representation is convenient but NOT space-efficient (11 bits total vs 4 bits in blocks).
++    Acts like FP16 but stores internally as 4-bit E2M1 value plus 8-bit E4M3 scale.
++    This representation is convenient but NOT space-efficient (12 bits total vs 4 bits in blocks).
+ 
+     For efficient storage, use NVFP4Block which amortizes the scale across 16 values.
+ 
+     Attributes:
+-        value: 4-bit E2M1 encoded value.
+-        scale: 7-bit E4M3 scale factor.
++        value: 4-bit E2M1 encoded value (stored in lower 4 bits of UInt8).
++        scale: E4M3 (FP8) scale factor using native Scalar[FP8].
+     """
+ 
+-    var value: FP4_E2M1
+-    """4-bit E2M1 encoded value."""
+-    var scale: E4M3Scale
+-    """7-bit E4M3 scale factor."""
++    var value: UInt8
++    """4-bit E2M1 encoded value (lower 4 bits used)."""
++    var scale: Scalar[FP8]
++    """E4M3 (FP8) scale factor using native type."""
+ 
+     fn __init__(
+-        out self, value: FP4_E2M1 = FP4_E2M1(), scale: E4M3Scale = E4M3Scale()
++        out self, value: UInt8 = 0, scale: Scalar[FP8] = Scalar[FP8](1.0)
+     ):
+         """Initialize NVFP4 from E2M1 value and E4M3 scale.
+ 
+         Args:
+-            value: E2M1 encoded value.
+-            scale: E4M3 scale factor.
++            value: E2M1 encoded value (4 bits in lower nibble).
++            scale: E4M3 (FP8) scale factor.
+         """
+-        self.value = value.copy()
+-        self.scale = scale.copy()
++        self.value = value & 0xF  # Only keep lower 4 bits
++        self.scale = scale
+ 
+     @staticmethod
+     fn from_float32(x: Float32) -> Self:
+@@ -250,10 +293,11 @@ struct NVFP4(Copyable, Movable, Representable, Stringable):
+         """
+         # Handle special cases
+         if isnan(x) or isinf(x):
+-            return NVFP4(FP4_E2M1.from_float32(x, scale=1.0), E4M3Scale(0x38))
++            var fp4_bits = _fp4_from_float32(x, 1.0)
++            return NVFP4(fp4_bits, Scalar[FP8](1.0))
+ 
+         if x == 0.0:
+-            return NVFP4(FP4_E2M1(0), E4M3Scale(0x38))
++            return NVFP4(0, Scalar[FP8](1.0))
+ 
+         # Compute scale: find value such that |x| / scale is in E2M1 range [0, 6]
+         var abs_x = x if x > 0 else -x
+@@ -269,13 +313,14 @@ struct NVFP4(Copyable, Movable, Representable, Stringable):
+             scale_val /= 2.0
+             exp_val -= 1
+ 
+-        # Create E4M3 scale
+-        var scale = E4M3Scale.from_float32(scale_val)
++        # Create E4M3 scale using helper function
++        var scale = _e4m3_from_float32(scale_val)
++        var scale_f32 = _e4m3_to_float32(scale)
+ 
+-        # Encode E2M1 value
+-        var value = FP4_E2M1.from_float32(x, scale=scale.to_float32())
++        # Encode E2M1 value using helper function
++        var fp4_bits = _fp4_from_float32(x, scale_f32)
+ 
+-        return NVFP4(value, scale)
++        return NVFP4(fp4_bits, scale)
+ 
+     @staticmethod
+     fn from_float32_stochastic(x: Float32, seed: UInt64) -> Self:
+@@ -305,10 +350,11 @@ struct NVFP4(Copyable, Movable, Representable, Stringable):
+         """
+         # Handle special cases
+         if isnan(x) or isinf(x):
+-            return NVFP4(FP4_E2M1.from_float32(x, scale=1.0), E4M3Scale(0x38))
++            var fp4_bits = _fp4_from_float32(x, 1.0)
++            return NVFP4(fp4_bits, Scalar[FP8](1.0))
+ 
+         if x == 0.0:
+-            return NVFP4(FP4_E2M1(0), E4M3Scale(0x38))
++            return NVFP4(0, Scalar[FP8](1.0))
+ 
+         # Compute scale same as deterministic version
+         var abs_x = x if x > 0 else -x
+@@ -323,18 +369,16 @@ struct NVFP4(Copyable, Movable, Representable, Stringable):
+             scale_val /= 2.0
+             exp_val -= 1
+ 
+-        var scale = E4M3Scale.from_float32(scale_val)
+-        var scale_f32 = scale.to_float32()
++        var scale = _e4m3_from_float32(scale_val)
++        var scale_f32 = _e4m3_to_float32(scale)
+ 
+         # Stochastic rounding for E2M1 encoding
+-        var value = NVFP4._fp4_stochastic_round(x, scale_f32, seed)
++        var fp4_bits = NVFP4._fp4_stochastic_round(x, scale_f32, seed)
+ 
+-        return NVFP4(value, scale)
++        return NVFP4(fp4_bits, scale)
+ 
+     @staticmethod
+-    fn _fp4_stochastic_round(
+-        x: Float32, scale: Float32, seed: UInt64
+-    ) -> FP4_E2M1:
++    fn _fp4_stochastic_round(x: Float32, scale: Float32, seed: UInt64) -> UInt8:
+         """Internal: Stochastic rounding helper using simple LCG.
+ 
+         Args:
+@@ -343,7 +387,7 @@ struct NVFP4(Copyable, Movable, Representable, Stringable):
+             seed: Random seed.
+ 
+         Returns:
+-            FP4_E2M1 value with stochastic rounding.
++            4-bit FP4 value (in lower 4 bits of UInt8) with stochastic rounding.
+         """
+         var scaled = x / scale
+         var sign: UInt8 = 0
+@@ -364,7 +408,7 @@ struct NVFP4(Copyable, Movable, Representable, Stringable):
+         # Boundaries use actual representable values to determine bucket
+         if abs_scaled < 0.5:
+             # Close to zero - round to 0
+-            return FP4_E2M1(sign << 3)
++            return sign << 3
+         elif abs_scaled < 1.0:
+             # Between 0 and 1.0 - stochastic round between them
+             lower = 0.0
+@@ -398,7 +442,7 @@ struct NVFP4(Copyable, Movable, Representable, Stringable):
+             upper_bits = 0b111  # exp=3, mantissa=1
+         else:
+             # At or above max
+-            return FP4_E2M1((sign << 3) | 0b111)
++            return (sign << 3) | 0b111
+ 
+         # Compute probability of rounding up
+         var distance = abs_scaled - lower
+@@ -417,7 +461,7 @@ struct NVFP4(Copyable, Movable, Representable, Stringable):
+         else:
+             result_bits = lower_bits
+ 
+-        return FP4_E2M1((sign << 3) | result_bits)
++        return (sign << 3) | result_bits
+ 
+     fn to_float32(self) -> Float32:
+         """Convert NVFP4 to Float32.
+@@ -425,7 +469,8 @@ struct NVFP4(Copyable, Movable, Representable, Stringable):
+         Returns:
+             Float32 representation.
+         """
+-        return self.value.to_float32(scale=self.scale.to_float32())
++        var scale_f32 = _e4m3_to_float32(self.scale)
++        return _fp4_to_float32(self.value, scale_f32)
+ 
+     fn __add__(self, other: NVFP4) -> NVFP4:
+         """Add two NVFP4 values (via Float32).
+@@ -477,8 +522,8 @@ struct NVFP4(Copyable, Movable, Representable, Stringable):
+         Returns:
+             Negated value.
+         """
+-        # Flip sign bit in E2M1 value
+-        var neg_value = FP4_E2M1(self.value.value ^ 0b1000)
++        # Flip sign bit in E2M1 value (bit 3)
++        var neg_value = self.value ^ 0b1000
+         return NVFP4(neg_value, self.scale)
+ 
+     fn __eq__(self, other: NVFP4) -> Bool:
+@@ -490,9 +535,10 @@ struct NVFP4(Copyable, Movable, Representable, Stringable):
+         Returns:
+             True if equal.
+         """
+-        return (
+-            self.value == other.value and self.scale.value == other.scale.value
+-        )
++        # Compare FP4 value bits and scale bits
++        var self_scale_bits = _e4m3_get_bits(self.scale)
++        var other_scale_bits = _e4m3_get_bits(other.scale)
++        return self.value == other.value and self_scale_bits == other_scale_bits
+ 
+     fn __ne__(self, other: NVFP4) -> Bool:
+         """Check inequality.
+@@ -564,20 +610,33 @@ struct NVFP4(Copyable, Movable, Representable, Stringable):
+             Representation string.
+         """
+         return (
+-            "NVFP4(value="
+-            + repr(self.value)
++            "NVFP4(value=0x"
++            + hex(Int(self.value))
+             + ", scale="
+-            + repr(self.scale)
++            + String(_e4m3_to_float32(self.scale))
+             + ")"
+         )
+ 
+ 
++fn hex(val: Int) -> String:
++    """Convert integer to hex string (simple implementation)."""
++    if val == 0:
++        return "0"
++    var digits = String("0123456789abcdef")
++    var result = String("")
++    var v = val if val >= 0 else -val
++    while v > 0:
++        result = digits[v % 16] + result
++        v //= 16
++    return result
++
++
+ struct NVFP4Block(Copyable, Movable, Representable, Stringable):
+     """NVFP4 block storage: 16 E2M1 values + 1 E4M3 scale (9 bytes total).
+ 
+     Memory layout:
+     - Bytes 0-7: 16 E2M1 values (4 bits each, packed 2 per byte)
+-    - Byte 8: E4M3 scale (7 bits used, 1 bit unused)
++    - Byte 8: E4M3 (FP8) scale
+ 
+     Bit packing:
+     Each byte stores 2 E2M1 values:
+@@ -603,23 +662,23 @@ struct NVFP4Block(Copyable, Movable, Representable, Stringable):
+ 
+     var data: SIMD[DType.uint8, 8]
+     """8 bytes containing 16 packed E2M1 values (2 per byte)."""
+-    var scale: E4M3Scale
+-    """Shared E4M3 scale factor for all 16 values."""
++    var scale: Scalar[FP8]
++    """Shared E4M3 (FP8) scale factor for all 16 values."""
+ 
+     fn __init__(out self):
+         """Initialize NVFP4Block with zeros."""
+         self.data = SIMD[DType.uint8, 8](0)
+-        self.scale = E4M3Scale(0x38)  # Scale = 1.0
++        self.scale = Scalar[FP8](1.0)  # Scale = 1.0
+ 
+-    fn __init__(out self, data: SIMD[DType.uint8, 8], scale: E4M3Scale):
++    fn __init__(out self, data: SIMD[DType.uint8, 8], scale: Scalar[FP8]):
+         """Initialize NVFP4Block from packed data and scale.
+ 
+         Args:
+             data: 8 bytes containing 16 packed E2M1 values.
+-            scale: E4M3 scale factor for the block.
++            scale: E4M3 (FP8) scale factor for the block.
+         """
+         self.data = data
+-        self.scale = scale.copy()
++        self.scale = scale
+ 
+     @staticmethod
+     fn from_float32_array(values: List[Float32]) raises -> Self:
+@@ -656,19 +715,19 @@ struct NVFP4Block(Copyable, Movable, Representable, Stringable):
+         if scale_val < 1e-10:
+             scale_val = 1.0
+ 
+-        var scale = E4M3Scale.from_float32(scale_val)
+-        var scale_f32 = scale.to_float32()
++        var scale = _e4m3_from_float32(scale_val)
++        var scale_f32 = _e4m3_to_float32(scale)
+ 
+         # Pack E2M1 values (2 per byte)
+         var data = SIMD[DType.uint8, 8](0)
+         for i in range(8):
+             # First value (upper 4 bits)
+-            var val1 = FP4_E2M1.from_float32(values[i * 2], scale=scale_f32)
++            var val1 = _fp4_from_float32(values[i * 2], scale_f32)
+             # Second value (lower 4 bits)
+-            var val2 = FP4_E2M1.from_float32(values[i * 2 + 1], scale=scale_f32)
++            var val2 = _fp4_from_float32(values[i * 2 + 1], scale_f32)
+ 
+             # Pack: upper 4 bits = val1, lower 4 bits = val2
+-            data[i] = ((val1.value & 0xF) << 4) | (val2.value & 0xF)
++            data[i] = ((val1 & 0xF) << 4) | (val2 & 0xF)
+ 
+         return NVFP4Block(data, scale)
+ 
+@@ -682,17 +741,17 @@ struct NVFP4Block(Copyable, Movable, Representable, Stringable):
+             Decoding is lossless given the quantization that occurred during encoding.
+         """
+         var result = List[Float32]()
+-        var scale_f32 = self.scale.to_float32()
++        var scale_f32 = _e4m3_to_float32(self.scale)
+ 
+         for i in range(8):
+             var byte = self.data[i]
+             # Extract upper 4 bits (first value)
+-            var val1 = FP4_E2M1((byte >> 4) & 0xF)
+-            result.append(val1.to_float32(scale=scale_f32))
++            var val1_bits = (byte >> 4) & 0xF
++            result.append(_fp4_to_float32(val1_bits, scale_f32))
+ 
+             # Extract lower 4 bits (second value)
+-            var val2 = FP4_E2M1(byte & 0xF)
+-            result.append(val2.to_float32(scale=scale_f32))
++            var val2_bits = byte & 0xF
++            result.append(_fp4_to_float32(val2_bits, scale_f32))
+ 
+         return result^
+ 
+@@ -715,13 +774,13 @@ struct NVFP4Block(Copyable, Movable, Representable, Stringable):
+         var is_upper = (index % 2) == 0
+ 
+         var byte = self.data[byte_idx]
+-        var fp4_val: FP4_E2M1
++        var fp4_bits: UInt8
+         if is_upper:
+-            fp4_val = FP4_E2M1((byte >> 4) & 0xF)
++            fp4_bits = (byte >> 4) & 0xF
+         else:
+-            fp4_val = FP4_E2M1(byte & 0xF)
++            fp4_bits = byte & 0xF
+ 
+-        return NVFP4(fp4_val, self.scale)
++        return NVFP4(fp4_bits, self.scale)
+ 
+     fn set(mut self, index: Int, value: NVFP4) raises -> None:
+         """Set NVFP4 value at index (0-15).
+@@ -742,9 +801,8 @@ struct NVFP4Block(Copyable, Movable, Representable, Stringable):
+ 
+         # Re-encode value with block's scale
+         var float_val = value.to_float32()
+-        var fp4_val = FP4_E2M1.from_float32(
+-            float_val, scale=self.scale.to_float32()
+-        )
++        var scale_f32 = _e4m3_to_float32(self.scale)
++        var fp4_bits = _fp4_from_float32(float_val, scale_f32)
+ 
+         var byte_idx = index // 2
+         var is_upper = (index % 2) == 0
+@@ -752,10 +810,10 @@ struct NVFP4Block(Copyable, Movable, Representable, Stringable):
+         var byte = self.data[byte_idx]
+         if is_upper:
+             # Update upper 4 bits
+-            byte = (byte & 0x0F) | ((fp4_val.value & 0xF) << 4)
++            byte = (byte & 0x0F) | ((fp4_bits & 0xF) << 4)
+         else:
+             # Update lower 4 bits
+-            byte = (byte & 0xF0) | (fp4_val.value & 0xF)
++            byte = (byte & 0xF0) | (fp4_bits & 0xF)
+ 
+         self.data[byte_idx] = byte
+ 
+@@ -767,7 +825,7 @@ struct NVFP4Block(Copyable, Movable, Representable, Stringable):
+         """
+         return (
+             "NVFP4Block(16 values, scale="
+-            + String(self.scale.to_float32())
++            + String(_e4m3_to_float32(self.scale))
+             + ")"
+         )
+ 
+@@ -777,4 +835,8 @@ struct NVFP4Block(Copyable, Movable, Representable, Stringable):
+         Returns:
+             Detailed string representation.
+         """
+-        return "NVFP4Block(scale=" + repr(self.scale) + ", data=8 bytes)"
++        return (
++            "NVFP4Block(scale="
++            + String(_e4m3_to_float32(self.scale))
++            + ", data=8 bytes)"
++        )
+diff --git a/shared/testing/layer_testers.mojo b/shared/testing/layer_testers.mojo
+index eb85d5eae..52bdb16bf 100644
+--- a/shared/testing/layer_testers.mojo
++++ b/shared/testing/layer_testers.mojo
+@@ -11,7 +11,7 @@ Each tester function:
+ 1. Creates synthetic input with special values
+ 2. Runs forward pass
+ 3. Validates output properties (shape, dtype, values)
+-4. Tests across all dtypes (FP4, FP8, FP16, FP32, BFloat16, Int8)
++4. Tests across all dtypes (FP4, FP8, FP16, FP32, BF16, Int8)
+ 
+ Backward Pass Testing:
+ - Uses seeded random tensors for reproducible gradient checking
+@@ -1125,6 +1125,9 @@ struct LayerTester:
+         assert_dtype(input, dtype, "BatchNorm backward: input dtype mismatch")
+ 
+         # Test gradient checking with appropriate epsilon and tolerance for dtype
++        # FIXME(#3011, unused) var epsilon = 1e-5 if dtype == DType.float32 else 1e-4
++        # FIXME(#3011, unused) var tolerance = 1e-2 if dtype == DType.float32 else 1e-1
++
+         # Note: Actual BatchNorm backward gradient checking would be implemented
+         # when BatchNorm forward pass is available
+         # For now, we validate that we can compute numerical gradients on the input
+diff --git a/shared/testing/special_values.mojo b/shared/testing/special_values.mojo
+index 53b5e0f91..ed839128e 100644
+--- a/shared/testing/special_values.mojo
++++ b/shared/testing/special_values.mojo
+@@ -1,7 +1,7 @@
+ """Special FP-Representable Test Values
+ 
+ Provides test values that are exactly representable in all float dtypes:
+-- FP4, FP8, FP16, FP32, BFloat16
++- FP4, FP8, FP16, FP32, BF16
+ 
+ These values are chosen for:
+ 1. Exact representation (no rounding errors)
+@@ -82,7 +82,7 @@ fn create_special_value_tensor(
+ 
+     Args:
+         shape: Tensor dimensions.
+-        dtype: Data type (FP4, FP8, FP16, FP32, BFloat16, or Int8).
++        dtype: Data type (FP4, FP8, FP16, FP32, BF16, or Int8).
+         value: Special value to fill (must be -1.0, -0.5, 0.0, 0.5, 1.0, or 1.5).
+ 
+     Returns:
+@@ -102,7 +102,7 @@ fn create_special_value_tensor(
+         # Create 4x4 tensor filled with negative ones (for ReLU testing)
+         var neg_ones = create_special_value_tensor([4, 4], DType.float32, -1.0)
+ 
+-        # Create 2x2 tensor filled with zeros (BFloat16)
++        # Create 2x2 tensor filled with zeros (BF16)
+         var zeros_bf16 = create_special_value_tensor([2, 2], DType.bfloat16, 0.0)
+         ```
+     """
+@@ -152,7 +152,7 @@ fn create_alternating_pattern_tensor(
+ 
+     Args:
+         shape: Tensor dimensions.
+-        dtype: Data type (FP4, FP8, FP16, FP32, BFloat16, or Int8).
++        dtype: Data type (FP4, FP8, FP16, FP32, BF16, or Int8).
+ 
+     Returns:
+         ExTensor with alternating special value pattern.
+@@ -267,7 +267,7 @@ fn create_seeded_random_tensor(
+ 
+     Args:
+         shape: Tensor dimensions.
+-        dtype: Data type (FP4, FP8, FP16, FP32, BFloat16, or Int8).
++        dtype: Data type (FP4, FP8, FP16, FP32, BF16, or Int8).
+         seed: Random seed for reproducibility (default: 42).
+         low: Minimum value for random range (default: -1.0).
+         high: Maximum value for random range (default: 1.0).
+diff --git a/shared/training/README.md b/shared/training/README.md
+index 2455fd7dd..9f8e18607 100644
+--- a/shared/training/README.md
++++ b/shared/training/README.md
+@@ -552,25 +552,25 @@ else:
+ 
+ - **Float16 (FP16)** ✓ - Fully supported, recommended for most use cases
+ - **Float32 (FP32)** ✓ - Default precision, maximum accuracy
+-- **BFloat16 (BF16)** ✓ - Custom implementation with uint16 storage (`shared/core/bfloat16.mojo`)
++- **BFloat16 (BF16)** ✓ - Custom implementation with uint16 storage (`shared/core/types/bf16.mojo`)
+ 
+ #### BFloat16 Custom Implementation
+ 
+-Since Mojo doesn't natively support BFloat16, we provide a custom `BFloat16` struct:
++Since Mojo doesn't natively support BFloat16, we provide a custom `BF16` struct:
+ 
+ ```mojo
+-from shared.core.bfloat16 import BFloat16
++from shared.core.types.bf16 import BF16
+ 
+ # Convert from Float32
+-var bf16 = BFloat16.from_float32(3.14159)
++var bf16 = BF16.from_float32(3.14159)
+ 
+ # Convert back to Float32
+ var f32 = bf16.to_float32()
+ 
+ # Arithmetic operations
+-var a = BFloat16.from_float32(2.0)
+-var b = BFloat16.from_float32(3.0)
+-var sum = a + b  # BFloat16(5.0)
++var a = BF16.from_float32(2.0)
++var b = BF16.from_float32(3.0)
++var sum = a + b  # BF16(5.0)
+ 
+ # Comparison
+ if a < b:
+diff --git a/shared/training/__init__.mojo b/shared/training/__init__.mojo
+index 52bd25c80..c7b049e2b 100644
+--- a/shared/training/__init__.mojo
++++ b/shared/training/__init__.mojo
+@@ -6,14 +6,15 @@ schedulers, metrics, callbacks, and training loops for ML Odyssey paper implemen
+ 
+ All components are implemented in Mojo for maximum performance.
+ 
+-RESOLVED(#3010): All training import tests in tests/shared/test_imports.mojo now use
+-actual implemented imports from this module:
+-- test_training_imports: SGD, MSELoss, StepLR, CosineAnnealingLR, EarlyStopping, ModelCheckpoint
+-- test_training_optimizers_imports: SGD
+-- test_training_schedulers_imports: StepLR, CosineAnnealingLR, ExponentialLR, WarmupLR, MultiStepLR, ReduceLROnPlateau
+-- test_training_metrics_imports: Accuracy (from shared.metrics)
+-- test_training_callbacks_imports: EarlyStopping, ModelCheckpoint, LoggingCallback
+-- test_training_loops_imports: TrainingState, Callback
++FIXME(#3010): Placeholder import tests in tests/shared/test_imports.mojo require:
++- test_training_imports (line 80+)
++- test_training_optimizers_imports (line 95+)
++- test_training_schedulers_imports (line 110+)
++- test_training_metrics_imports (line 125+)
++- test_training_callbacks_imports (line 140+)
++- test_training_loops_imports (line 155+)
++All tests marked as "(placeholder)" and require uncommented imports as Issue #49 progresses.
++See Issue #49 for details.
+ """
+ 
+ from python import PythonObject
+@@ -413,7 +414,7 @@ struct TrainingLoop[
+         var total_loss = Float64(0.0)
+         var num_batches = Int(0)
+ 
+-        # Tensor slicing is implemented (Issue #3013: split(), reshape(), etc.)
++        # TODO(#3013): Iterate through batches when Python integration is complete
+         # The data_loader is currently a PythonObject, but step() requires ExTensor.
+         # Real blocker: Python↔Mojo interop for data loading (Track 4 initiative)
+         # Once data loading infrastructure is ready, integrate batching here.
+diff --git a/shared/training/dtype_utils.mojo b/shared/training/dtype_utils.mojo
+index 013cc4a31..8e1eca803 100644
+--- a/shared/training/dtype_utils.mojo
++++ b/shared/training/dtype_utils.mojo
+@@ -1,12 +1,6 @@
+ """DType aliases and utilities for mixed precision training.
+ 
+-Provides convenience aliases and dtype utilities for mixed precision training
+-
+-IMPORTANT: BFloat16 Alias
+---------------------------
+-BFloat16 is not yet available in Mojo, so `bfloat16_dtype` currently aliases
+-to `DType.float16`. This is a TEMPORARY workaround to enable forward-compatible
+-code.
++Provides convenience aliases and dtype utilities for mixed precision training.
+ 
+ Key Differences:
+ - Float16 (FP16):  1 sign + 5 exponent + 10 mantissa = 16 bits
+@@ -17,13 +11,16 @@ Key Differences:
+   - Range: ~1e-38 to 3.4e38 (same as FP32)
+   - Precision: ~2 decimal digits
+ 
+-BF16 trades precision for range compared to FP16. When Mojo adds native BF16
+-support, this comptime will be updated to use the real BF16 dtype.
++BF16 trades precision for range compared to FP16. BF16 is now natively
++supported in Mojo via DType.bfloat16.
++
++Note:
++    DType.bfloat16 is NOT supported on Apple Silicon.
+ 
+ Usage:
+     from shared.training.dtype_utils import bfloat16_dtype, is_reduced_precision
+ 
+-    # Use bfloat16_dtype instead of DType.bfloat16
++    # Use bfloat16_dtype for BFloat16 training
+     var params = ExTensor.zeros((100, 100), bfloat16_dtype)
+ 
+     # Check if dtype is reduced precision
+@@ -63,25 +60,19 @@ High precision for numerical stability. Standard IEEE 754 format
+ - Memory: 8 bytes
+ """
+ 
+-# WARNING: This is a temporary comptime until BFloat16 is available in Mojo
+-# Currently maps to Float16, which has different numerical properties than BF16
+-comptime bfloat16_dtype = DType.float16
+-"""BFloat16 (BF16) dtype - Brain floating point (TEMPORARY ALIAS).
++comptime bfloat16_dtype = DType.bfloat16
++"""BFloat16 (BF16) dtype - Brain floating point.
+ 
+-⚠️ WARNING: BFloat16 is not yet available in Mojo. This currently aliases to
+-DType.float16 as a temporary workaround. The numerical behavior will change
+-when real BF16 support is added.
++Native Mojo BFloat16 support via DType.bfloat16.
+ 
+-Expected BF16 properties (when available):
++Properties:
+ - 1 sign bit, 8 exponent bits, 7 mantissa bits
+ - Range: ~1e-38 to 3.4e38 (same as FP32)
+ - Memory: 2 bytes
+ - Better for training than FP16 due to wider exponent range
+ 
+-Current behavior (aliased to FP16):
+-- 1 sign bit, 5 exponent bits, 10 mantissa bits
+-- Range: ~6e-8 to 65504 (narrower than BF16)
+-- More precision but less range than true BF16
++Note:
++    NOT supported on Apple Silicon. Use DType.float16 on Apple hardware.
+ """
+ 
+ 
+@@ -104,14 +95,12 @@ fn is_reduced_precision(dtype: DType) -> Bool:
+ 
+         Example:
+             ```mojo
+-            f is_reduced_precision(model.dtype()):
++            if is_reduced_precision(model.dtype()):
+                 # Use gradient scaling
+                 var scaler = GradientScaler()
+             ```
+     """
+-    return (
+-        dtype == DType.float16
+-    )  # Currently only FP16, will include BF16 when available
++    return dtype == DType.float16 or dtype == DType.bfloat16
+ 
+ 
+ fn is_floating_point(dtype: DType) -> Bool:
+@@ -121,17 +110,18 @@ fn is_floating_point(dtype: DType) -> Bool:
+             dtype: DType to check.
+ 
+     Returns:
+-            True if dtype is float16, float32, or float64.
++            True if dtype is float16, bfloat16, float32, or float64.
+ 
+         Example:
+             ```mojo
+-        if is_floating_point(tensor.dtype()):
++            if is_floating_point(tensor.dtype()):
+                 # Can use floating point operations
+                 var result = tensor / 2.0
+             ```
+     """
+     return (
+         dtype == DType.float16
++        or dtype == DType.bfloat16
+         or dtype == DType.float32
+         or dtype == DType.float64
+     )
+@@ -140,14 +130,14 @@ fn is_floating_point(dtype: DType) -> Bool:
+ fn get_dtype_precision_bits(dtype: DType) -> Int:
+     """Get the number of mantissa bits for a floating point dtype.
+ 
+-        Returns the precision (mantissa bits) for floating point dtypes
++        Returns the precision (mantissa bits) for floating point dtypes.
+         Useful for understanding numerical precision limits.
+ 
+     Args:
+             dtype: DType to query.
+ 
+     Returns:
+-            Number of mantissa bits (10 for FP16, 23 for FP32, 52 for FP64).
++            Number of mantissa bits (10 for FP16, 7 for BF16, 23 for FP32, 52 for FP64).
+             Returns 0 for non-floating-point dtypes.
+ 
+         Example:
+@@ -158,6 +148,8 @@ fn get_dtype_precision_bits(dtype: DType) -> Int:
+     """
+     if dtype == DType.float16:
+         return 10  # FP16: 10 mantissa bits
++    elif dtype == DType.bfloat16:
++        return 7  # BF16: 7 mantissa bits
+     elif dtype == DType.float32:
+         return 23  # FP32: 23 mantissa bits
+     elif dtype == DType.float64:
+@@ -169,14 +161,14 @@ fn get_dtype_precision_bits(dtype: DType) -> Int:
+ fn get_dtype_exponent_bits(dtype: DType) -> Int:
+     """Get the number of exponent bits for a floating point dtype.
+ 
+-        Returns the exponent bits for floating point dtypes
+-        Useful for understanding numerical range limits
++        Returns the exponent bits for floating point dtypes.
++        Useful for understanding numerical range limits.
+ 
+     Args:
+             dtype: DType to query.
+ 
+     Returns:
+-            Number of exponent bits (5 for FP16, 8 for FP32/BF16, 11 for FP64).
++            Number of exponent bits (5 for FP16, 8 for BF16/FP32, 11 for FP64).
+             Returns 0 for non-floating-point dtypes.
+ 
+         Example:
+@@ -187,6 +179,8 @@ fn get_dtype_exponent_bits(dtype: DType) -> Int:
+     """
+     if dtype == DType.float16:
+         return 5  # FP16: 5 exponent bits (narrow range)
++    elif dtype == DType.bfloat16:
++        return 8  # BF16: 8 exponent bits (same range as FP32)
+     elif dtype == DType.float32:
+         return 8  # FP32: 8 exponent bits (wide range)
+     elif dtype == DType.float64:
+@@ -202,7 +196,7 @@ fn dtype_to_string(dtype: DType) -> String:
+             dtype: DType to convert.
+ 
+     Returns:
+-            String representation (e.g., "float16", "float32", "int32").
++            String representation (e.g., "float16", "bfloat16", "float32", "int32").
+ 
+         Example:
+             ```mojo
+@@ -212,6 +206,8 @@ fn dtype_to_string(dtype: DType) -> String:
+     """
+     if dtype == DType.float16:
+         return "float16"
++    elif dtype == DType.bfloat16:
++        return "bfloat16"
+     elif dtype == DType.float32:
+         return "float32"
+     elif dtype == DType.float64:
+@@ -283,7 +279,7 @@ fn recommend_precision_dtype(
+ fn print_dtype_info(dtype: DType):
+     """Print detailed information about a DType.
+ 
+-        Displays precision, range, and memory usage for the given dtype
++        Displays precision, range, and memory usage for the given dtype.
+         Useful for debugging and understanding dtype characteristics.
+ 
+     Args:
+@@ -291,7 +287,7 @@ fn print_dtype_info(dtype: DType):
+ 
+         Example:
+             ```mojo
+-            rint_dtype_info(DType.float16)
++            print_dtype_info(DType.float16)
+             # Output:
+             # DType: float16
+             # Precision: 10 mantissa bits
+@@ -312,6 +308,10 @@ fn print_dtype_info(dtype: DType):
+         if dtype == DType.float16:
+             print("  Range: ~6e-8 to 65504")
+             print("  Memory: 2 bytes")
++        elif dtype == DType.bfloat16:
++            print("  Range: ~1e-38 to 3.4e38 (same as FP32)")
++            print("  Memory: 2 bytes")
++            print("  Note: NOT supported on Apple Silicon")
+         elif dtype == DType.float32:
+             print("  Range: ~1e-38 to 3.4e38")
+             print("  Memory: 4 bytes")
+diff --git a/shared/training/gradient_ops.mojo b/shared/training/gradient_ops.mojo
+index 8fd957f5d..5dcc93d48 100644
+--- a/shared/training/gradient_ops.mojo
++++ b/shared/training/gradient_ops.mojo
+@@ -25,6 +25,7 @@ Example:
+ """
+ 
+ from shared.core.extensor import ExTensor
++from shared.core.types.dtype_aliases import BF16
+ 
+ 
+ fn accumulate_gradient_inplace(
+@@ -108,8 +109,8 @@ fn _accumulate_bfloat16(
+     mut accumulated: ExTensor, new_grad: ExTensor, size: Int
+ ) raises:
+     """Direct bfloat16 accumulation using pointer operations."""
+-    var acc_ptr = accumulated._data.bitcast[BFloat16]()
+-    var grad_ptr = new_grad._data.bitcast[BFloat16]()
++    var acc_ptr = accumulated._data.bitcast[Scalar[BF16]]()
++    var grad_ptr = new_grad._data.bitcast[Scalar[BF16]]()
+ 
+     for i in range(size):
+         acc_ptr[i] = acc_ptr[i] + grad_ptr[i]
+@@ -158,7 +159,7 @@ fn scale_gradient_inplace(mut gradient: ExTensor, scale: Float32) raises:
+     elif dtype == DType.float16:
+         _scale_float16(gradient, Float16(scale), size)
+     elif dtype == DType.bfloat16:
+-        _scale_bfloat16(gradient, BFloat16(scale), size)
++        _scale_bfloat16(gradient, Scalar[BF16](scale), size)
+     else:
+         # Fallback for unsupported dtypes
+         _scale_fallback(gradient, Float64(scale), size)
+@@ -180,9 +181,11 @@ fn _scale_float16(mut gradient: ExTensor, scale: Float16, size: Int) raises:
+         grad_ptr[i] = grad_ptr[i] * scale
+ 
+ 
+-fn _scale_bfloat16(mut gradient: ExTensor, scale: BFloat16, size: Int) raises:
++fn _scale_bfloat16(
++    mut gradient: ExTensor, scale: Scalar[BF16], size: Int
++) raises:
+     """Direct bfloat16 scaling using pointer operations."""
+-    var grad_ptr = gradient._data.bitcast[BFloat16]()
++    var grad_ptr = gradient._data.bitcast[Scalar[BF16]]()
+ 
+     for i in range(size):
+         grad_ptr[i] = grad_ptr[i] * scale
+@@ -251,7 +254,7 @@ fn _zero_float16(mut gradient: ExTensor, size: Int) raises:
+ 
+ fn _zero_bfloat16(mut gradient: ExTensor, size: Int) raises:
+     """Direct bfloat16 zeroing using pointer operations."""
+-    var grad_ptr = gradient._data.bitcast[BFloat16]()
++    var grad_ptr = gradient._data.bitcast[Scalar[BF16]]()
+ 
+     for i in range(size):
+         grad_ptr[i] = 0.0
+diff --git a/shared/training/mixed_precision.mojo b/shared/training/mixed_precision.mojo
+index c1ee7579b..45d5a5a55 100644
+--- a/shared/training/mixed_precision.mojo
++++ b/shared/training/mixed_precision.mojo
+@@ -280,7 +280,31 @@ fn convert_to_fp32_master(params: ExTensor) raises -> ExTensor:
+ 
+     # If FP16, use SIMD-optimized conversion when available
+     if params.dtype() == DType.float16:
+-        _convert_fp16_to_fp32_simd(params, result)
++        # TODO(#3015): Implement SIMD FP16→FP32 vectorization
++        #
++        # Current Limitation: Mojo v0.26.1+ does not support SIMD vectorization for
++        # FP16 load operations. This prevents efficient bulk conversion from FP16 to FP32.
++        #
++        # Compiler Limitation Details:
++        # - DTypePointer.load[width=N]() doesn't support FP16 types
++        # - FP16 SIMD types exist but load/store operations are unimplemented
++        # - No way to vectorize bulk FP16→FP32 conversions in current compiler
++        #
++        # Workaround: Scalar loop conversion (one element at a time)
++        # Performance Impact: ~10-15x slower than FP32→FP32 SIMD path
++        # Expected Speedup When Fixed: ~4x (matching FP32→FP32 performance)
++        #
++        # Implementation Plan:
++        # When Mojo adds FP16 SIMD load support:
++        # 1. Load FP16 vectors with DTypePointer[Float16].load[width]()
++        # 2. Convert to FP32 with explicit cast or builtin function
++        # 3. Store with DTypePointer[Float32].store[width]()
++        #
++        # Reference: Track Mojo compiler releases for FP16 SIMD support
++        var src_ptr = params._data.bitcast[Float16]()
++        var dst_ptr = result._data.bitcast[Float32]()
++        for i in range(size):
++            dst_ptr[i] = Float32(src_ptr[i])
+         return result
+ 
+     # Generic path for other dtypes
+@@ -338,7 +362,9 @@ fn update_model_from_master(
+         _update_fp32_from_fp32_simd(master_params, model_params)
+         return
+ 
+-    # If FP16, use SIMD-optimized conversion when available
++    # If FP16, use optimized conversion (scalar until Mojo supports FP16 SIMD)
++    # TODO(#3015): Implement SIMD FP32→FP16 vectorization when compiler support available
++    # See convert_to_fp32_master() for detailed notes on FP16 SIMD limitations
+     if model_params.dtype() == DType.float16:
+         _convert_fp32_to_fp16_simd(master_params, model_params)
+         return
+diff --git a/shared/training/trainer_interface.mojo b/shared/training/trainer_interface.mojo
+index 3aff01bd3..42f20f533 100644
+--- a/shared/training/trainer_interface.mojo
++++ b/shared/training/trainer_interface.mojo
+@@ -390,6 +390,7 @@ struct DataLoader(Copyable, Movable):
+         # Tensor slicing is implemented in ExTensor.slice() and __getitem__()
+         # The real blocker is integrating with Python data loaders (Track 4)
+         # For now, we'll just create placeholders
++        # TODO(#3013): Implement proper tensor slicing in ExTensor
+ 
+         self.current_batch += 1
+ 
+diff --git a/shared/utils/__init__.mojo b/shared/utils/__init__.mojo
+index a7ff32f79..915a282f7 100644
+--- a/shared/utils/__init__.mojo
++++ b/shared/utils/__init__.mojo
+@@ -23,12 +23,13 @@ Example:
+     config = load_config("experiment.yaml")
+     ```
+ 
+-RESOLVED(#3010): All utils import tests in tests/shared/test_imports.mojo now use
+-actual implemented imports from this module:
+-- test_utils_imports: Logger, LogLevel, get_logger, load_config, save_config, Config
+-- test_utils_logging_imports: Logger, LogLevel, get_logger, StreamHandler, FileHandler
+-- test_utils_visualization_imports: plot_training_curves (from shared.visualization)
+-- test_utils_config_imports: Config, load_config, save_config, ConfigValidator
++FIXME(#3010): Placeholder import tests in tests/shared/test_imports.mojo require:
++- test_utils_imports (line 210+)
++- test_utils_logging_imports (line 220+)
++- test_utils_visualization_imports (line 230+)
++- test_utils_config_imports (line 240+)
++All tests marked as "(placeholder)" and require uncommented imports as Issue #49 progresses.
++See Issue #49 for details
+ """
+ 
+ # Package version
+diff --git a/tests/core/types/test_fp4_base.mojo b/tests/core/types/test_fp4_base.mojo
+deleted file mode 100644
+index 653439c51..000000000
+--- a/tests/core/types/test_fp4_base.mojo
++++ /dev/null
+@@ -1,402 +0,0 @@
+-"""Tests for FP4_E2M1 base type encoding and decoding.
+-
+-Tests cover:
+-- All 8 representable positive values (E2M1 format)
+-- All 8 representable negative values
+-- Round-trip conversion accuracy
+-- Quantization between representable values
+-- Special values (NaN, Infinity, zero)
+-- Scale factor handling
+-- Comparison operators
+-- String representations
+-
+-This addresses TEST-010 (P0 CRITICAL): FP4_E2M1 was previously 0% tested.
+-
+-All tests use pure functional API.
+-"""
+-
+-from shared.core.types.fp4 import FP4_E2M1
+-from tests.shared.conftest import (
+-    assert_true,
+-    assert_equal,
+-    assert_almost_equal,
+-)
+-from math import isnan, isinf
+-
+-
+-# ============================================================================
+-# E2M1 Representable Values Tests
+-# ============================================================================
+-
+-
+-fn test_fp4_representable_positive_values() raises:
+-    """Test all 8 representable positive E2M1 values.
+-
+-    E2M1 format with bias=1:
+-    - exp=0, mantissa=0: 0.0
+-    - exp=1, mantissa=0: 2^0 * (1 + 0) = 1.0
+-    - exp=1, mantissa=1: 2^0 * (1 + 1) = 1.5
+-    - exp=2, mantissa=0: 2^1 * (1 + 0) = 2.0
+-    - exp=2, mantissa=1: 2^1 * (1 + 1) = 3.0
+-    - exp=3, mantissa=0: 2^2 * (1 + 0) = 4.0
+-    - exp=3, mantissa=1: 2^2 * (1 + 1) = 6.0
+-    """
+-    # Test zero
+-    var fp4_zero = FP4_E2M1.from_float32(0.0, scale=1.0)
+-    var decoded_zero = fp4_zero.to_float32(scale=1.0)
+-    assert_almost_equal(decoded_zero, Float32(0.0), tolerance=1e-6)
+-
+-    # Test 1.0
+-    var fp4_one = FP4_E2M1.from_float32(1.0, scale=1.0)
+-    var decoded_one = fp4_one.to_float32(scale=1.0)
+-    assert_almost_equal(decoded_one, Float32(1.0), tolerance=1e-6)
+-
+-    # Test 1.5
+-    var fp4_onefive = FP4_E2M1.from_float32(1.5, scale=1.0)
+-    var decoded_onefive = fp4_onefive.to_float32(scale=1.0)
+-    assert_almost_equal(decoded_onefive, Float32(1.5), tolerance=1e-6)
+-
+-    # Test 2.0
+-    var fp4_two = FP4_E2M1.from_float32(2.0, scale=1.0)
+-    var decoded_two = fp4_two.to_float32(scale=1.0)
+-    assert_almost_equal(decoded_two, Float32(2.0), tolerance=1e-6)
+-
+-    # Test 3.0
+-    var fp4_three = FP4_E2M1.from_float32(3.0, scale=1.0)
+-    var decoded_three = fp4_three.to_float32(scale=1.0)
+-    assert_almost_equal(decoded_three, Float32(3.0), tolerance=1e-6)
+-
+-    # Test 4.0
+-    var fp4_four = FP4_E2M1.from_float32(4.0, scale=1.0)
+-    var decoded_four = fp4_four.to_float32(scale=1.0)
+-    assert_almost_equal(decoded_four, Float32(4.0), tolerance=1e-6)
+-
+-    # Test 6.0 (max value)
+-    var fp4_six = FP4_E2M1.from_float32(6.0, scale=1.0)
+-    var decoded_six = fp4_six.to_float32(scale=1.0)
+-    assert_almost_equal(decoded_six, Float32(6.0), tolerance=1e-6)
+-
+-
+-fn test_fp4_representable_negative_values() raises:
+-    """Test all 8 representable negative E2M1 values."""
+-    # Test -0.0 (distinct from +0.0 in bit pattern)
+-    var fp4_neg_zero = FP4_E2M1.from_float32(-0.0, scale=1.0)
+-    var decoded_neg_zero = fp4_neg_zero.to_float32(scale=1.0)
+-    assert_almost_equal(decoded_neg_zero, Float32(0.0), tolerance=1e-6)
+-
+-    # Test -1.0
+-    var fp4_neg_one = FP4_E2M1.from_float32(-1.0, scale=1.0)
+-    var decoded_neg_one = fp4_neg_one.to_float32(scale=1.0)
+-    assert_almost_equal(decoded_neg_one, Float32(-1.0), tolerance=1e-6)
+-
+-    # Test -1.5
+-    var fp4_neg_onefive = FP4_E2M1.from_float32(-1.5, scale=1.0)
+-    var decoded_neg_onefive = fp4_neg_onefive.to_float32(scale=1.0)
+-    assert_almost_equal(decoded_neg_onefive, Float32(-1.5), tolerance=1e-6)
+-
+-    # Test -2.0
+-    var fp4_neg_two = FP4_E2M1.from_float32(-2.0, scale=1.0)
+-    var decoded_neg_two = fp4_neg_two.to_float32(scale=1.0)
+-    assert_almost_equal(decoded_neg_two, Float32(-2.0), tolerance=1e-6)
+-
+-    # Test -3.0
+-    var fp4_neg_three = FP4_E2M1.from_float32(-3.0, scale=1.0)
+-    var decoded_neg_three = fp4_neg_three.to_float32(scale=1.0)
+-    assert_almost_equal(decoded_neg_three, Float32(-3.0), tolerance=1e-6)
+-
+-    # Test -4.0
+-    var fp4_neg_four = FP4_E2M1.from_float32(-4.0, scale=1.0)
+-    var decoded_neg_four = fp4_neg_four.to_float32(scale=1.0)
+-    assert_almost_equal(decoded_neg_four, Float32(-4.0), tolerance=1e-6)
+-
+-    # Test -6.0 (max negative value)
+-    var fp4_neg_six = FP4_E2M1.from_float32(-6.0, scale=1.0)
+-    var decoded_neg_six = fp4_neg_six.to_float32(scale=1.0)
+-    assert_almost_equal(decoded_neg_six, Float32(-6.0), tolerance=1e-6)
+-
+-
+-# ============================================================================
+-# Round-Trip Conversion Tests
+-# ============================================================================
+-
+-
+-fn test_fp4_round_trip_exact_values() raises:
+-    """Test round-trip conversion for exact representable values."""
+-    var exact_values = List[Float32]()
+-    exact_values.append(0.0)
+-    exact_values.append(1.0)
+-    exact_values.append(1.5)
+-    exact_values.append(2.0)
+-    exact_values.append(3.0)
+-    exact_values.append(4.0)
+-    exact_values.append(6.0)
+-
+-    for i in range(len(exact_values)):
+-        var original = exact_values[i]
+-        var fp4_val = FP4_E2M1.from_float32(original, scale=1.0)
+-        var decoded = fp4_val.to_float32(scale=1.0)
+-        assert_almost_equal(decoded, original, tolerance=1e-6)
+-
+-
+-fn test_fp4_round_trip_negative_exact() raises:
+-    """Test round-trip conversion for exact negative values."""
+-    var exact_values = List[Float32]()
+-    exact_values.append(-1.0)
+-    exact_values.append(-1.5)
+-    exact_values.append(-2.0)
+-    exact_values.append(-3.0)
+-    exact_values.append(-4.0)
+-    exact_values.append(-6.0)
+-
+-    for i in range(len(exact_values)):
+-        var original = exact_values[i]
+-        var fp4_val = FP4_E2M1.from_float32(original, scale=1.0)
+-        var decoded = fp4_val.to_float32(scale=1.0)
+-        assert_almost_equal(decoded, original, tolerance=1e-6)
+-
+-
+-# ============================================================================
+-# Quantization Tests (Between Representable Values)
+-# ============================================================================
+-
+-
+-fn test_fp4_quantization_rounding() raises:
+-    """Test quantization of values between representable points."""
+-    # 1.2 should round to 1.0 (closer than to 1.5)
+-    var fp4_1_2 = FP4_E2M1.from_float32(1.2, scale=1.0)
+-    var decoded_1_2 = fp4_1_2.to_float32(scale=1.0)
+-    assert_almost_equal(decoded_1_2, Float32(1.0), tolerance=1e-6)
+-
+-    # 1.4 should round to 1.5 (closer than to 1.0)
+-    var fp4_1_4 = FP4_E2M1.from_float32(1.4, scale=1.0)
+-    var decoded_1_4 = fp4_1_4.to_float32(scale=1.0)
+-    assert_almost_equal(decoded_1_4, Float32(1.5), tolerance=1e-6)
+-
+-    # 2.7 should round to 3.0 (closer than to 2.0)
+-    var fp4_2_7 = FP4_E2M1.from_float32(2.7, scale=1.0)
+-    var decoded_2_7 = fp4_2_7.to_float32(scale=1.0)
+-    assert_almost_equal(decoded_2_7, Float32(3.0), tolerance=1e-6)
+-
+-    # 4.9 should round to 4.0 (closer than to 6.0)
+-    var fp4_4_9 = FP4_E2M1.from_float32(4.9, scale=1.0)
+-    var decoded_4_9 = fp4_4_9.to_float32(scale=1.0)
+-    assert_almost_equal(decoded_4_9, Float32(4.0), tolerance=1e-6)
+-
+-
+-fn test_fp4_quantization_clamping() raises:
+-    """Test clamping of values outside representable range."""
+-    # Value > 6.0 should clamp to 6.0
+-    var fp4_large = FP4_E2M1.from_float32(10.0, scale=1.0)
+-    var decoded_large = fp4_large.to_float32(scale=1.0)
+-    assert_almost_equal(decoded_large, Float32(6.0), tolerance=1e-6)
+-
+-    # Value < 0.5 should map to 0.0
+-    var fp4_small = FP4_E2M1.from_float32(0.3, scale=1.0)
+-    var decoded_small = fp4_small.to_float32(scale=1.0)
+-    assert_almost_equal(decoded_small, Float32(0.0), tolerance=1e-6)
+-
+-
+-# ============================================================================
+-# Special Values Tests
+-# ============================================================================
+-
+-
+-fn test_fp4_special_value_nan() raises:
+-    """Test NaN handling - should map to max value (0b0111)."""
+-    var nan_val = Float32(0.0) / Float32(0.0)  # Create NaN
+-    var fp4_nan = FP4_E2M1.from_float32(nan_val, scale=1.0)
+-    var decoded_nan = fp4_nan.to_float32(scale=1.0)
+-
+-    # NaN maps to max value (6.0)
+-    assert_almost_equal(decoded_nan, Float32(6.0), tolerance=1e-6)
+-
+-
+-fn test_fp4_special_value_infinity() raises:
+-    """Test Infinity handling - should clamp to max representable."""
+-    # Positive infinity
+-    var pos_inf = Float32(1.0) / Float32(0.0)
+-    var fp4_pos_inf = FP4_E2M1.from_float32(pos_inf, scale=1.0)
+-    var decoded_pos_inf = fp4_pos_inf.to_float32(scale=1.0)
+-    assert_almost_equal(decoded_pos_inf, Float32(6.0), tolerance=1e-6)
+-
+-    # Negative infinity
+-    var neg_inf = Float32(-1.0) / Float32(0.0)
+-    var fp4_neg_inf = FP4_E2M1.from_float32(neg_inf, scale=1.0)
+-    var decoded_neg_inf = fp4_neg_inf.to_float32(scale=1.0)
+-    assert_almost_equal(decoded_neg_inf, Float32(-6.0), tolerance=1e-6)
+-
+-
+-fn test_fp4_special_value_zero() raises:
+-    """Test zero value encoding/decoding."""
+-    # Positive zero
+-    var fp4_pos_zero = FP4_E2M1.from_float32(0.0, scale=1.0)
+-    var decoded_pos_zero = fp4_pos_zero.to_float32(scale=1.0)
+-    assert_almost_equal(decoded_pos_zero, Float32(0.0), tolerance=1e-6)
+-
+-    # Very small value (should map to zero)
+-    var fp4_tiny = FP4_E2M1.from_float32(1e-10, scale=1.0)
+-    var decoded_tiny = fp4_tiny.to_float32(scale=1.0)
+-    assert_almost_equal(decoded_tiny, Float32(0.0), tolerance=1e-6)
+-
+-
+-# ============================================================================
+-# Scale Factor Tests
+-# ============================================================================
+-
+-
+-fn test_fp4_with_scale_factor() raises:
+-    """Test encoding/decoding with different scale factors."""
+-    # Scale = 2.0: value 12.0 becomes 6.0 after scaling
+-    var fp4_scaled = FP4_E2M1.from_float32(12.0, scale=2.0)
+-    var decoded_scaled = fp4_scaled.to_float32(scale=2.0)
+-    assert_almost_equal(decoded_scaled, Float32(12.0), tolerance=1e-5)
+-
+-    # Scale = 0.5: value 3.0 becomes 6.0 after scaling
+-    var fp4_small_scale = FP4_E2M1.from_float32(3.0, scale=0.5)
+-    var decoded_small_scale = fp4_small_scale.to_float32(scale=0.5)
+-    assert_almost_equal(decoded_small_scale, Float32(3.0), tolerance=1e-5)
+-
+-
+-fn test_fp4_scale_ranges() raises:
+-    """Test that scale factor extends representable range."""
+-    # With scale=10.0, we can represent values up to 60.0
+-    var fp4_large_scale = FP4_E2M1.from_float32(60.0, scale=10.0)
+-    var decoded_large_scale = fp4_large_scale.to_float32(scale=10.0)
+-    assert_almost_equal(decoded_large_scale, Float32(60.0), tolerance=1e-5)
+-
+-    # With scale=0.1, we can represent values down to 0.1
+-    var fp4_small_range = FP4_E2M1.from_float32(0.15, scale=0.1)
+-    var decoded_small_range = fp4_small_range.to_float32(scale=0.1)
+-    assert_almost_equal(decoded_small_range, Float32(0.15), tolerance=0.05)
+-
+-
+-# ============================================================================
+-# Comparison Operator Tests
+-# ============================================================================
+-
+-
+-fn test_fp4_comparison_equality() raises:
+-    """Test equality comparison operators."""
+-    var fp4_a = FP4_E2M1.from_float32(2.0, scale=1.0)
+-    var fp4_b = FP4_E2M1.from_float32(2.0, scale=1.0)
+-    var fp4_c = FP4_E2M1.from_float32(3.0, scale=1.0)
+-
+-    # Test __eq__
+-    assert_true(fp4_a == fp4_b, "Equal values should be ==")
+-    assert_true(not (fp4_a == fp4_c), "Different values should not be ==")
+-
+-    # Test __ne__
+-    assert_true(fp4_a != fp4_c, "Different values should be !=")
+-    assert_true(not (fp4_a != fp4_b), "Equal values should not be !=")
+-
+-
+-# ============================================================================
+-# String Representation Tests
+-# ============================================================================
+-
+-
+-fn test_fp4_string_representation() raises:
+-    """Test __str__ method."""
+-    var fp4_val = FP4_E2M1.from_float32(3.0, scale=1.0)
+-    var str_repr = String(fp4_val)
+-
+-    # Should contain "FP4_E2M1" and the value
+-    assert_true(len(str_repr) > 0, "String representation should not be empty")
+-
+-
+-fn test_fp4_repr_representation() raises:
+-    """Test __repr__ method."""
+-    var fp4_val = FP4_E2M1.from_float32(3.0, scale=1.0)
+-    var repr_str = repr(fp4_val)
+-
+-    # Should contain "FP4_E2M1", "bits", and "value"
+-    assert_true(len(repr_str) > 0, "Repr should not be empty")
+-
+-
+-# ============================================================================
+-# Bit Pattern Tests
+-# ============================================================================
+-
+-
+-fn test_fp4_bit_patterns() raises:
+-    """Test specific bit patterns for representable values."""
+-    # 0.0 should have exp=0, mantissa=0 (bits: 0b0000)
+-    var fp4_zero = FP4_E2M1.from_float32(0.0, scale=1.0)
+-    assert_equal(Int(fp4_zero.value), 0)
+-
+-    # 1.0 should have exp=1, mantissa=0 (bits: 0b0010)
+-    var fp4_one = FP4_E2M1.from_float32(1.0, scale=1.0)
+-    assert_equal(Int(fp4_one.value), 0b0010)
+-
+-    # 1.5 should have exp=1, mantissa=1 (bits: 0b0011)
+-    var fp4_onefive = FP4_E2M1.from_float32(1.5, scale=1.0)
+-    assert_equal(Int(fp4_onefive.value), 0b0011)
+-
+-    # 6.0 should have exp=3, mantissa=1 (bits: 0b0111)
+-    var fp4_six = FP4_E2M1.from_float32(6.0, scale=1.0)
+-    assert_equal(Int(fp4_six.value), 0b0111)
+-
+-    # -1.0 should have sign=1, exp=1, mantissa=0 (bits: 0b1010)
+-    var fp4_neg_one = FP4_E2M1.from_float32(-1.0, scale=1.0)
+-    assert_equal(Int(fp4_neg_one.value), 0b1010)
+-
+-
+-fn main() raises:
+-    """Run all FP4_E2M1 base type tests."""
+-    print("Running FP4_E2M1 base type tests...")
+-
+-    # Representable values
+-    test_fp4_representable_positive_values()
+-    print("✓ Positive representable values")
+-
+-    test_fp4_representable_negative_values()
+-    print("✓ Negative representable values")
+-
+-    # Round-trip conversion
+-    test_fp4_round_trip_exact_values()
+-    print("✓ Round-trip (exact values)")
+-
+-    test_fp4_round_trip_negative_exact()
+-    print("✓ Round-trip (negative exact)")
+-
+-    # Quantization
+-    test_fp4_quantization_rounding()
+-    print("✓ Quantization rounding")
+-
+-    test_fp4_quantization_clamping()
+-    print("✓ Quantization clamping")
+-
+-    # Special values
+-    test_fp4_special_value_nan()
+-    print("✓ Special value (NaN)")
+-
+-    test_fp4_special_value_infinity()
+-    print("✓ Special value (Infinity)")
+-
+-    test_fp4_special_value_zero()
+-    print("✓ Special value (zero)")
+-
+-    # Scale factors
+-    test_fp4_with_scale_factor()
+-    print("✓ Scale factor handling")
+-
+-    test_fp4_scale_ranges()
+-    print("✓ Scale ranges")
+-
+-    # Comparison operators
+-    test_fp4_comparison_equality()
+-    print("✓ Comparison operators")
+-
+-    # String representations
+-    test_fp4_string_representation()
+-    print("✓ String representation (__str__)")
+-
+-    test_fp4_repr_representation()
+-    print("✓ Repr representation (__repr__)")
+-
+-    # Bit patterns
+-    test_fp4_bit_patterns()
+-    print("✓ Bit patterns")
+-
+-    print("\nAll FP4_E2M1 base type tests passed!")
+-    print("TEST-010 (P0 CRITICAL) - RESOLVED")
+diff --git a/tests/core/types/test_fp4_stochastic.mojo b/tests/core/types/test_fp4_stochastic.mojo
+deleted file mode 100644
+index 94ba0dbb5..000000000
+--- a/tests/core/types/test_fp4_stochastic.mojo
++++ /dev/null
+@@ -1,337 +0,0 @@
+-"""Tests for FP4 stochastic rounding.
+-
+-Tests cover:
+-- Stochastic rounding correctness
+-- Deterministic behavior with same seed
+-- Distribution of rounding decisions
+-- Comparison with round-to-nearest
+-- MXFP4 and NVFP4 stochastic methods
+-
+-All tests use pure functional API.
+-"""
+-
+-from shared.core.types.mxfp4 import MXFP4
+-from shared.core.types.nvfp4 import NVFP4
+-from tests.shared.conftest import (
+-    assert_true,
+-    assert_equal,
+-    assert_almost_equal,
+-)
+-
+-
+-# ============================================================================
+-# Deterministic Behavior Tests
+-# ============================================================================
+-
+-
+-fn test_mxfp4_stochastic_deterministic() raises:
+-    """Test MXFP4 stochastic rounding is deterministic with same seed."""
+-    var value = Float32(1.25)  # Halfway between 1.0 and 1.5
+-
+-    var result1 = MXFP4.from_float32_stochastic(value, seed=12345)
+-    var result2 = MXFP4.from_float32_stochastic(value, seed=12345)
+-
+-    # Same seed should produce same result
+-    assert_equal(result1.value.value, result2.value.value)
+-    assert_equal(result1.scale.exponent, result2.scale.exponent)
+-
+-
+-fn test_nvfp4_stochastic_deterministic() raises:
+-    """Test NVFP4 stochastic rounding is deterministic with same seed."""
+-    var value = Float32(1.25)  # Halfway between 1.0 and 1.5
+-
+-    var result1 = NVFP4.from_float32_stochastic(value, seed=12345)
+-    var result2 = NVFP4.from_float32_stochastic(value, seed=12345)
+-
+-    # Same seed should produce same result
+-    assert_equal(result1.value.value, result2.value.value)
+-    assert_equal(result1.scale.value, result2.scale.value)
+-
+-
+-fn test_mxfp4_stochastic_different_seeds() raises:
+-    """Test MXFP4 stochastic rounding varies with different seeds."""
+-    var value = Float32(1.25)  # Halfway between 1.0 and 1.5
+-
+-    # Try multiple seeds to find different results
+-    var result1 = MXFP4.from_float32_stochastic(value, seed=1)
+-    var result2 = MXFP4.from_float32_stochastic(value, seed=2)
+-    var result3 = MXFP4.from_float32_stochastic(value, seed=3)
+-    var result4 = MXFP4.from_float32_stochastic(value, seed=4)
+-    var result5 = MXFP4.from_float32_stochastic(value, seed=5)
+-
+-    # Collect unique results
+-    var unique_count = 1
+-    var first_val = result1.to_float32()
+-
+-    if abs(result2.to_float32() - first_val) > 0.01:
+-        unique_count += 1
+-    if (
+-        abs(result3.to_float32() - first_val) > 0.01
+-        and abs(result3.to_float32() - result2.to_float32()) > 0.01
+-    ):
+-        unique_count += 1
+-
+-    # Should get at least 1 unique value (may get both 1.0 and 1.5)
+-    assert_true(unique_count >= 1, "Expected variation with different seeds")
+-
+-
+-fn test_nvfp4_stochastic_different_seeds() raises:
+-    """Test NVFP4 stochastic rounding varies with different seeds."""
+-    var value = Float32(1.25)  # Halfway between 1.0 and 1.5
+-
+-    # Try multiple seeds
+-    var result1 = NVFP4.from_float32_stochastic(value, seed=1)
+-    var result2 = NVFP4.from_float32_stochastic(value, seed=2)
+-    var result3 = NVFP4.from_float32_stochastic(value, seed=3)
+-
+-    # At least one should differ (probabilistically)
+-    var all_same = (
+-        abs(result1.to_float32() - result2.to_float32()) < 0.01
+-        and abs(result2.to_float32() - result3.to_float32()) < 0.01
+-    )
+-
+-    # This could fail with very low probability, but unlikely
+-    # (failing means we got same result 3 times in a row for 50/50 coin flip)
+-
+-
+-# ============================================================================
+-# Distribution Tests
+-# ============================================================================
+-
+-
+-fn test_mxfp4_stochastic_distribution() raises:
+-    """Test MXFP4 stochastic rounding distribution."""
+-    var value = Float32(1.25)  # Exactly halfway between 1.0 and 1.5
+-
+-    # Run stochastic rounding many times with different seeds
+-    var count_lower = 0
+-    var count_upper = 0
+-
+-    for seed in range(100):
+-        var result = MXFP4.from_float32_stochastic(value, seed=UInt64(seed))
+-        var decoded = result.to_float32()
+-
+-        # Check if rounded down (closer to 1.0) or up (closer to 1.5)
+-        if decoded < 1.25:
+-            count_lower += 1
+-        else:
+-            count_upper += 1
+-
+-    # For value exactly halfway, expect roughly 50/50 distribution
+-    # Allow very wide variance (1-99% range) to avoid flaky tests
+-    # Note: If distribution is extremely skewed (0 or 100), there may be an implementation bug
+-    assert_true(
+-        count_lower >= 1 and count_lower <= 99, "Distribution too skewed"
+-    )
+-    assert_true(
+-        count_upper >= 1 and count_upper <= 99, "Distribution too skewed"
+-    )
+-
+-    print(
+-        "MXFP4 stochastic: lower="
+-        + String(count_lower)
+-        + ", upper="
+-        + String(count_upper)
+-    )
+-
+-
+-fn test_nvfp4_stochastic_distribution() raises:
+-    """Test NVFP4 stochastic rounding distribution."""
+-    var value = Float32(1.25)  # Exactly halfway between 1.0 and 1.5
+-
+-    # Run stochastic rounding many times with different seeds
+-    var count_lower = 0
+-    var count_upper = 0
+-
+-    for seed in range(100):
+-        var result = NVFP4.from_float32_stochastic(value, seed=UInt64(seed))
+-        var decoded = result.to_float32()
+-
+-        # Check if rounded down (closer to 1.0) or up (closer to 1.5)
+-        if decoded < 1.25:
+-            count_lower += 1
+-        else:
+-            count_upper += 1
+-
+-    # For value exactly halfway, expect roughly 50/50 distribution
+-    # Allow very wide variance (1-99% range) to avoid flaky tests
+-    # Note: If distribution is extremely skewed (0 or 100), there may be an implementation bug
+-    assert_true(
+-        count_lower >= 1 and count_lower <= 99, "Distribution too skewed"
+-    )
+-    assert_true(
+-        count_upper >= 1 and count_upper <= 99, "Distribution too skewed"
+-    )
+-
+-    print(
+-        "NVFP4 stochastic: lower="
+-        + String(count_lower)
+-        + ", upper="
+-        + String(count_upper)
+-    )
+-
+-
+-# ============================================================================
+-# Comparison with Deterministic Rounding
+-# ============================================================================
+-
+-
+-fn test_mxfp4_stochastic_vs_deterministic() raises:
+-    """Compare MXFP4 stochastic vs deterministic rounding."""
+-    var value = Float32(1.3)  # Closer to 1.5 than 1.0
+-
+-    var deterministic = MXFP4.from_float32(value)
+-    var stochastic = MXFP4.from_float32_stochastic(value, seed=42)
+-
+-    # Deterministic should round to nearest (1.5)
+-    var det_decoded = deterministic.to_float32()
+-
+-    # Stochastic should round based on probability
+-    # Value is 1.3, which is 0.3/0.5 = 60% of the way from 1.0 to 1.5
+-    # So should round to 1.5 with ~60% probability, 1.0 with ~40% probability
+-
+-    # Run stochastic many times to verify distribution
+-    var count_15 = 0
+-    var count_10 = 0
+-
+-    for seed in range(100):
+-        var result = MXFP4.from_float32_stochastic(value, seed=UInt64(seed))
+-        var decoded = result.to_float32()
+-
+-        if abs(decoded - 1.5) < 0.1:
+-            count_15 += 1
+-        elif abs(decoded - 1.0) < 0.1:
+-            count_10 += 1
+-
+-    # Expect roughly 60/40 split (allow wide variance 30-90% to avoid flaky tests)
+-    assert_true(
+-        count_15 >= 30 and count_15 <= 90, "Stochastic distribution incorrect"
+-    )
+-
+-    print(
+-        "Stochastic for 1.3: 1.5="
+-        + String(count_15)
+-        + "%, 1.0="
+-        + String(count_10)
+-        + "%"
+-    )
+-
+-
+-fn test_nvfp4_stochastic_vs_deterministic() raises:
+-    """Compare NVFP4 stochastic vs deterministic rounding."""
+-    var value = Float32(1.3)  # Closer to 1.5 than 1.0
+-
+-    var deterministic = NVFP4.from_float32(value)
+-    var stochastic = NVFP4.from_float32_stochastic(value, seed=42)
+-
+-    # Run stochastic many times to verify distribution
+-    var count_15 = 0
+-    var count_10 = 0
+-
+-    for seed in range(100):
+-        var result = NVFP4.from_float32_stochastic(value, seed=UInt64(seed))
+-        var decoded = result.to_float32()
+-
+-        if abs(decoded - 1.5) < 0.1:
+-            count_15 += 1
+-        elif abs(decoded - 1.0) < 0.1:
+-            count_10 += 1
+-
+-    # Expect roughly 60/40 split (allow wide variance 30-90% to avoid flaky tests)
+-    assert_true(
+-        count_15 >= 30 and count_15 <= 90, "Stochastic distribution incorrect"
+-    )
+-
+-    print(
+-        "Stochastic for 1.3: 1.5="
+-        + String(count_15)
+-        + "%, 1.0="
+-        + String(count_10)
+-        + "%"
+-    )
+-
+-
+-# ============================================================================
+-# Special Cases
+-# ============================================================================
+-
+-
+-fn test_mxfp4_stochastic_zero() raises:
+-    """Test MXFP4 stochastic rounding for zero."""
+-    var result = MXFP4.from_float32_stochastic(0.0, seed=12345)
+-    assert_almost_equal(result.to_float32(), 0.0, tolerance=1e-5)
+-
+-
+-fn test_nvfp4_stochastic_zero() raises:
+-    """Test NVFP4 stochastic rounding for zero."""
+-    var result = NVFP4.from_float32_stochastic(0.0, seed=12345)
+-    assert_almost_equal(result.to_float32(), 0.0, tolerance=1e-5)
+-
+-
+-fn test_mxfp4_stochastic_negative() raises:
+-    """Test MXFP4 stochastic rounding preserves sign."""
+-    var value = Float32(-1.25)
+-
+-    var result = MXFP4.from_float32_stochastic(value, seed=12345)
+-    var decoded = result.to_float32()
+-
+-    # Should be negative
+-    assert_true(decoded <= 0.0, "Sign not preserved")
+-
+-
+-fn test_nvfp4_stochastic_negative() raises:
+-    """Test NVFP4 stochastic rounding preserves sign."""
+-    var value = Float32(-1.25)
+-
+-    var result = NVFP4.from_float32_stochastic(value, seed=12345)
+-    var decoded = result.to_float32()
+-
+-    # Should be negative
+-    assert_true(decoded <= 0.0, "Sign not preserved")
+-
+-
+-fn main() raises:
+-    """Run all FP4 stochastic rounding tests."""
+-    print("Running FP4 stochastic rounding tests...")
+-
+-    # Deterministic behavior
+-    test_mxfp4_stochastic_deterministic()
+-    print("✓ MXFP4 deterministic with same seed")
+-
+-    test_nvfp4_stochastic_deterministic()
+-    print("✓ NVFP4 deterministic with same seed")
+-
+-    test_mxfp4_stochastic_different_seeds()
+-    print("✓ MXFP4 varies with different seeds")
+-
+-    test_nvfp4_stochastic_different_seeds()
+-    print("✓ NVFP4 varies with different seeds")
+-
+-    # Distribution tests
+-    test_mxfp4_stochastic_distribution()
+-    print("✓ MXFP4 stochastic distribution")
+-
+-    test_nvfp4_stochastic_distribution()
+-    print("✓ NVFP4 stochastic distribution")
+-
+-    # Comparison with deterministic
+-    test_mxfp4_stochastic_vs_deterministic()
+-    print("✓ MXFP4 stochastic vs deterministic")
+-
+-    test_nvfp4_stochastic_vs_deterministic()
+-    print("✓ NVFP4 stochastic vs deterministic")
+-
+-    # Special cases
+-    test_mxfp4_stochastic_zero()
+-    print("✓ MXFP4 stochastic zero")
+-
+-    test_nvfp4_stochastic_zero()
+-    print("✓ NVFP4 stochastic zero")
+-
+-    test_mxfp4_stochastic_negative()
+-    print("✓ MXFP4 stochastic negative")
+-
+-    test_nvfp4_stochastic_negative()
+-    print("✓ NVFP4 stochastic negative")
+-
+-    print("\nAll FP4 stochastic rounding tests passed!")
+diff --git a/tests/core/types/test_fp4_tensor.mojo b/tests/core/types/test_fp4_tensor.mojo
+deleted file mode 100644
+index ec4900987..000000000
+--- a/tests/core/types/test_fp4_tensor.mojo
++++ /dev/null
+@@ -1,467 +0,0 @@
+-"""Tests for FP4 tensor conversion operations.
+-
+-Tests cover:
+-- Tensor conversion (to_mxfp4, from_mxfp4, to_nvfp4, from_nvfp4)
+-- Multi-dimensional tensors
+-- Padding behavior for non-multiple sizes
+-- Round-trip accuracy
+-- Memory efficiency verification
+-
+-All tests use pure functional API.
+-"""
+-
+-from shared.core.extensor import ExTensor, zeros, ones, full
+-from tests.shared.conftest import (
+-    assert_true,
+-    assert_equal,
+-    assert_almost_equal,
+-)
+-
+-
+-# ============================================================================
+-# MXFP4 Tensor Conversion Tests
+-# ============================================================================
+-
+-
+-fn test_mxfp4_tensor_conversion_exact_size() raises:
+-    """Test MXFP4 conversion for tensor with exact block size."""
+-    # Create tensor with exactly 64 elements (2 blocks of 32)
+-    var t = zeros([64], DType.float32)
+-
+-    # Fill with test values
+-    for i in range(64):
+-        t._data.bitcast[Float32]()[i] = Float32(i) * 0.1
+-
+-    # Convert to MXFP4
+-    var mxfp4_t = t.to_mxfp4()
+-
+-    # Verify size: 2 blocks × 17 bytes = 34 bytes
+-    assert_equal(mxfp4_t.numel(), 34)
+-    assert_true(
+-        mxfp4_t.dtype() == DType.uint8, "Expected MXFP4 dtype to be uint8"
+-    )
+-
+-    # Convert back
+-    var restored = mxfp4_t.from_mxfp4()
+-
+-    # Verify size restored
+-    assert_equal(restored.numel(), 64)
+-    assert_true(
+-        restored.dtype() == DType.float32,
+-        "Expected restored dtype to be float32",
+-    )
+-
+-    # Verify approximate accuracy
+-    var total_error = Float32(0.0)
+-    for i in range(64):
+-        var expected = Float32(i) * 0.1
+-        var decoded = restored._data.bitcast[Float32]()[i]
+-        total_error += abs(decoded - expected)
+-
+-    # Average error should be reasonable
+-    var avg_error = total_error / 64.0
+-    assert_true(avg_error < 0.5, "Average error too large")
+-
+-
+-fn test_mxfp4_tensor_conversion_padding() raises:
+-    """Test MXFP4 conversion handles padding correctly."""
+-    # Create tensor with 50 elements (requires 2 blocks, 14 padding zeros)
+-    var t = zeros([50], DType.float32)
+-
+-    # Fill with test values
+-    for i in range(50):
+-        t._data.bitcast[Float32]()[i] = Float32(i) * 0.1
+-
+-    # Convert to MXFP4
+-    var mxfp4_t = t.to_mxfp4()
+-
+-    # Verify size: 2 blocks × 17 bytes = 34 bytes
+-    assert_equal(mxfp4_t.numel(), 34)
+-
+-    # Convert back (implementation restores original size, not padded size)
+-    var restored = mxfp4_t.from_mxfp4()
+-
+-    # Verify size restored to original (50 elements, not padded 64)
+-    assert_equal(restored.numel(), 50)
+-
+-    # Verify all 50 values are approximately correct
+-    # Note: FP4 has limited precision, use larger tolerance for higher values
+-    for i in range(50):
+-        var expected = Float32(i) * 0.1
+-        var decoded = restored._data.bitcast[Float32]()[i]
+-        var error = abs(decoded - expected)
+-        # Tolerance scales with value magnitude for low-precision formats
+-        var tolerance = max(Float32(1.0), expected * 0.5)
+-        assert_true(
+-            error < tolerance, "Value " + String(i) + " error too large"
+-        )
+-
+-
+-fn test_mxfp4_tensor_conversion_multidim() raises:
+-    """Test MXFP4 conversion for multi-dimensional tensor."""
+-    # Create 2D tensor (4, 16) = 64 elements
+-    var t = zeros([4, 16], DType.float32)
+-
+-    # Fill with test values
+-    for i in range(64):
+-        t._data.bitcast[Float32]()[i] = Float32(i % 32) * 0.1
+-
+-    # Convert to MXFP4
+-    var mxfp4_t = t.to_mxfp4()
+-
+-    # Convert back
+-    var restored = mxfp4_t.from_mxfp4()
+-
+-    # Verify approximate accuracy
+-    for i in range(64):
+-        var expected = Float32(i % 32) * 0.1
+-        var decoded = restored._data.bitcast[Float32]()[i]
+-        var error = abs(decoded - expected)
+-        assert_true(error < 0.5, "Error too large")
+-
+-
+-# ============================================================================
+-# NVFP4 Tensor Conversion Tests
+-# ============================================================================
+-
+-
+-fn test_nvfp4_tensor_conversion_exact_size() raises:
+-    """Test NVFP4 conversion for tensor with exact block size."""
+-    # Create tensor with exactly 64 elements (4 blocks of 16)
+-    var t = zeros([64], DType.float32)
+-
+-    # Fill with test values
+-    for i in range(64):
+-        t._data.bitcast[Float32]()[i] = Float32(i) * 0.1
+-
+-    # Convert to NVFP4
+-    var nvfp4_t = t.to_nvfp4()
+-
+-    # Verify size: 4 blocks × 9 bytes = 36 bytes
+-    assert_equal(nvfp4_t.numel(), 36)
+-    assert_true(
+-        nvfp4_t.dtype() == DType.uint8, "Expected NVFP4 dtype to be uint8"
+-    )
+-
+-    # Convert back
+-    var restored = nvfp4_t.from_nvfp4()
+-
+-    # Verify size restored
+-    assert_equal(restored.numel(), 64)
+-    assert_true(
+-        restored.dtype() == DType.float32,
+-        "Expected restored dtype to be float32",
+-    )
+-
+-    # Verify approximate accuracy
+-    var total_error = Float32(0.0)
+-    for i in range(64):
+-        var expected = Float32(i) * 0.1
+-        var decoded = restored._data.bitcast[Float32]()[i]
+-        total_error += abs(decoded - expected)
+-
+-    # Average error should be reasonable
+-    var avg_error = total_error / 64.0
+-    assert_true(avg_error < 0.5, "Average error too large")
+-
+-
+-fn test_nvfp4_tensor_conversion_padding() raises:
+-    """Test NVFP4 conversion handles padding correctly."""
+-    # Create tensor with 50 elements (requires 4 blocks, 14 padding zeros)
+-    var t = zeros([50], DType.float32)
+-
+-    # Fill with test values
+-    for i in range(50):
+-        t._data.bitcast[Float32]()[i] = Float32(i) * 0.1
+-
+-    # Convert to NVFP4
+-    var nvfp4_t = t.to_nvfp4()
+-
+-    # Verify size: 4 blocks × 9 bytes = 36 bytes (ceil(50/16) = 4)
+-    assert_equal(nvfp4_t.numel(), 36)
+-
+-    # Convert back (implementation restores original size, not padded size)
+-    var restored = nvfp4_t.from_nvfp4()
+-
+-    # Verify size restored to original (50 elements, not padded 64)
+-    assert_equal(restored.numel(), 50)
+-
+-    # Verify all 50 values are approximately correct
+-    # Note: FP4 has limited precision, use larger tolerance for higher values
+-    for i in range(50):
+-        var expected = Float32(i) * 0.1
+-        var decoded = restored._data.bitcast[Float32]()[i]
+-        var error = abs(decoded - expected)
+-        # Tolerance scales with value magnitude for low-precision formats
+-        var tolerance = max(Float32(0.8), expected * 0.5)
+-        assert_true(
+-            error < tolerance, "Value " + String(i) + " error too large"
+-        )
+-
+-
+-fn test_nvfp4_tensor_conversion_multidim() raises:
+-    """Test NVFP4 conversion for multi-dimensional tensor."""
+-    # Create 2D tensor (4, 16) = 64 elements
+-    var t = zeros([4, 16], DType.float32)
+-
+-    # Fill with test values
+-    for i in range(64):
+-        t._data.bitcast[Float32]()[i] = Float32(i % 16) * 0.1
+-
+-    # Convert to NVFP4
+-    var nvfp4_t = t.to_nvfp4()
+-
+-    # Convert back
+-    var restored = nvfp4_t.from_nvfp4()
+-
+-    # Verify approximate accuracy
+-    for i in range(64):
+-        var expected = Float32(i % 16) * 0.1
+-        var decoded = restored._data.bitcast[Float32]()[i]
+-        var error = abs(decoded - expected)
+-        assert_true(error < 0.4, "Error too large")
+-
+-
+-# ============================================================================
+-# Memory Efficiency Tests
+-# ============================================================================
+-
+-
+-fn test_mxfp4_memory_efficiency() raises:
+-    """Verify MXFP4 provides expected compression."""
+-    # Create tensor with 320 elements (10 blocks)
+-    var t = zeros([320], DType.float32)
+-
+-    # Original size: 320 * 4 bytes = 1280 bytes
+-    # MXFP4 size: 10 blocks * 17 bytes = 170 bytes
+-    # Compression: ~7.5x
+-
+-    var mxfp4_t = t.to_mxfp4()
+-
+-    # Verify compressed size
+-    assert_equal(mxfp4_t.numel(), 170)
+-
+-    # Calculate compression ratio
+-    var original_bytes = 320 * 4
+-    var compressed_bytes = mxfp4_t.numel()
+-    var compression_ratio = Float32(original_bytes) / Float32(compressed_bytes)
+-
+-    print("MXFP4 compression: " + String(compression_ratio) + "x")
+-    assert_true(compression_ratio > 7.0, "Compression ratio too low")
+-
+-
+-fn test_nvfp4_memory_efficiency() raises:
+-    """Verify NVFP4 provides expected compression."""
+-    # Create tensor with 320 elements (20 blocks)
+-    var t = zeros([320], DType.float32)
+-
+-    # Original size: 320 * 4 bytes = 1280 bytes
+-    # NVFP4 size: 20 blocks * 9 bytes = 180 bytes
+-    # Compression: ~7.1x
+-
+-    var nvfp4_t = t.to_nvfp4()
+-
+-    # Verify compressed size
+-    assert_equal(nvfp4_t.numel(), 180)
+-
+-    # Calculate compression ratio
+-    var original_bytes = 320 * 4
+-    var compressed_bytes = nvfp4_t.numel()
+-    var compression_ratio = Float32(original_bytes) / Float32(compressed_bytes)
+-
+-    print("NVFP4 compression: " + String(compression_ratio) + "x")
+-    assert_true(compression_ratio > 7.0, "Compression ratio too low")
+-
+-
+-# ============================================================================
+-# Error Handling Tests
+-# ============================================================================
+-
+-
+-fn test_mxfp4_conversion_requires_float() raises:
+-    """Test MXFP4 conversion requires floating-point tensor."""
+-    var t = zeros([1], DType.int32)
+-
+-    try:
+-        var mxfp4_t = t.to_mxfp4()
+-        assert_true(False, "Expected error for non-float tensor")
+-    except e:
+-        # Expected error
+-        pass
+-
+-
+-fn test_nvfp4_conversion_requires_float() raises:
+-    """Test NVFP4 conversion requires floating-point tensor."""
+-    var t = zeros([1], DType.int32)
+-
+-    try:
+-        var nvfp4_t = t.to_nvfp4()
+-        assert_true(False, "Expected error for non-float tensor")
+-    except e:
+-        # Expected error
+-        pass
+-
+-
+-fn test_mxfp4_decoding_requires_uint8() raises:
+-    """Test MXFP4 decoding requires uint8 tensor."""
+-    var t = zeros([1], DType.int32)
+-
+-    try:
+-        var restored = t.from_mxfp4()
+-        assert_true(False, "Expected error for non-uint8 tensor")
+-    except e:
+-        # Expected error
+-        pass
+-
+-
+-fn test_nvfp4_decoding_requires_uint8() raises:
+-    """Test NVFP4 decoding requires uint8 tensor."""
+-    var t = zeros([1], DType.int32)
+-
+-    try:
+-        var restored = t.from_nvfp4()
+-        assert_true(False, "Expected error for non-uint8 tensor")
+-    except e:
+-        # Expected error
+-        pass
+-
+-
+-fn test_mxfp4_decoding_requires_block_alignment() raises:
+-    """Test MXFP4 decoding requires block-aligned size."""
+-    var t = zeros([1], DType.uint8)  # Not a multiple of 17
+-
+-    try:
+-        var restored = t.from_mxfp4()
+-        assert_true(False, "Expected error for non-aligned size")
+-    except e:
+-        # Expected error
+-        pass
+-
+-
+-fn test_nvfp4_decoding_requires_block_alignment() raises:
+-    """Test NVFP4 decoding requires block-aligned size."""
+-    var t = zeros([1], DType.uint8)  # Not a multiple of 9
+-
+-    try:
+-        var restored = t.from_nvfp4()
+-        assert_true(False, "Expected error for non-aligned size")
+-    except e:
+-        # Expected error
+-        pass
+-
+-
+-# ============================================================================
+-# Round-Trip Tests
+-# ============================================================================
+-
+-
+-fn test_mxfp4_roundtrip_large_tensor() raises:
+-    """Test MXFP4 round-trip for large tensor."""
+-    # Create large tensor (1000 elements)
+-    var t = zeros([1000], DType.float32)
+-
+-    # Fill with test pattern
+-    for i in range(1000):
+-        t._data.bitcast[Float32]()[i] = Float32(i % 100) * 0.01
+-
+-    # Round-trip
+-    var mxfp4_t = t.to_mxfp4()
+-    var restored = mxfp4_t.from_mxfp4()
+-
+-    # Check approximate accuracy
+-    var errors = 0
+-    for i in range(1000):
+-        var expected = Float32(i % 100) * 0.01
+-        var decoded = restored._data.bitcast[Float32]()[i]
+-        var error = abs(decoded - expected)
+-        if error > 0.5:
+-            errors += 1
+-
+-    # Allow some errors due to quantization
+-    assert_true(errors < 100, "Too many errors in round-trip")
+-
+-
+-fn test_nvfp4_roundtrip_large_tensor() raises:
+-    """Test NVFP4 round-trip for large tensor."""
+-    # Create large tensor (1000 elements)
+-    var t = zeros([1000], DType.float32)
+-
+-    # Fill with test pattern
+-    for i in range(1000):
+-        t._data.bitcast[Float32]()[i] = Float32(i % 100) * 0.01
+-
+-    # Round-trip
+-    var nvfp4_t = t.to_nvfp4()
+-    var restored = nvfp4_t.from_nvfp4()
+-
+-    # Check approximate accuracy
+-    var errors = 0
+-    for i in range(1000):
+-        var expected = Float32(i % 100) * 0.01
+-        var decoded = restored._data.bitcast[Float32]()[i]
+-        var error = abs(decoded - expected)
+-        if error > 0.4:
+-            errors += 1
+-
+-    # Allow some errors due to quantization
+-    assert_true(errors < 100, "Too many errors in round-trip")
+-
+-
+-fn main() raises:
+-    """Run all FP4 tensor conversion tests."""
+-    print("Running FP4 tensor conversion tests...")
+-
+-    # MXFP4 conversion tests
+-    test_mxfp4_tensor_conversion_exact_size()
+-    print("✓ MXFP4 exact size conversion")
+-
+-    test_mxfp4_tensor_conversion_padding()
+-    print("✓ MXFP4 padding handling")
+-
+-    test_mxfp4_tensor_conversion_multidim()
+-    print("✓ MXFP4 multi-dimensional tensor")
+-
+-    # NVFP4 conversion tests
+-    test_nvfp4_tensor_conversion_exact_size()
+-    print("✓ NVFP4 exact size conversion")
+-
+-    test_nvfp4_tensor_conversion_padding()
+-    print("✓ NVFP4 padding handling")
+-
+-    test_nvfp4_tensor_conversion_multidim()
+-    print("✓ NVFP4 multi-dimensional tensor")
+-
+-    # Memory efficiency
+-    test_mxfp4_memory_efficiency()
+-    print("✓ MXFP4 memory efficiency")
+-
+-    test_nvfp4_memory_efficiency()
+-    print("✓ NVFP4 memory efficiency")
+-
+-    # Error handling
+-    test_mxfp4_conversion_requires_float()
+-    print("✓ MXFP4 requires float tensor")
+-
+-    test_nvfp4_conversion_requires_float()
+-    print("✓ NVFP4 requires float tensor")
+-
+-    test_mxfp4_decoding_requires_uint8()
+-    print("✓ MXFP4 decoding requires uint8")
+-
+-    test_nvfp4_decoding_requires_uint8()
+-    print("✓ NVFP4 decoding requires uint8")
+-
+-    test_mxfp4_decoding_requires_block_alignment()
+-    print("✓ MXFP4 decoding requires alignment")
+-
+-    test_nvfp4_decoding_requires_block_alignment()
+-    print("✓ NVFP4 decoding requires alignment")
+-
+-    # Round-trip tests
+-    test_mxfp4_roundtrip_large_tensor()
+-    print("✓ MXFP4 large tensor round-trip")
+-
+-    test_nvfp4_roundtrip_large_tensor()
+-    print("✓ NVFP4 large tensor round-trip")
+-
+-    print("\nAll FP4 tensor conversion tests passed!")
+diff --git a/tests/core/types/test_mxfp4_block.mojo b/tests/core/types/test_mxfp4_block.mojo
+index bd2d632f0..f3536d664 100644
+--- a/tests/core/types/test_mxfp4_block.mojo
++++ b/tests/core/types/test_mxfp4_block.mojo
+@@ -13,8 +13,7 @@ All tests use pure functional API.
+ 
+ from math import isinf, isnan
+ 
+-from shared.core.types.mxfp4 import MXFP4, MXFP4Block, E8M0Scale
+-from shared.core.types.fp4 import FP4_E2M1
++from shared.core.types.mxfp4 import MXFP4, MXFP4Block
+ from tests.shared.conftest import (
+     assert_true,
+     assert_equal,
+@@ -121,12 +120,15 @@ fn test_mxfp4_block_roundtrip_large() raises:
+     var decoded = block.to_float32_array()
+ 
+     # Verify approximate reconstruction
+-    # FP4 round-trip quantization error can be 30-50% for large values
++    # E8M0 scale is power-of-2 only, so scale can be up to 2x off from optimal.
++    # Combined with FP4 quantization, smaller values in the block can have
++    # larger relative error (up to 100%) when scale is rounded up.
+     for i in range(32):
+         var expected = Float32(10.0) + Float32(i) * 2.0
+         var error = abs(decoded[i] - expected)
+-        # Allow relative error up to 50% for large values due to FP4 precision
+-        assert_true(error < expected * 0.5, "Round-trip error too large")
++        # Allow relative error up to 100% to account for E8M0 scale quantization
++        # (scale can be 2x too large, causing values to round differently)
++        assert_true(error < expected * 1.0, "Round-trip error too large")
+ 
+ 
+ fn test_mxfp4_block_roundtrip_mixed_signs() raises:
+@@ -179,7 +181,7 @@ fn test_mxfp4_block_scale_computation() raises:
+ 
+     var block1 = MXFP4Block.from_float32_array(values1)
+     # Scale should be roughly max/6 = (31/32)/6 ≈ 0.16
+-    var scale1 = block1.scale.to_float32()
++    var scale1 = Float32(block1.scale)
+     assert_true(scale1 > 0.1 and scale1 < 0.3, "Scale 1 out of range")
+ 
+     # Test 2: All values in [0, 10]
+@@ -189,7 +191,7 @@ fn test_mxfp4_block_scale_computation() raises:
+ 
+     var block2 = MXFP4Block.from_float32_array(values2)
+     # Scale should be larger
+-    var scale2 = block2.scale.to_float32()
++    var scale2 = Float32(block2.scale)
+     assert_true(scale2 > scale1, "Scale 2 should be larger")
+ 
+ 
+@@ -352,7 +354,7 @@ fn test_mxfp4_block_negative_scale_computation() raises:
+     var block = MXFP4Block.from_float32_array(values)
+ 
+     # Scale should be positive (computed from abs(max))
+-    var scale_val = block.scale.to_float32()
++    var scale_val = Float32(block.scale)
+     assert_true(scale_val > 0, "Scale should be positive")
+ 
+     # Decoded values should preserve sign
+@@ -375,7 +377,7 @@ fn test_mxfp4_block_all_zeros() raises:
+     var block = MXFP4Block.from_float32_array(values)
+ 
+     # Scale should fallback to 1.0 (not 0.0)
+-    var scale_val = block.scale.to_float32()
++    var scale_val = Float32(block.scale)
+     assert_true(scale_val > 0.5, "Scale should fallback to 1.0")
+ 
+     # Decoded values should be zero
+@@ -393,7 +395,7 @@ fn test_mxfp4_block_near_zero() raises:
+     var block = MXFP4Block.from_float32_array(values)
+ 
+     # Scale should fallback to 1.0
+-    var scale_val = block.scale.to_float32()
++    var scale_val = Float32(block.scale)
+     assert_true(scale_val > 0.5, "Scale should fallback to 1.0")
+ 
+ 
+diff --git a/tests/core/types/test_nvfp4_block.mojo b/tests/core/types/test_nvfp4_block.mojo
+index c9c12850a..d8595145f 100644
+--- a/tests/core/types/test_nvfp4_block.mojo
++++ b/tests/core/types/test_nvfp4_block.mojo
+@@ -13,8 +13,7 @@ All tests use pure functional API.
+ """
+ 
+ from math import isinf, isnan
+-from shared.core.types.nvfp4 import NVFP4, NVFP4Block, E4M3Scale
+-from shared.core.types.fp4 import FP4_E2M1
++from shared.core.types.nvfp4 import NVFP4, NVFP4Block
+ from tests.shared.conftest import (
+     assert_true,
+     assert_equal,
+@@ -179,7 +178,7 @@ fn test_nvfp4_block_scale_computation() raises:
+ 
+     var block1 = NVFP4Block.from_float32_array(values1)
+     # Scale should be roughly max/6 = (15/16)/6 ≈ 0.16
+-    var scale1 = block1.scale.to_float32()
++    var scale1 = Float32(block1.scale)
+     assert_true(scale1 > 0.1 and scale1 < 0.3, "Scale 1 out of range")
+ 
+     # Test 2: All values in [0, 10]
+@@ -189,7 +188,7 @@ fn test_nvfp4_block_scale_computation() raises:
+ 
+     var block2 = NVFP4Block.from_float32_array(values2)
+     # Scale should be larger
+-    var scale2 = block2.scale.to_float32()
++    var scale2 = Float32(block2.scale)
+     assert_true(scale2 > scale1, "Scale 2 should be larger")
+ 
+ 
+@@ -395,7 +394,7 @@ fn test_nvfp4_block_negative_scale_computation() raises:
+     var block = NVFP4Block.from_float32_array(values)
+ 
+     # Scale should be positive (computed from abs(max))
+-    var scale_val = block.scale.to_float32()
++    var scale_val = Float32(block.scale)
+     assert_true(scale_val > 0, "Scale should be positive")
+ 
+     # Decoded values should preserve sign
+diff --git a/tests/models/test_alexnet_layers.mojo b/tests/models/test_alexnet_layers.mojo
+index 32092805d..e40ce97d8 100644
+--- a/tests/models/test_alexnet_layers.mojo
++++ b/tests/models/test_alexnet_layers.mojo
+@@ -1098,11 +1098,10 @@ fn main() raises:
+     test_conv1_forward_float32()
+     print(" OK")
+ 
+-    # RESOLVED(#3009): test_conv1_forward_float16 now uses FP32 accumulation internally
+-    # for improved precision. See: https://github.com/mvillmow/ProjectOdyssey/issues/3009
+-    print("  test_conv1_forward_float16...", end="")
+-    test_conv1_forward_float16()
+-    print(" OK")
++    # FIXME(#3009): test_conv1_forward_float16 disabled - float16 precision insufficient
++    # for 11x11 kernel accumulation (363 multiplications per output element).
++    # See: https://github.com/mvillmow/ProjectOdyssey/issues/2701
++    print("  test_conv1_forward_float16... FIXME(#3009)")
+ 
+     print("  test_conv1_backward_float32...", end="")
+     test_conv1_backward_float32()
+@@ -1113,11 +1112,10 @@ fn main() raises:
+     test_conv2_forward_float32()
+     print(" OK")
+ 
+-    # RESOLVED(#3009): test_conv2_forward_float16 now uses FP32 accumulation internally
+-    # for improved precision. See: https://github.com/mvillmow/ProjectOdyssey/issues/3009
+-    print("  test_conv2_forward_float16...", end="")
+-    test_conv2_forward_float16()
+-    print(" OK")
++    # FIXME(#3009): test_conv2_forward_float16 disabled - float16 precision insufficient
++    # for 5x5 kernel with 64 input channels (1600 multiplications per output element).
++    # See: https://github.com/mvillmow/ProjectOdyssey/issues/2701
++    print("  test_conv2_forward_float16... FIXME(#3009)")
+ 
+     # Conv2 backward - uses sampled gradient checking (200 samples)
+     print("  test_conv2_backward_float32...", end="")
+@@ -1129,11 +1127,10 @@ fn main() raises:
+     test_conv3_forward_float32()
+     print(" OK")
+ 
+-    # RESOLVED(#3009): test_conv3_forward_float16 now uses FP32 accumulation internally
+-    # for improved precision. See: https://github.com/mvillmow/ProjectOdyssey/issues/3009
+-    print("  test_conv3_forward_float16...", end="")
+-    test_conv3_forward_float16()
+-    print(" OK")
++    # FIXME(#3009): test_conv3_forward_float16 disabled - float16 precision insufficient
++    # for 3x3 kernel with 192 input channels (1728 multiplications per output element).
++    # See: https://github.com/mvillmow/ProjectOdyssey/issues/2701
++    print("  test_conv3_forward_float16... FIXME(#3009)")
+ 
+     # Conv3 backward - uses sampled gradient checking (100 samples)
+     print("  test_conv3_backward_float32...", end="")
+diff --git a/tests/models/test_lenet5_fc_layers.mojo b/tests/models/test_lenet5_fc_layers.mojo
+index 95efd4907..ce00e0db7 100644
+--- a/tests/models/test_lenet5_fc_layers.mojo
++++ b/tests/models/test_lenet5_fc_layers.mojo
+@@ -183,10 +183,11 @@ fn test_fc3_forward_float32() raises:
+ fn test_fc3_forward_float16() raises:
+     """Test FC3 (84→10) forward pass with float16.
+ 
+-    RESOLVED(#3009): This test now uses FP32 accumulation internally
+-    for improved precision, matching industry-standard mixed precision
+-    (NVIDIA TensorCores, PyTorch, TensorFlow behavior).
+-    See: https://github.com/mvillmow/ProjectOdyssey/issues/3009
++    FIXME(#3009): This test may fail due to float16 precision limitations.
++    FC3 performs 84 multiplications per output, which can cause accumulation
++    errors in float16 (limited to ~3.3 decimal digits precision).
++
++    If this test fails, we need to implement float32 accumulation in linear().
+     """
+     var dtype = DType.float16
+     var _result = create_fc3_parameters(dtype)
+diff --git a/tests/scripts/test_dashboard.py b/tests/scripts/test_dashboard.py
+index 92ae9c545..d75cbebe0 100644
+--- a/tests/scripts/test_dashboard.py
++++ b/tests/scripts/test_dashboard.py
+@@ -32,6 +32,7 @@ def setUp(self):
+     def tearDown(self):
+         """Clean up test fixtures."""
+         import shutil
++
+         shutil.rmtree(self.temp_dir, ignore_errors=True)
+ 
+     def create_test_run(self, run_id: str, metrics: dict):
+@@ -79,11 +80,14 @@ def test_read_metric_csv_not_found(self):
+ 
+     def test_read_all_metrics(self):
+         """Test reading all metrics for a run."""
+-        self.create_test_run("multi_metric", {
+-            "loss": [1.0, 0.5],
+-            "accuracy": [0.5, 0.8],
+-            "lr": [0.01, 0.001],
+-        })
++        self.create_test_run(
++            "multi_metric",
++            {
++                "loss": [1.0, 0.5],
++                "accuracy": [0.5, 0.8],
++                "lr": [0.01, 0.001],
++            },
++        )
+ 
+         metrics = read_all_metrics("multi_metric")
+         self.assertEqual(len(metrics), 3)
+diff --git a/tests/scripts/test_dependency_resolver.py b/tests/scripts/test_dependency_resolver.py
+index ad8e1b85f..afa9e61fe 100644
+--- a/tests/scripts/test_dependency_resolver.py
++++ b/tests/scripts/test_dependency_resolver.py
+@@ -188,6 +188,7 @@ def worker(issue_num):
+                 self.resolver.mark_in_progress(issue_num)
+                 # Small delay to increase chance of race conditions
+                 import time
++
+                 time.sleep(0.01)
+                 self.resolver.mark_completed(issue_num)
+                 results.append(issue_num)
+diff --git a/tests/scripts/test_worktree_manager.py b/tests/scripts/test_worktree_manager.py
+index 6662c95a6..9b0104aee 100644
+--- a/tests/scripts/test_worktree_manager.py
++++ b/tests/scripts/test_worktree_manager.py
+@@ -36,6 +36,7 @@ def setup_method(self):
+     def teardown_method(self):
+         """Clean up test fixtures."""
+         import shutil
++
+         shutil.rmtree(self.temp_dir, ignore_errors=True)
+ 
+     @mock.patch("implement_issues.run")
+@@ -184,6 +185,7 @@ def setup_method(self):
+     def teardown_method(self):
+         """Clean up test fixtures."""
+         import shutil
++
+         shutil.rmtree(self.temp_dir, ignore_errors=True)
+ 
+     @mock.patch("implement_issues.run")
+@@ -204,10 +206,7 @@ def create_worktree(issue_num):
+             except Exception as e:
+                 errors.append(e)
+ 
+-        threads = [
+-            threading.Thread(target=create_worktree, args=(i,))
+-            for i in range(100, 110)
+-        ]
++        threads = [threading.Thread(target=create_worktree, args=(i,)) for i in range(100, 110)]
+ 
+         for t in threads:
+             t.start()
+diff --git a/tests/shared/conftest.mojo b/tests/shared/conftest.mojo
+index b5fbaeb72..d4543088e 100644
+--- a/tests/shared/conftest.mojo
++++ b/tests/shared/conftest.mojo
+@@ -67,112 +67,30 @@ struct TestFixtures:
+         """Set random seed for deterministic test execution."""
+         seed(Self.deterministic_seed())
+ 
+-    @staticmethod
+-    fn small_tensor() -> ExTensor:
+-        """Create small 3x3 tensor for unit tests.
+-
+-        Returns:
+-            3x3 ExTensor with deterministic values (0.1).
+-
+-        Example:
+-            ```mojo
+-            var t = TestFixtures.small_tensor()
+-            assert_shape(t, [3, 3])
+-            ```
+-        """
+-        return ExTensor.full([3, 3], 0.1)
+-
+-    @staticmethod
+-    fn random_tensor(rows: Int, cols: Int) -> ExTensor:
+-        """Create random tensor with deterministic seed.
+-
+-        Args:
+-            rows: Number of rows.
+-            cols: Number of columns.
+-
+-        Returns:
+-            Random ExTensor with shape [rows, cols].
+-
+-        Note:
+-            Uses deterministic seed (42) for reproducibility.
+-
+-        Example:
+-            ```mojo
+-            var t = TestFixtures.random_tensor(5, 10)
+-            assert_shape(t, [5, 10])
+-            ```
+-        """
+-        Self.set_seed()
+-        return ExTensor.randn([rows, cols])
+-
+-    @staticmethod
+-    fn simple_linear_model() -> SimpleMLP:
+-        """Create simple linear model for testing.
+-
+-        Returns a 2-layer MLP with:
+-        - Input dimension: 10
+-        - Hidden dimension: 5
+-        - Output dimension: 1
+-        - Uses ReLU activation
+-        - Initialized with constant value 0.1
+-
+-        Returns:
+-            SimpleMLP instance configured for unit testing.
+-
+-        Example:
+-            ```mojo
+-            var model = TestFixtures.simple_linear_model()
+-            var input_vec = TestFixtures.create_test_vector(10)
+-            var output = model.forward(input_vec)
+-            ```
+-
+-        See Also:
+-            - create_simple_model(): Alternative model factory
+-            - SimpleMLP: Model type definition
+-        """
+-        return SimpleMLP(
+-            input_dim=10,
+-            hidden_dim=5,
+-            output_dim=1,
+-            num_hidden_layers=1,
+-            init_value=0.1,
+-        )
+-
+-    @staticmethod
+-    fn synthetic_dataset(
+-        n_samples: Int = 100,
+-    ) -> List[Tuple[List[Float32], List[Float32]]]:
+-        """Create synthetic dataset for testing.
+-
+-        Generates deterministic synthetic data with configurable sample count.
+-
+-        Args:
+-            n_samples: Number of samples to generate (default: 100).
+-
+-        Returns:
+-            List of (input, output) tuples for each sample.
+-            Input dimension: 10
+-            Output dimension: 1
+-            Seed: 42 (deterministic)
+-
+-        Example:
+-            ```mojo
+-            var dataset = TestFixtures.synthetic_dataset(n_samples=50)
+-            var first_sample = dataset[0]
+-            var data = first_sample[0]
+-            var label = first_sample[1]
+-            ```
+-
+-        See Also:
+-            - create_simple_dataset(): Full dataset creation with customization
+-            - create_mock_dataloader(): Wraps dataset in data loader
+-        """
+-        return create_simple_dataset(
+-            n_samples=n_samples,
+-            input_dim=10,
+-            output_dim=1,
+-            seed_value=Self.deterministic_seed(),
+-        )
++    # FIXME(#3010): Placeholder tensor fixture methods in tests/shared/conftest.mojo
++    # TODO(#1538): Add tensor fixture methods when Tensor type is implemented
++    # @staticmethod
++    # fn small_tensor() -> Tensor:
++    #     """Create small 3x3 tensor for unit tests.
++    #
++    #     Returns:
++    #         3x3 ExTensor with deterministic values (0.1).
++    #     """
++    #     pass
++
++    # FIXME(#3010): Placeholder model fixture methods in tests/shared/conftest.mojo
++    # TODO(#1538): Add model fixture methods when models are implemented
++    # @staticmethod
++    # fn simple_linear_model() -> Linear:
++    #     """Create simple Linear layer with known weights."""
++    #     pass
++
++    # FIXME(#3010): Placeholder dataset fixture methods in tests/shared/conftest.mojo
++    # TODO(#1538): Add dataset fixture methods when datasets are implemented
++    # @staticmethod
++    # fn synthetic_dataset(n_samples: Int = 100) -> TensorDataset:
++    #     """Create synthetic dataset for testing."""
++    #     pass
+ 
+ 
+ # ============================================================================
+diff --git a/tests/shared/core/test_bf8.mojo b/tests/shared/core/test_bf8.mojo
+deleted file mode 100644
+index eb231cb17..000000000
+--- a/tests/shared/core/test_bf8.mojo
++++ /dev/null
+@@ -1,365 +0,0 @@
+-"""Tests for BF8 data type and tensor conversions.
+-
+-Tests cover:
+-- BF8 creation from Float32
+-- BF8 to Float32 conversion
+-- Special values (zero, NaN, Inf)
+-- Range clamping (±57344 max value)
+-- Tensor conversion (to_bf8, from_bf8)
+-- Round-trip conversion accuracy
+-"""
+-
+-from tests.shared.conftest import (
+-    assert_almost_equal,
+-    assert_close_float,
+-    assert_equal,
+-    assert_equal_int,
+-    assert_shape,
+-    assert_shape_equal,
+-    assert_true,
+-)
+-from tests.shared.conftest import TestFixtures
+-from shared.core.extensor import (
+-    ExTensor,
+-    zeros,
+-    ones,
+-    full,
+-)
+-from shared.core.types.bf8 import BF8
+-from math import isnan, isinf
+-
+-
+-# ============================================================================
+-# BF8 Basic Conversion Tests
+-# ============================================================================
+-
+-
+-fn test_bf8_zero() raises:
+-    """Test BF8 representation of zero."""
+-    var bf8_zero = BF8.from_float32(0.0)
+-    var result = bf8_zero.to_float32()
+-
+-    assert_equal(bf8_zero.value, 0)
+-    assert_almost_equal(result, Float32(0.0), tolerance=1e-7)
+-
+-
+-fn test_bf8_positive_values() raises:
+-    """Test BF8 encoding of positive values."""
+-    # Test small positive value
+-    var bf8_small = BF8.from_float32(1.0)
+-    var result_small = bf8_small.to_float32()
+-    assert_almost_equal(result_small, Float32(1.0), tolerance=0.3)
+-
+-    # Test medium positive value
+-    var bf8_medium = BF8.from_float32(10.0)
+-    var result_medium = bf8_medium.to_float32()
+-    assert_almost_equal(result_medium, Float32(10.0), tolerance=3.0)
+-
+-    # Test large positive value
+-    var bf8_large = BF8.from_float32(100.0)
+-    var result_large = bf8_large.to_float32()
+-    assert_almost_equal(result_large, Float32(100.0), tolerance=30.0)
+-
+-    # Test very large positive value (within BF8 range)
+-    var bf8_vlarge = BF8.from_float32(1000.0)
+-    var result_vlarge = bf8_vlarge.to_float32()
+-    assert_almost_equal(result_vlarge, Float32(1000.0), tolerance=300.0)
+-
+-
+-fn test_bf8_negative_values() raises:
+-    """Test BF8 encoding of negative values."""
+-    # Test small negative value
+-    var bf8_small = BF8.from_float32(-1.0)
+-    var result_small = bf8_small.to_float32()
+-    assert_almost_equal(result_small, Float32(-1.0), tolerance=0.3)
+-
+-    # Test medium negative value
+-    var bf8_medium = BF8.from_float32(-10.0)
+-    var result_medium = bf8_medium.to_float32()
+-    assert_almost_equal(result_medium, Float32(-10.0), tolerance=3.0)
+-
+-    # Test large negative value
+-    var bf8_large = BF8.from_float32(-100.0)
+-    var result_large = bf8_large.to_float32()
+-    assert_almost_equal(result_large, Float32(-100.0), tolerance=30.0)
+-
+-    # Test very large negative value (within BF8 range)
+-    var bf8_vlarge = BF8.from_float32(-1000.0)
+-    var result_vlarge = bf8_vlarge.to_float32()
+-    assert_almost_equal(result_vlarge, Float32(-1000.0), tolerance=300.0)
+-
+-
+-fn test_bf8_range_clamping() raises:
+-    """Test BF8 clamping of values outside representable range."""
+-    # BF8 E5M2 max value is approximately 57344
+-
+-    # Test positive overflow
+-    var bf8_overflow = BF8.from_float32(100000.0)
+-    var result_overflow = bf8_overflow.to_float32()
+-    assert_true(
+-        result_overflow <= 57344.0, "BF8 should clamp large positive values"
+-    )
+-    assert_true(result_overflow > 50000.0, "BF8 max should be near 57344")
+-
+-    # Test negative overflow
+-    var bf8_underflow = BF8.from_float32(-100000.0)
+-    var result_underflow = bf8_underflow.to_float32()
+-    assert_true(
+-        result_underflow >= -57344.0, "BF8 should clamp large negative values"
+-    )
+-    assert_true(result_underflow < -50000.0, "BF8 min should be near -57344")
+-
+-
+-fn test_bf8_subnormal_values() raises:
+-    """Test BF8 encoding of very small (subnormal) values."""
+-    # BF8 E5M2 min normal value is 2^-14 = 0.00006103515625
+-
+-    # Test value in subnormal range
+-    var bf8_tiny = BF8.from_float32(0.00005)
+-    var result_tiny = bf8_tiny.to_float32()
+-    assert_true(result_tiny >= 0.0, "BF8 subnormal should be non-negative")
+-    assert_true(result_tiny < 0.0001, "BF8 subnormal should be small")
+-
+-    # Test value below subnormal range (should be zero)
+-    var bf8_very_tiny = BF8.from_float32(0.00001)
+-    var result_very_tiny = bf8_very_tiny.to_float32()
+-    assert_almost_equal(result_very_tiny, Float32(0.0), tolerance=1e-7)
+-
+-
+-fn test_bf8_special_values_nan() raises:
+-    """Test BF8 encoding of NaN."""
+-    var nan_val = Float32(0.0) / Float32(0.0)
+-    var bf8_nan = BF8.from_float32(nan_val)
+-    var result = bf8_nan.to_float32()
+-
+-    # Check that result is NaN
+-    assert_true(isnan(result), "BF8 should preserve NaN")
+-
+-
+-fn test_bf8_special_values_inf() raises:
+-    """Test BF8 encoding of infinity."""
+-    # Positive infinity
+-    var pos_inf = Float32(1.0) / Float32(0.0)
+-    var bf8_pos_inf = BF8.from_float32(pos_inf)
+-    var result_pos = bf8_pos_inf.to_float32()
+-    assert_true(
+-        isinf(result_pos) and result_pos > 0, "BF8 should preserve +Inf"
+-    )
+-
+-    # Negative infinity
+-    var neg_inf = Float32(-1.0) / Float32(0.0)
+-    var bf8_neg_inf = BF8.from_float32(neg_inf)
+-    var result_neg = bf8_neg_inf.to_float32()
+-    assert_true(
+-        isinf(result_neg) and result_neg < 0, "BF8 should preserve -Inf"
+-    )
+-
+-
+-fn test_bf8_equality() raises:
+-    """Test BF8 equality comparison."""
+-    var bf8_a = BF8.from_float32(3.14)
+-    var bf8_b = BF8.from_float32(3.14)
+-    var bf8_c = BF8.from_float32(2.71)
+-
+-    assert_true(bf8_a == bf8_b, "Equal BF8 values should compare equal")
+-    assert_true(bf8_a != bf8_c, "Different BF8 values should compare not equal")
+-
+-
+-# ============================================================================
+-# Tensor Conversion Tests
+-# ============================================================================
+-
+-
+-fn test_tensor_to_bf8() raises:
+-    """Test converting Float32 tensor to BF8."""
+-    var shape = List[Int]()
+-    shape.append(2)
+-    shape.append(3)
+-
+-    # Create Float32 tensor with specific values
+-    var t = zeros(shape, DType.float32)
+-    t._data.bitcast[Float32]()[0] = 1.0
+-    t._data.bitcast[Float32]()[1] = -2.5
+-    t._data.bitcast[Float32]()[2] = 10.0
+-    t._data.bitcast[Float32]()[3] = -5.0
+-    t._data.bitcast[Float32]()[4] = 0.5
+-    t._data.bitcast[Float32]()[5] = 1000.0
+-
+-    # Convert to BF8
+-    var bf8_tensor = t.to_bf8()
+-
+-    # Check dtype is uint8
+-    assert_true(
+-        bf8_tensor.dtype() == DType.uint8, "BF8 tensor should have uint8 dtype"
+-    )
+-
+-    # Check shape is preserved
+-    assert_shape_equal(bf8_tensor.shape(), t.shape())
+-
+-    # Check that values are encoded (not zero)
+-    var has_nonzero = False
+-    for i in range(6):
+-        if bf8_tensor._data.bitcast[UInt8]()[i] != 0:
+-            has_nonzero = True
+-    assert_true(has_nonzero, "BF8 tensor should have encoded values")
+-
+-
+-fn test_tensor_from_bf8() raises:
+-    """Test converting BF8 tensor back to Float32."""
+-    var shape = List[Int]()
+-    shape.append(2)
+-    shape.append(2)
+-
+-    # Create Float32 tensor
+-    var original = ones(shape, DType.float32)
+-    original._data.bitcast[Float32]()[0] = 3.0
+-    original._data.bitcast[Float32]()[1] = -1.5
+-    original._data.bitcast[Float32]()[2] = 7.0
+-    original._data.bitcast[Float32]()[3] = -10.0
+-
+-    # Convert to BF8 and back
+-    var bf8_tensor = original.to_bf8()
+-    var restored = bf8_tensor.from_bf8()
+-
+-    # Check dtype is float32
+-    assert_true(
+-        restored.dtype() == DType.float32,
+-        "Restored tensor should have float32 dtype",
+-    )
+-
+-    # Check shape is preserved
+-    assert_shape_equal(restored.shape(), original.shape())
+-
+-    # Check values are approximately restored (with BF8 precision loss)
+-    # BF8 has less precision than FP8, so use larger tolerances
+-    assert_almost_equal(
+-        restored._data.bitcast[Float32]()[0], Float32(3.0), tolerance=1.0
+-    )
+-    assert_almost_equal(
+-        restored._data.bitcast[Float32]()[1], Float32(-1.5), tolerance=0.5
+-    )
+-    assert_almost_equal(
+-        restored._data.bitcast[Float32]()[2], Float32(7.0), tolerance=2.0
+-    )
+-    assert_almost_equal(
+-        restored._data.bitcast[Float32]()[3], Float32(-10.0), tolerance=3.0
+-    )
+-
+-
+-fn test_tensor_bf8_roundtrip() raises:
+-    """Test round-trip conversion Float32 -> BF8 -> Float32."""
+-    var shape = List[Int]()
+-    shape.append(5)
+-
+-    # Create tensor with various values
+-    var original = zeros(shape, DType.float32)
+-    original._data.bitcast[Float32]()[0] = 0.0
+-    original._data.bitcast[Float32]()[1] = 1.0
+-    original._data.bitcast[Float32]()[2] = -5.0
+-    original._data.bitcast[Float32]()[3] = 20.0
+-    original._data.bitcast[Float32]()[4] = -50.0
+-
+-    # Round-trip conversion
+-    var bf8_tensor = original.to_bf8()
+-    var restored = bf8_tensor.from_bf8()
+-
+-    # Verify approximate equality (accounting for BF8 precision loss)
+-    # BF8 has only 2 mantissa bits, so precision loss is significant
+-    for i in range(5):
+-        var orig_val = original._data.bitcast[Float32]()[i]
+-        var restored_val = restored._data.bitcast[Float32]()[i]
+-
+-        # Use tolerance proportional to magnitude (larger than FP8)
+-        var tolerance = max(abs(orig_val) * 0.25, Float32(0.5))
+-        assert_almost_equal(restored_val, orig_val, tolerance=tolerance)
+-
+-
+-fn test_tensor_to_bf8_requires_float() raises:
+-    """Test that to_bf8() requires floating-point tensor."""
+-    var shape = List[Int]()
+-    shape.append(3)
+-
+-    # Create int32 tensor
+-    var int_tensor = zeros(shape, DType.int32)
+-
+-    # Try to convert to BF8 (should raise error)
+-    var raised_error = False
+-    try:
+-        var _ = int_tensor.to_bf8()
+-    except:
+-        raised_error = True
+-
+-    assert_true(
+-        raised_error, "to_bf8() should raise error for non-float tensor"
+-    )
+-
+-
+-fn test_tensor_from_bf8_requires_uint8() raises:
+-    """Test that from_bf8() requires uint8 tensor."""
+-    var shape = List[Int]()
+-    shape.append(3)
+-
+-    # Create float32 tensor (not uint8)
+-    var float_tensor = zeros(shape, DType.float32)
+-
+-    # Try to convert from BF8 (should raise error)
+-    var raised_error = False
+-    try:
+-        var _ = float_tensor.from_bf8()
+-    except:
+-        raised_error = True
+-
+-    assert_true(
+-        raised_error, "from_bf8() should raise error for non-uint8 tensor"
+-    )
+-
+-
+-# ============================================================================
+-# Main Test Runner
+-# ============================================================================
+-
+-
+-fn main() raises:
+-    """Run all BF8 tests."""
+-    print("\n=== BF8 Basic Conversion Tests ===")
+-    test_bf8_zero()
+-    print("✓ BF8 zero encoding")
+-
+-    test_bf8_positive_values()
+-    print("✓ BF8 positive values")
+-
+-    test_bf8_negative_values()
+-    print("✓ BF8 negative values")
+-
+-    test_bf8_range_clamping()
+-    print("✓ BF8 range clamping")
+-
+-    test_bf8_subnormal_values()
+-    print("✓ BF8 subnormal values")
+-
+-    test_bf8_special_values_nan()
+-    print("✓ BF8 NaN handling")
+-
+-    test_bf8_special_values_inf()
+-    print("✓ BF8 infinity handling")
+-
+-    test_bf8_equality()
+-    print("✓ BF8 equality comparison")
+-
+-    print("\n=== Tensor Conversion Tests ===")
+-    test_tensor_to_bf8()
+-    print("✓ Tensor to BF8 conversion")
+-
+-    test_tensor_from_bf8()
+-    print("✓ Tensor from BF8 conversion")
+-
+-    test_tensor_bf8_roundtrip()
+-    print("✓ Tensor BF8 round-trip")
+-
+-    test_tensor_to_bf8_requires_float()
+-    print("✓ to_bf8() type validation")
+-
+-    test_tensor_from_bf8_requires_uint8()
+-    print("✓ from_bf8() type validation")
+-
+-    print("\n=== All BF8 Tests Passed! ===\n")
+diff --git a/tests/shared/core/test_bfloat16.mojo b/tests/shared/core/test_bfloat16.mojo
+deleted file mode 100644
+index 979ff203a..000000000
+--- a/tests/shared/core/test_bfloat16.mojo
++++ /dev/null
+@@ -1,296 +0,0 @@
+-"""Tests for BFloat16 implementation.
+-
+-Tests conversion, arithmetic, comparison, and special values for the
+-custom BFloat16 type.
+-"""
+-
+-from shared.core.bfloat16 import BFloat16, print_bfloat16_bits
+-from testing import assert_equal, assert_true, assert_false
+-
+-
+-fn test_bfloat16_zero() raises:
+-    """Test BFloat16 zero values."""
+-    print("Testing BFloat16 zero...")
+-
+-    var zero = BFloat16._zero()
+-    var neg_zero = BFloat16._neg_zero()
+-
+-    assert_equal(zero.to_float32(), 0.0, "Zero should convert to 0.0")
+-    assert_equal(
+-        neg_zero.to_float32(), -0.0, "Negative zero should convert to -0.0"
+-    )
+-
+-    # Check bit patterns
+-    assert_equal(zero.bits, 0x0000, "Zero bits should be 0x0000")
+-    assert_equal(neg_zero.bits, 0x8000, "Negative zero bits should be 0x8000")
+-
+-    print("✓ BFloat16 zero test passed")
+-
+-
+-fn test_bfloat16_special_values() raises:
+-    """Test BFloat16 special values (inf, nan)."""
+-    print("Testing BFloat16 special values...")
+-
+-    var inf = BFloat16._inf()
+-    var neg_inf = BFloat16._neg_inf()
+-    var nan = BFloat16._nan()
+-
+-    # Check conversions
+-    assert_true(inf.to_float32() > 1e30, "Inf should be very large positive")
+-    assert_true(
+-        neg_inf.to_float32() < -1e30, "Neg inf should be very large negative"
+-    )
+-
+-    # Check predicates
+-    assert_true(inf.is_inf(), "Inf should be detected as infinite")
+-    assert_true(neg_inf.is_inf(), "Neg inf should be detected as infinite")
+-    assert_true(nan.is_nan(), "NaN should be detected as NaN")
+-
+-    assert_false(inf.is_nan(), "Inf should not be NaN")
+-    assert_false(nan.is_inf(), "NaN should not be infinite")
+-
+-    assert_true(inf.is_finite() == False, "Inf should not be finite")
+-    assert_true(nan.is_finite() == False, "NaN should not be finite")
+-
+-    print("✓ BFloat16 special values test passed")
+-
+-
+-fn test_bfloat16_conversion_from_float32() raises:
+-    """Test Float32 -> BFloat16 conversion."""
+-    print("Testing Float32 -> BFloat16 conversion...")
+-
+-    # Test simple values
+-    var bf16_1 = BFloat16.from_float32(1.0)
+-    var bf16_2 = BFloat16.from_float32(2.0)
+-    var bf16_half = BFloat16.from_float32(0.5)
+-
+-    assert_true(abs(bf16_1.to_float32() - 1.0) < 1e-6, "1.0 should round-trip")
+-    assert_true(abs(bf16_2.to_float32() - 2.0) < 1e-6, "2.0 should round-trip")
+-    assert_true(
+-        abs(bf16_half.to_float32() - 0.5) < 1e-6, "0.5 should round-trip"
+-    )
+-
+-    # Test negative values
+-    var bf16_neg = BFloat16.from_float32(-3.14)
+-    assert_true(
+-        bf16_neg.to_float32() < 0.0, "Negative value should stay negative"
+-    )
+-
+-    print("✓ Float32 -> BFloat16 conversion test passed")
+-
+-
+-fn test_bfloat16_conversion_precision() raises:
+-    """Test BFloat16 precision and rounding."""
+-    print("Testing BFloat16 precision...")
+-
+-    # BFloat16 has 7 mantissa bits, so precision is limited
+-    # For example, 3.14159 should be rounded to nearest representable value
+-
+-    var pi = BFloat16.from_float32(3.14159)
+-    var pi_f32 = pi.to_float32()
+-
+-    # Should be close but not exact (BF16 has only 7 mantissa bits)
+-    assert_true(
+-        abs(pi_f32 - 3.14159) < 0.01, "Pi should be approximately correct"
+-    )
+-
+-    # Test that truncation vs rounding makes a difference
+-    var pi_trunc = BFloat16.from_float32_truncate(3.14159)
+-    var pi_round = BFloat16.from_float32(3.14159)
+-
+-    # They should be slightly different
+-    print("  Pi truncated: " + String(pi_trunc.to_float32()))
+-    print("  Pi rounded: " + String(pi_round.to_float32()))
+-
+-    print("✓ BFloat16 precision test passed")
+-
+-
+-fn test_bfloat16_arithmetic() raises:
+-    """Test BFloat16 arithmetic operations."""
+-    print("Testing BFloat16 arithmetic...")
+-
+-    var a = BFloat16.from_float32(3.0)
+-    var b = BFloat16.from_float32(2.0)
+-
+-    # Addition
+-    var sum = a + b
+-    assert_true(abs(sum.to_float32() - 5.0) < 1e-6, "3 + 2 = 5")
+-
+-    # Subtraction
+-    var diff = a - b
+-    assert_true(abs(diff.to_float32() - 1.0) < 1e-6, "3 - 2 = 1")
+-
+-    # Multiplication
+-    var prod = a * b
+-    assert_true(abs(prod.to_float32() - 6.0) < 1e-6, "3 * 2 = 6")
+-
+-    # Division
+-    var quot = a / b
+-    assert_true(abs(quot.to_float32() - 1.5) < 1e-6, "3 / 2 = 1.5")
+-
+-    # Negation
+-    var neg = -a
+-    assert_true(abs(neg.to_float32() - (-3.0)) < 1e-6, "-3 = -3")
+-
+-    print("✓ BFloat16 arithmetic test passed")
+-
+-
+-fn test_bfloat16_comparison() raises:
+-    """Test BFloat16 comparison operations."""
+-    print("Testing BFloat16 comparison...")
+-
+-    var a = BFloat16.from_float32(3.0)
+-    var b = BFloat16.from_float32(2.0)
+-    var c = BFloat16.from_float32(3.0)
+-
+-    # Equality
+-    assert_true(a == c, "3.0 == 3.0")
+-    assert_false(a == b, "3.0 != 2.0")
+-
+-    # Inequality
+-    assert_false(a != c, "3.0 not != 3.0")
+-    assert_true(a != b, "3.0 != 2.0")
+-
+-    # Less than
+-    assert_true(b < a, "2.0 < 3.0")
+-    assert_false(a < b, "3.0 not < 2.0")
+-
+-    # Less than or equal
+-    assert_true(b <= a, "2.0 <= 3.0")
+-    assert_true(a <= c, "3.0 <= 3.0")
+-
+-    # Greater than
+-    assert_true(a > b, "3.0 > 2.0")
+-    assert_false(b > a, "2.0 not > 3.0")
+-
+-    # Greater than or equal
+-    assert_true(a >= b, "3.0 >= 2.0")
+-    assert_true(a >= c, "3.0 >= 3.0")
+-
+-    print("✓ BFloat16 comparison test passed")
+-
+-
+-fn test_bfloat16_nan_comparison() raises:
+-    """Test BFloat16 NaN comparison behavior."""
+-    print("Testing BFloat16 NaN comparison...")
+-
+-    var nan = BFloat16._nan()
+-    var one = BFloat16.from_float32(1.0)
+-
+-    # NaN != NaN (IEEE 754 standard)
+-    assert_false(nan == nan, "NaN should not equal NaN")
+-    assert_true(nan != nan, "NaN should not equal NaN")
+-
+-    # NaN comparisons are always false
+-    assert_false(nan < one, "NaN < 1.0 should be false")
+-    assert_false(nan > one, "NaN > 1.0 should be false")
+-    assert_false(one == nan, "1.0 == NaN should be false")
+-
+-    print("✓ BFloat16 NaN comparison test passed")
+-
+-
+-fn test_bfloat16_range() raises:
+-    """Test BFloat16 range (should match Float32 range)."""
+-    print("Testing BFloat16 range...")
+-
+-    # BFloat16 should handle large values like Float32
+-    var large = BFloat16.from_float32(1e20)
+-    var small = BFloat16.from_float32(1e-20)
+-
+-    assert_true(large.to_float32() > 1e19, "Large values should be preserved")
+-    assert_true(small.to_float32() < 1e-19, "Small values should be preserved")
+-
+-    # Test values that overflow Float16 but not BFloat16
+-    var big = BFloat16.from_float32(100000.0)
+-    assert_true(big.is_finite(), "100000 should be finite in BF16")
+-    assert_true(
+-        abs(big.to_float32() - 100000.0) < 1000.0,
+-        "100000 should be approximately correct",
+-    )
+-
+-    print("✓ BFloat16 range test passed")
+-
+-
+-fn test_bfloat16_bit_patterns() raises:
+-    """Test specific bit patterns for correctness."""
+-    print("Testing BFloat16 bit patterns...")
+-
+-    # Test known bit patterns
+-    # 1.0 in BF16: sign=0, exp=127 (0x7F), mantissa=0
+-    # Bits: 0 01111111 0000000 = 0x3F80
+-    var one = BFloat16.from_float32(1.0)
+-    assert_equal(one.bits, 0x3F80, "1.0 should have bits 0x3F80")
+-
+-    # 2.0 in BF16: sign=0, exp=128 (0x80), mantissa=0
+-    # Bits: 0 10000000 0000000 = 0x4000
+-    var two = BFloat16.from_float32(2.0)
+-    assert_equal(two.bits, 0x4000, "2.0 should have bits 0x4000")
+-
+-    # 0.5 in BF16: sign=0, exp=126 (0x7E), mantissa=0
+-    # Bits: 0 01111110 0000000 = 0x3F00
+-    var half = BFloat16.from_float32(0.5)
+-    assert_equal(half.bits, 0x3F00, "0.5 should have bits 0x3F00")
+-
+-    print("✓ BFloat16 bit patterns test passed")
+-
+-
+-fn test_bfloat16_negation_bit_flip() raises:
+-    """Test that negation flips only the sign bit."""
+-    print("Testing BFloat16 negation bit flip...")
+-
+-    var pos = BFloat16.from_float32(3.14)
+-    var neg = -pos
+-
+-    # Check that only sign bit differs
+-    var xor_result = pos.bits ^ neg.bits
+-    assert_equal(xor_result, 0x8000, "Negation should flip only sign bit")
+-
+-    print("✓ BFloat16 negation bit flip test passed")
+-
+-
+-fn test_bfloat16_string_representation() raises:
+-    """Test BFloat16 string conversion."""
+-    print("Testing BFloat16 string representation...")
+-
+-    var value = BFloat16.from_float32(3.14)
+-    var str_repr = value.__str__()
+-
+-    # Should contain "BFloat16" and the value
+-    print("  String representation: " + str_repr)
+-
+-    print("✓ BFloat16 string representation test passed")
+-
+-
+-fn main() raises:
+-    print("\n" + "=" * 70)
+-    print("BFLOAT16 IMPLEMENTATION TESTS")
+-    print("=" * 70)
+-    print()
+-
+-    test_bfloat16_zero()
+-    test_bfloat16_special_values()
+-    test_bfloat16_conversion_from_float32()
+-    test_bfloat16_conversion_precision()
+-    test_bfloat16_arithmetic()
+-    test_bfloat16_comparison()
+-    test_bfloat16_nan_comparison()
+-    test_bfloat16_range()
+-    test_bfloat16_bit_patterns()
+-    test_bfloat16_negation_bit_flip()
+-    test_bfloat16_string_representation()
+-
+-    print()
+-    print("=" * 70)
+-    print("ALL BFLOAT16 TESTS PASSED! ✓")
+-    print("=" * 70)
+-    print()
+-
+-    # Demonstrate BFloat16 usage
+-    print("BFloat16 Example:")
+-    print("-" * 70)
+-    var pi = BFloat16.from_float32(3.14159265359)
+-    print("Original Float32: 3.14159265359")
+-    print("BFloat16 value: " + String(pi.to_float32()))
+-    print()
+-    print("Bit representation:")
+-    print_bfloat16_bits(pi)
+diff --git a/tests/shared/core/test_extensor_slicing.mojo b/tests/shared/core/test_extensor_slicing.mojo
+index 003263afe..2450a0f3f 100644
+--- a/tests/shared/core/test_extensor_slicing.mojo
++++ b/tests/shared/core/test_extensor_slicing.mojo
+@@ -1,4 +1,4 @@
+-"""Unit tests for ExTensor slicing and indexing operations (#2721).
++"""Unit tests for ExTensor slicing and indexing operations (#3013).
+ 
+ Tests cover:
+ - Basic 1D slicing (tensor[start:end])
+diff --git a/tests/shared/core/test_fp4.mojo b/tests/shared/core/test_fp4.mojo
+deleted file mode 100644
+index beab67b2e..000000000
+--- a/tests/shared/core/test_fp4.mojo
++++ /dev/null
+@@ -1,475 +0,0 @@
+-"""Tests for FP4_E2M1 base format.
+-
+-Tests cover:
+-- FP4_E2M1 creation from Float32 with different scales
+-- FP4_E2M1 to Float32 conversion
+-- All representable values in E2M1 format
+-- Special values (zero, NaN, Inf)
+-- Scale factor impact on encoding/decoding
+-- Edge cases and boundary values
+-"""
+-
+-from tests.shared.conftest import (
+-    assert_almost_equal,
+-    assert_close_float,
+-    assert_equal,
+-    assert_equal_int,
+-    assert_true,
+-)
+-from shared.core.types.fp4 import FP4_E2M1
+-from math import isnan, isinf
+-
+-
+-# ============================================================================
+-# FP4_E2M1 Basic Conversion Tests
+-# ============================================================================
+-
+-
+-fn test_fp4_e2m1_zero() raises:
+-    """Test FP4_E2M1 representation of zero."""
+-    var fp4_zero = FP4_E2M1.from_float32(0.0, scale=1.0)
+-    var result = fp4_zero.to_float32(scale=1.0)
+-
+-    assert_equal(fp4_zero.value, 0)
+-    assert_almost_equal(result, Float32(0.0), tolerance=1e-7)
+-
+-
+-fn test_fp4_e2m1_negative_zero() raises:
+-    """Test FP4_E2M1 representation of negative zero."""
+-    var fp4_neg_zero = FP4_E2M1.from_float32(-0.0, scale=1.0)
+-    var result = fp4_neg_zero.to_float32(scale=1.0)
+-
+-    # Negative zero should be represented as zero
+-    assert_almost_equal(result, Float32(0.0), tolerance=1e-7)
+-
+-
+-fn test_fp4_e2m1_representable_values() raises:
+-    """Test all representable values in E2M1 format."""
+-    # E2M1 representable values (unscaled):
+-    # exp=0: 0
+-    # exp=1, mantissa=0: 1.0
+-    # exp=1, mantissa=1: 1.5
+-    # exp=2, mantissa=0: 2.0
+-    # exp=2, mantissa=1: 3.0
+-    # exp=3, mantissa=0: 4.0
+-    # exp=3, mantissa=1: 6.0
+-
+-    var values = List[Float32]()
+-    values.append(0.0)
+-    values.append(1.0)
+-    values.append(1.5)
+-    values.append(2.0)
+-    values.append(3.0)
+-    values.append(4.0)
+-    values.append(6.0)
+-
+-    for i in range(len(values)):
+-        var val = values[i]
+-        var fp4 = FP4_E2M1.from_float32(val, scale=1.0)
+-        var result = fp4.to_float32(scale=1.0)
+-        assert_almost_equal(result, val, tolerance=0.1)
+-
+-
+-fn test_fp4_e2m1_positive_values() raises:
+-    """Test FP4_E2M1 encoding of positive values with scale=1."""
+-    # Test values that should map to representable values
+-    var fp4_one = FP4_E2M1.from_float32(1.0, scale=1.0)
+-    var result_one = fp4_one.to_float32(scale=1.0)
+-    assert_almost_equal(result_one, Float32(1.0), tolerance=0.3)
+-
+-    var fp4_two = FP4_E2M1.from_float32(2.0, scale=1.0)
+-    var result_two = fp4_two.to_float32(scale=1.0)
+-    assert_almost_equal(result_two, Float32(2.0), tolerance=0.5)
+-
+-    var fp4_three = FP4_E2M1.from_float32(3.0, scale=1.0)
+-    var result_three = fp4_three.to_float32(scale=1.0)
+-    assert_almost_equal(result_three, Float32(3.0), tolerance=0.5)
+-
+-
+-fn test_fp4_e2m1_negative_values() raises:
+-    """Test FP4_E2M1 encoding of negative values with scale=1."""
+-    var fp4_neg_one = FP4_E2M1.from_float32(-1.0, scale=1.0)
+-    var result_neg_one = fp4_neg_one.to_float32(scale=1.0)
+-    assert_almost_equal(result_neg_one, Float32(-1.0), tolerance=0.3)
+-
+-    var fp4_neg_two = FP4_E2M1.from_float32(-2.0, scale=1.0)
+-    var result_neg_two = fp4_neg_two.to_float32(scale=1.0)
+-    assert_almost_equal(result_neg_two, Float32(-2.0), tolerance=0.5)
+-
+-    var fp4_neg_three = FP4_E2M1.from_float32(-3.0, scale=1.0)
+-    var result_neg_three = fp4_neg_three.to_float32(scale=1.0)
+-    assert_almost_equal(result_neg_three, Float32(-3.0), tolerance=0.5)
+-
+-
+-fn test_fp4_e2m1_range_clamping() raises:
+-    """Test FP4_E2M1 clamping of values outside representable range."""
+-    # E2M1 max value (unscaled) is 6.0
+-
+-    # Test positive overflow
+-    var fp4_overflow = FP4_E2M1.from_float32(10.0, scale=1.0)
+-    var result_overflow = fp4_overflow.to_float32(scale=1.0)
+-    assert_almost_equal(result_overflow, Float32(6.0), tolerance=0.1)
+-
+-    # Test negative overflow
+-    var fp4_underflow = FP4_E2M1.from_float32(-10.0, scale=1.0)
+-    var result_underflow = fp4_underflow.to_float32(scale=1.0)
+-    assert_almost_equal(result_underflow, Float32(-6.0), tolerance=0.1)
+-
+-
+-fn test_fp4_e2m1_small_values() raises:
+-    """Test FP4_E2M1 encoding of very small values (below min representable)."""
+-    # Values below 0.5 (when scale=1) should map to zero
+-    var fp4_tiny = FP4_E2M1.from_float32(0.1, scale=1.0)
+-    var result_tiny = fp4_tiny.to_float32(scale=1.0)
+-    assert_almost_equal(result_tiny, Float32(0.0), tolerance=1e-7)
+-
+-    var fp4_very_tiny = FP4_E2M1.from_float32(0.01, scale=1.0)
+-    var result_very_tiny = fp4_very_tiny.to_float32(scale=1.0)
+-    assert_almost_equal(result_very_tiny, Float32(0.0), tolerance=1e-7)
+-
+-
+-fn test_fp4_e2m1_scale_impact() raises:
+-    """Test how different scale factors affect encoding."""
+-    # With scale=2.0, we can represent larger values
+-    var fp4_scaled = FP4_E2M1.from_float32(12.0, scale=2.0)
+-    var result_scaled = fp4_scaled.to_float32(scale=2.0)
+-    assert_almost_equal(result_scaled, Float32(12.0), tolerance=1.0)
+-
+-    # With scale=0.5, we can represent smaller values more precisely
+-    var fp4_small_scale = FP4_E2M1.from_float32(0.5, scale=0.5)
+-    var result_small_scale = fp4_small_scale.to_float32(scale=0.5)
+-    assert_almost_equal(result_small_scale, Float32(0.5), tolerance=0.2)
+-
+-
+-fn test_fp4_e2m1_special_values_nan() raises:
+-    """Test FP4_E2M1 encoding of NaN."""
+-    var nan_val = Float32(0.0) / Float32(0.0)
+-    var fp4_nan = FP4_E2M1.from_float32(nan_val, scale=1.0)
+-
+-    # NaN is encoded as max value (0b0111)
+-    assert_equal(fp4_nan.value, 0b0111)
+-
+-
+-fn test_fp4_e2m1_special_values_inf() raises:
+-    """Test FP4_E2M1 encoding of infinity."""
+-    # Positive infinity
+-    var pos_inf = Float32(1.0) / Float32(0.0)
+-    var fp4_pos_inf = FP4_E2M1.from_float32(pos_inf, scale=1.0)
+-    assert_equal(fp4_pos_inf.value, 0b0111)  # Max positive value
+-
+-    # Negative infinity
+-    var neg_inf = Float32(-1.0) / Float32(0.0)
+-    var fp4_neg_inf = FP4_E2M1.from_float32(neg_inf, scale=1.0)
+-    assert_equal(fp4_neg_inf.value, 0b1111)  # Max negative value
+-
+-
+-fn test_fp4_e2m1_equality() raises:
+-    """Test FP4_E2M1 equality comparison."""
+-    var fp4_a = FP4_E2M1.from_float32(2.0, scale=1.0)
+-    var fp4_b = FP4_E2M1.from_float32(2.0, scale=1.0)
+-    var fp4_c = FP4_E2M1.from_float32(3.0, scale=1.0)
+-
+-    assert_true(fp4_a == fp4_b, "Equal FP4_E2M1 values should compare equal")
+-    assert_true(
+-        fp4_a != fp4_c, "Different FP4_E2M1 values should compare not equal"
+-    )
+-
+-
+-fn test_fp4_e2m1_bit_patterns() raises:
+-    """Test specific bit patterns in E2M1 format."""
+-    # Test zero: sign=0, exp=0, mantissa=0
+-    var fp4_zero = FP4_E2M1(0b0000)
+-    assert_almost_equal(
+-        fp4_zero.to_float32(scale=1.0), Float32(0.0), tolerance=1e-7
+-    )
+-
+-    # Test positive max: sign=0, exp=3, mantissa=1
+-    var fp4_max = FP4_E2M1(0b0111)
+-    assert_almost_equal(
+-        fp4_max.to_float32(scale=1.0), Float32(6.0), tolerance=0.1
+-    )
+-
+-    # Test negative max: sign=1, exp=3, mantissa=1
+-    var fp4_neg_max = FP4_E2M1(0b1111)
+-    assert_almost_equal(
+-        fp4_neg_max.to_float32(scale=1.0), Float32(-6.0), tolerance=0.1
+-    )
+-
+-    # Test 1.0: sign=0, exp=1, mantissa=0
+-    var fp4_one = FP4_E2M1(0b0010)
+-    assert_almost_equal(
+-        fp4_one.to_float32(scale=1.0), Float32(1.0), tolerance=0.1
+-    )
+-
+-
+-fn test_fp4_e2m1_quantization() raises:
+-    """Test quantization to nearest representable value."""
+-    # 1.25 should quantize to either 1.0 or 1.5
+-    var fp4_1_25 = FP4_E2M1.from_float32(1.25, scale=1.0)
+-    var result_1_25 = fp4_1_25.to_float32(scale=1.0)
+-    assert_true(
+-        result_1_25 >= 1.0 and result_1_25 <= 1.5,
+-        "1.25 should quantize to 1.0 or 1.5",
+-    )
+-
+-    # 2.5 should quantize to either 2.0 or 3.0
+-    var fp4_2_5 = FP4_E2M1.from_float32(2.5, scale=1.0)
+-    var result_2_5 = fp4_2_5.to_float32(scale=1.0)
+-    assert_true(
+-        result_2_5 >= 2.0 and result_2_5 <= 3.0,
+-        "2.5 should quantize to 2.0 or 3.0",
+-    )
+-
+-
+-# ============================================================================
+-# String Representation Tests
+-# ============================================================================
+-
+-
+-fn test_fp4_e2m1_str_representation() raises:
+-    """Test __str__ method for FP4_E2M1."""
+-    var fp4_one = FP4_E2M1.from_float32(1.0, scale=1.0)
+-    var str_repr = fp4_one.__str__()
+-
+-    # Should contain "FP4_E2M1" and the value
+-    assert_true("FP4_E2M1" in str_repr, "__str__ should contain FP4_E2M1")
+-
+-
+-fn test_fp4_e2m1_repr_representation() raises:
+-    """Test __repr__ method for FP4_E2M1."""
+-    var fp4_two = FP4_E2M1.from_float32(2.0, scale=1.0)
+-    var repr_str = fp4_two.__repr__()
+-
+-    # Should contain "FP4_E2M1" and "bits="
+-    assert_true("FP4_E2M1" in repr_str, "__repr__ should contain FP4_E2M1")
+-    assert_true("bits=" in repr_str, "__repr__ should contain bits=")
+-
+-
+-fn test_fp4_e2m1_repr_zero() raises:
+-    """Test __repr__ for zero value."""
+-    var fp4_zero = FP4_E2M1(0b0000)
+-    var repr_str = fp4_zero.__repr__()
+-    assert_true(len(repr_str) > 0, "__repr__ should produce non-empty string")
+-
+-
+-fn test_fp4_e2m1_repr_max() raises:
+-    """Test __repr__ for max value."""
+-    var fp4_max = FP4_E2M1(0b0111)
+-    var repr_str = fp4_max.__repr__()
+-    assert_true(len(repr_str) > 0, "__repr__ should produce non-empty string")
+-
+-
+-# ============================================================================
+-# All 16 FP4 Values Tests
+-# ============================================================================
+-
+-
+-fn test_fp4_e2m1_all_16_values() raises:
+-    """Test decoding of all 16 possible FP4 bit patterns."""
+-    # All 16 possible 4-bit values: 0x0 to 0xF
+-    # Testing that all can be decoded without errors
+-    for i in range(16):
+-        var fp4 = FP4_E2M1(UInt8(i))
+-        var _ = fp4.to_float32(scale=1.0)
+-        # Should produce a valid float (not NaN unless explicitly set)
+-        assert_true(
+-            len(fp4.__str__()) > 0,
+-            "All values should produce string representation",
+-        )
+-
+-
+-fn test_fp4_e2m1_positive_values_all() raises:
+-    """Test all positive FP4 bit patterns (sign bit = 0)."""
+-    # Positive values: 0x0 to 0x7
+-    var values: List[UInt8] = []
+-    values.append(0b0000)  # Zero
+-    values.append(0b0001)  # exp=0, mantissa=1 (invalid)
+-    values.append(0b0010)  # exp=1, mantissa=0 = 1.0
+-    values.append(0b0011)  # exp=1, mantissa=1 = 1.5
+-    values.append(0b0100)  # exp=2, mantissa=0 = 2.0
+-    values.append(0b0101)  # exp=2, mantissa=1 = 3.0
+-    values.append(0b0110)  # exp=3, mantissa=0 = 4.0
+-    values.append(0b0111)  # exp=3, mantissa=1 = 6.0
+-
+-    for i in range(len(values)):
+-        var fp4 = FP4_E2M1(values[i])
+-        var decoded = fp4.to_float32(scale=1.0)
+-        assert_true(decoded >= 0.0, "Positive values should be >= 0")
+-
+-
+-fn test_fp4_e2m1_negative_values_all() raises:
+-    """Test all negative FP4 bit patterns (sign bit = 1)."""
+-    # Negative values: 0x8 to 0xF
+-    var values: List[UInt8] = []
+-    values.append(0b1000)  # -Zero
+-    values.append(0b1001)  # exp=0, mantissa=1 (invalid)
+-    values.append(0b1010)  # exp=1, mantissa=0 = -1.0
+-    values.append(0b1011)  # exp=1, mantissa=1 = -1.5
+-    values.append(0b1100)  # exp=2, mantissa=0 = -2.0
+-    values.append(0b1101)  # exp=2, mantissa=1 = -3.0
+-    values.append(0b1110)  # exp=3, mantissa=0 = -4.0
+-    values.append(0b1111)  # exp=3, mantissa=1 = -6.0
+-
+-    for i in range(len(values)):
+-        var fp4 = FP4_E2M1(values[i])
+-        var decoded = fp4.to_float32(scale=1.0)
+-        assert_true(decoded <= 0.0, "Negative values should be <= 0")
+-
+-
+-fn test_fp4_e2m1_value_extraction() raises:
+-    """Test bit pattern extraction in to_float32."""
+-    # Test that correct components are extracted
+-    var fp4_test = FP4_E2M1(0b0101)  # exp=2, mantissa=1 = 3.0
+-    var result = fp4_test.to_float32(scale=1.0)
+-    assert_almost_equal(result, Float32(3.0), tolerance=0.1)
+-
+-
+-fn test_fp4_e2m1_scale_zero_edge_case() raises:
+-    """Test encoding with various edge case scales."""
+-    # Test with scale=1.0
+-    var fp4_a = FP4_E2M1.from_float32(3.0, scale=1.0)
+-    var result_a = fp4_a.to_float32(scale=1.0)
+-    assert_almost_equal(result_a, Float32(3.0), tolerance=0.5)
+-
+-    # Test with scale=0.5
+-    var fp4_b = FP4_E2M1.from_float32(1.5, scale=0.5)
+-    var result_b = fp4_b.to_float32(scale=0.5)
+-    assert_almost_equal(result_b, Float32(1.5), tolerance=0.3)
+-
+-    # Test with scale=2.0
+-    var fp4_c = FP4_E2M1.from_float32(6.0, scale=2.0)
+-    var result_c = fp4_c.to_float32(scale=2.0)
+-    assert_almost_equal(result_c, Float32(6.0), tolerance=1.0)
+-
+-
+-fn test_fp4_e2m1_not_equal() raises:
+-    """Test __ne__ operator."""
+-    var fp4_a = FP4_E2M1.from_float32(1.0, scale=1.0)
+-    var fp4_b = FP4_E2M1.from_float32(2.0, scale=1.0)
+-
+-    assert_true(fp4_a != fp4_b, "Different FP4 values should not be equal")
+-
+-
+-fn test_fp4_e2m1_equal_direct_init() raises:
+-    """Test equality with direct initialization."""
+-    var fp4_a = FP4_E2M1(0b0010)
+-    var fp4_b = FP4_E2M1(0b0010)
+-
+-    assert_true(fp4_a == fp4_b, "Same bit patterns should be equal")
+-
+-
+-fn test_fp4_e2m1_edge_case_boundaries() raises:
+-    """Test boundary conditions for quantization."""
+-    # Test value just below max
+-    var fp4_below_max = FP4_E2M1.from_float32(5.9, scale=1.0)
+-    var result_below_max = fp4_below_max.to_float32(scale=1.0)
+-    assert_true(result_below_max <= 6.0, "Value should not exceed max")
+-
+-    # Test value just above min representable
+-    var fp4_above_min = FP4_E2M1.from_float32(1.01, scale=1.0)
+-    var result_above_min = fp4_above_min.to_float32(scale=1.0)
+-    assert_true(result_above_min >= 0.5, "Value should be at least 0.5")
+-
+-
+-fn test_fp4_e2m1_negative_scale() raises:
+-    """Test behavior with scale factor variations."""
+-    # Test inverse scale relationship
+-    var value = Float32(3.0)
+-    var fp4_scaled_up = FP4_E2M1.from_float32(value, scale=0.5)
+-    var result_scaled_up = fp4_scaled_up.to_float32(scale=0.5)
+-    assert_almost_equal(result_scaled_up, value, tolerance=0.5)
+-
+-    var fp4_scaled_down = FP4_E2M1.from_float32(value, scale=2.0)
+-    var result_scaled_down = fp4_scaled_down.to_float32(scale=2.0)
+-    assert_almost_equal(result_scaled_down, value, tolerance=0.5)
+-
+-
+-# ============================================================================
+-# Main Test Runner
+-# ============================================================================
+-
+-
+-fn main() raises:
+-    """Run all FP4_E2M1 tests."""
+-    print("\n=== FP4_E2M1 Basic Conversion Tests ===")
+-    test_fp4_e2m1_zero()
+-    print("✓ FP4_E2M1 zero encoding")
+-
+-    test_fp4_e2m1_negative_zero()
+-    print("✓ FP4_E2M1 negative zero handling")
+-
+-    test_fp4_e2m1_representable_values()
+-    print("✓ FP4_E2M1 all representable values")
+-
+-    test_fp4_e2m1_positive_values()
+-    print("✓ FP4_E2M1 positive values")
+-
+-    test_fp4_e2m1_negative_values()
+-    print("✓ FP4_E2M1 negative values")
+-
+-    test_fp4_e2m1_range_clamping()
+-    print("✓ FP4_E2M1 range clamping")
+-
+-    test_fp4_e2m1_small_values()
+-    print("✓ FP4_E2M1 small values")
+-
+-    test_fp4_e2m1_scale_impact()
+-    print("✓ FP4_E2M1 scale factor impact")
+-
+-    test_fp4_e2m1_special_values_nan()
+-    print("✓ FP4_E2M1 NaN handling")
+-
+-    test_fp4_e2m1_special_values_inf()
+-    print("✓ FP4_E2M1 infinity handling")
+-
+-    test_fp4_e2m1_equality()
+-    print("✓ FP4_E2M1 equality comparison")
+-
+-    test_fp4_e2m1_bit_patterns()
+-    print("✓ FP4_E2M1 bit pattern verification")
+-
+-    test_fp4_e2m1_quantization()
+-    print("✓ FP4_E2M1 quantization behavior")
+-
+-    print("\n=== FP4_E2M1 String Representation Tests ===")
+-    test_fp4_e2m1_str_representation()
+-    print("✓ FP4_E2M1 __str__ method")
+-
+-    test_fp4_e2m1_repr_representation()
+-    print("✓ FP4_E2M1 __repr__ method")
+-
+-    test_fp4_e2m1_repr_zero()
+-    print("✓ FP4_E2M1 __repr__ for zero")
+-
+-    test_fp4_e2m1_repr_max()
+-    print("✓ FP4_E2M1 __repr__ for max")
+-
+-    print("\n=== All 16 FP4 Values Tests ===")
+-    test_fp4_e2m1_all_16_values()
+-    print("✓ All 16 possible FP4 bit patterns")
+-
+-    test_fp4_e2m1_positive_values_all()
+-    print("✓ All positive FP4 bit patterns")
+-
+-    test_fp4_e2m1_negative_values_all()
+-    print("✓ All negative FP4 bit patterns")
+-
+-    test_fp4_e2m1_value_extraction()
+-    print("✓ Bit pattern extraction")
+-
+-    test_fp4_e2m1_scale_zero_edge_case()
+-    print("✓ Edge case scales")
+-
+-    test_fp4_e2m1_not_equal()
+-    print("✓ __ne__ operator")
+-
+-    test_fp4_e2m1_equal_direct_init()
+-    print("✓ __eq__ operator with direct init")
+-
+-    test_fp4_e2m1_edge_case_boundaries()
+-    print("✓ Boundary conditions")
+-
+-    test_fp4_e2m1_negative_scale()
+-    print("✓ Scale factor variations")
+-
+-    print("\n=== All FP4_E2M1 Tests Passed! ===\n")
+diff --git a/tests/shared/core/test_fp8.mojo b/tests/shared/core/test_fp8.mojo
+deleted file mode 100644
+index 1424038b9..000000000
+--- a/tests/shared/core/test_fp8.mojo
++++ /dev/null
+@@ -1,353 +0,0 @@
+-"""Tests for FP8 data type and tensor conversions.
+-
+-Tests cover:
+-- FP8 creation from Float32
+-- FP8 to Float32 conversion
+-- Special values (zero, NaN, Inf)
+-- Range clamping (±240 max value)
+-- Tensor conversion (to_fp8, from_fp8)
+-- Round-trip conversion accuracy
+-"""
+-
+-from tests.shared.conftest import (
+-    assert_almost_equal,
+-    assert_close_float,
+-    assert_equal,
+-    assert_equal_int,
+-    assert_shape,
+-    assert_shape_equal,
+-    assert_true,
+-)
+-from tests.shared.conftest import TestFixtures
+-from shared.core.extensor import (
+-    ExTensor,
+-    zeros,
+-    ones,
+-    full,
+-)
+-from shared.core.types.fp8 import FP8
+-from math import isnan, isinf
+-
+-
+-# ============================================================================
+-# FP8 Basic Conversion Tests
+-# ============================================================================
+-
+-
+-fn test_fp8_zero() raises:
+-    """Test FP8 representation of zero."""
+-    var fp8_zero = FP8.from_float32(0.0)
+-    var result = fp8_zero.to_float32()
+-
+-    assert_equal(fp8_zero.value, 0)
+-    assert_almost_equal(result, Float32(0.0), tolerance=1e-7)
+-
+-
+-fn test_fp8_positive_values() raises:
+-    """Test FP8 encoding of positive values."""
+-    # Test small positive value
+-    var fp8_small = FP8.from_float32(1.0)
+-    var result_small = fp8_small.to_float32()
+-    assert_almost_equal(result_small, Float32(1.0), tolerance=0.2)
+-
+-    # Test medium positive value
+-    var fp8_medium = FP8.from_float32(10.0)
+-    var result_medium = fp8_medium.to_float32()
+-    assert_almost_equal(result_medium, Float32(10.0), tolerance=2.0)
+-
+-    # Test large positive value
+-    var fp8_large = FP8.from_float32(100.0)
+-    var result_large = fp8_large.to_float32()
+-    assert_almost_equal(result_large, Float32(100.0), tolerance=15.0)
+-
+-
+-fn test_fp8_negative_values() raises:
+-    """Test FP8 encoding of negative values."""
+-    # Test small negative value
+-    var fp8_small = FP8.from_float32(-1.0)
+-    var result_small = fp8_small.to_float32()
+-    assert_almost_equal(result_small, Float32(-1.0), tolerance=0.2)
+-
+-    # Test medium negative value
+-    var fp8_medium = FP8.from_float32(-10.0)
+-    var result_medium = fp8_medium.to_float32()
+-    assert_almost_equal(result_medium, Float32(-10.0), tolerance=2.0)
+-
+-    # Test large negative value
+-    var fp8_large = FP8.from_float32(-100.0)
+-    var result_large = fp8_large.to_float32()
+-    assert_almost_equal(result_large, Float32(-100.0), tolerance=15.0)
+-
+-
+-fn test_fp8_range_clamping() raises:
+-    """Test FP8 clamping of values outside representable range."""
+-    # FP8 E4M3 max value is approximately 240
+-
+-    # Test positive overflow
+-    var fp8_overflow = FP8.from_float32(1000.0)
+-    var result_overflow = fp8_overflow.to_float32()
+-    assert_true(
+-        result_overflow <= 240.0, "FP8 should clamp large positive values"
+-    )
+-    assert_true(result_overflow > 200.0, "FP8 max should be near 240")
+-
+-    # Test negative overflow
+-    var fp8_underflow = FP8.from_float32(-1000.0)
+-    var result_underflow = fp8_underflow.to_float32()
+-    assert_true(
+-        result_underflow >= -240.0, "FP8 should clamp large negative values"
+-    )
+-    assert_true(result_underflow < -200.0, "FP8 min should be near -240")
+-
+-
+-fn test_fp8_subnormal_values() raises:
+-    """Test FP8 encoding of very small (subnormal) values."""
+-    # FP8 E4M3 min normal value is 2^-6 = 0.015625
+-
+-    # Test value in subnormal range
+-    var fp8_tiny = FP8.from_float32(0.01)
+-    var result_tiny = fp8_tiny.to_float32()
+-    assert_true(result_tiny >= 0.0, "FP8 subnormal should be non-negative")
+-    assert_true(result_tiny < 0.02, "FP8 subnormal should be small")
+-
+-    # Test value below subnormal range (should be zero)
+-    var fp8_very_tiny = FP8.from_float32(0.001)
+-    var result_very_tiny = fp8_very_tiny.to_float32()
+-    assert_almost_equal(result_very_tiny, Float32(0.0), tolerance=1e-7)
+-
+-
+-fn test_fp8_special_values_nan() raises:
+-    """Test FP8 encoding of NaN."""
+-    var nan_val = Float32(0.0) / Float32(0.0)
+-    var fp8_nan = FP8.from_float32(nan_val)
+-    var result = fp8_nan.to_float32()
+-
+-    # Check that result is NaN
+-    assert_true(isnan(result), "FP8 should preserve NaN")
+-
+-
+-fn test_fp8_special_values_inf() raises:
+-    """Test FP8 encoding of infinity."""
+-    # Positive infinity
+-    var pos_inf = Float32(1.0) / Float32(0.0)
+-    var fp8_pos_inf = FP8.from_float32(pos_inf)
+-    var result_pos = fp8_pos_inf.to_float32()
+-    assert_true(
+-        isinf(result_pos) and result_pos > 0, "FP8 should preserve +Inf"
+-    )
+-
+-    # Negative infinity
+-    var neg_inf = Float32(-1.0) / Float32(0.0)
+-    var fp8_neg_inf = FP8.from_float32(neg_inf)
+-    var result_neg = fp8_neg_inf.to_float32()
+-    assert_true(
+-        isinf(result_neg) and result_neg < 0, "FP8 should preserve -Inf"
+-    )
+-
+-
+-fn test_fp8_equality() raises:
+-    """Test FP8 equality comparison."""
+-    var fp8_a = FP8.from_float32(3.14)
+-    var fp8_b = FP8.from_float32(3.14)
+-    var fp8_c = FP8.from_float32(2.71)
+-
+-    assert_true(fp8_a == fp8_b, "Equal FP8 values should compare equal")
+-    assert_true(fp8_a != fp8_c, "Different FP8 values should compare not equal")
+-
+-
+-# ============================================================================
+-# Tensor Conversion Tests
+-# ============================================================================
+-
+-
+-fn test_tensor_to_fp8() raises:
+-    """Test converting Float32 tensor to FP8."""
+-    var shape = List[Int]()
+-    shape.append(2)
+-    shape.append(3)
+-
+-    # Create Float32 tensor with specific values
+-    var t = zeros(shape, DType.float32)
+-    t._data.bitcast[Float32]()[0] = 1.0
+-    t._data.bitcast[Float32]()[1] = -2.5
+-    t._data.bitcast[Float32]()[2] = 10.0
+-    t._data.bitcast[Float32]()[3] = -5.0
+-    t._data.bitcast[Float32]()[4] = 0.5
+-    t._data.bitcast[Float32]()[5] = 100.0
+-
+-    # Convert to FP8
+-    var fp8_tensor = t.to_fp8()
+-
+-    # Check dtype is uint8
+-    assert_true(
+-        fp8_tensor.dtype() == DType.uint8, "FP8 tensor should have uint8 dtype"
+-    )
+-
+-    # Check shape is preserved
+-    assert_shape_equal(fp8_tensor.shape(), t.shape())
+-
+-    # Check that values are encoded (not zero)
+-    var has_nonzero = False
+-    for i in range(6):
+-        if fp8_tensor._data.bitcast[UInt8]()[i] != 0:
+-            has_nonzero = True
+-    assert_true(has_nonzero, "FP8 tensor should have encoded values")
+-
+-
+-fn test_tensor_from_fp8() raises:
+-    """Test converting FP8 tensor back to Float32."""
+-    var shape = List[Int]()
+-    shape.append(2)
+-    shape.append(2)
+-
+-    # Create Float32 tensor
+-    var original = ones(shape, DType.float32)
+-    original._data.bitcast[Float32]()[0] = 3.0
+-    original._data.bitcast[Float32]()[1] = -1.5
+-    original._data.bitcast[Float32]()[2] = 7.0
+-    original._data.bitcast[Float32]()[3] = -10.0
+-
+-    # Convert to FP8 and back
+-    var fp8_tensor = original.to_fp8()
+-    var restored = fp8_tensor.from_fp8()
+-
+-    # Check dtype is float32
+-    assert_true(
+-        restored.dtype() == DType.float32,
+-        "Restored tensor should have float32 dtype",
+-    )
+-
+-    # Check shape is preserved
+-    assert_shape_equal(restored.shape(), original.shape())
+-
+-    # Check values are approximately restored (with FP8 precision loss)
+-    assert_almost_equal(
+-        restored._data.bitcast[Float32]()[0], Float32(3.0), tolerance=0.5
+-    )
+-    assert_almost_equal(
+-        restored._data.bitcast[Float32]()[1], Float32(-1.5), tolerance=0.3
+-    )
+-    assert_almost_equal(
+-        restored._data.bitcast[Float32]()[2], Float32(7.0), tolerance=1.0
+-    )
+-    assert_almost_equal(
+-        restored._data.bitcast[Float32]()[3], Float32(-10.0), tolerance=2.0
+-    )
+-
+-
+-fn test_tensor_fp8_roundtrip() raises:
+-    """Test round-trip conversion Float32 -> FP8 -> Float32."""
+-    var shape = List[Int]()
+-    shape.append(5)
+-
+-    # Create tensor with various values
+-    var original = zeros(shape, DType.float32)
+-    original._data.bitcast[Float32]()[0] = 0.0
+-    original._data.bitcast[Float32]()[1] = 1.0
+-    original._data.bitcast[Float32]()[2] = -5.0
+-    original._data.bitcast[Float32]()[3] = 20.0
+-    original._data.bitcast[Float32]()[4] = -50.0
+-
+-    # Round-trip conversion
+-    var fp8_tensor = original.to_fp8()
+-    var restored = fp8_tensor.from_fp8()
+-
+-    # Verify approximate equality (accounting for FP8 precision loss)
+-    for i in range(5):
+-        var orig_val = original._data.bitcast[Float32]()[i]
+-        var restored_val = restored._data.bitcast[Float32]()[i]
+-
+-        # Use tolerance proportional to magnitude
+-        var tolerance = max(abs(orig_val) * 0.15, Float32(0.5))
+-        assert_almost_equal(restored_val, orig_val, tolerance=tolerance)
+-
+-
+-fn test_tensor_to_fp8_requires_float() raises:
+-    """Test that to_fp8() requires floating-point tensor."""
+-    var shape = List[Int]()
+-    shape.append(3)
+-
+-    # Create int32 tensor
+-    var int_tensor = zeros(shape, DType.int32)
+-
+-    # Try to convert to FP8 (should raise error)
+-    var raised_error = False
+-    try:
+-        var _ = int_tensor.to_fp8()
+-    except:
+-        raised_error = True
+-
+-    assert_true(
+-        raised_error, "to_fp8() should raise error for non-float tensor"
+-    )
+-
+-
+-fn test_tensor_from_fp8_requires_uint8() raises:
+-    """Test that from_fp8() requires uint8 tensor."""
+-    var shape = List[Int]()
+-    shape.append(3)
+-
+-    # Create float32 tensor (not uint8)
+-    var float_tensor = zeros(shape, DType.float32)
+-
+-    # Try to convert from FP8 (should raise error)
+-    var raised_error = False
+-    try:
+-        var _ = float_tensor.from_fp8()
+-    except:
+-        raised_error = True
+-
+-    assert_true(
+-        raised_error, "from_fp8() should raise error for non-uint8 tensor"
+-    )
+-
+-
+-# ============================================================================
+-# Main Test Runner
+-# ============================================================================
+-
+-
+-fn main() raises:
+-    """Run all FP8 tests."""
+-    print("\n=== FP8 Basic Conversion Tests ===")
+-    test_fp8_zero()
+-    print("✓ FP8 zero encoding")
+-
+-    test_fp8_positive_values()
+-    print("✓ FP8 positive values")
+-
+-    test_fp8_negative_values()
+-    print("✓ FP8 negative values")
+-
+-    test_fp8_range_clamping()
+-    print("✓ FP8 range clamping")
+-
+-    test_fp8_subnormal_values()
+-    print("✓ FP8 subnormal values")
+-
+-    test_fp8_special_values_nan()
+-    print("✓ FP8 NaN handling")
+-
+-    test_fp8_special_values_inf()
+-    print("✓ FP8 infinity handling")
+-
+-    test_fp8_equality()
+-    print("✓ FP8 equality comparison")
+-
+-    print("\n=== Tensor Conversion Tests ===")
+-    test_tensor_to_fp8()
+-    print("✓ Tensor to FP8 conversion")
+-
+-    test_tensor_from_fp8()
+-    print("✓ Tensor from FP8 conversion")
+-
+-    test_tensor_fp8_roundtrip()
+-    print("✓ Tensor FP8 round-trip")
+-
+-    test_tensor_to_fp8_requires_float()
+-    print("✓ to_fp8() type validation")
+-
+-    test_tensor_from_fp8_requires_uint8()
+-    print("✓ from_fp8() type validation")
+-
+-    print("\n=== All FP8 Tests Passed! ===\n")
+diff --git a/tests/shared/core/test_mxfp4.mojo b/tests/shared/core/test_mxfp4.mojo
+deleted file mode 100644
+index c7cb60760..000000000
+--- a/tests/shared/core/test_mxfp4.mojo
++++ /dev/null
+@@ -1,649 +0,0 @@
+-"""Tests for MXFP4 (Microscaling FP4) data type.
+-
+-Tests cover:
+-- E8M0Scale creation and conversion
+-- MXFP4 creation from Float32
+-- MXFP4 to Float32 conversion
+-- Arithmetic operations (+, -, *, /, neg)
+-- Comparison operations (==, !=, <, <=, >, >=)
+-- Special values (zero, NaN, Inf)
+-- Wide dynamic range (2^-127 to 2^128)
+-- Edge cases and boundary values
+-"""
+-
+-from tests.shared.conftest import (
+-    assert_almost_equal,
+-    assert_close_float,
+-    assert_equal,
+-    assert_equal_int,
+-    assert_true,
+-)
+-from shared.core.types.mxfp4 import MXFP4, MXFP4Block, E8M0Scale
+-from math import isnan, isinf
+-from collections import List
+-
+-
+-# ============================================================================
+-# E8M0Scale Tests
+-# ============================================================================
+-
+-
+-fn test_e8m0_scale_basic() raises:
+-    """Test E8M0 scale creation and conversion."""
+-    # Test scale = 1.0 (exponent = 127)
+-    var scale_one = E8M0Scale.from_float32(1.0)
+-    assert_equal(scale_one.exponent, 127)
+-    assert_almost_equal(scale_one.to_float32(), Float32(1.0), tolerance=1e-6)
+-
+-    # Test scale = 2.0 (exponent = 128)
+-    var scale_two = E8M0Scale.from_float32(2.0)
+-    assert_equal(scale_two.exponent, 128)
+-    assert_almost_equal(scale_two.to_float32(), Float32(2.0), tolerance=1e-6)
+-
+-    # Test scale = 0.5 (exponent = 126)
+-    var scale_half = E8M0Scale.from_float32(0.5)
+-    assert_equal(scale_half.exponent, 126)
+-    assert_almost_equal(scale_half.to_float32(), Float32(0.5), tolerance=1e-6)
+-
+-
+-fn test_e8m0_scale_powers_of_two() raises:
+-    """Test E8M0 scale with various powers of 2."""
+-    # Test 2^-10 = 0.0009765625
+-    var scale_small = E8M0Scale.from_float32(0.0009765625)
+-    var result_small = scale_small.to_float32()
+-    assert_almost_equal(result_small, Float32(0.0009765625), tolerance=1e-7)
+-
+-    # Test 2^10 = 1024.0
+-    var scale_large = E8M0Scale.from_float32(1024.0)
+-    var result_large = scale_large.to_float32()
+-    assert_almost_equal(result_large, Float32(1024.0), tolerance=1.0)
+-
+-
+-fn test_e8m0_scale_edge_cases() raises:
+-    """Test E8M0 scale edge cases."""
+-    # Test zero (should return minimum scale)
+-    var scale_zero = E8M0Scale.from_float32(0.0)
+-    assert_equal(scale_zero.exponent, 0)
+-
+-    # Test negative (should return minimum scale)
+-    var scale_neg = E8M0Scale.from_float32(-1.0)
+-    assert_equal(scale_neg.exponent, 0)
+-
+-    # Test infinity (should return maximum scale)
+-    var pos_inf = Float32(1.0) / Float32(0.0)
+-    var scale_inf = E8M0Scale.from_float32(pos_inf)
+-    assert_equal(scale_inf.exponent, 255)
+-
+-
+-# ============================================================================
+-# MXFP4 Basic Conversion Tests
+-# ============================================================================
+-
+-
+-fn test_mxfp4_zero() raises:
+-    """Test MXFP4 representation of zero."""
+-    var mxfp4_zero = MXFP4.from_float32(0.0)
+-    var result = mxfp4_zero.to_float32()
+-
+-    assert_equal(mxfp4_zero.value.value, 0)
+-    assert_almost_equal(result, Float32(0.0), tolerance=1e-7)
+-
+-
+-fn test_mxfp4_positive_values() raises:
+-    """Test MXFP4 encoding of positive values."""
+-    # Test small positive value
+-    var mxfp4_small = MXFP4.from_float32(1.0)
+-    var result_small = mxfp4_small.to_float32()
+-    assert_almost_equal(result_small, Float32(1.0), tolerance=0.3)
+-
+-    # Test medium positive value
+-    var mxfp4_medium = MXFP4.from_float32(10.0)
+-    var result_medium = mxfp4_medium.to_float32()
+-    assert_almost_equal(result_medium, Float32(10.0), tolerance=2.0)
+-
+-    # Test large positive value
+-    var mxfp4_large = MXFP4.from_float32(100.0)
+-    var result_large = mxfp4_large.to_float32()
+-    assert_almost_equal(result_large, Float32(100.0), tolerance=20.0)
+-
+-
+-fn test_mxfp4_negative_values() raises:
+-    """Test MXFP4 encoding of negative values."""
+-    # Test small negative value
+-    var mxfp4_small = MXFP4.from_float32(-1.0)
+-    var result_small = mxfp4_small.to_float32()
+-    assert_almost_equal(result_small, Float32(-1.0), tolerance=0.3)
+-
+-    # Test medium negative value
+-    var mxfp4_medium = MXFP4.from_float32(-10.0)
+-    var result_medium = mxfp4_medium.to_float32()
+-    assert_almost_equal(result_medium, Float32(-10.0), tolerance=2.0)
+-
+-    # Test large negative value
+-    var mxfp4_large = MXFP4.from_float32(-100.0)
+-    var result_large = mxfp4_large.to_float32()
+-    assert_almost_equal(result_large, Float32(-100.0), tolerance=20.0)
+-
+-
+-fn test_mxfp4_wide_dynamic_range() raises:
+-    """Test MXFP4 wide dynamic range (E8M0 scale)."""
+-    # Test very small value (near 2^-127)
+-    var mxfp4_tiny = MXFP4.from_float32(1e-30)
+-    var result_tiny = mxfp4_tiny.to_float32()
+-    assert_true(
+-        result_tiny > 0.0 and result_tiny < 1e-20,
+-        "MXFP4 should handle tiny values",
+-    )
+-
+-    # Test very large value (within Float32 range)
+-    var mxfp4_huge = MXFP4.from_float32(1e30)
+-    var result_huge = mxfp4_huge.to_float32()
+-    assert_true(result_huge > 1e25, "MXFP4 should handle huge values")
+-
+-
+-fn test_mxfp4_special_values_nan() raises:
+-    """Test MXFP4 encoding of NaN."""
+-    var nan_val = Float32(0.0) / Float32(0.0)
+-    var mxfp4_nan = MXFP4.from_float32(nan_val)
+-    var _ = mxfp4_nan.to_float32()
+-
+-    # NaN encoding: E2M1 value should be max (0b0111)
+-    assert_equal(mxfp4_nan.value.value, 0b0111)
+-
+-
+-fn test_mxfp4_special_values_inf() raises:
+-    """Test MXFP4 encoding of infinity."""
+-    # Positive infinity
+-    var pos_inf = Float32(1.0) / Float32(0.0)
+-    var mxfp4_pos_inf = MXFP4.from_float32(pos_inf)
+-    var _ = mxfp4_pos_inf.to_float32()
+-
+-    # Should encode as max E2M1 value with max scale
+-    assert_equal(mxfp4_pos_inf.value.value, 0b0111)
+-
+-    # Negative infinity
+-    var neg_inf = Float32(-1.0) / Float32(0.0)
+-    var mxfp4_neg_inf = MXFP4.from_float32(neg_inf)
+-    var _ = mxfp4_neg_inf.to_float32()
+-
+-    # Should encode as max negative E2M1 value
+-    assert_equal(mxfp4_neg_inf.value.value, 0b1111)
+-
+-
+-# ============================================================================
+-# MXFP4 Arithmetic Operations
+-# ============================================================================
+-
+-
+-fn test_mxfp4_addition() raises:
+-    """Test MXFP4 addition."""
+-    var a = MXFP4.from_float32(3.0)
+-    var b = MXFP4.from_float32(2.0)
+-    var result = a + b
+-
+-    assert_almost_equal(result.to_float32(), Float32(5.0), tolerance=1.5)
+-
+-
+-fn test_mxfp4_subtraction() raises:
+-    """Test MXFP4 subtraction."""
+-    var a = MXFP4.from_float32(5.0)
+-    var b = MXFP4.from_float32(2.0)
+-    var result = a - b
+-
+-    assert_almost_equal(result.to_float32(), Float32(3.0), tolerance=1.0)
+-
+-
+-fn test_mxfp4_multiplication() raises:
+-    """Test MXFP4 multiplication."""
+-    var a = MXFP4.from_float32(3.0)
+-    var b = MXFP4.from_float32(2.0)
+-    var result = a * b
+-
+-    assert_almost_equal(result.to_float32(), Float32(6.0), tolerance=2.0)
+-
+-
+-fn test_mxfp4_division() raises:
+-    """Test MXFP4 division."""
+-    var a = MXFP4.from_float32(6.0)
+-    var b = MXFP4.from_float32(2.0)
+-    var result = a / b
+-
+-    assert_almost_equal(result.to_float32(), Float32(3.0), tolerance=1.0)
+-
+-
+-fn test_mxfp4_negation() raises:
+-    """Test MXFP4 negation."""
+-    var a = MXFP4.from_float32(3.0)
+-    var result = -a
+-
+-    assert_almost_equal(result.to_float32(), Float32(-3.0), tolerance=1.0)
+-
+-    # Test double negation
+-    var result2 = -result
+-    assert_almost_equal(result2.to_float32(), Float32(3.0), tolerance=1.0)
+-
+-
+-# ============================================================================
+-# MXFP4 Comparison Operations
+-# ============================================================================
+-
+-
+-fn test_mxfp4_equality() raises:
+-    """Test MXFP4 equality comparison."""
+-    # Use values that encode to different E2M1 representations
+-    # 3.0 encodes to exp=2, mantissa=1 (value 3.0)
+-    # 6.0 encodes to exp=3, mantissa=1 (value 6.0)
+-    var a = MXFP4.from_float32(3.0)
+-    var b = MXFP4.from_float32(3.0)
+-    var c = MXFP4.from_float32(6.0)
+-
+-    assert_true(a == b, "Equal MXFP4 values should compare equal")
+-    assert_true(a != c, "Different MXFP4 values should compare not equal")
+-
+-
+-fn test_mxfp4_inequality() raises:
+-    """Test MXFP4 inequality operators."""
+-    var small = MXFP4.from_float32(1.0)
+-    var large = MXFP4.from_float32(5.0)
+-
+-    assert_true(small < large, "Small < Large should be true")
+-    assert_true(small <= large, "Small <= Large should be true")
+-    assert_true(large > small, "Large > Small should be true")
+-    assert_true(large >= small, "Large >= Small should be true")
+-
+-
+-fn test_mxfp4_comparison_edge_cases() raises:
+-    """Test MXFP4 comparison with edge cases."""
+-    var zero = MXFP4.from_float32(0.0)
+-    var positive = MXFP4.from_float32(1.0)
+-    var negative = MXFP4.from_float32(-1.0)
+-
+-    assert_true(negative < zero, "Negative < Zero should be true")
+-    assert_true(zero < positive, "Zero < Positive should be true")
+-    assert_true(negative < positive, "Negative < Positive should be true")
+-
+-
+-# ============================================================================
+-# MXFP4 Round-trip Tests
+-# ============================================================================
+-
+-
+-fn test_mxfp4_roundtrip_small_values() raises:
+-    """Test MXFP4 round-trip for small values.
+-
+-    Note: E2M1 has minimum normal value of 1.0, so values like 0.5 will
+-    quantize to either 0 or 1.0. A tolerance of 0.5 accounts for this.
+-    """
+-    var original = Float32(0.5)
+-    var mxfp4 = MXFP4.from_float32(original)
+-    var restored = mxfp4.to_float32()
+-
+-    assert_almost_equal(restored, original, tolerance=0.5)
+-
+-
+-fn test_mxfp4_roundtrip_medium_values() raises:
+-    """Test MXFP4 round-trip for medium values."""
+-    var original = Float32(42.0)
+-    var mxfp4 = MXFP4.from_float32(original)
+-    var restored = mxfp4.to_float32()
+-
+-    assert_almost_equal(restored, original, tolerance=10.0)
+-
+-
+-fn test_mxfp4_roundtrip_large_values() raises:
+-    """Test MXFP4 round-trip for large values."""
+-    var original = Float32(1000.0)
+-    var mxfp4 = MXFP4.from_float32(original)
+-    var restored = mxfp4.to_float32()
+-
+-    assert_almost_equal(restored, original, tolerance=250.0)
+-
+-
+-fn test_mxfp4_precision_vs_fp8() raises:
+-    """Test that MXFP4 has comparable or better range than FP8."""
+-    # MXFP4 should handle very large values better than FP8 (max ~240)
+-    var large_val = Float32(10000.0)
+-    var mxfp4 = MXFP4.from_float32(large_val)
+-    var restored = mxfp4.to_float32()
+-
+-    # Should preserve order of magnitude
+-    assert_true(
+-        restored > 5000.0, "MXFP4 should preserve large values better than FP8"
+-    )
+-
+-
+-# ============================================================================
+-# MXFP4Block Scale Edge Case Tests (GitHub Issue #2379)
+-# ============================================================================
+-
+-
+-fn test_e8m0_scale_from_zero() raises:
+-    """Test E8M0Scale.from_float32(0.0) direct behavior.
+-
+-    Edge case: Zero scale should return minimum scale (exponent = 0).
+-    This represents 2^(0 - 127) = 2^-127, the smallest representable scale.
+-    """
+-    var scale = E8M0Scale.from_float32(0.0)
+-    assert_equal(scale.exponent, 0)
+-
+-    # Convert back to float and verify it's a very small positive number
+-    var scale_f32 = scale.to_float32()
+-    assert_true(
+-        scale_f32 > 0.0, "Zero scale should convert to tiny positive value"
+-    )
+-    assert_true(scale_f32 < 1e-30, "Zero scale should be extremely small")
+-
+-
+-fn test_mxfp4_block_all_zeros() raises:
+-    """Test MXFP4Block with all zeros.
+-
+-    Edge case: Block with all zeros should:
+-    1. Trigger the fallback (max_abs = 0.0 < 1e-10)
+-    2. Use scale = 1.0 (exponent = 127)
+-    3. Encode all values as 0 (since 0.0 / scale = 0.0)
+-    4. Round-trip losslessly to zeros.
+-    """
+-    # Create a block with 32 zeros
+-    var values = List[Float32]()
+-    for _ in range(32):
+-        values.append(Float32(0.0))
+-
+-    # Encode to MXFP4Block
+-    var block = MXFP4Block.from_float32_array(values)
+-
+-    # Verify scale is 1.0 (exponent = 127)
+-    assert_equal(block.scale.exponent, 127)
+-    var scale_f32 = block.scale.to_float32()
+-    assert_almost_equal(scale_f32, Float32(1.0), tolerance=1e-6)
+-
+-    # Verify all packed values are 0
+-    for i in range(16):
+-        assert_equal(block.data[i], 0)
+-
+-    # Decode and verify round-trip
+-    var decoded = block.to_float32_array()
+-    assert_equal(len(decoded), 32)
+-    for i in range(32):
+-        assert_almost_equal(decoded[i], Float32(0.0), tolerance=1e-7)
+-
+-
+-fn test_mxfp4_block_near_zero_values() raises:
+-    """Test MXFP4Block with very small values < 1e-10.
+-
+-    Edge case: Block with values < 1e-10 should trigger fallback to scale=1.0.
+-    Normally scale = max(abs) / 6.0 would be tiny. The fallback ensures
+-    we use scale = 1.0 instead, avoiding numerical instability.
+-    """
+-    # Create a block with values < 1e-10
+-    var values = List[Float32]()
+-    for i in range(32):
+-        # Use values like 1e-12, 5e-13, etc.
+-        values.append(Float32(1e-12) * Float32(i + 1))
+-
+-    # Encode to MXFP4Block
+-    var block = MXFP4Block.from_float32_array(values)
+-
+-    # Verify scale is 1.0 (exponent = 127)
+-    assert_equal(block.scale.exponent, 127)
+-    var scale_f32 = block.scale.to_float32()
+-    assert_almost_equal(scale_f32, Float32(1.0), tolerance=1e-6)
+-
+-    # Verify no NaN or Inf in decoded values
+-    var decoded = block.to_float32_array()
+-    assert_equal(len(decoded), 32)
+-    for i in range(32):
+-        # Values should be either 0 or very small (quantized to E2M1 minimum)
+-        var val = decoded[i]
+-        assert_true(not isnan(val), "Decoded value should not be NaN")
+-        assert_true(not isinf(val), "Decoded value should not be Inf")
+-
+-
+-fn test_mxfp4_block_near_threshold_edge_case() raises:
+-    """Test MXFP4Block with values near the 1e-10 threshold.
+-
+-    Edge case: max_abs values near 1e-10 (where max_abs / 6.0 < 1e-10).
+-    To trigger fallback with threshold 1e-10, max_abs must be < 6e-10.
+-    Using values around 1e-11 ensures fallback is triggered.
+-    """
+-    # Create a block with values that trigger the fallback
+-    # max_abs = 1e-11 * 32 = 3.2e-10, and 3.2e-10 / 6.0 = 5.3e-11 < 1e-10 (fallback triggers)
+-    var values = List[Float32]()
+-    var threshold_val = Float32(1e-11)
+-    for i in range(32):
+-        values.append(threshold_val * Float32(i + 1))
+-
+-    # Encode to MXFP4Block
+-    var block = MXFP4Block.from_float32_array(values)
+-
+-    # Verify scale is 1.0 (fallback applies)
+-    assert_equal(block.scale.exponent, 127)
+-
+-    # Verify decode works without NaN/Inf
+-    var decoded = block.to_float32_array()
+-    assert_equal(len(decoded), 32)
+-    for i in range(32):
+-        assert_true(not isnan(decoded[i]), "Should not produce NaN")
+-        assert_true(not isinf(decoded[i]), "Should not produce Inf")
+-
+-
+-fn test_mxfp4_block_mixed_zero_and_small() raises:
+-    """Test MXFP4Block with mixed zeros and tiny values.
+-
+-    Edge case: Block with some zeros and some tiny values (mixed scenario).
+-    Should still trigger fallback since max_abs might be < 1e-10.
+-    """
+-    var values = List[Float32]()
+-
+-    # Mix zeros and small values
+-    for i in range(32):
+-        if i % 2 == 0:
+-            values.append(Float32(0.0))
+-        else:
+-            values.append(Float32(1e-12) * Float32(i))
+-
+-    # Encode to MXFP4Block
+-    var block = MXFP4Block.from_float32_array(values)
+-
+-    # Should use fallback scale = 1.0
+-    assert_equal(block.scale.exponent, 127)
+-
+-    # Round-trip should work
+-    var decoded = block.to_float32_array()
+-    assert_equal(len(decoded), 32)
+-
+-    # Verify decoded values
+-    for i in range(32):
+-        if i % 2 == 0:
+-            # Zeros should round-trip to zero
+-            assert_almost_equal(decoded[i], Float32(0.0), tolerance=1e-7)
+-        else:
+-            # Non-zeros should remain non-negative and not be NaN/Inf
+-            assert_true(decoded[i] >= 0.0, "Should remain non-negative")
+-            assert_true(not isnan(decoded[i]), "Should not be NaN")
+-            assert_true(not isinf(decoded[i]), "Should not be Inf")
+-
+-
+-fn test_mxfp4_block_zero_roundtrip_lossless() raises:
+-    """Test that zero blocks round-trip losslessly.
+-
+-    Requirement: Zero blocks should encode as all-zero with scale=1.0
+-    and decode back to all zeros without any data corruption.
+-    """
+-    var values = List[Float32]()
+-    for _ in range(32):
+-        values.append(Float32(0.0))
+-
+-    # Encode
+-    var block = MXFP4Block.from_float32_array(values)
+-
+-    # Verify internal representation
+-    var scale_f32 = block.scale.to_float32()
+-    assert_almost_equal(scale_f32, Float32(1.0), tolerance=1e-6)
+-
+-    # Verify all bits are zero
+-    for i in range(16):
+-        assert_equal(block.data[i], 0)
+-
+-    # Decode
+-    var decoded = block.to_float32_array()
+-
+-    # Verify perfect round-trip
+-    assert_equal(len(decoded), 32)
+-    for i in range(32):
+-        assert_almost_equal(decoded[i], Float32(0.0), tolerance=1e-10)
+-
+-
+-fn test_mxfp4_block_scale_computation_no_division_by_zero() raises:
+-    """Test that scale computation handles division by zero safely.
+-
+-    Requirement: When max_abs = 0.0, computing scale = max_abs / 6.0 = 0.0
+-    should not cause NaN or undefined behavior. The fallback to scale=1.0
+-    should handle this gracefully.
+-    """
+-    # Create multiple blocks with all zeros to ensure consistent behavior
+-    for _ in range(3):
+-        var values = List[Float32]()
+-        for _ in range(32):
+-            values.append(Float32(0.0))
+-
+-        var block = MXFP4Block.from_float32_array(values)
+-
+-        # Should always have scale = 1.0
+-        var scale_f32 = block.scale.to_float32()
+-        assert_almost_equal(scale_f32, Float32(1.0), tolerance=1e-6)
+-
+-        # Decode should be consistent
+-        var decoded = block.to_float32_array()
+-        for i in range(32):
+-            assert_equal(decoded[i], Float32(0.0))
+-
+-
+-fn test_mxfp4_block_normal_scale_computation_still_works() raises:
+-    """Test that normal (non-zero) scale computation still works correctly.
+-
+-    Regression: Ensure that adding fallback logic for zero doesn't break
+-    normal scale computation for typical values.
+-    """
+-    # Create block with normal-sized values (max_abs = 12.0)
+-    var values = List[Float32]()
+-    for i in range(32):
+-        values.append(Float32(i + 1) * 0.4)  # Range 0.4 to 12.8
+-
+-    # Encode
+-    var block = MXFP4Block.from_float32_array(values)
+-
+-    # Scale should be computed as max(12.8) / 6.0 ≈ 2.13
+-    var scale_f32 = block.scale.to_float32()
+-    # Scale should be reasonable - definitely above 1.0 for these values
+-    assert_true(
+-        scale_f32 >= 1.5,
+-        "Scale should be computed normally for non-zero values",
+-    )
+-    assert_true(scale_f32 <= 4.0, "Scale should be reasonable")
+-
+-    # Decode and verify reasonable round-trip
+-    var decoded = block.to_float32_array()
+-    assert_equal(len(decoded), 32)
+-
+-
+-# ============================================================================
+-# Main Test Runner
+-# ============================================================================
+-
+-
+-fn main() raises:
+-    """Run all MXFP4 tests."""
+-    print("\n=== E8M0Scale Tests ===")
+-    test_e8m0_scale_basic()
+-    print("✓ E8M0 scale basic operations")
+-
+-    test_e8m0_scale_powers_of_two()
+-    print("✓ E8M0 scale powers of two")
+-
+-    test_e8m0_scale_edge_cases()
+-    print("✓ E8M0 scale edge cases")
+-
+-    print("\n=== MXFP4 Basic Conversion Tests ===")
+-    test_mxfp4_zero()
+-    print("✓ MXFP4 zero encoding")
+-
+-    test_mxfp4_positive_values()
+-    print("✓ MXFP4 positive values")
+-
+-    test_mxfp4_negative_values()
+-    print("✓ MXFP4 negative values")
+-
+-    test_mxfp4_wide_dynamic_range()
+-    print("✓ MXFP4 wide dynamic range")
+-
+-    test_mxfp4_special_values_nan()
+-    print("✓ MXFP4 NaN handling")
+-
+-    test_mxfp4_special_values_inf()
+-    print("✓ MXFP4 infinity handling")
+-
+-    print("\n=== MXFP4 Arithmetic Operations ===")
+-    test_mxfp4_addition()
+-    print("✓ MXFP4 addition")
+-
+-    test_mxfp4_subtraction()
+-    print("✓ MXFP4 subtraction")
+-
+-    test_mxfp4_multiplication()
+-    print("✓ MXFP4 multiplication")
+-
+-    test_mxfp4_division()
+-    print("✓ MXFP4 division")
+-
+-    test_mxfp4_negation()
+-    print("✓ MXFP4 negation")
+-
+-    print("\n=== MXFP4 Comparison Operations ===")
+-    test_mxfp4_equality()
+-    print("✓ MXFP4 equality")
+-
+-    test_mxfp4_inequality()
+-    print("✓ MXFP4 inequality operators")
+-
+-    test_mxfp4_comparison_edge_cases()
+-    print("✓ MXFP4 comparison edge cases")
+-
+-    print("\n=== MXFP4 Round-trip Tests ===")
+-    test_mxfp4_roundtrip_small_values()
+-    print("✓ MXFP4 round-trip (small values)")
+-
+-    test_mxfp4_roundtrip_medium_values()
+-    print("✓ MXFP4 round-trip (medium values)")
+-
+-    test_mxfp4_roundtrip_large_values()
+-    print("✓ MXFP4 round-trip (large values)")
+-
+-    test_mxfp4_precision_vs_fp8()
+-    print("✓ MXFP4 vs FP8 range comparison")
+-
+-    print("\n=== MXFP4Block Scale Edge Case Tests ===")
+-    test_e8m0_scale_from_zero()
+-    print("✓ E8M0 scale from zero")
+-
+-    test_mxfp4_block_all_zeros()
+-    print("✓ MXFP4 block with all zeros")
+-
+-    test_mxfp4_block_near_zero_values()
+-    print("✓ MXFP4 block with near-zero values")
+-
+-    test_mxfp4_block_near_threshold_edge_case()
+-    print("✓ MXFP4 block near 1e-10 threshold")
+-
+-    test_mxfp4_block_mixed_zero_and_small()
+-    print("✓ MXFP4 block mixed zeros and tiny values")
+-
+-    test_mxfp4_block_zero_roundtrip_lossless()
+-    print("✓ MXFP4 block zero round-trip (lossless)")
+-
+-    test_mxfp4_block_scale_computation_no_division_by_zero()
+-    print("✓ MXFP4 block scale computation (no division by zero)")
+-
+-    test_mxfp4_block_normal_scale_computation_still_works()
+-    print("✓ MXFP4 block normal scale computation (regression test)")
+-
+-    print("\n=== All MXFP4 Tests Passed! ===\n")
+diff --git a/tests/shared/core/test_nvfp4.mojo b/tests/shared/core/test_nvfp4.mojo
+deleted file mode 100644
+index 43e1f2258..000000000
+--- a/tests/shared/core/test_nvfp4.mojo
++++ /dev/null
+@@ -1,439 +0,0 @@
+-"""Tests for NVFP4 (NVIDIA FP4) data type.
+-
+-Tests cover:
+-- E4M3Scale creation and conversion
+-- NVFP4 creation from Float32
+-- NVFP4 to Float32 conversion
+-- Arithmetic operations (+, -, *, /, neg)
+-- Comparison operations (==, !=, <, <=, >, >=)
+-- Special values (zero, NaN, Inf)
+-- Balanced dynamic range (E4M3 scale)
+-- Edge cases and boundary values
+-- Accuracy comparison with MXFP4
+-"""
+-
+-from tests.shared.conftest import (
+-    assert_almost_equal,
+-    assert_close_float,
+-    assert_equal,
+-    assert_equal_int,
+-    assert_true,
+-)
+-from shared.core.types.nvfp4 import NVFP4, E4M3Scale
+-from math import isnan, isinf
+-
+-
+-# ============================================================================
+-# E4M3Scale Tests
+-# ============================================================================
+-
+-
+-fn test_e4m3_scale_basic() raises:
+-    """Test E4M3 scale creation and conversion."""
+-    # Test scale = 1.0 (exp=7, mantissa=0)
+-    var scale_one = E4M3Scale.from_float32(1.0)
+-    assert_equal(scale_one.value, 0x38)  # 0b0111000
+-    assert_almost_equal(scale_one.to_float32(), Float32(1.0), tolerance=1e-6)
+-
+-    # Test scale = 2.0 (exp=8, mantissa=0)
+-    var scale_two = E4M3Scale.from_float32(2.0)
+-    var result_two = scale_two.to_float32()
+-    assert_almost_equal(result_two, Float32(2.0), tolerance=1e-6)
+-
+-    # Test scale = 0.5 (exp=6, mantissa=0)
+-    var scale_half = E4M3Scale.from_float32(0.5)
+-    var result_half = scale_half.to_float32()
+-    assert_almost_equal(result_half, Float32(0.5), tolerance=1e-6)
+-
+-
+-fn test_e4m3_scale_mantissa_precision() raises:
+-    """Test E4M3 scale with fractional values (uses mantissa bits)."""
+-    # E4M3 can represent non-power-of-2 scales due to 3-bit mantissa
+-    var scale_1_5 = E4M3Scale.from_float32(1.5)
+-    var result_1_5 = scale_1_5.to_float32()
+-    assert_almost_equal(result_1_5, Float32(1.5), tolerance=0.15)
+-
+-    var scale_3_5 = E4M3Scale.from_float32(3.5)
+-    var result_3_5 = scale_3_5.to_float32()
+-    assert_almost_equal(result_3_5, Float32(3.5), tolerance=0.5)
+-
+-
+-fn test_e4m3_scale_range() raises:
+-    """Test E4M3 scale dynamic range (similar to FP8 E4M3)."""
+-    # E4M3 max value is approximately 240
+-    var scale_large = E4M3Scale.from_float32(200.0)
+-    var result_large = scale_large.to_float32()
+-    assert_true(
+-        result_large > 150.0 and result_large < 250.0,
+-        "E4M3 should handle values up to ~240",
+-    )
+-
+-    # E4M3 min normal value is 2^-6 = 0.015625
+-    var scale_small = E4M3Scale.from_float32(0.02)
+-    var result_small = scale_small.to_float32()
+-    assert_true(
+-        result_small > 0.01 and result_small < 0.03,
+-        "E4M3 should handle small normal values",
+-    )
+-
+-
+-fn test_e4m3_scale_edge_cases() raises:
+-    """Test E4M3 scale edge cases."""
+-    # Test zero (should return zero)
+-    var scale_zero = E4M3Scale.from_float32(0.0)
+-    assert_equal(scale_zero.value, 0)
+-
+-    # Test negative (should return zero)
+-    var scale_neg = E4M3Scale.from_float32(-1.0)
+-    assert_equal(scale_neg.value, 0)
+-
+-    # Test overflow (should clamp to max)
+-    var scale_overflow = E4M3Scale.from_float32(1000.0)
+-    assert_equal(scale_overflow.value, 0x7F)  # Max value
+-
+-
+-# ============================================================================
+-# NVFP4 Basic Conversion Tests
+-# ============================================================================
+-
+-
+-fn test_nvfp4_zero() raises:
+-    """Test NVFP4 representation of zero."""
+-    var nvfp4_zero = NVFP4.from_float32(0.0)
+-    var result = nvfp4_zero.to_float32()
+-
+-    assert_equal(nvfp4_zero.value.value, 0)
+-    assert_almost_equal(result, Float32(0.0), tolerance=1e-7)
+-
+-
+-fn test_nvfp4_positive_values() raises:
+-    """Test NVFP4 encoding of positive values."""
+-    # Test small positive value
+-    var nvfp4_small = NVFP4.from_float32(1.0)
+-    var result_small = nvfp4_small.to_float32()
+-    assert_almost_equal(result_small, Float32(1.0), tolerance=0.3)
+-
+-    # Test medium positive value
+-    var nvfp4_medium = NVFP4.from_float32(10.0)
+-    var result_medium = nvfp4_medium.to_float32()
+-    assert_almost_equal(result_medium, Float32(10.0), tolerance=2.0)
+-
+-    # Test large positive value
+-    var nvfp4_large = NVFP4.from_float32(100.0)
+-    var result_large = nvfp4_large.to_float32()
+-    assert_almost_equal(result_large, Float32(100.0), tolerance=20.0)
+-
+-
+-fn test_nvfp4_negative_values() raises:
+-    """Test NVFP4 encoding of negative values."""
+-    # Test small negative value
+-    var nvfp4_small = NVFP4.from_float32(-1.0)
+-    var result_small = nvfp4_small.to_float32()
+-    assert_almost_equal(result_small, Float32(-1.0), tolerance=0.3)
+-
+-    # Test medium negative value
+-    var nvfp4_medium = NVFP4.from_float32(-10.0)
+-    var result_medium = nvfp4_medium.to_float32()
+-    assert_almost_equal(result_medium, Float32(-10.0), tolerance=2.0)
+-
+-    # Test large negative value
+-    var nvfp4_large = NVFP4.from_float32(-100.0)
+-    var result_large = nvfp4_large.to_float32()
+-    assert_almost_equal(result_large, Float32(-100.0), tolerance=20.0)
+-
+-
+-fn test_nvfp4_balanced_dynamic_range() raises:
+-    """Test NVFP4 balanced dynamic range (E4M3 scale)."""
+-    # E4M3 has narrower range than E8M0 but better precision
+-    # Test small value
+-    var nvfp4_small = NVFP4.from_float32(0.01)
+-    var result_small = nvfp4_small.to_float32()
+-    assert_true(
+-        result_small >= 0.0 and result_small < 0.05,
+-        "NVFP4 should handle small values",
+-    )
+-
+-    # Test large value (within E4M3 range ~240)
+-    var nvfp4_large = NVFP4.from_float32(200.0)
+-    var result_large = nvfp4_large.to_float32()
+-    assert_true(result_large > 150.0, "NVFP4 should handle values up to ~240")
+-
+-
+-fn test_nvfp4_special_values_nan() raises:
+-    """Test NVFP4 encoding of NaN."""
+-    var nan_val = Float32(0.0) / Float32(0.0)
+-    var nvfp4_nan = NVFP4.from_float32(nan_val)
+-
+-    # NaN encoding: E2M1 value should be max (0b0111)
+-    assert_equal(nvfp4_nan.value.value, 0b0111)
+-
+-
+-fn test_nvfp4_special_values_inf() raises:
+-    """Test NVFP4 encoding of infinity."""
+-    # Positive infinity
+-    var pos_inf = Float32(1.0) / Float32(0.0)
+-    var nvfp4_pos_inf = NVFP4.from_float32(pos_inf)
+-
+-    # Should encode as max E2M1 value
+-    assert_equal(nvfp4_pos_inf.value.value, 0b0111)
+-
+-    # Negative infinity
+-    var neg_inf = Float32(-1.0) / Float32(0.0)
+-    var nvfp4_neg_inf = NVFP4.from_float32(neg_inf)
+-
+-    # Should encode as max negative E2M1 value
+-    assert_equal(nvfp4_neg_inf.value.value, 0b1111)
+-
+-
+-# ============================================================================
+-# NVFP4 Arithmetic Operations
+-# ============================================================================
+-
+-
+-fn test_nvfp4_addition() raises:
+-    """Test NVFP4 addition."""
+-    var a = NVFP4.from_float32(3.0)
+-    var b = NVFP4.from_float32(2.0)
+-    var result = a + b
+-
+-    assert_almost_equal(result.to_float32(), Float32(5.0), tolerance=1.5)
+-
+-
+-fn test_nvfp4_subtraction() raises:
+-    """Test NVFP4 subtraction."""
+-    var a = NVFP4.from_float32(5.0)
+-    var b = NVFP4.from_float32(2.0)
+-    var result = a - b
+-
+-    assert_almost_equal(result.to_float32(), Float32(3.0), tolerance=1.0)
+-
+-
+-fn test_nvfp4_multiplication() raises:
+-    """Test NVFP4 multiplication."""
+-    var a = NVFP4.from_float32(3.0)
+-    var b = NVFP4.from_float32(2.0)
+-    var result = a * b
+-
+-    assert_almost_equal(result.to_float32(), Float32(6.0), tolerance=2.0)
+-
+-
+-fn test_nvfp4_division() raises:
+-    """Test NVFP4 division."""
+-    var a = NVFP4.from_float32(6.0)
+-    var b = NVFP4.from_float32(2.0)
+-    var result = a / b
+-
+-    assert_almost_equal(result.to_float32(), Float32(3.0), tolerance=1.0)
+-
+-
+-fn test_nvfp4_negation() raises:
+-    """Test NVFP4 negation."""
+-    var a = NVFP4.from_float32(3.0)
+-    var result = -a
+-
+-    assert_almost_equal(result.to_float32(), Float32(-3.0), tolerance=1.0)
+-
+-    # Test double negation
+-    var result2 = -result
+-    assert_almost_equal(result2.to_float32(), Float32(3.0), tolerance=1.0)
+-
+-
+-# ============================================================================
+-# NVFP4 Comparison Operations
+-# ============================================================================
+-
+-
+-fn test_nvfp4_equality() raises:
+-    """Test NVFP4 equality comparison."""
+-    # Use values that encode to different E2M1 representations
+-    # 3.0 encodes to exp=2, mantissa=1 (value 3.0)
+-    # 6.0 encodes to exp=3, mantissa=1 (value 6.0)
+-    var a = NVFP4.from_float32(3.0)
+-    var b = NVFP4.from_float32(3.0)
+-    var c = NVFP4.from_float32(6.0)
+-
+-    assert_true(a == b, "Equal NVFP4 values should compare equal")
+-    assert_true(a != c, "Different NVFP4 values should compare not equal")
+-
+-
+-fn test_nvfp4_inequality() raises:
+-    """Test NVFP4 inequality operators."""
+-    var small = NVFP4.from_float32(1.0)
+-    var large = NVFP4.from_float32(5.0)
+-
+-    assert_true(small < large, "Small < Large should be true")
+-    assert_true(small <= large, "Small <= Large should be true")
+-    assert_true(large > small, "Large > Small should be true")
+-    assert_true(large >= small, "Large >= Small should be true")
+-
+-
+-fn test_nvfp4_comparison_edge_cases() raises:
+-    """Test NVFP4 comparison with edge cases."""
+-    var zero = NVFP4.from_float32(0.0)
+-    var positive = NVFP4.from_float32(1.0)
+-    var negative = NVFP4.from_float32(-1.0)
+-
+-    assert_true(negative < zero, "Negative < Zero should be true")
+-    assert_true(zero < positive, "Zero < Positive should be true")
+-    assert_true(negative < positive, "Negative < Positive should be true")
+-
+-
+-# ============================================================================
+-# NVFP4 Round-trip Tests
+-# ============================================================================
+-
+-
+-fn test_nvfp4_roundtrip_small_values() raises:
+-    """Test NVFP4 round-trip for small values.
+-
+-    Note: E2M1 has minimum normal value of 1.0, so values like 0.5 will
+-    quantize to either 0 or 1.0. A tolerance of 0.5 accounts for this.
+-    """
+-    var original = Float32(0.5)
+-    var nvfp4 = NVFP4.from_float32(original)
+-    var restored = nvfp4.to_float32()
+-
+-    assert_almost_equal(restored, original, tolerance=0.5)
+-
+-
+-fn test_nvfp4_roundtrip_medium_values() raises:
+-    """Test NVFP4 round-trip for medium values."""
+-    var original = Float32(42.0)
+-    var nvfp4 = NVFP4.from_float32(original)
+-    var restored = nvfp4.to_float32()
+-
+-    assert_almost_equal(restored, original, tolerance=10.0)
+-
+-
+-fn test_nvfp4_roundtrip_large_values() raises:
+-    """Test NVFP4 round-trip for large values."""
+-    var original = Float32(200.0)
+-    var nvfp4 = NVFP4.from_float32(original)
+-    var restored = nvfp4.to_float32()
+-
+-    assert_almost_equal(restored, original, tolerance=50.0)
+-
+-
+-fn test_nvfp4_accuracy_vs_mxfp4() raises:
+-    """Test NVFP4 accuracy compared to MXFP4 (paper claims better results)."""
+-    # According to paper, E4M3 "achieves the best results"
+-    # Test mid-range values where mantissa precision matters
+-
+-    var test_val = Float32(7.5)
+-    var nvfp4 = NVFP4.from_float32(test_val)
+-    var restored = nvfp4.to_float32()
+-
+-    # NVFP4 should preserve mid-range values reasonably well
+-    # due to E4M3 mantissa providing finer-grained scaling
+-    var error = abs(restored - test_val)
+-    var relative_error = error / test_val
+-
+-    # Expect relative error < 30% for mid-range values
+-    assert_true(
+-        relative_error < 0.3,
+-        "NVFP4 should have good accuracy for mid-range values",
+-    )
+-
+-
+-fn test_nvfp4_smaller_blocks() raises:
+-    """Test that NVFP4 uses smaller blocks (16 vs 32 for MXFP4)."""
+-    # This is a design property test - NVFP4 uses 16-element blocks
+-    # Smaller blocks provide "modest improvements in accuracy"
+-    # Cannot test block behavior directly yet (no block implementation)
+-    # but we can verify individual values work correctly
+-
+-    # Create 16 different values to simulate a block
+-    var values_match = True
+-    for i in range(16):
+-        var val = Float32(i + 1)  # Values 1.0 to 16.0
+-        var nvfp4 = NVFP4.from_float32(val)
+-        var restored = nvfp4.to_float32()
+-        var tolerance = max(val * 0.3, Float32(1.0))
+-        if abs(restored - val) > tolerance:
+-            values_match = False
+-
+-    assert_true(values_match, "NVFP4 should handle 16-value sequences")
+-
+-
+-# ============================================================================
+-# Main Test Runner
+-# ============================================================================
+-
+-
+-fn main() raises:
+-    """Run all NVFP4 tests."""
+-    print("\n=== E4M3Scale Tests ===")
+-    test_e4m3_scale_basic()
+-    print("✓ E4M3 scale basic operations")
+-
+-    test_e4m3_scale_mantissa_precision()
+-    print("✓ E4M3 scale mantissa precision")
+-
+-    test_e4m3_scale_range()
+-    print("✓ E4M3 scale dynamic range")
+-
+-    test_e4m3_scale_edge_cases()
+-    print("✓ E4M3 scale edge cases")
+-
+-    print("\n=== NVFP4 Basic Conversion Tests ===")
+-    test_nvfp4_zero()
+-    print("✓ NVFP4 zero encoding")
+-
+-    test_nvfp4_positive_values()
+-    print("✓ NVFP4 positive values")
+-
+-    test_nvfp4_negative_values()
+-    print("✓ NVFP4 negative values")
+-
+-    test_nvfp4_balanced_dynamic_range()
+-    print("✓ NVFP4 balanced dynamic range")
+-
+-    test_nvfp4_special_values_nan()
+-    print("✓ NVFP4 NaN handling")
+-
+-    test_nvfp4_special_values_inf()
+-    print("✓ NVFP4 infinity handling")
+-
+-    print("\n=== NVFP4 Arithmetic Operations ===")
+-    test_nvfp4_addition()
+-    print("✓ NVFP4 addition")
+-
+-    test_nvfp4_subtraction()
+-    print("✓ NVFP4 subtraction")
+-
+-    test_nvfp4_multiplication()
+-    print("✓ NVFP4 multiplication")
+-
+-    test_nvfp4_division()
+-    print("✓ NVFP4 division")
+-
+-    test_nvfp4_negation()
+-    print("✓ NVFP4 negation")
+-
+-    print("\n=== NVFP4 Comparison Operations ===")
+-    test_nvfp4_equality()
+-    print("✓ NVFP4 equality")
+-
+-    test_nvfp4_inequality()
+-    print("✓ NVFP4 inequality operators")
+-
+-    test_nvfp4_comparison_edge_cases()
+-    print("✓ NVFP4 comparison edge cases")
+-
+-    print("\n=== NVFP4 Round-trip Tests ===")
+-    test_nvfp4_roundtrip_small_values()
+-    print("✓ NVFP4 round-trip (small values)")
+-
+-    test_nvfp4_roundtrip_medium_values()
+-    print("✓ NVFP4 round-trip (medium values)")
+-
+-    test_nvfp4_roundtrip_large_values()
+-    print("✓ NVFP4 round-trip (large values)")
+-
+-    test_nvfp4_accuracy_vs_mxfp4()
+-    print("✓ NVFP4 accuracy analysis")
+-
+-    test_nvfp4_smaller_blocks()
+-    print("✓ NVFP4 block size verification")
+-
+-    print("\n=== All NVFP4 Tests Passed! ===\n")
+diff --git a/tests/shared/core/test_shape.mojo b/tests/shared/core/test_shape.mojo
+index f5fdf99c2..aecc17bd1 100644
+--- a/tests/shared/core/test_shape.mojo
++++ b/tests/shared/core/test_shape.mojo
+@@ -287,13 +287,15 @@ fn test_split_equal() raises:
+     var shape = List[Int]()
+     shape.append(12)
+     var a = arange(0.0, 12.0, 1.0, DType.float32)
+-    var parts = split(a, 3)
+-
+-    # Should give 3 tensors of size 4 each
+-    if len(parts) != 3:
+-        raise Error("Should split into 3 parts")
+-    for i in range(3):
+-        assert_numel(parts[i], 4, "Each part should have 4 elements")
++    # TODO(#3013): Implement split()
++    # var parts = split(a, 3)
++    #
++    # # Should give 3 tensors of size 4 each
++    # if len(parts) != 3:
++    #     raise Error("Should split into 3 parts")
++    # for i in range(3):
++    #     assert_numel(parts[i], 4, "Each part should have 4 elements")
++    _ = a  # Suppress unused variable warning
+ 
+ 
+ fn test_split_unequal() raises:
+@@ -303,17 +305,16 @@ fn test_split_unequal() raises:
+     var shape = List[Int]()
+     shape.append(10)
+     var a = arange(0.0, 10.0, 1.0, DType.float32)
+-    var indices = List[Int]()
+-    indices.append(3)
+-    indices.append(7)
+-    var parts = split_with_indices(a, indices)
+-
+-    # Should give 3 tensors of sizes 3, 4, 3
+-    if len(parts) != 3:
+-        raise Error("Should split into 3 parts")
+-    assert_numel(parts[0], 3, "First part should have 3 elements")
+-    assert_numel(parts[1], 4, "Second part should have 4 elements")
+-    assert_numel(parts[2], 3, "Third part should have 3 elements")
++    # TODO(#3013): Implement split with indices
++    # var parts = split(a, [3, 5, 10])
++    #
++    # # Should give 3 tensors of sizes 3, 4, 3
++    # if len(parts) != 3:
++    #     raise Error("Should split into 3 parts")
++    # assert_numel(parts[0], 3, "First part should have 3 elements")
++    # assert_numel(parts[1], 4, "Second part should have 4 elements")
++    # assert_numel(parts[2], 3, "Third part should have 3 elements")
++    _ = a  # Suppress unused variable warning
+ 
+ 
+ # ============================================================================
+@@ -326,7 +327,7 @@ fn test_tile_1d() raises:
+     var shape = List[Int]()
+     shape.append(3)
+     var a = arange(0.0, 3.0, 1.0, DType.float32)  # [0, 1, 2]
+-    # varb = tile(a, 3)  # TODO(#2718): Implement tile()
++    # varb = tile(a, 3)  # TODO(#3013): Implement tile()
+ 
+     # Result: [0, 1, 2, 0, 1, 2, 0, 1, 2] (9 elements)
+     # assert_numel(b, 9, "Tiled tensor should have 9 elements")
+@@ -339,7 +340,7 @@ fn test_tile_multidim() raises:
+     shape.append(2)
+     shape.append(3)
+     var a = ones(shape, DType.float32)  # 2x3
+-    # varb = tile(a, (2, 3))  # TODO(#2718): Implement tile() with tuple
++    # varb = tile(a, (2, 3))  # TODO(#3013): Implement tile() with tuple
+ 
+     # Result should be 4x9 (2*2 rows, 3*3 cols)
+     # assert_numel(b, 36, "Should have 36 elements (4*9)")
+@@ -356,7 +357,7 @@ fn test_repeat_elements() raises:
+     var shape = List[Int]()
+     shape.append(3)
+     var a = arange(0.0, 3.0, 1.0, DType.float32)  # [0, 1, 2]
+-    # varb = repeat(a, 2)  # TODO(#2718): Implement repeat()
++    # varb = repeat(a, 2)  # TODO(#3013): Implement repeat()
+ 
+     # Result: [0, 0, 1, 1, 2, 2] (6 elements)
+     # assert_numel(b, 6, "Repeated tensor should have 6 elements")
+@@ -369,7 +370,7 @@ fn test_repeat_axis() raises:
+     shape.append(2)
+     shape.append(3)
+     var a = ones(shape, DType.float32)  # 2x3
+-    # varb = repeat(a, 2, axis=0)  # TODO(#2718): Implement repeat() with axis
++    # varb = repeat(a, 2, axis=0)  # TODO(#3013): Implement repeat() with axis
+ 
+     # Result should be 4x3 (each row repeated twice)
+     # assert_numel(b, 12, "Should have 12 elements (4*3)")
+@@ -389,7 +390,7 @@ fn test_broadcast_to_compatible() raises:
+     # var target_shape = List[Int]()
+     # target_shape[0] = 4
+     # target_shape[1] = 3
+-    # varb = broadcast_to(a, target_shape)  # TODO(#2718): Implement broadcast_to()
++    # varb = broadcast_to(a, target_shape)  # TODO(#3013): Implement broadcast_to()
+ 
+     # Result should be 4x3 (broadcasting (3,) to (4,3))
+     # assert_dim(b, 2, "Broadcasted tensor should be 2D")
+@@ -435,7 +436,7 @@ fn test_permute_axes() raises:
+     shape.append(3)
+     shape.append(4)
+     var a = ones(shape, DType.float32)  # Shape (2, 3, 4)
+-    # varb = permute(a, (2, 0, 1))  # TODO(#2718): Implement permute()
++    # varb = permute(a, (2, 0, 1))  # TODO(#3013): Implement permute()
+ 
+     # Result should be (4, 2, 3)
+     # assert_dim(b, 3, "Should still be 3D")
+diff --git a/tests/shared/testing/test_layer_testers_analytical.mojo b/tests/shared/testing/test_layer_testers_analytical.mojo
+index 30534df1e..e10c5da7a 100644
+--- a/tests/shared/testing/test_layer_testers_analytical.mojo
++++ b/tests/shared/testing/test_layer_testers_analytical.mojo
+@@ -1,6 +1,6 @@
+ """Test gradient validation in layer testers.
+ 
+-Demonstrates the new validate_analytical parameter introduced in #2710.
++Demonstrates the new validate_analytical parameter introduced in #3011.
+ This test file shows how to enable analytical gradient validation in layer tests.
+ 
+ Example usage:
+diff --git a/tests/shared/testing/test_special_values.mojo b/tests/shared/testing/test_special_values.mojo
+index 8ffa327ab..1dfc72b18 100644
+--- a/tests/shared/testing/test_special_values.mojo
++++ b/tests/shared/testing/test_special_values.mojo
+@@ -7,7 +7,7 @@ Tests FP-representable test value utilities:
+ - Value invariant verification
+ - Seeded random tensor generation for gradient checking
+ 
+-Ensures special values work correctly across all dtypes: FP4, FP8, FP16, FP32, BFloat16, Int8
++Ensures special values work correctly across all dtypes: FP4, FP8, FP16, FP32, BF16, Int8
+ """
+ 
+ from shared.testing.special_values import (
+@@ -240,16 +240,16 @@ fn test_dtypes_float16() raises:
+ fn test_dtypes_bfloat16() raises:
+     """Test special values work with bfloat16.
+ 
+-    NOTE: BFloat16 is a custom type in shared.core.bfloat16 but is not
++    NOTE: BF16 is a custom type in shared.core.types.bf16 but is not
+     yet integrated with Mojo's runtime DType system. This test is skipped
+     until DType.bfloat16 is added to Mojo or we implement custom dtype handling.
+ 
+-    TODO(#2731): Enable BFloat16 DType support testing
++    TODO(#3015): Enable BF16 DType support testing
+ 
+     Current Status:
+-    - BFloat16 struct exists in shared.core.bfloat16
++    - BF16 struct exists in shared.core.types.bf16
+     - Mojo's DType enum does not include DType.bfloat16
+-    - Cannot create tensors with BFloat16 dtype through standard ExTensor API
++    - Cannot create tensors with BF16 dtype through standard ExTensor API
+ 
+     Implementation Requirements:
+     - Wait for Mojo to add DType.bfloat16 to the DType enum
+@@ -259,12 +259,12 @@ fn test_dtypes_bfloat16() raises:
+     Once Available:
+     1. Uncomment the test code below
+     2. Verify special values (0.5, 1.0, 1.5, -0.5, -1.0) are representable
+-    3. Add BFloat16 SIMD operations similar to FP32 paths
+-    4. Test mixed precision training with BFloat16 parameters
++    3. Add BF16 SIMD operations similar to FP32 paths
++    4. Test mixed precision training with BF16 parameters
+ 
+-    Reference: shared.core.bfloat16 module for current BFloat16 implementation
++    Reference: shared.core.types.bf16 module for current BF16 implementation
+     """
+-    # TODO(#2731): Uncomment when Mojo adds DType.bfloat16
++    # TODO(#3015): Uncomment when Mojo adds DType.bfloat16
+     # var tensor = create_special_value_tensor([2, 2], DType.bfloat16, 1.0)
+     # assert_dtype(tensor, DType.bfloat16, "Should be bfloat16")
+     # verify_special_value_invariants(tensor, 1.0)
+@@ -482,7 +482,7 @@ fn main() raises:
+     test_dtypes_float16()
+     print("✓ test_dtypes_float16")
+ 
+-    # BFloat16 dtype not yet supported in Mojo
++    # BF16 dtype not yet supported in Mojo
+     test_dtypes_bfloat16()
+     print("✓ test_dtypes_bfloat16 (skipped - DType.bfloat16 not supported)")
+ 
+diff --git a/tests/shared/training/test_dtype_utils.mojo b/tests/shared/training/test_dtype_utils.mojo
+index de6bf788a..77c18f371 100644
+--- a/tests/shared/training/test_dtype_utils.mojo
++++ b/tests/shared/training/test_dtype_utils.mojo
+@@ -29,11 +29,11 @@ fn test_dtype_aliases() raises:
+         float64_dtype, DType.float64, "float64_dtype should be DType.float64"
+     )
+ 
+-    # BFloat16 currently aliases to float16
++    # BFloat16 now uses native DType.bfloat16
+     assert_equal(
+         bfloat16_dtype,
+-        DType.float16,
+-        "bfloat16_dtype should currently comptime to DType.float16",
++        DType.bfloat16,
++        "bfloat16_dtype should be DType.bfloat16",
+     )
+ 
+     print("✓ DType aliases test passed")
+@@ -190,21 +190,20 @@ fn test_recommend_precision_dtype() raises:
+ 
+ 
+ fn test_bfloat16_alias_behavior() raises:
+-    """Test that bfloat16 comptime works as expected."""
+-    print("Testing bfloat16 comptime behavior...")
++    """Test that bfloat16 uses native DType.bfloat16."""
++    print("Testing bfloat16 native dtype behavior...")
+ 
+-    # Verify bfloat16_dtype can be used like DType.float16
++    # Verify bfloat16_dtype uses native DType.bfloat16
+     from shared.core import zeros
+ 
+     var tensor = zeros(List[Int](), bfloat16_dtype)
+     assert_equal(
+         tensor.dtype(),
+-        DType.float16,
+-        "BF16 tensor should have float16 dtype (aliased)",
++        DType.bfloat16,
++        "BF16 tensor should have native bfloat16 dtype",
+     )
+ 
+-    print("✓ BFloat16 comptime behavior test passed")
+-    print("⚠ Note: bfloat16_dtype currently aliases to float16")
++    print("✓ BFloat16 native dtype behavior test passed")
+ 
+ 
+ fn main() raises:
+@@ -227,5 +226,4 @@ fn main() raises:
+     print("ALL DTYPE UTILITIES TESTS PASSED! ✓")
+     print("=" * 70)
+     print()
+-    print("⚠ REMINDER: bfloat16_dtype is currently aliased to DType.float16")
+-    print("   This will change when Mojo adds native BFloat16 support.")
++    print("✓ bfloat16_dtype now uses native DType.bfloat16")
+diff --git a/tests/shared/training/test_training_loop.mojo b/tests/shared/training/test_training_loop.mojo
+index 93ce1bce3..ec0823b10 100644
+--- a/tests/shared/training/test_training_loop.mojo
++++ b/tests/shared/training/test_training_loop.mojo
+@@ -99,7 +99,7 @@ fn test_training_loop_full_epoch() raises:
+ 
+     Note:
+         run_epoch() currently returns 0.0 as a placeholder until Python/Mojo
+-        data loader integration is complete (TODO #2721). This test verifies
++        data loader integration is complete (TODO #3013). This test verifies
+         that the method exists and returns a valid Float32.
+     """
+     # Create model, optimizer, and loss function
+@@ -118,7 +118,7 @@ fn test_training_loop_full_epoch() raises:
+ 
+     var py_loader = Python.none()
+ 
+-    # Run one epoch - currently returns 0.0 as placeholder (TODO #2721)
++    # Run one epoch - currently returns 0.0 as placeholder (TODO #3013)
+     var avg_loss = training_loop.run_epoch(py_loader)
+ 
+     # Verify return type is Float32 (even if value is placeholder 0.0)
+@@ -138,7 +138,7 @@ fn test_training_loop_multiple_epochs() raises:
+ 
+     Note:
+         This test uses step() directly instead of run_epoch() since the
+-        data loader integration is pending (TODO #2721).
++        data loader integration is pending (TODO #3013).
+     """
+     # Create model, optimizer, and loss function
+     var model = create_simple_model()

--- a/tests/002-dtype-native-migration/expected/rubric.yaml
+++ b/tests/002-dtype-native-migration/expected/rubric.yaml
@@ -1,0 +1,117 @@
+requirements:
+  # Core Functionality - Type Aliases
+  - id: "R001"
+    description: "dtype_aliases.mojo created with correct type mappings"
+    weight: 3.0
+    evaluation: "binary"
+
+  - id: "R002"
+    description: "All custom dtype structs replaced with native types"
+    weight: 2.5
+    evaluation: "scaled"
+    scoring:
+      1.0: "All 5 types migrated (BF16, FP8, BF8, FP4, E8M0)"
+      0.8: "4 types migrated"
+      0.6: "3 types migrated"
+      0.4: "2 types migrated"
+      0.2: "1 type migrated"
+      0.0: "No types migrated"
+
+  # E8M0 Handling (Critical)
+  - id: "R003"
+    description: "E8M0 conversion helpers implemented correctly"
+    weight: 2.5
+    evaluation: "scaled"
+    scoring:
+      1.0: "Both _e8m0_from_float32 and _e8m0_to_float32 work correctly"
+      0.7: "Helpers exist but have minor issues"
+      0.4: "Only one helper implemented"
+      0.0: "No E8M0 helpers or native conversion used (will fail)"
+
+  # Test Validation
+  - id: "R004"
+    description: "All tests pass after migration"
+    weight: 3.0
+    evaluation: "binary"
+    validation_command: "pixi run mojo test tests/"
+
+  # Code Compilation
+  - id: "R005"
+    description: "Code compiles without errors"
+    weight: 2.0
+    evaluation: "binary"
+    validation_command: "pixi run mojo build src/"
+
+  # Patchfile Quality
+  - id: "R006"
+    description: "Changes are focused (no unrelated modifications)"
+    weight: 1.5
+    evaluation: "scaled"
+    scoring:
+      1.0: "All changes directly related to dtype migration"
+      0.7: "Minor unrelated changes present"
+      0.4: "Some unrelated refactoring included"
+      0.0: "Significant scope creep"
+
+  - id: "R007"
+    description: "Obsolete files properly deleted"
+    weight: 1.0
+    evaluation: "scaled"
+    scoring:
+      1.0: "All obsolete dtype files and tests deleted"
+      0.7: "Most obsolete files deleted"
+      0.4: "Some obsolete files remain"
+      0.0: "No cleanup performed"
+
+  # Code Quality
+  - id: "R008"
+    description: "Uses comptime not alias (per Mojo best practice)"
+    weight: 1.0
+    evaluation: "binary"
+
+  - id: "R009"
+    description: "Bitcast patterns correct for byte conversions"
+    weight: 1.0
+    evaluation: "scaled"
+    scoring:
+      1.0: "All bitcast operations use correct patterns"
+      0.7: "Minor issues with bitcast patterns"
+      0.4: "Some incorrect patterns"
+      0.0: "Bitcast patterns broken or missing"
+
+  # Imports and Exports
+  - id: "R010"
+    description: "Module imports/exports updated correctly"
+    weight: 1.0
+    evaluation: "binary"
+
+categories:
+  functional_correctness:
+    weight: 2.0
+    description: "Migration works correctly, code compiles, tests pass"
+
+  semantic_alignment:
+    weight: 2.0
+    description: "Solution follows expected architecture (type aliases, E8M0 helpers)"
+
+  completeness:
+    weight: 1.5
+    description: "All types migrated, all obsolete code removed"
+
+  code_quality:
+    weight: 1.0
+    description: "Follows Mojo idioms (comptime, bitcast patterns)"
+
+  diff_quality:
+    weight: 1.0
+    description: "Minimal, focused changes without scope creep"
+
+grading:
+  pass_threshold: 0.70
+  min_correctness: 0.80
+  grade_scale:
+    A: 0.95
+    B: 0.85
+    C: 0.75
+    D: 0.65
+    F: 0.0

--- a/tests/002-dtype-native-migration/prompt.md
+++ b/tests/002-dtype-native-migration/prompt.md
@@ -1,0 +1,117 @@
+# Task: Migrate Custom DTypes to Mojo Native Types
+
+## Background
+
+Mojo v0.26.1 now includes native support for exotic floating-point types that were
+previously implemented as custom structs in this codebase. The current implementation
+uses workarounds because earlier Mojo versions lacked native BFloat16, FP8, and other
+exotic dtype support.
+
+The codebase currently contains custom struct implementations for:
+- `BF16` (BFloat16 - 8 exponent bits, 7 mantissa bits)
+- `FP8` (E4M3 - 4 exponent bits, 3 mantissa bits)
+- `BF8` (E5M2 - 5 exponent bits, 2 mantissa bits)
+- `FP4_E2M1` (4-bit float - 2 exponent bits, 1 mantissa bit)
+- `E8M0Scale` (exponent-only scaling format - 8 exponent bits, 0 mantissa bits)
+
+These custom implementations need to be migrated to use Mojo's native `DType` built-in
+types for better performance, SIMD integration, and reduced maintenance burden.
+
+## Objective
+
+Migrate all custom dtype struct implementations to Mojo's native built-in types while
+maintaining backward compatibility through type aliases.
+
+## Requirements
+
+### 1. Create Type Aliases File
+
+Create a new file `shared/core/types/dtype_aliases.mojo` that defines type aliases
+mapping the old names to new native types:
+
+| Old Type | Native DType |
+|----------|--------------|
+| `BF16` | `DType.bfloat16` |
+| `FP8` | `DType.float8_e4m3fn` |
+| `BF8` | `DType.float8_e5m2` |
+| `FP4` | `DType.float4_e2m1fn` |
+| `E8M0` | `DType.float8_e8m0fnu` |
+
+Use `comptime` (not `alias`) for declarations to follow current Mojo best practices.
+
+### 2. Handle E8M0 Specially
+
+**Critical**: The E8M0 format (exponent-only, no mantissa) requires manual conversion
+helpers because native Mojo conversion does not handle this edge case correctly.
+
+You must implement:
+- `_e8m0_from_float32(scale: Float32) -> Scalar[E8M0]` - Convert Float32 to E8M0
+- `_e8m0_to_float32(e8m0_val: Scalar[E8M0]) -> Float32` - Convert E8M0 to Float32
+
+The E8M0 format stores only the exponent, representing power-of-2 values. Conversion
+requires extracting/reconstructing the exponent via bitcast operations.
+
+### 3. Update Dependent Code
+
+Update all code that uses the old struct types:
+- Replace `E8M0Scale` struct field access with bitcast patterns
+- Replace custom struct constructors with native scalar creation
+- Update MXFP4 and NVFP4 blocked format handlers
+- Update the extensor encode/decode methods
+
+### 4. Delete Obsolete Files
+
+After migration, delete:
+- Old dtype struct implementation files in `shared/core/types/`
+- Obsolete test files that tested the old custom implementations
+- Remove deleted test files from CI workflow patterns
+
+### 5. Ensure All Tests Pass
+
+Run `pixi run mojo test tests/` and ensure all tests pass. If tests fail due to
+tolerance issues with E8M0 quantization, adjust test tolerances appropriately
+(E8M0's power-of-2 constraint can cause up to 2x scale difference).
+
+### 6. Update Imports
+
+Update `shared/core/__init__.mojo` to export from the new `dtype_aliases.mojo`
+instead of individual dtype files.
+
+## Constraints
+
+**IMPORTANT: The following actions are FORBIDDEN:**
+
+1. **No Git History Access**: You CANNOT access git commits, logs, or history.
+   Do NOT use `git log`, `git show`, `git diff <commit>`, or similar commands.
+
+2. **No GitHub API Access**: You CANNOT access GitHub issues, pull requests,
+   or any GitHub API. Do NOT use `gh` CLI commands or make API requests.
+
+3. **No Remote Operations**: You CANNOT create remote branches, push to remote,
+   or create pull requests.
+
+4. **No Commit Modification**: You CANNOT amend, reset, or modify the initial
+   git commit. Your changes will be captured as a diff against HEAD.
+
+5. **Local Changes Only**: All your work must be done as local file modifications.
+   The evaluation system will capture your changes via `git diff HEAD`.
+
+## Validation
+
+You CAN and SHOULD run these commands to verify your solution:
+- `pixi run mojo build src/` - Verify code compiles
+- `pixi run mojo test tests/` - Run tests to verify functionality
+- `pixi run mojo format src/` - Format your code
+
+## Expected Output
+
+When complete, your workspace should contain:
+- New file: `shared/core/types/dtype_aliases.mojo` with type definitions
+- Modified files: Updated to use native types instead of custom structs
+- Deleted files: Old custom dtype implementation files
+
+Your solution will be evaluated based on:
+1. Functional correctness (tests pass)
+2. Completeness (all types migrated)
+3. Code quality (follows Mojo idioms)
+4. Change minimality (focused, no unrelated changes)

--- a/tests/002-dtype-native-migration/test.yaml
+++ b/tests/002-dtype-native-migration/test.yaml
@@ -1,0 +1,40 @@
+id: "002-dtype-native-migration"
+name: "Migrate Custom DTypes to Mojo Native Types"
+description: |
+  Migrate custom dtype struct implementations (BF16, FP8, BF8, FP4, E8M0)
+  to Mojo's native built-in types. This is a complex refactoring task that
+  tests an agent's ability to understand a large codebase and make
+  coordinated changes across multiple files.
+
+source:
+  repo: "https://github.com/mvillmow/ProjectOdyssey"
+  hash: "68a608896097f0b519ac2a410c7d6d645f921439"
+
+task:
+  prompt_file: "prompt.md"
+  timeout_seconds: 7200
+  max_turns: 50
+
+tiers:
+  - T2
+  - T3
+  - T4
+  - T5
+
+runs_per_tier: 10
+
+validation:
+  criteria_file: "expected/criteria.md"
+  rubric_file: "expected/rubric.yaml"
+  reference_patch: "expected/reference/reference.patch"
+
+evaluation:
+  output_format: "patchfile_and_workspace"
+  patchfile_command: "git diff HEAD"
+
+tags:
+  - "mojo"
+  - "refactoring"
+  - "dtype"
+  - "architecture"
+  - "t2-plus"


### PR DESCRIPTION
## Summary

- Add sophisticated test case (002-dtype-native-migration) for T2+ tier evaluation based on ProjectOdyssey PR #3017
- Implement patchfile generation and reference solution comparison in LLM judge
- Add `max_turns` configuration support for limiting agent conversation turns

## Test Case Details

The new test case evaluates agents on migrating custom dtype struct implementations to Mojo's native built-in types:
- **Source**: ProjectOdyssey at commit `68a608896097f0b519ac2a410c7d6d645f921439`
- **Reference**: PR #3017 (8211-line patch)
- **Constraints**: No git history access, no GitHub API, no remote operations
- **Limits**: 50 turns, 2-hour timeout

## Test plan
- [x] Python imports verified (`from scylla.e2e.models import ExperimentConfig`)
- [x] Test directory structure created with all required files
- [x] Reference patch generated from PR #3017
- [ ] Run E2E test with new test case

🤖 Generated with [Claude Code](https://claude.com/claude-code)