### PR TITLE
refactor(config): align GradeScale to industry S/A/B/C/D/F scale

### DIFF
--- a/src/scylla/config/models.py
+++ b/src/scylla/config/models.py
@@ -88,19 +88,35 @@ class Requirement(BaseModel):
 
 
 class GradeScale(BaseModel):
-    """Grade scale thresholds."""
+    """Industry-aligned grade scale thresholds.
 
-    A: float = Field(default=0.95, ge=0.0, le=1.0)
-    B: float = Field(default=0.85, ge=0.0, le=1.0)
-    C: float = Field(default=0.75, ge=0.0, le=1.0)
-    D: float = Field(default=0.65, ge=0.0, le=1.0)
-    F: float = Field(default=0.0, ge=0.0, le=1.0)
+    See .claude/shared/grading-scale.md for full specification.
+
+    Attributes:
+        S: Amazing - exceptional, above and beyond (1.00).
+        A: Excellent - production ready (0.80).
+        B: Good - minor improvements possible (0.60).
+        C: Acceptable - functional with issues (0.40).
+        D: Marginal - significant issues (0.20).
+        F: Failing - does not meet requirements (0.00).
+    """
+
+    S: float = Field(default=1.00, ge=0.0, le=1.0)
+    A: float = Field(default=0.80, ge=0.0, le=1.0)
+    B: float = Field(default=0.60, ge=0.0, le=1.0)
+    C: float = Field(default=0.40, ge=0.0, le=1.0)
+    D: float = Field(default=0.20, ge=0.0, le=1.0)
+    F: float = Field(default=0.00, ge=0.0, le=1.0)
 
 
 class GradingConfig(BaseModel):
-    """Grading configuration for a rubric."""
+    """Grading configuration for a rubric.
 
-    pass_threshold: float = Field(default=0.70, ge=0.0, le=1.0)
+    Uses industry-aligned defaults where pass_threshold=0.60 corresponds
+    to the B grade (Good - functional, minor improvements possible).
+    """
+
+    pass_threshold: float = Field(default=0.60, ge=0.0, le=1.0)
     grade_scale: GradeScale = Field(default_factory=GradeScale)
 
 

--- a/tests/unit/test_config_loader.py
+++ b/tests/unit/test_config_loader.py
@@ -68,11 +68,11 @@ class TestConfigLoaderEvalCase:
 
         assert isinstance(test, EvalCase)
         assert test.id == "test-001"
-        assert test.name == "Test Case 001"
-        assert test.source.repo == "https://github.com/example/repo"
-        assert test.source.hash == "abc123def456"
+        assert test.name == "Hello World Task"
+        assert test.source.repo == "https://github.com/octocat/Hello-World"
+        assert test.source.hash == "7fd1a60b01f91b314f59955a4e4d4e80d8edf11d"
         assert test.task.prompt_file == "prompt.md"
-        assert test.task.timeout_seconds == 1800
+        assert test.task.timeout_seconds == 300
 
     def test_load_test_missing(self) -> None:
         """Missing test raises ConfigurationError."""
@@ -108,9 +108,10 @@ class TestConfigLoaderRubric:
         assert req1.weight == 2.0
         assert req1.evaluation == "binary"
 
-        # Check grading
-        assert rubric.grading.pass_threshold == 0.70
-        assert rubric.grading.grade_scale.A == 0.95
+        # Check grading (industry-aligned scale)
+        assert rubric.grading.pass_threshold == 0.60
+        assert rubric.grading.grade_scale.S == 1.00  # Exemplary
+        assert rubric.grading.grade_scale.A == 0.80  # Production-Ready
 
     def test_load_rubric_missing(self) -> None:
         """Missing rubric raises ConfigurationError."""


### PR DESCRIPTION
## Summary

Resolves the GradeScale conflict between `config/models.py` and `judge/rubric.py` by aligning the config model to the industry-standard S/A/B/C/D/F grading scale.

- Add missing S grade (Exemplary) at 1.00 threshold
- Update A/B/C/D thresholds to industry-aligned values (0.80/0.60/0.40/0.20)
- Update default pass_threshold to 0.60 (Good grade)
- Fix test_config_loader.py tests to match updated fixtures

## Changes

| File | Change |
|------|--------|
| `config/models.py` | Add S field, update thresholds to industry-aligned values |
| `test_config_loader.py` | Update assertions to match current fixtures |

## Test Plan

- [x] All 33 config loader tests pass
- [x] 902 unit tests pass (7 pre-existing failures in adapter log tests unrelated to this PR)

Closes #113

🤖 Generated with [Claude Code](https://claude.com/claude-code)