### PR TITLE
refactor(rubric): replace academic grading with industry-aligned scale

### DIFF
--- a/.claude/shared/grading-scale.md
+++ b/.claude/shared/grading-scale.md
@@ -1,0 +1,134 @@
+# Grading Scale Definition
+
+> Version 1.0 | Last Updated: 2026-01-02
+
+This document defines the **single source of truth** for grading scales used across
+all ProjectScylla rubrics. All `rubric.yaml` files reference this definition.
+
+## Industry-Aligned Grade Scale
+
+ProjectScylla uses an industry-aligned grading scale focused on **production readiness**
+rather than academic performance. This approach was chosen based on industry standards
+from SonarQube, LLM evaluation frameworks, and QA scorecard best practices.
+
+### Grade Thresholds
+
+| Grade | Threshold | Label | Description |
+|-------|-----------|-------|-------------|
+| S | 1.00 | Amazing | Exceptional work that goes above and beyond requirements |
+| A | 0.80 | Excellent | Production ready, no significant issues |
+| B | 0.60 | Good | Minor improvements possible, meets requirements |
+| C | 0.40 | Acceptable | Functional with some issues, partial credit |
+| D | 0.20 | Marginal | Significant issues, barely functional |
+| F | 0.00 | Failing | Does not meet requirements |
+
+### YAML Definition
+
+Use this exact definition in rubric files (or reference this document):
+
+```yaml
+grading:
+  pass_threshold: 0.60  # Minimum score to pass (Good)
+  grade_scale:
+    S: 1.00    # Amazing - above and beyond
+    A: 0.80    # Excellent - production ready
+    B: 0.60    # Good - minor improvements possible
+    C: 0.40    # Acceptable - functional with issues
+    D: 0.20    # Marginal - significant issues
+    F: 0.0     # Failing - does not meet requirements
+```
+
+## Grade Assignment Logic
+
+Grades are assigned using a **greater-than-or-equal** comparison in descending order:
+
+```python
+def assign_grade(score: float) -> str:
+    if score >= 1.00: return "S"   # Amazing
+    if score >= 0.80: return "A"   # Excellent
+    if score >= 0.60: return "B"   # Good
+    if score >= 0.40: return "C"   # Acceptable
+    if score >= 0.20: return "D"   # Marginal
+    return "F"                      # Failing
+```
+
+## Pass/Fail Determination
+
+A score is considered **passing** if it meets the `pass_threshold`:
+
+- **Default pass threshold**: 0.60 (Good)
+- Individual tests may override this in their `rubric.yaml`
+
+### Pass Threshold Guidelines
+
+| Threshold | Use Case |
+|-----------|----------|
+| 0.80 | High-stakes evaluations requiring production quality |
+| 0.60 | Standard evaluations (default) |
+| 0.40 | Lenient evaluations accepting partial implementations |
+
+## Rationale
+
+### Why Not Academic A-F (95/85/75/65)?
+
+Academic grading scales have several issues for software evaluation:
+
+1. **Grade inflation bias**: 95% for an A is unrealistic for complex tasks
+2. **D grade is meaningless**: In industry, you pass or fail
+3. **No "production ready" semantics**: Academic scales don't map to deployment decisions
+
+### Industry Alignment
+
+This scale aligns with industry practices:
+
+- **SonarQube**: Quality gates with customizable pass/fail thresholds
+- **LLM Evaluation**: 5-point scales (1-5) mapping to 0.0-1.0
+- **QA Scorecards**: Pass thresholds with bonus sections for exceptional work
+- **ISO 5055**: Pass/fail based on weakness density thresholds
+
+### Score Interpretation
+
+| Score Range | Interpretation | Action |
+|-------------|----------------|--------|
+| 1.00 | Perfect + bonus criteria | Ship immediately |
+| 0.80-0.99 | Production ready | Ship with confidence |
+| 0.60-0.79 | Meets requirements | Ship after minor fixes |
+| 0.40-0.59 | Partial success | Rework required |
+| 0.20-0.39 | Major issues | Significant rework |
+| 0.00-0.19 | Failed | Start over |
+
+## Usage in Rubric Files
+
+### Option 1: Reference This Document (Recommended)
+
+```yaml
+# rubric.yaml
+requirements:
+  # ... requirements ...
+
+grading:
+  pass_threshold: 0.60
+  # Grade scale: See .claude/shared/grading-scale.md
+```
+
+### Option 2: Inline Definition
+
+If a test requires a non-standard scale, define it inline with justification:
+
+```yaml
+grading:
+  pass_threshold: 0.80  # Stricter for security-critical tests
+  grade_scale:
+    A: 1.00
+    A-: 0.80
+    B: 0.60
+    C: 0.40
+    D: 0.20
+    F: 0.0
+```
+
+## Related Documents
+
+- [Rubric Schema](../../docs/design/rubric-schema.md) - Full rubric YAML specification
+- [Metrics Definitions](metrics-definitions.md) - Quality and economic metrics
+- [Evaluation Guidelines](evaluation-guidelines.md) - LLM-as-Judge methodology

