### PR TITLE
refactor(pricing): centralize token cost calculation and model pricing

### DIFF
--- a/src/scylla/config/__init__.py
+++ b/src/scylla/config/__init__.py
@@ -35,6 +35,12 @@ from .models import (
     TierConfig,
     ValidationConfig,
 )
+from .pricing import (
+    MODEL_PRICING,
+    ModelPricing,
+    calculate_cost,
+    get_model_pricing,
+)
 
 __all__ = [
     # Loader
@@ -55,6 +61,11 @@ __all__ = [
     "TierConfig",
     # Model Models
     "ModelConfig",
+    # Pricing Models
+    "ModelPricing",
+    "MODEL_PRICING",
+    "get_model_pricing",
+    "calculate_cost",
     # Defaults Models
     "DefaultsConfig",
     "EvaluationConfig",

--- a/src/scylla/config/pricing.py
+++ b/src/scylla/config/pricing.py
@@ -1,0 +1,161 @@
+"""Centralized model pricing configuration.
+
+This module provides a single source of truth for model pricing data
+and cost calculation utilities.
+
+Python Justification: Required for Pydantic models and configuration.
+"""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, Field
+
+
+class ModelPricing(BaseModel):
+    """Pricing information for a specific model.
+
+    All prices are in USD per million tokens for consistency.
+
+    Attributes:
+        model_id: Model identifier.
+        input_cost_per_million: Cost per million input tokens.
+        output_cost_per_million: Cost per million output tokens.
+        cached_cost_per_million: Cost per million cached tokens (if supported).
+    """
+
+    model_id: str
+    input_cost_per_million: float = Field(ge=0.0)
+    output_cost_per_million: float = Field(ge=0.0)
+    cached_cost_per_million: float = Field(default=0.0, ge=0.0)
+
+
+# Default pricing for unknown models (conservative estimate)
+DEFAULT_PRICING = ModelPricing(
+    model_id="default",
+    input_cost_per_million=3.0,
+    output_cost_per_million=15.0,
+    cached_cost_per_million=0.0,
+)
+
+# Centralized model pricing data (as of January 2025)
+# All prices in USD per million tokens
+MODEL_PRICING: dict[str, ModelPricing] = {
+    # Anthropic Claude 4 models
+    "claude-sonnet-4-20250514": ModelPricing(
+        model_id="claude-sonnet-4-20250514",
+        input_cost_per_million=3.0,
+        output_cost_per_million=15.0,
+    ),
+    "claude-opus-4-20250514": ModelPricing(
+        model_id="claude-opus-4-20250514",
+        input_cost_per_million=15.0,
+        output_cost_per_million=75.0,
+    ),
+    "claude-opus-4-5-20251101": ModelPricing(
+        model_id="claude-opus-4-5-20251101",
+        input_cost_per_million=15.0,
+        output_cost_per_million=75.0,
+    ),
+    # Anthropic Claude 3.5 models
+    "claude-3-5-sonnet-20241022": ModelPricing(
+        model_id="claude-3-5-sonnet-20241022",
+        input_cost_per_million=3.0,
+        output_cost_per_million=15.0,
+    ),
+    "claude-3-5-haiku-20241022": ModelPricing(
+        model_id="claude-3-5-haiku-20241022",
+        input_cost_per_million=1.0,
+        output_cost_per_million=5.0,
+    ),
+    # OpenAI GPT models
+    "gpt-4": ModelPricing(
+        model_id="gpt-4",
+        input_cost_per_million=30.0,
+        output_cost_per_million=60.0,
+    ),
+    "gpt-4-turbo": ModelPricing(
+        model_id="gpt-4-turbo",
+        input_cost_per_million=10.0,
+        output_cost_per_million=30.0,
+    ),
+    "gpt-4o": ModelPricing(
+        model_id="gpt-4o",
+        input_cost_per_million=5.0,
+        output_cost_per_million=15.0,
+    ),
+    "gpt-3.5-turbo": ModelPricing(
+        model_id="gpt-3.5-turbo",
+        input_cost_per_million=0.5,
+        output_cost_per_million=1.5,
+    ),
+}
+
+
+def get_model_pricing(model_id: str | None) -> ModelPricing:
+    """Get pricing for a specific model.
+
+    Args:
+        model_id: Model identifier. If None or not found, returns default pricing.
+
+    Returns:
+        ModelPricing for the specified model.
+    """
+    if model_id is None:
+        return DEFAULT_PRICING
+    return MODEL_PRICING.get(model_id, DEFAULT_PRICING)
+
+
+def calculate_cost(
+    tokens_input: int,
+    tokens_output: int,
+    tokens_cached: int = 0,
+    model: str | None = None,
+) -> float:
+    """Calculate cost for token usage.
+
+    Args:
+        tokens_input: Number of input tokens.
+        tokens_output: Number of output tokens.
+        tokens_cached: Number of cached tokens (optional).
+        model: Model identifier for specific pricing.
+
+    Returns:
+        Total cost in USD.
+    """
+    pricing = get_model_pricing(model)
+    return (
+        (tokens_input / 1_000_000) * pricing.input_cost_per_million
+        + (tokens_output / 1_000_000) * pricing.output_cost_per_million
+        + (tokens_cached / 1_000_000) * pricing.cached_cost_per_million
+    )
+
+
+# Backward compatibility: convert per-1K to per-million
+def get_input_cost_per_1k(model: str | None) -> float:
+    """Get input cost per 1K tokens (for backward compatibility).
+
+    Prefer using calculate_cost() or get_model_pricing() for new code.
+
+    Args:
+        model: Model identifier.
+
+    Returns:
+        Cost per 1K input tokens.
+    """
+    pricing = get_model_pricing(model)
+    return pricing.input_cost_per_million / 1000
+
+
+def get_output_cost_per_1k(model: str | None) -> float:
+    """Get output cost per 1K tokens (for backward compatibility).
+
+    Prefer using calculate_cost() or get_model_pricing() for new code.
+
+    Args:
+        model: Model identifier.
+
+    Returns:
+        Cost per 1K output tokens.
+    """
+    pricing = get_model_pricing(model)
+    return pricing.output_cost_per_million / 1000

--- a/tests/unit/config/test_pricing.py
+++ b/tests/unit/config/test_pricing.py
@@ -1,0 +1,120 @@
+"""Tests for centralized pricing configuration.
+
+Python justification: Required for pytest testing framework.
+"""
+
+import pytest
+
+from scylla.config.pricing import (
+    DEFAULT_PRICING,
+    MODEL_PRICING,
+    ModelPricing,
+    calculate_cost,
+    get_input_cost_per_1k,
+    get_model_pricing,
+    get_output_cost_per_1k,
+)
+
+
+class TestModelPricing:
+    """Tests for ModelPricing dataclass."""
+
+    def test_default_pricing_exists(self) -> None:
+        """Default pricing should exist."""
+        assert DEFAULT_PRICING is not None
+        assert DEFAULT_PRICING.model_id == "default"
+
+    def test_model_pricing_dict_not_empty(self) -> None:
+        """MODEL_PRICING should contain known models."""
+        assert len(MODEL_PRICING) > 0
+        assert "claude-sonnet-4-20250514" in MODEL_PRICING
+
+    def test_pricing_values_positive(self) -> None:
+        """All pricing values should be positive."""
+        for model_id, pricing in MODEL_PRICING.items():
+            assert pricing.input_cost_per_million >= 0
+            assert pricing.output_cost_per_million >= 0
+            assert pricing.cached_cost_per_million >= 0
+
+
+class TestGetModelPricing:
+    """Tests for get_model_pricing function."""
+
+    def test_known_model(self) -> None:
+        """Known model should return specific pricing."""
+        pricing = get_model_pricing("claude-sonnet-4-20250514")
+        assert pricing.model_id == "claude-sonnet-4-20250514"
+        assert pricing.input_cost_per_million == 3.0
+        assert pricing.output_cost_per_million == 15.0
+
+    def test_unknown_model(self) -> None:
+        """Unknown model should return default pricing."""
+        pricing = get_model_pricing("unknown-model")
+        assert pricing == DEFAULT_PRICING
+
+    def test_none_model(self) -> None:
+        """None model should return default pricing."""
+        pricing = get_model_pricing(None)
+        assert pricing == DEFAULT_PRICING
+
+
+class TestCalculateCost:
+    """Tests for calculate_cost function."""
+
+    def test_basic_calculation(self) -> None:
+        """Basic cost calculation with known model."""
+        # 1M input tokens * $3/M + 1M output tokens * $15/M = $18
+        cost = calculate_cost(
+            tokens_input=1_000_000,
+            tokens_output=1_000_000,
+            model="claude-sonnet-4-20250514",
+        )
+        assert cost == pytest.approx(18.0)
+
+    def test_small_token_count(self) -> None:
+        """Cost calculation with small token count."""
+        # 1000 input * $3/M + 1000 output * $15/M = $0.018
+        cost = calculate_cost(
+            tokens_input=1000,
+            tokens_output=1000,
+            model="claude-sonnet-4-20250514",
+        )
+        assert cost == pytest.approx(0.018)
+
+    def test_with_cached_tokens(self) -> None:
+        """Cost calculation with cached tokens (zero cost by default)."""
+        cost = calculate_cost(
+            tokens_input=1000,
+            tokens_output=1000,
+            tokens_cached=1000,
+            model="claude-sonnet-4-20250514",
+        )
+        # Cached tokens have 0 cost by default
+        assert cost == pytest.approx(0.018)
+
+    def test_zero_tokens(self) -> None:
+        """Zero tokens should result in zero cost."""
+        cost = calculate_cost(0, 0)
+        assert cost == 0.0
+
+
+class TestBackwardCompatibility:
+    """Tests for backward compatibility functions."""
+
+    def test_get_input_cost_per_1k(self) -> None:
+        """get_input_cost_per_1k should convert per-million to per-1k."""
+        # Sonnet: $3/M = $0.003/1k
+        cost = get_input_cost_per_1k("claude-sonnet-4-20250514")
+        assert cost == pytest.approx(0.003)
+
+    def test_get_output_cost_per_1k(self) -> None:
+        """get_output_cost_per_1k should convert per-million to per-1k."""
+        # Sonnet: $15/M = $0.015/1k
+        cost = get_output_cost_per_1k("claude-sonnet-4-20250514")
+        assert cost == pytest.approx(0.015)
+
+    def test_opus_pricing(self) -> None:
+        """Opus should have higher pricing than Sonnet."""
+        opus_input = get_input_cost_per_1k("claude-opus-4-20250514")
+        sonnet_input = get_input_cost_per_1k("claude-sonnet-4-20250514")
+        assert opus_input > sonnet_input


### PR DESCRIPTION
## Summary

Creates a single source of truth for model pricing and cost calculation, replacing duplicate hardcoded pricing dictionaries.

### Before
- `adapters/base.py`: Hardcoded pricing dicts (per-1K units)
- `token_tracking.py`: Hardcoded default parameters (per-million units)
- Different unit conventions causing confusion

### After
- Centralized `config/pricing.py` with all pricing data
- Consistent per-million units throughout
- `calculate_cost()` function for easy cost calculation
- Backward-compatible helper functions for per-1K conversion

## New Files

| File | Description |
|------|-------------|
| `src/scylla/config/pricing.py` | ModelPricing model, MODEL_PRICING dict, calculate_cost() |
| `tests/unit/config/test_pricing.py` | 13 tests covering all pricing functionality |

## Changes

| File | Change |
|------|--------|
| `adapters/base.py` | Import and use centralized pricing |
| `token_tracking.py` | Add model parameter, use centralized pricing |
| `config/__init__.py` | Export pricing utilities |

## Test Plan

- [x] All 13 new pricing tests pass
- [x] All 144 token tracking and adapter tests pass (7 pre-existing failures)

Closes #115

🤖 Generated with [Claude Code](https://claude.com/claude-code)