### PR TITLE
refactor(results): add base types and cross-reference documentation

### DIFF
--- a/src/scylla/core/__init__.py
+++ b/src/scylla/core/__init__.py
@@ -1,0 +1,16 @@
+"""Core types and base classes for ProjectScylla.
+
+This module provides foundational types used across the codebase.
+"""
+
+from scylla.core.results import (
+    BaseExecutionInfo,
+    BaseRunMetrics,
+    BaseRunResult,
+)
+
+__all__ = [
+    "BaseExecutionInfo",
+    "BaseRunMetrics",
+    "BaseRunResult",
+]

--- a/src/scylla/core/results.py
+++ b/src/scylla/core/results.py
@@ -1,0 +1,89 @@
+"""Base result types for evaluation runs.
+
+This module provides foundational types that are extended by domain-specific
+result classes throughout the codebase. These base types ensure consistent
+field naming and structure across different modules.
+
+Python Justification: Required for dataclass and Pydantic base types.
+
+Architecture Notes:
+    The codebase has multiple result types for different purposes:
+
+    RunResult variants:
+    - metrics/aggregator.py:RunResult - For statistical aggregation (minimal fields)
+    - executor/runner.py:RunResult - For execution tracking (Pydantic, with ExecutionInfo)
+    - e2e/models.py:RunResult - For E2E test results (detailed, with paths)
+    - reporting/result.py:RunResult - For persistence (nested info objects)
+
+    ExecutionInfo variants:
+    - executor/runner.py:ExecutionInfo - For container execution (detailed)
+    - reporting/result.py:ExecutionInfo - For result persistence (minimal)
+
+    This module provides base types with shared fields that domain-specific
+    types can extend or compose.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass
+class BaseExecutionInfo:
+    """Base execution information shared across all result types.
+
+    Attributes:
+        exit_code: Process/container exit code (0 = success).
+        duration_seconds: Total execution duration.
+        timed_out: Whether execution timed out.
+    """
+
+    exit_code: int
+    duration_seconds: float
+    timed_out: bool = False
+
+
+@dataclass
+class BaseRunMetrics:
+    """Base metrics shared across run result types.
+
+    Attributes:
+        tokens_input: Number of input tokens consumed.
+        tokens_output: Number of output tokens generated.
+        cost_usd: Total cost in USD.
+    """
+
+    tokens_input: int
+    tokens_output: int
+    cost_usd: float
+
+
+@dataclass
+class BaseRunResult:
+    """Base run result with common fields.
+
+    Attributes:
+        run_number: Run number/identifier.
+        cost_usd: Cost in USD.
+        duration_seconds: Execution duration.
+    """
+
+    run_number: int
+    cost_usd: float
+    duration_seconds: float
+
+
+# Type aliases for backward compatibility and documentation
+# These help document the relationship between base types and domain types
+
+# metrics/aggregator.py uses these fields for aggregation:
+# - run_id (str), pass_rate (float), impl_rate (float), cost_usd (float), duration_seconds (float)
+
+# executor/runner.py uses these fields for tracking:
+# - run_number (int), status (RunStatus), execution_info (ExecutionInfo), judgment (JudgmentResult)
+
+# e2e/models.py uses these fields for E2E results:
+# - run_number, exit_code, tokens_*, cost_usd, duration_seconds, judge_*, workspace_path, logs_path
+
+# reporting/result.py uses composition:
+# - test_id, tier_id, model_id, run_number, execution (ExecutionInfo), metrics (MetricsInfo), etc.

--- a/src/scylla/e2e/models.py
+++ b/src/scylla/e2e/models.py
@@ -116,6 +116,13 @@ class RunResult:
     Captures all execution details, metrics, and judge evaluation
     for one run of an agent against the canonical task.
 
+    This is the E2E testing result with detailed paths and judge fields.
+    For other RunResult types, see:
+    - executor/runner.py:RunResult (execution tracking with status)
+    - reporting/result.py:RunResult (persistence with nested info)
+    - metrics/aggregator.py:RunResult (statistical aggregation)
+    - core/results.py:BaseRunResult (base type)
+
     Attributes:
         run_number: The run number (1-indexed)
         exit_code: Process exit code
@@ -125,7 +132,7 @@ class RunResult:
         duration_seconds: Execution duration
         judge_score: LLM judge's score (0.0 - 1.0)
         judge_passed: Whether the run passed
-        judge_grade: Letter grade (A-F)
+        judge_grade: Letter grade (S-F)
         judge_reasoning: Judge's reasoning text
         workspace_path: Path to preserved workspace
         logs_path: Path to execution logs

--- a/src/scylla/executor/runner.py
+++ b/src/scylla/executor/runner.py
@@ -57,7 +57,13 @@ class InsufficientRunsError(RunnerError):
 
 
 class ExecutionInfo(BaseModel):
-    """Information about a single execution."""
+    """Detailed execution information for container runs.
+
+    This is the executor's detailed execution info, including container
+    and output details. For simpler execution info, see:
+    - reporting/result.py:ExecutionInfo (minimal, for persistence)
+    - core/results.py:BaseExecutionInfo (base type)
+    """
 
     container_id: str = Field(..., description="Docker container ID")
     exit_code: int = Field(..., description="Container exit code")
@@ -79,7 +85,15 @@ class JudgmentResult(BaseModel):
 
 
 class RunResult(BaseModel):
-    """Result of a single run."""
+    """Result of a single run with execution tracking.
+
+    This is the executor's run result with status tracking and optional
+    judgment. For other RunResult types, see:
+    - e2e/models.py:RunResult (E2E testing with judge fields)
+    - reporting/result.py:RunResult (persistence with nested info)
+    - metrics/aggregator.py:RunResult (statistical aggregation)
+    - core/results.py:BaseRunResult (base type)
+    """
 
     run_number: int = Field(..., description="Run number (1-10)")
     status: RunStatus = Field(..., description="Run status")

--- a/src/scylla/metrics/aggregator.py
+++ b/src/scylla/metrics/aggregator.py
@@ -23,7 +23,13 @@ AggregatedStats = Statistics
 
 @dataclass
 class RunResult:
-    """Result from a single evaluation run.
+    """Result from a single evaluation run for aggregation.
+
+    This is a simplified result type used for statistical aggregation.
+    For detailed execution results, see:
+    - executor/runner.py:RunResult (execution tracking)
+    - e2e/models.py:RunResult (E2E test results)
+    - reporting/result.py:RunResult (persistence)
 
     Attributes:
         run_id: Unique identifier for the run.

--- a/src/scylla/reporting/result.py
+++ b/src/scylla/reporting/result.py
@@ -11,7 +11,13 @@ from pathlib import Path
 
 @dataclass
 class ExecutionInfo:
-    """Execution metadata for a run."""
+    """Execution metadata for a run.
+
+    This is the minimal execution info for result persistence.
+    For other ExecutionInfo types, see:
+    - executor/runner.py:ExecutionInfo (detailed with container info)
+    - core/results.py:BaseExecutionInfo (base type)
+    """
 
     status: str
     duration_seconds: float
@@ -50,7 +56,15 @@ class GradingInfo:
 class RunResult:
     """Complete result for a single evaluation run.
 