--- a/docs/design/rubric-schema.md
+++ b/docs/design/rubric-schema.md
@@ -1,6 +1,6 @@
 # Rubric Schema Specification
 
-> Version 1.0 | Last Updated: 2025-12-30
+> Version 1.1 | Last Updated: 2026-01-02
 
 This document defines the YAML schema for `rubric.yaml` files used in ProjectScylla's
 LLM-as-Judge evaluation system. These files specify the requirements and scoring
@@ -268,31 +268,46 @@ grading:
 
 Letter grade thresholds. If omitted, only pass/fail is reported.
 
+> **Centralized Definition**: See [grading-scale.md](/.claude/shared/grading-scale.md) for the
+> standard industry-aligned grade scale used across all ProjectScylla rubrics.
+
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
-| `A` | number | No | Threshold for A grade |
-| `B` | number | No | Threshold for B grade |
-| `C` | number | No | Threshold for C grade |
-| `D` | number | No | Threshold for D grade |
-| `F` | number | No | Threshold for F grade |
+| `S` | number | No | Amazing - exceptional, above and beyond (1.00) |
+| `A` | number | No | Excellent - production ready (0.80) |
+| `B` | number | No | Good - minor improvements possible (0.60) |
+| `C` | number | No | Acceptable - functional with issues (0.40) |
+| `D` | number | No | Marginal - significant issues (0.20) |
+| `F` | number | No | Failing - does not meet requirements (0.00) |
 
 **Rules**:
 
-- Thresholds must be in descending order (A > B > C > D > F)
-- F is typically `0.0` (any score below D)
+- Thresholds must be in descending order (S > A > B > C > D > F)
+- F is always `0.0` (any score below D)
 - Score >= threshold receives that grade
 
-**Example**:
+**Industry-Aligned Scale** (Recommended):
 ```yaml
 grading:
-  pass_threshold: 0.70
+  pass_threshold: 0.60
   grade_scale:
-    A: 0.95   # >= 95% is an A
-    B: 0.85   # >= 85% is a B
-    C: 0.75   # >= 75% is a C
-    D: 0.65   # >= 65% is a D
-    F: 0.0    # < 65% is an F
+    S: 1.00    # Amazing - above and beyond
+    A: 0.80    # Excellent - production ready
+    B: 0.60    # Good - minor improvements possible
+    C: 0.40    # Acceptable - functional with issues
+    D: 0.20    # Marginal - significant issues
+    F: 0.0     # Failing - does not meet requirements
 ```
+
+**Why Industry-Aligned vs Academic Scale**:
+
+The traditional academic scale (A=95%, B=85%, etc.) was replaced with an industry-aligned
+scale for several reasons:
+
+1. **Production semantics**: Grades map to deployment decisions (ship/fix/rework)
+2. **No grade inflation**: Academic 95% threshold is unrealistic for complex tasks
+3. **Meaningful differentiation**: Each grade represents a distinct action item
+4. **Industry alignment**: Matches SonarQube, LLM evaluation, and QA scorecard patterns
 
 ## Scoring Methodology
 
@@ -462,17 +477,18 @@ requirements:
 # Grading configuration (required)
 grading:
   # Minimum weighted score to pass (required)
