### PR TITLE
refactor(grading): unify letter grade assignment to industry-aligned scale

### DIFF
--- a/plan-glittery-frolicking-lagoon.md
+++ b/plan-glittery-frolicking-lagoon.md
@@ -1,0 +1,176 @@
+# Plan: Reorganize E2E Results Directory Structure
+
+## Summary
+
+Simplify the E2E results directory structure by:
+1. Flattening the hierarchy (workspace as peer of runs, logs in parent)
+2. Creating hierarchical reports (JSON + markdown) at every level with relative links
+3. Changing judge prompts to use file paths instead of inlined content
+4. Copying grading materials to the root directory
+
+## New Directory Structure
+
+```
+results/<timestamp>-<experiment-id>/
+├── repo/                           # Cloned base repository
+├── prompt.md                       # Task prompt (uniform across all tiers)
+├── criteria.md                     # Grading criteria (uniform across all tiers)
+├── rubric.yaml                     # Grading rubric (uniform across all tiers)
+├── judge_prompt.md                 # Judge prompt template (uniform across all tiers)
+├── report.json                     # Overall results + links to tiers
+├── report.md                       # Executive summary + tier links
+│
+└── T0/                             # Tier directory (not tiers/T0/)
+    ├── report.json                 # Tier summary + links to subtests
+    ├── report.md                   # Tier summary + subtest links
+    │
+    └── 00-empty/                   # Subtest directory
+        ├── config/                 # Subtest configuration (CLAUDE.md, skills, etc.)
+        ├── workspace/              # Shared worktree across all runs
+        ├── report.json             # Subtest summary + links to runs
+        ├── report.md               # Subtest summary + run links
+        │
+        ├── run_01/                 # Individual run
+        │   ├── output.txt          # Agent stdout
+        │   ├── command_log.json    # Execution details
+        │   ├── judgment.json       # LLM judge result
+        │   ├── report.json         # Run results
+        │   └── report.md           # Run report
+        │
+        └── run_02/
+            └── ... (same structure)
+```
+
+**Note**: `prompt.md`, `criteria.md`, `rubric.yaml`, and `judge_prompt.md` are at the **experiment root** because they're uniform across all tiers/subtests/runs. Only `output.txt`, `judgment.json`, and run-specific reports vary per run.
+
+## Key Changes
+
+### 1. Directory Structure Changes
+
+| Current | New | Rationale |
+|---------|-----|-----------|
+| `tiers/T0/` | `T0/` | Flatten hierarchy |
+| `run_01/workspace/` | `<subtest>/workspace/` | Workspace shared across runs |
+| `run_01/logs/` | `run_01/` | Logs directly in run directory |
+| N/A | `prompt.md`, `criteria.md`, `rubric.yaml`, `judge_prompt.md` at root | Uniform across all tiers/subtests |
+
+### 2. Report Hierarchy
+
+**Every level gets JSON + markdown reports**:
+
+| Level | JSON File | Markdown File | Contents |
+|-------|-----------|---------------|----------|
+| Experiment | `report.json` | `report.md` | Summary + links to tier reports |
+| Tier | `T0/report.json` | `T0/report.md` | Tier summary + links to subtest reports |
+| Subtest | `T0/00/report.json` | `T0/00/report.md` | Subtest summary + links to run reports |
+| Run | `T0/00/run_01/report.json` | `T0/00/run_01/report.md` | Full run details |
+
+### 3. Judge Prompt Changes
+
+**Current** (inlined content):
+```markdown
+## Task Given to Agent
+<full task prompt text pasted here>
+
+## Agent's Output
+<full stdout pasted here>
+
+## Workspace State After Agent Execution
+<full file listing with contents>
+```
+
+**New** (file references at experiment root):
+
+The `judge_prompt.md` template is saved once at the **experiment root** since task prompt, criteria, and rubric are uniform across all tiers/subtests/runs. Per-run invocation substitutes only the `output.txt` and `workspace` paths.
+
+```markdown
+## Task Given to Agent
+See: <absolute path to experiment/prompt.md>
+
+## Agent's Output
+See: <absolute path to run_XX/output.txt>  <!-- Substituted per run -->
+
+## Workspace
+See: <absolute path to subtest/workspace/>  <!-- Substituted per subtest -->
+
+## Grading Methodology
+See: <absolute path to experiment/criteria.md>
+See: <absolute path to experiment/rubric.yaml>
+
+Read the files at the paths above and evaluate the agent's work.
+```
+
+**Why file paths instead of inlined content:**
+- Avoids `[Errno 7] Argument list too long` for T6 (large configs)
+- Makes judge prompts reproducible and auditable
+- Enables the judge to read files directly without context limits
+
+### 4. JSON Report Format
+
+Each JSON report has:
+- `summary`: Aggregated metrics for this level
+- `best`: Pointer to best-performing child (for non-run levels)
+- `children`: Relative paths to child reports
+
+**Example: `T0/report.json`**:
+```json
+{
+  "tier": "T0",
+  "name": "Prompts",
+  "summary": {
+    "total_subtests": 24,
+    "passed": 22,
+    "failed": 2,
+    "best_score": 0.95,
+    "total_cost": 12.34,
+    "total_duration": 3600
+  },
+  "best": {
+    "subtest": "03-full",
+    "score": 0.95,
+    "report": "./03-full/report.json"
+  },
+  "children": [
+    {"id": "00-empty", "report": "./00-empty/report.json"},
+    {"id": "01-vanilla", "report": "./01-vanilla/report.json"}
+  ]
+}
+```
+
+## Files to Modify
+
+| File | Changes |
+|------|---------|
+| `src/scylla/e2e/runner.py` | Change `tiers/` to flat structure, copy criteria/rubric to root, generate hierarchical reports |
+| `src/scylla/e2e/subtest_executor.py` | Move workspace to subtest level, flatten run directories |
+| `src/scylla/e2e/workspace_manager.py` | Update worktree paths (workspace at subtest level) |
+| `src/scylla/e2e/llm_judge.py` | Change `_build_judge_prompt()` to use file paths instead of inlined content |
+| `src/scylla/e2e/run_report.py` | Generate JSON reports, update markdown format with relative links |
+| `src/scylla/e2e/models.py` | Add report path fields to result classes |
+
+## Implementation Steps
+
+### Phase 1: Directory Structure (4 changes)
+
+1. **`runner.py:_create_experiment_dir()`**: Remove `tiers/` and `summary/` subdirs, copy criteria/rubric to root
+2. **`runner.py:_run_tier()`**: Use `experiment_dir / tier_id.value` instead of `experiment_dir / "tiers" / tier_id.value`
+3. **`subtest_executor.py:run_subtest()`**: Create workspace at subtest level, pass shared path to all runs
+4. **`subtest_executor.py:_execute_single_run()`**: Remove `workspace/` and `logs/` subdirs, files directly in run dir
+
+### Phase 2: Judge Prompt Refactoring (3 changes)
+
+5. **`llm_judge.py:_build_judge_prompt()`**: Accept file paths, build prompt with paths to files instead of inlined content
+6. **`runner.py:_create_experiment_dir()`**: Save `judge_prompt.md` template at experiment root (uniform across all tiers)
+7. **`subtest_executor.py:_execute_single_run()`**: Save agent output to `run_XX/output.txt`, pass paths to judge
+
+### Phase 3: Hierarchical Reports (3 changes)
+
+8. **`run_report.py`**: Add `save_run_report_json()`, `save_subtest_report()`, `save_tier_report()` functions
+9. **`runner.py`**: Call tier report generation after each tier, generate final experiment report with links
+10. **`models.py`**: Add `report_path` fields to `RunResult`, `SubTestResult`, `TierResult`
+
+## Testing
+
+1. `pixi run pytest tests/unit/e2e/` - Unit tests
+2. `--tiers T0 --runs 1` - Single tier validation
+3. Verify relative links in generated reports