-    Contains all execution, metrics, judgment, and grading data.
+    Contains all execution, metrics, judgment, and grading data
+    using composition with nested info objects.
+
+    This is the persistence result with nested info objects.
+    For other RunResult types, see:
+    - executor/runner.py:RunResult (execution tracking with status)
+    - e2e/models.py:RunResult (E2E testing with paths)
+    - metrics/aggregator.py:RunResult (statistical aggregation)
+    - core/results.py:BaseRunResult (base type)
     """
 
     test_id: str


### PR DESCRIPTION
## Summary
- Create centralized base types in `core/results.py`: `BaseExecutionInfo`, `BaseRunMetrics`, `BaseRunResult`
- Add cross-reference documentation to all result type definitions across the codebase
- Establish clear hierarchy of result types while maintaining backward compatibility

## Changes
### New Files
- `src/scylla/core/__init__.py` - Core module exports
- `src/scylla/core/results.py` - Base types with shared fields

### Updated Documentation
- `executor/runner.py`: `RunResult`, `ExecutionInfo` with cross-references
- `e2e/models.py`: `RunResult` with cross-references
- `reporting/result.py`: `RunResult`, `ExecutionInfo` with cross-references
- `metrics/aggregator.py`: `RunResult` with cross-references (from prior work)

## Test plan
- [x] All unit tests pass (`pixi run pytest tests/unit/`)
- [x] Aggregator tests pass (15 tests)
- [x] E2E and reporting tests pass (125 tests)
- [x] Executor tests pass (126 tests)

Closes #116

🤖 Generated with [Claude Code](https://claude.com/claude-code)