### PR TITLE
refactor(metrics): consolidate duplicate statistics functions

### DIFF
--- a/src/scylla/metrics/cross_tier.py
+++ b/src/scylla/metrics/cross_tier.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 
 from scylla.metrics.aggregator import TierStatistics
+from scylla.metrics.statistics import calculate_variance
 
 
 @dataclass
@@ -86,15 +87,6 @@ class TierTransitionAssessment:
     reason: str
 
 
-def _calculate_variance(values: list[float]) -> float:
-    """Calculate variance of a list of values."""
-    if len(values) < 2:
-        return 0.0
-    mean = sum(values) / len(values)
-    squared_diffs = [(v - mean) ** 2 for v in values]
-    return sum(squared_diffs) / len(values)
-
-
 def calculate_frontier_cop(
     tier_stats: dict[str, "TierStatistics"],
 ) -> tuple[float, str]:
@@ -166,7 +158,7 @@ class CrossTierAnalyzer:
             getattr(t, metric).median
             for t in self.tier_stats.values()
         ]
-        return _calculate_variance(values)
+        return calculate_variance(values)
 
     def interpret_sensitivity(self, variance: float) -> str:
         """Interpret variance as sensitivity level.


### PR DESCRIPTION
## Summary

Consolidates duplicate statistics calculation functions into the canonical `statistics.py` module.

- Remove duplicate `_calculate_*` functions from `aggregator.py`
- Make `AggregatedStats` a type alias for `Statistics` for backward compatibility
- Import `calculate_variance` from `statistics.py` in `cross_tier.py`
- Net reduction of ~76 lines of duplicate code

## Changes

| File | Change |
|------|--------|
| `aggregator.py` | Remove 6 duplicate functions, import from `statistics.py` |
| `cross_tier.py` | Remove `_calculate_variance`, import from `statistics.py` |

## Test Plan

- [x] All 230 metrics tests pass (`pixi run pytest tests/unit/metrics/ -v`)
- [x] No breaking changes to public API (`AggregatedStats` aliased for compatibility)

Closes #112

🤖 Generated with [Claude Code](https://claude.com/claude-code)