--- a/plan-toasty-weaving-frog.md
+++ b/plan-toasty-weaving-frog.md
@@ -1,0 +1,535 @@
+# Plan: Create test-002 - Mojo Hello World Test
+
+## Overview
+
+Create a new test fixture `test-002` that evaluates an AI agent's ability to add a simple Mojo "Hello, World!" example to the Modular repository, following Mojo v0.26.1 best practices and integrating with the Bazel build system.
+
+## Source Configuration
+
+- **Repository**: https://github.com/modular/modular/tree/main
+- **Commit**: `14df6466f35f2e1ee7afad3c3d9936e6da4f8cc6`
+- **Task**: Add a Mojo hello world example that integrates with the repository structure
+
+## Files to Create
+
+### 1. Main Test Definition
+**File**: `tests/fixtures/tests/test-002/test.yaml`
+
+```yaml
+id: "test-002"
+name: "Mojo Hello World Task"
+description: |
+  Test AI agent's ability to add a Mojo example to the Modular repository.
+  Agent must discover proper location, write Mojo v0.26.1 code, integrate
+  with Bazel build system, and provide full documentation.
+
+source:
+  repo: "https://github.com/modular/modular"
+  hash: "14df6466f35f2e1ee7afad3c3d9936e6da4f8cc6"
+
+task:
+  prompt_file: "prompt.md"
+  timeout_seconds: 7200
+
+validation:
+  criteria_file: "expected/criteria.md"
+  rubric_file: "expected/rubric.yaml"
+
+tiers:
+  - T0  # Prompts (24 sub-tests)
+  - T1  # Skills (10 sub-tests)
+  - T2  # Tooling (15 sub-tests)
+  - T3  # Delegation (41 sub-tests)
+  - T4  # Hierarchy (7 sub-tests)
+  - T5  # Hybrid (15 sub-tests)
+  - T6  # Super (1 sub-test)
+```
+
+### 2. Task Prompt
+**File**: `tests/fixtures/tests/test-002/prompt.md`
+
+```markdown
+# Task: Add a Mojo Hello World Example
+
+Add a simple Mojo "Hello, World!" example to this repository that follows
+the project's patterns and conventions.
+
+## Requirements
+
+1. **Discover Location**: Explore the repository structure to find the
+   appropriate location for Mojo examples
+2. **Create Mojo File**: Write `hello.mojo` using Mojo v0.26.1 syntax
+3. **Bazel Integration**: Add BUILD.bazel file if required by the project
+4. **Output**: The program must print exactly: `Hello, world`
+5. **Documentation**: Include module docstring, inline comments, and
+   update any relevant README files
+
+## Mojo v0.26.1 Requirements
+
+- Use `fn main()` as entry point
+- Use `print()` for output (NOT `print_string()`)
+- Ensure code passes `mojo build` without errors or warnings
+- Follow ownership patterns (`out self`, `mut self`, etc.)
+
+## Expected Output
+
+When running the example:
+```
+Hello, world
+```
+
+## Success Criteria
+
+- Example discovered proper location in repository
+- Code compiles with `mojo build` (zero errors/warnings)
+- Code compiles with `bazel build` if Bazel is used
+- Running the example prints "Hello, world"
+- Exit code is 0
+- Module docstring present
+- README updated or created as appropriate
+```
+
+### 3. Evaluation Criteria
+**File**: `tests/fixtures/tests/test-002/expected/criteria.md`
+
+```markdown
+# Evaluation Criteria for Mojo Hello World
+
+## R001: Location Discovery (Weight: 1.0)
+Agent must explore the repository and place the example in an appropriate
+location that follows existing project conventions.
+
+**Verification**: Check that file is placed in a sensible location (e.g.,
+examples/, mojo/examples/, or similar directory with existing examples)
+
+## R002: File Creation (Weight: 2.0)
+Agent must create a `hello.mojo` file.
+
+**Verification**: Check if a .mojo file exists with hello world functionality
+
+## R003: Mojo Syntax Compliance (Weight: 2.5)
+Code must follow Mojo v0.26.1 syntax standards:
+- `fn main()` entry point
+- `print()` function for output
+- No deprecated patterns (inout, @value, DynamicVector)
+- Proper constructor patterns if any structs used
+
+**Verification**: Run `mojo build <file>` and check for zero errors/warnings
+
+## R004: Correct Output (Weight: 2.0)
+The program must print exactly "Hello, world" when executed.
+
+**Verification**: Run compiled binary and check stdout matches "Hello, world"
+
+## R005: Bazel Integration (Weight: 1.5)
+If repository uses Bazel, agent must create/update BUILD.bazel.
+
+**Verification**: Run `bazel build //<path>:hello` succeeds
+
+## R006: Documentation - Module Docstring (Weight: 1.0)
+Source file must include a module docstring explaining purpose.
+
+**Verification**: Parse file for docstring at module level
+
+## R007: Documentation - Inline Comments (Weight: 0.5)
+Code should have appropriate inline comments for clarity.
+
+**Verification**: Check for meaningful comments in source
+
+## R008: Documentation - README (Weight: 1.0)
+README should be updated or created to document the example.
+
+**Verification**: Check for README.md mentioning the hello world example
+
+## R009: Clean Exit (Weight: 0.5)
+Program must exit with code 0.
+
+**Verification**: Check exit code after execution
+
+## R010: No Warnings (Weight: 1.0)
+Compilation must produce zero warnings.
+
+**Verification**: Capture stderr from mojo build, check empty
+
+## R011: Memory Safety (Weight: 1.5)
+Code must follow Mojo memory safety patterns:
+- Proper ownership transfer with `^` operator
+- No use-after-move patterns
+- No uninitialized list/collection access
+- Pointer safety if applicable
+
+**Verification**: Run `check-memory-safety` skill validation
+**Skill**: ProjectOdyssey/.claude/skills/check-memory-safety
+
+## R012: Ownership Patterns (Weight: 1.0)
+Code must follow correct ownership conventions:
+- `out self` in constructors (not `mut self`)
+- `mut self` in mutating methods
+- No `inout` keyword anywhere
+- `var` parameter for ownership transfer in function args
+
+**Verification**: Run `validate-mojo-patterns` skill validation
+**Skill**: ProjectOdyssey/.claude/skills/validate-mojo-patterns
+
+## R013: No Deprecated Patterns (Weight: 1.0)
+Code must not use deprecated Mojo patterns:
+- No `@value` decorator (use `@fieldwise_init` + traits)
+- No `DynamicVector` (use `List`)
+- No `inout` keyword (use `mut`)
+- Tuple return syntax `-> Tuple[T1, T2]` not `-> (T1, T2)`
+
+**Verification**: Run `mojo-lint-syntax` skill validation
+**Skill**: ProjectOdyssey/.claude/skills/mojo-lint-syntax
+```
+
+### 4. Rubric File
+**File**: `tests/fixtures/tests/test-002/expected/rubric.yaml`
+
+```yaml
+requirements:
+  # Core Functionality (Weight: 6.5)
+  - id: "R001"
+    description: "Location Discovery - Example placed in appropriate directory"
+    weight: 1.0
+    evaluation: "scaled"
+
+  - id: "R002"
+    description: "File Creation - hello.mojo exists"
+    weight: 2.0
+    evaluation: "binary"
+
+  - id: "R003"
+    description: "Mojo Syntax Compliance - v0.26.1 standards"
+    weight: 2.5
+    evaluation: "scaled"
+    criteria:
+      - "fn main() entry point"
+      - "print() function used"
+      - "No deprecated patterns (inout, @value, DynamicVector)"
+      - "out self in constructors (if any)"
+      - "mut self in mutating methods (if any)"
+      - "Proper List literal syntax"
+      - "Tuple return syntax correct"
+
+  - id: "R004"
+    description: "Correct Output - prints Hello, world"
+    weight: 2.0
+    evaluation: "binary"
+
+  # Build Integration (Weight: 2.5)
+  - id: "R005"
+    description: "Bazel Integration - BUILD.bazel created/updated"
+    weight: 1.5
+    evaluation: "scaled"
+    criteria:
+      - "BUILD.bazel file exists or updated"
+      - "mojo_binary or appropriate rule used"
+      - "bazel build succeeds"
+
+  - id: "R010"
+    description: "Zero compilation warnings"
+    weight: 1.0
+    evaluation: "binary"
+
+  # Documentation (Weight: 2.5)
+  - id: "R006"
+    description: "Module Docstring present"
+    weight: 1.0
+    evaluation: "binary"
+
+  - id: "R007"
+    description: "Inline Comments for clarity"
+    weight: 0.5
+    evaluation: "scaled"
+
+  - id: "R008"
+    description: "README documentation"
+    weight: 1.0
+    evaluation: "scaled"
+    criteria:
+      - "README exists or updated"
+      - "Example documented"
+      - "Build instructions included"
+
+  # Execution (Weight: 0.5)
+  - id: "R009"
+    description: "Clean Exit (code 0)"
+    weight: 0.5
+    evaluation: "binary"
+
+  # Memory Safety & Ownership (Weight: 2.5) - From ProjectOdyssey Skills
+  - id: "R011"
+    description: "Memory Safety - No ownership violations"
+    weight: 1.5
+    evaluation: "scaled"
+    criteria:
+      - "Proper ownership transfer with ^ operator"
+      - "No use-after-move patterns"
+      - "No uninitialized access"
+      - "Pointer safety (if applicable)"
+    skill_validation: "check-memory-safety"
+
+  - id: "R012"
+    description: "Ownership Patterns - Correct conventions"
+    weight: 1.0
+    evaluation: "scaled"
+    criteria:
+      - "out self in constructors (not mut self)"
+      - "mut self in mutating methods"
+      - "No inout keyword anywhere"
+      - "var parameter for ownership transfer"
+    skill_validation: "validate-mojo-patterns"
+
+  # Deprecated Patterns (Weight: 1.0) - From ProjectOdyssey Skills
+  - id: "R013"
+    description: "No Deprecated Patterns"
+    weight: 1.0
+    evaluation: "binary"
+    criteria:
+      - "No @value decorator (use @fieldwise_init)"
+      - "No DynamicVector (use List)"
+      - "No inout keyword (use mut)"
+      - "Tuple return syntax -> Tuple[T1, T2] not -> (T1, T2)"
+    skill_validation: "mojo-lint-syntax"
+
+grading:
+  pass_threshold: 0.70
+  grade_scale:
+    A: 0.95
+    B: 0.85
+    C: 0.75
+    D: 0.65
+    F: 0.0
+
+# Total weight: 15.0
+# Functional (R001-R004): 7.5 (50%)
+# Build/Compile (R005, R010): 2.5 (17%)
+# Documentation (R006-R008): 2.5 (17%)
+# Safety/Patterns (R009, R011-R013): 2.5 (17%)
+```
+
+### 5. Test Config
+**File**: `tests/fixtures/tests/test-002/config.yaml`
+
+```yaml
+timeout_seconds: 7200
+max_cost_usd: 10.0
+```
+
+### 6. Tier Sub-Test Directories
+
+Copy the entire tier structure from test-001:
+- `t0/` - 24 prompt ablation sub-tests (00-empty through 23-B18)
+- `t1/` - 10 skills sub-tests (01-agent through 10-advise-plugin)
+- `t2/` - 15 tooling sub-tests (01-file-ops-only through 15-custom-mcp)
+- `t3/` - 41 delegation sub-tests (01-architecture-design through 41-all-L5)
+- `t4/` - 7 hierarchy sub-tests (01-chief-architect through 07-tooling-orchestrator)
+- `t5/` - 15 hybrid sub-tests
+- `t6/` - 1 super sub-test
+
+## Implementation Steps
+
+1. **Create directory structure**:
+   ```
+   tests/fixtures/tests/test-002/
+   ├── test.yaml
+   ├── prompt.md
+   ├── config.yaml
+   ├── expected/
+   │   ├── criteria.md
+   │   └── rubric.yaml
+   ├── t0/ (copy from test-001)
+   ├── t1/ (copy from test-001)
+   ├── t2/ (copy from test-001)
+   ├── t3/ (copy from test-001)
+   ├── t4/ (copy from test-001)
+   ├── t5/ (copy from test-001)
+   └── t6/ (copy from test-001)
+   ```
+
+2. **Create test-002 specific files** (test.yaml, prompt.md, criteria.md, rubric.yaml, config.yaml)
+
+3. **Copy tier directories** from test-001 (they contain system prompt variations and skill configurations that are test-agnostic)
+
+## Alignment with Judge System Prompt
+
+The rubric aligns with `config/judge/system_prompt.md`:
+
+| Judge Criterion | Test-002 Coverage |
+|-----------------|-------------------|
+| Correctness (50%) | R003 (syntax), R004 (output), R009 (exit), R011 (memory) |
+| Completeness | R001 (location), R002 (file), R005 (Bazel) |
+| Code Structure (30%) | R003 (patterns), R007 (comments), R012 (ownership) |
+| Documentation | R006 (docstring), R007 (comments), R008 (README) |
+| Linting Compliance | R003 (mojo build), R010 (warnings), R013 (deprecated) |
+| Security/Safety (20%) | R011 (memory safety), R012 (ownership) |
+
+## ProjectOdyssey Skills & Agents Integration
+
+The test configuration must integrate Mojo-specific skills and agents from ProjectOdyssey:
+
+### Skills to Include (T1 - Skills Tier)
+Source: `https://github.com/mvillmow/ProjectOdyssey/tree/main/.claude/skills`
+
+| Skill | Purpose | Rubric Alignment |
+|-------|---------|------------------|
+| `mojo-lint-syntax` | v0.26.1 syntax validation | R003, R010 |
+| `validate-mojo-patterns` | Pattern checking (out self, mut, etc.) | R003, R012 |
+| `check-memory-safety` | Ownership and memory safety | R011, R012 |
+| `mojo-build-package` | Build and package compilation | R005 |
+| `mojo-format` | Code formatting | R007 |
+| `mojo-type-safety` | Type system verification | R003 |
+
+### Agents to Include (T3 - Delegation Tier)
+Source: `https://github.com/mvillmow/ProjectOdyssey/tree/main/.claude/agents`
+
+| Agent | Level | Purpose |
+|-------|-------|---------|
+| `mojo-syntax-validator` | L3 | Validates v0.26.1 syntax patterns |
+| `mojo-language-review-specialist` | L3 | Reviews Mojo idioms and conventions |
+
+### New Tier Sub-Tests for T1 (Skills)
+
+Create a new sub-test specifically for Mojo skills:
+**File**: `tests/fixtures/tests/test-002/t1/11-mojo-skills/config.yaml`
+
+```yaml
+name: "Mojo Skills Bundle"
+description: "All 7 Mojo-specific skills for development validation"
+extends_previous: true
+skills:
+  - mojo-lint-syntax
+  - validate-mojo-patterns
+  - check-memory-safety
+  - mojo-build-package
+  - mojo-format
+  - mojo-type-safety
+  - mojo-test-runner
+skills_source: "https://github.com/mvillmow/ProjectOdyssey/tree/main/.claude/skills"
+```
+
+### New Tier Sub-Tests for T3 (Delegation)
+
+Add Mojo-specific agent delegations:
+**File**: `tests/fixtures/tests/test-002/t3/42-mojo-syntax-validator/config.yaml`
+
+```yaml
+name: "Mojo Syntax Validator Agent"
+description: "L3 specialist for validating Mojo v0.26.1 syntax"
+extends_previous: true
+agent: mojo-syntax-validator
+agent_source: "https://github.com/mvillmow/ProjectOdyssey/tree/main/.claude/agents"
+```
+
+**File**: `tests/fixtures/tests/test-002/t3/43-mojo-language-review/config.yaml`
+
+```yaml
+name: "Mojo Language Review Specialist"
+description: "L3 specialist for Mojo idioms and SIMD optimization"
+extends_previous: true
+agent: mojo-language-review-specialist
+agent_source: "https://github.com/mvillmow/ProjectOdyssey/tree/main/.claude/agents"
+```
+
+### Updated Rubric with Memory Safety
+
+Add these requirements to `expected/rubric.yaml`:
+
+```yaml
+  - id: "R011"
+    description: "Memory Safety - No ownership violations"
+    weight: 1.5
+    evaluation: "scaled"
+    criteria:
+      - "Proper ownership transfer with ^"
+      - "No use-after-move"
+      - "No uninitialized access"
+      - "Pointer safety (if applicable)"
+
+  - id: "R012"
+    description: "Ownership Patterns - Correct conventions"
+    weight: 1.0
+    evaluation: "scaled"
+    criteria:
+      - "out self in constructors"
+      - "mut self in mutating methods"
+      - "No inout keyword"
+      - "var parameter for ownership transfer"
+
+  - id: "R013"
+    description: "No Deprecated Patterns"
+    weight: 1.0
+    evaluation: "binary"
+    criteria:
+      - "No @value decorator"
+      - "No DynamicVector"
+      - "No inout keyword"
+      - "Tuple return syntax correct"
+```
+
+## Critical Files
+
+- `/home/mvillmow/ProjectScylla/tests/fixtures/tests/test-001/` - Reference implementation
+- `/home/mvillmow/ProjectScylla/config/judge/system_prompt.md` - Judge criteria
+- `/home/mvillmow/ProjectScylla/.claude/shared/mojo-guidelines.md` - Mojo best practices
+- `/home/mvillmow/ProjectScylla/.claude/shared/mojo-anti-patterns.md` - Common mistakes
+- `https://github.com/mvillmow/ProjectOdyssey/.claude/skills/` - Mojo skills source
+- `https://github.com/mvillmow/ProjectOdyssey/.claude/agents/` - Mojo agents source
+
+## Mojo v0.26.1 Best Practices for Rubric
+
+The rubric enforces these Mojo standards (from ProjectOdyssey skills/agents):
+
+### Constructor & Method Patterns
+1. `fn main()` as entry point (not `def main()`)
+2. `out self` in constructors (NEVER `mut self` or `inout self`)
+3. `mut self` in mutating methods
+4. Implicit `read` for immutable access (no explicit `read self`)
+
+### Ownership & Memory
+5. `^` transfer operator for List/Dict/String returns
+6. `var` parameter for ownership transfer in function args
+7. No `ImplicitlyCopyable` with heap-allocated fields
+8. Proper initialization before access (use `append()` not index assignment)
+
+### Syntax & Types
+9. `print()` for output (not `print_string()`)
+10. List literals `[1, 2, 3]` not `List[Int](1, 2, 3)`
+11. `Tuple[T1, T2]` return type not `-> (T1, T2)`
+12. `@fieldwise_init` + traits instead of `@value`
+13. `List` instead of `DynamicVector`
+
+### Compilation
+14. Zero compiler errors
+15. Zero compiler warnings
+16. `mojo build -I .` for executables
+17. `mojo package` for library files
+
+---
+
+## Implementation Summary
+
+### Files to Create
+1. `tests/fixtures/tests/test-002/test.yaml` - Main test definition
+2. `tests/fixtures/tests/test-002/prompt.md` - Task prompt
+3. `tests/fixtures/tests/test-002/config.yaml` - Test configuration
+4. `tests/fixtures/tests/test-002/expected/criteria.md` - 13 evaluation criteria
+5. `tests/fixtures/tests/test-002/expected/rubric.yaml` - Weighted rubric
+
+### Directories to Copy from test-001
+- `t0/` through `t6/` - All tier sub-test configurations
+
+### New Sub-Tests to Create
+- `t1/11-mojo-skills/` - Mojo skills bundle (7 skills)
+- `t3/42-mojo-syntax-validator/` - Mojo syntax validator agent
+- `t3/43-mojo-language-review/` - Mojo language review specialist agent
+
+### External Dependencies
+- **Skills**: https://github.com/mvillmow/ProjectOdyssey/.claude/skills/
+- **Agents**: https://github.com/mvillmow/ProjectOdyssey/.claude/agents/
+
+### Test Coverage
+- 13 requirements (R001-R013)
+- Total weight: 15.0 points
+- Pass threshold: 70%
+- Integrates with existing judge system at `config/judge/system_prompt.md`