-  # 0.70 means 70% weighted score needed
-  pass_threshold: 0.70
+  # 0.60 means 60% weighted score needed (Good grade)
+  pass_threshold: 0.60
 
-  # Letter grade thresholds (optional)
-  # Comment out to use pass/fail only
+  # Industry-aligned grade scale
+  # See .claude/shared/grading-scale.md for full specification
   grade_scale:
-    A: 0.95   # Excellent - near perfect
-    B: 0.85   # Good - minor issues
-    C: 0.75   # Satisfactory - some issues
-    D: 0.65   # Below standard - significant issues
-    F: 0.0    # Failing - major problems
+    S: 1.00    # Amazing - above and beyond
+    A: 0.80    # Excellent - production ready
+    B: 0.60    # Good - minor improvements possible
+    C: 0.40    # Acceptable - functional with issues
+    D: 0.20    # Marginal - significant issues
+    F: 0.0     # Failing - does not meet requirements
 
 # Total weights: 2.0 + 2.0 + 1.0 + 1.5 + 1.0 + 1.0 + 0.5 = 9.0
 # Maximum possible score: 9.0 / 9.0 = 1.0 (100%)
@@ -516,6 +532,7 @@ grading:
 
 ## Related Documents
 
+- [Grading Scale Definition](/.claude/shared/grading-scale.md) - **Single source of truth** for grade thresholds
 - [Test Schema Specification](test-schema.md) - Test case YAML schema
 - [Evaluation Guidelines](/.claude/shared/evaluation-guidelines.md) - Evaluation methodology
 - [Metrics Definitions](/.claude/shared/metrics-definitions.md) - Quality metrics including Pass-Rate