--- a/src/scylla/e2e/llm_judge.py
+++ b/src/scylla/e2e/llm_judge.py
@@ -17,6 +17,8 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
+from scylla.metrics.grading import assign_letter_grade
+
 logger = logging.getLogger(__name__)
 
 
@@ -59,17 +61,8 @@ class JudgeResult:
         }
 
 
-def _score_to_grade(score: float) -> str:
-    """Convert numeric score to letter grade."""
-    if score >= 0.9:
-        return "A"
-    elif score >= 0.8:
-        return "B"
-    elif score >= 0.7:
-        return "C"
-    elif score >= 0.6:
-        return "D"
-    return "F"
+# Alias for industry-aligned grade assignment
+_score_to_grade = assign_letter_grade
 
 
 def _build_judge_prompt(

--- a/src/scylla/judge/evaluator.py
+++ b/src/scylla/judge/evaluator.py
@@ -17,6 +17,8 @@ from typing import Any, Protocol
 
 from pydantic import BaseModel, Field
 
+from scylla.metrics.grading import assign_letter_grade
+
 logger = logging.getLogger(__name__)
 
 
@@ -240,25 +242,9 @@ def weighted_consensus(scores: list[JudgeScore]) -> float:
     return sum(s.score * s.confidence for s in scores) / total_confidence
 
 
-def assign_grade(score: float) -> str:
-    """Assign letter grade based on score.
-
-    Args:
-        score: Score (0.0 to 1.0).
-
-    Returns:
-        Letter grade (A/B/C/D/F).
-    """
-    if score >= 0.95:
-        return "A"
-    elif score >= 0.85:
-        return "B"
-    elif score >= 0.75:
-        return "C"
-    elif score >= 0.65:
-        return "D"
-    else:
-        return "F"
+# Backward-compatible alias for assign_letter_grade
+# Use assign_letter_grade from scylla.metrics.grading for new code
+assign_grade = assign_letter_grade
 
 
 class JudgeEvaluator:

--- a/src/scylla/judge/prompts.py
+++ b/src/scylla/judge/prompts.py
@@ -81,9 +81,9 @@ class EvaluationSummary(BaseModel):
     @field_validator("letter_grade")
     @classmethod
     def validate_letter_grade(cls, v: str) -> str:
-        """Validate letter grade is A-F."""
-        if v not in ["A", "B", "C", "D", "F"]:
-            raise ValueError(f"Invalid letter grade: {v}. Must be A, B, C, D, or F.")
+        """Validate letter grade is S-F (industry-aligned scale)."""
+        if v not in ["S", "A", "B", "C", "D", "F"]:
+            raise ValueError(f"Invalid letter grade: {v}. Must be S, A, B, C, D, or F.")
         return v
 
 

--- a/src/scylla/metrics/aggregator.py
+++ b/src/scylla/metrics/aggregator.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 
+from scylla.metrics.grading import assign_letter_grade
 from scylla.metrics.statistics import (
     Statistics,
     calculate_all,
@@ -86,19 +87,6 @@ def _calculate_composite_score(pass_rate: float, impl_rate: float) -> float:
     return (pass_rate + impl_rate) / 2
 
 
-def _assign_letter_grade(score: float) -> str:
-    """Assign letter grade."""
-    if score >= 0.95:
-        return "A"
-    elif score >= 0.85:
-        return "B"
-    elif score >= 0.75:
-        return "C"
-    elif score >= 0.65:
-        return "D"
-    return "F"
-
-
 class RunAggregator:
     """Aggregator for multiple evaluation runs.
 
@@ -152,7 +140,7 @@ class RunAggregator:
         composite_stats = calculate_all(composite_scores)
 
         # Determine grade from median composite score
-        grade = _assign_letter_grade(composite_stats.median)
+        grade = assign_letter_grade(composite_stats.median)
 
         return TierStatistics(
             tier_id=tier_id,

--- a/src/scylla/metrics/grading.py
+++ b/src/scylla/metrics/grading.py
@@ -122,28 +122,33 @@ def calculate_composite_score(
 
 
 def assign_letter_grade(score: float) -> str:
-    """Assign letter grade based on score.
+    """Assign letter grade based on score using industry-aligned scale.
+
+    See .claude/shared/grading-scale.md for full specification.
 
     Grade thresholds:
-        A: >= 0.95
-        B: >= 0.85
-        C: >= 0.75
-        D: >= 0.65
-        F: < 0.65
+        S: == 1.00 (Amazing - exceptional, above and beyond)
+        A: >= 0.80 (Excellent - production ready)
+        B: >= 0.60 (Good - minor improvements possible)
+        C: >= 0.40 (Acceptable - functional with issues)
+        D: >= 0.20 (Marginal - significant issues)
+        F: < 0.20 (Failing - does not meet requirements)
 
     Args:
         score: Score (0.0 to 1.0).
 
     Returns:
-        Letter grade (A/B/C/D/F).
+        Letter grade (S/A/B/C/D/F).
     """
-    if score >= 0.95:
+    if score >= 1.0:
+        return "S"
+    elif score >= 0.80:
         return "A"
-    elif score >= 0.85:
+    elif score >= 0.60:
         return "B"
-    elif score >= 0.75:
+    elif score >= 0.40:
         return "C"
-    elif score >= 0.65:
+    elif score >= 0.20:
         return "D"
     else:
         return "F"

--- a/src/scylla/reporting/scorecard.py
+++ b/src/scylla/reporting/scorecard.py
@@ -93,13 +93,15 @@ class ModelScorecard:
 def _grade_to_points(grade: str) -> float:
     """Convert letter grade to point value for averaging.
 
+    Uses industry-aligned scale where S is the highest grade.
+
     Args:
-        grade: Letter grade (A, B, C, D, F with optional +/-)
+        grade: Letter grade (S, A, B, C, D, F with optional +/-)
 
     Returns:
-        Numeric point value
+        Numeric point value (0.0 to 5.0)
     """
-    base_points = {"A": 4.0, "B": 3.0, "C": 2.0, "D": 1.0, "F": 0.0}
+    base_points = {"S": 5.0, "A": 4.0, "B": 3.0, "C": 2.0, "D": 1.0, "F": 0.0}
 
     if not grade:
         return 0.0
@@ -114,19 +116,23 @@ def _grade_to_points(grade: str) -> float:
         elif modifier == "-":
             points -= 0.3
 
-    return max(0.0, min(4.3, points))
+    return max(0.0, min(5.0, points))
 
 
 def _points_to_grade(points: float) -> str:
     """Convert point value back to letter grade.
 
+    Uses industry-aligned scale where S is the highest grade.
+
     Args:
-        points: Numeric point value
+        points: Numeric point value (0.0 to 5.0)
 
     Returns:
-        Letter grade string
+        Letter grade string (S, A, B, C, D, or F with optional +/-)
     """
-    if points >= 3.85:
+    if points >= 4.85:
+        return "S"
+    elif points >= 3.85:
         return "A"
     elif points >= 3.5:
         return "A-"

--- a/tests/unit/judge/test_evaluator.py
+++ b/tests/unit/judge/test_evaluator.py
@@ -80,26 +80,35 @@ class TestWeightedConsensus:
 
 
 class TestAssignGrade:
-    """Tests for grade assignment."""
+    """Tests for grade assignment using industry-aligned scale."""
+
+    def test_grade_s(self) -> None:
+        """S grade requires perfect score (1.0)."""
+        assert assign_grade(1.0) == "S"
 
     def test_grade_a(self) -> None:
-        assert assign_grade(0.95) == "A"
-        assert assign_grade(1.0) == "A"
+        """A grade: >= 0.80 (Excellent - production ready)."""
+        assert assign_grade(0.80) == "A"
+        assert assign_grade(0.99) == "A"
 
     def test_grade_b(self) -> None:
-        assert assign_grade(0.85) == "B"
-        assert assign_grade(0.94) == "B"
+        """B grade: >= 0.60 (Good - minor improvements possible)."""
+        assert assign_grade(0.60) == "B"
+        assert assign_grade(0.79) == "B"
 
     def test_grade_c(self) -> None:
-        assert assign_grade(0.75) == "C"
-        assert assign_grade(0.84) == "C"
+        """C grade: >= 0.40 (Acceptable - functional with issues)."""
+        assert assign_grade(0.40) == "C"
+        assert assign_grade(0.59) == "C"
 
     def test_grade_d(self) -> None:
-        assert assign_grade(0.65) == "D"
-        assert assign_grade(0.74) == "D"
+        """D grade: >= 0.20 (Marginal - significant issues)."""
+        assert assign_grade(0.20) == "D"
+        assert assign_grade(0.39) == "D"
 
     def test_grade_f(self) -> None:
-        assert assign_grade(0.64) == "F"
+        """F grade: < 0.20 (Failing - does not meet requirements)."""
+        assert assign_grade(0.19) == "F"
         assert assign_grade(0.0) == "F"
 
 

--- a/tests/unit/metrics/test_grading.py
+++ b/tests/unit/metrics/test_grading.py
@@ -98,26 +98,35 @@ class TestCalculateCompositeScore:
 
 
 class TestAssignLetterGrade:
-    """Tests for letter grade assignment."""
+    """Tests for letter grade assignment using industry-aligned scale."""
+
+    def test_grade_s(self) -> None:
+        """S grade requires perfect score (1.0)."""
+        assert assign_letter_grade(1.0) == "S"
 
     def test_grade_a(self) -> None:
-        assert assign_letter_grade(0.95) == "A"
-        assert assign_letter_grade(1.0) == "A"
+        """A grade: >= 0.80 (Excellent - production ready)."""
+        assert assign_letter_grade(0.80) == "A"
+        assert assign_letter_grade(0.99) == "A"
 
     def test_grade_b(self) -> None:
-        assert assign_letter_grade(0.85) == "B"
-        assert assign_letter_grade(0.94) == "B"
+        """B grade: >= 0.60 (Good - minor improvements possible)."""
+        assert assign_letter_grade(0.60) == "B"
+        assert assign_letter_grade(0.79) == "B"
 
     def test_grade_c(self) -> None:
-        assert assign_letter_grade(0.75) == "C"
-        assert assign_letter_grade(0.84) == "C"
+        """C grade: >= 0.40 (Acceptable - functional with issues)."""
+        assert assign_letter_grade(0.40) == "C"
+        assert assign_letter_grade(0.59) == "C"
 
     def test_grade_d(self) -> None:
-        assert assign_letter_grade(0.65) == "D"
-        assert assign_letter_grade(0.74) == "D"
+        """D grade: >= 0.20 (Marginal - significant issues)."""
+        assert assign_letter_grade(0.20) == "D"
+        assert assign_letter_grade(0.39) == "D"
 
     def test_grade_f(self) -> None:
-        assert assign_letter_grade(0.64) == "F"
+        """F grade: < 0.20 (Failing - does not meet requirements)."""
+        assert assign_letter_grade(0.19) == "F"
         assert assign_letter_grade(0.0) == "F"
 
 
@@ -181,28 +190,31 @@ class TestGradingResult:
 
 
 class TestGradeRun:
-    """Tests for grade_run function."""
+    """Tests for grade_run function using industry-aligned scale."""
 
     def test_passing_run(self) -> None:
+        """Passing run with high weighted score -> A grade."""
         result = grade_run(passed=True, weighted_score=0.9, cost_usd=1.0)
         assert result.pass_rate == 1.0
         assert result.impl_rate == 0.9
         assert result.cost_of_pass == 1.0
         assert result.composite_score == pytest.approx(0.95)
-        assert result.letter_grade == "A"
+        assert result.letter_grade == "A"  # 0.95 >= 0.80
 
     def test_failing_run(self) -> None:
+        """Failing run with moderate weighted score -> D grade."""
         result = grade_run(passed=False, weighted_score=0.5, cost_usd=1.0)
         assert result.pass_rate == 0.0
         assert result.impl_rate == 0.5
         assert math.isinf(result.cost_of_pass)
         assert result.composite_score == pytest.approx(0.25)
-        assert result.letter_grade == "F"
+        assert result.letter_grade == "D"  # 0.25 >= 0.20
 
     def test_mixed_run(self) -> None:
+        """Passing run with moderate weighted score -> A grade."""
         result = grade_run(passed=True, weighted_score=0.7, cost_usd=2.0)
         assert result.pass_rate == 1.0
         assert result.impl_rate == 0.7
         assert result.cost_of_pass == 2.0
         assert result.composite_score == pytest.approx(0.85)
-        assert result.letter_grade == "B"
+        assert result.letter_grade == "A"  # 0.85 >= 0.80


### PR DESCRIPTION
## Summary

Consolidates 5 duplicate letter grade implementations into a single canonical function using the industry-aligned S/A/B/C/D/F scale.

### Before (5 different implementations)
| File | Function | Thresholds |
|------|----------|------------|
| grading.py | `assign_letter_grade()` | 0.95/0.85/0.75/0.65 (A/B/C/D/F) |
| aggregator.py | `_assign_letter_grade()` | 0.95/0.85/0.75/0.65 (A/B/C/D/F) |
| evaluator.py | `assign_grade()` | 0.95/0.85/0.75/0.65 (A/B/C/D/F) |
| llm_judge.py | `_score_to_grade()` | 0.9/0.8/0.7/0.6 (different!) |
| rubric.py | `assign_grade()` | 1.0/0.8/0.6/0.4/0.2 (S/A/B/C/D/F) |

### After (1 canonical implementation)
All modules now use `assign_letter_grade()` from `grading.py` with industry-aligned thresholds:
- S: 1.00 (Exemplary)
- A: ≥0.80 (Production-Ready)
- B: ≥0.60 (Functional)
- C: ≥0.40 (Partial)
- D: ≥0.20 (Minimal)
- F: <0.20 (Failing)

## Changes

| File | Change |
|------|--------|
| `grading.py` | Update to industry-aligned thresholds |
| `aggregator.py` | Import from grading.py, remove duplicate |
| `evaluator.py` | Create alias to grading.py function |
| `llm_judge.py` | Create alias to grading.py function |
| `prompts.py` | Update validator to accept S grade |
| `scorecard.py` | Add S grade support to point functions |

## Test Plan

- [x] All 418 metrics and judge tests pass
- [x] All 904 unit tests pass (7 pre-existing failures in adapter logs)
- [x] Tests updated to use industry-aligned thresholds

Closes #114

🤖 Generated with [Claude Code](https://claude.com/claude-code)