--- a/schemas/rubric.schema.json
+++ b/schemas/rubric.schema.json
@@ -62,40 +62,47 @@
         },
         "grade_scale": {
           "type": "object",
-          "description": "Letter grade thresholds (optional)",
+          "description": "Letter grade thresholds. See .claude/shared/grading-scale.md for standard definition. Industry-aligned scale: S(1.0)=Amazing, A(0.8)=Excellent, B(0.6)=Good, C(0.4)=Acceptable, D(0.2)=Marginal, F(0.0)=Failing",
           "additionalProperties": false,
           "properties": {
-            "A": {
+            "S": {
               "type": "number",
-              "description": "Threshold for A grade",
+              "description": "Amazing - exceptional, above and beyond",
               "minimum": 0,
               "maximum": 1,
-              "examples": [0.95]
+              "examples": [1.00]
+            },
+            "A": {
+              "type": "number",
+              "description": "Excellent - production ready, no issues",
+              "minimum": 0,
+              "maximum": 1,
+              "examples": [0.80]
             },
             "B": {
               "type": "number",
-              "description": "Threshold for B grade",
+              "description": "Good - minor improvements possible",
               "minimum": 0,
               "maximum": 1,
-              "examples": [0.85]
+              "examples": [0.60]
             },
             "C": {
               "type": "number",
-              "description": "Threshold for C grade",
+              "description": "Acceptable - functional with some issues",
               "minimum": 0,
               "maximum": 1,
-              "examples": [0.75]
+              "examples": [0.40]
             },
             "D": {
               "type": "number",
-              "description": "Threshold for D grade",
+              "description": "Marginal - significant issues",
               "minimum": 0,
               "maximum": 1,
-              "examples": [0.65]
+              "examples": [0.20]
             },
             "F": {
               "type": "number",
-              "description": "Threshold for F grade (typically 0.0)",
+              "description": "Failing - does not meet requirements",
               "minimum": 0,
               "maximum": 1,
               "examples": [0.0]

--- a/tests/001-justfile-to-makefile/expected/rubric.yaml
+++ b/tests/001-justfile-to-makefile/expected/rubric.yaml
@@ -86,10 +86,12 @@ categories:
     description: "Proper cleanup/teardown script"
 
 grading:
-  pass_threshold: 0.70
+  pass_threshold: 0.60
+  # Industry-aligned grade scale - see .claude/shared/grading-scale.md
   grade_scale:
-    A: 0.95
-    B: 0.85
-    C: 0.75
-    D: 0.65
-    F: 0.0
+    S: 1.00    # Amazing - above and beyond
+    A: 0.80    # Excellent - production ready
+    B: 0.60    # Good - minor improvements possible
+    C: 0.40    # Acceptable - functional with issues
+    D: 0.20    # Marginal - significant issues
+    F: 0.0     # Failing - does not meet requirements

--- a/tests/002-dtype-native-migration/expected/rubric.yaml
+++ b/tests/002-dtype-native-migration/expected/rubric.yaml
@@ -107,11 +107,13 @@ categories:
     description: "Minimal, focused changes without scope creep"
 
 grading:
-  pass_threshold: 0.70
+  pass_threshold: 0.60
   min_correctness: 0.80
+  # Industry-aligned grade scale - see .claude/shared/grading-scale.md
   grade_scale:
-    A: 0.95
-    B: 0.85
-    C: 0.75
-    D: 0.65
-    F: 0.0
+    S: 1.00    # Amazing - above and beyond
+    A: 0.80    # Excellent - production ready
+    B: 0.60    # Good - minor improvements possible
+    C: 0.40    # Acceptable - functional with issues
+    D: 0.20    # Marginal - significant issues
+    F: 0.0     # Failing - does not meet requirements

--- a/tests/fixtures/tests/test-001/expected/rubric.yaml
+++ b/tests/fixtures/tests/test-001/expected/rubric.yaml
@@ -11,10 +11,12 @@ requirements:
     evaluation: "scaled"
 
 grading:
-  pass_threshold: 0.70
+  pass_threshold: 0.60
+  # Industry-aligned grade scale - see .claude/shared/grading-scale.md
   grade_scale:
-    A: 0.95
-    B: 0.85
-    C: 0.75
-    D: 0.65
-    F: 0.0
+    S: 1.00    # Amazing - above and beyond
+    A: 0.80    # Excellent - production ready
+    B: 0.60    # Good - minor improvements possible
+    C: 0.40    # Acceptable - functional with issues
+    D: 0.20    # Marginal - significant issues
+    F: 0.0     # Failing - does not meet requirements

--- a/tests/fixtures/tests/test-002/expected/rubric.yaml
+++ b/tests/fixtures/tests/test-002/expected/rubric.yaml
@@ -122,13 +122,15 @@ requirements:
     skill_source: "https://github.com/mvillmow/ProjectOdyssey/.claude/skills/mojo-format"
 
 grading:
-  pass_threshold: 0.70
+  pass_threshold: 0.60
+  # Industry-aligned grade scale - see .claude/shared/grading-scale.md
   grade_scale:
-    A: 0.95
-    B: 0.85
-    C: 0.75
-    D: 0.65
-    F: 0.0
+    S: 1.00    # Amazing - above and beyond
+    A: 0.80    # Excellent - production ready
+    B: 0.60    # Good - minor improvements possible
+    C: 0.40    # Acceptable - functional with issues
+    D: 0.20    # Marginal - significant issues
+    F: 0.0     # Failing - does not meet requirements
 
 # Total weight: 17.5
 # Functional (R001-R004): 7.5 (43%)


### PR DESCRIPTION
## Summary

- Replaces academic grading scale (A=95%, B=85%) with industry-aligned scale focused on production readiness
- Creates centralized grading definition at `.claude/shared/grading-scale.md` as single source of truth
- Adds S grade (1.00) for exceptional work, shifts A to 0.80 for production-ready
- Changes default pass threshold from 0.70 to 0.60 (Good grade)
- Adds score validation - scores > 1.0 now raise `RubricValidationError`

## Grade Scale

| Grade | Threshold | Description |
|-------|-----------|-------------|
| S | 1.00 | Amazing - exceptional, above and beyond |
| A | 0.80 | Excellent - production ready |
| B | 0.60 | Good - minor improvements possible |
| C | 0.40 | Acceptable - functional with issues |
| D | 0.20 | Marginal - significant issues |
| F | 0.00 | Failing - does not meet requirements |

## Test plan

- [x] All 50 unit tests pass (`pixi run pytest tests/unit/judge/test_rubric.py`)
- [x] New tests for S grade assignment
- [x] New tests for score validation (>1.0 and <0.0 raise errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)