### PR TITLE
chore: upgrade all Claude 4 models to 4.5 equivalents

### DIFF
--- a/config/models/claude-haiku-4-5.yaml
+++ b/config/models/claude-haiku-4-5.yaml
@@ -1,5 +1,5 @@
-# Claude Opus 4.5 Model Configuration
-model_id: "claude-opus-4-5"
+# Claude Haiku 4.5 Model Configuration
+model_id: "claude-haiku-4-5-20250929"
 name: "Claude Haiku 4.5"
 provider: "anthropic"
 adapter: "claude_code"

--- a/config/models/claude-opus-4.yaml
+++ b/config/models/claude-opus-4.yaml
@@ -1,6 +1,6 @@
 # Claude Opus 4.5 Model Configuration
-model_id: "claude-opus-4"
-name: "Claude Opus 4"
+model_id: "claude-opus-4-5"
+name: "Claude Opus 4.5"
 provider: "anthropic"
 adapter: "claude_code"
 temperature: 0.0

--- a/config/models/claude-sonnet-4.yaml
+++ b/config/models/claude-sonnet-4.yaml
@@ -1,6 +1,6 @@
-# Claude Sonnet 4 Model Configuration
-model_id: "claude-sonnet-4-20250514"
-name: "Claude Sonnet 4"
+# Claude Sonnet 4.5 Model Configuration
+model_id: "claude-sonnet-4-5-20250929"
+name: "Claude Sonnet 4.5"
 provider: "anthropic"
 adapter: "claude_code"
 temperature: 0.0

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -60,7 +60,7 @@ RUN chmod +x /entrypoint.sh
 # These are documented but not set here - they're injected by the orchestrator
 #
 # TIER           - Test tier (T0, T1, T2, T3, T4, T5, T6)
-# MODEL          - Model identifier (e.g., claude-sonnet-4-20250514)
+# MODEL          - Model identifier (e.g., claude-sonnet-4-5-20250929)
 # RUN_NUMBER     - Run number (1-9 for prompt sensitivity)
 # ANTHROPIC_API_KEY - API key for Claude (passed from host)
 # OPENAI_API_KEY    - API key for OpenAI models (if needed)

--- a/docker/README.md
+++ b/docker/README.md
@@ -32,7 +32,7 @@ docker run -e ANTHROPIC_API_KEY=$ANTHROPIC_API_KEY scylla-runner:latest --valida
 ```bash
 docker run \
     -e TIER=T0 \
-    -e MODEL=claude-sonnet-4-20250514 \
+    -e MODEL=claude-sonnet-4-5-20250929 \
     -e RUN_NUMBER=1 \
     -e TEST_ID=test-001 \
     -e ANTHROPIC_API_KEY=$ANTHROPIC_API_KEY \
@@ -66,7 +66,7 @@ The `scylla-runner:latest` image includes:
 | Variable | Description | Values | Example |
 |----------|-------------|--------|---------|
 | `TIER` | Test tier | T0-T6 | `T0` |
-| `MODEL` | Model identifier | Any valid model ID | `claude-sonnet-4-20250514` |
+| `MODEL` | Model identifier | Any valid model ID | `claude-sonnet-4-5-20250929` |
 | `RUN_NUMBER` | Run number for prompt sensitivity | 1-9 | `1` |
 | `TEST_ID` | Unique test identifier | Any string | `test-abc-001` |
 

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -21,7 +21,7 @@ services:
       - OPENAI_API_KEY=${OPENAI_API_KEY:-}
       # Test configuration (override as needed)
       - TIER=${TIER:-T0}
-      - MODEL=${MODEL:-claude-sonnet-4-20250514}
+      - MODEL=${MODEL:-claude-sonnet-4-5-20250929}
       - RUN_NUMBER=${RUN_NUMBER:-1}
       - TEST_ID=${TEST_ID:-local-test}
       - TIMEOUT=${TIMEOUT:-300}

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -71,7 +71,7 @@ Examples:
     docker run -e ANTHROPIC_API_KEY=\$KEY scylla-runner:latest --validate
 
     # Run a test
-    docker run -e TIER=T0 -e MODEL=claude-sonnet-4-20250514 -e RUN_NUMBER=1 \\
+    docker run -e TIER=T0 -e MODEL=claude-sonnet-4-5-20250929 -e RUN_NUMBER=1 \\
                -e TEST_ID=test-001 -e ANTHROPIC_API_KEY=\$KEY \\
                -v /path/to/workspace:/workspace \\
                scylla-runner:latest --run

--- a/docs/design/adapter-interface.md
+++ b/docs/design/adapter-interface.md
@@ -18,7 +18,7 @@ Adapters are the bridge between the Scylla test runner and specific AI agent imp
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
-| `model` | `str` | Yes | Model identifier (e.g., "claude-sonnet-4-20250514") |
+| `model` | `str` | Yes | Model identifier (e.g., "claude-sonnet-4-5-20250929") |
 | `prompt_file` | `Path` | Yes | Path to the prompt markdown file |
 | `workspace` | `Path` | Yes | Working directory for the agent |
 | `output_dir` | `Path` | Yes | Directory for logs and metrics output |

--- a/src/scylla/adapters/claude_code.py
+++ b/src/scylla/adapters/claude_code.py
@@ -34,7 +34,7 @@ class ClaudeCodeAdapter(BaseAdapter):
     Example:
         >>> adapter = ClaudeCodeAdapter()
         >>> config = AdapterConfig(
-        ...     model="claude-sonnet-4-20250514",
+        ...     model="claude-sonnet-4-5-20250929",
         ...     prompt_file=Path("prompt.md"),
         ...     workspace=Path("/workspace"),
         ...     output_dir=Path("/output"),

--- a/src/scylla/adapters/cline.py
+++ b/src/scylla/adapters/cline.py
@@ -34,7 +34,7 @@ class ClineAdapter(BaseAdapter):
     Example:
         >>> adapter = ClineAdapter()
         >>> config = AdapterConfig(
-        ...     model="claude-sonnet-4-20250514",
+        ...     model="claude-sonnet-4-5-20250929",
         ...     prompt_file=Path("prompt.md"),
         ...     workspace=Path("/workspace"),
         ...     output_dir=Path("/output"),

--- a/src/scylla/config/pricing.py
+++ b/src/scylla/config/pricing.py
@@ -41,16 +41,11 @@ DEFAULT_PRICING = ModelPricing(
 # Centralized model pricing data (as of January 2025)
 # All prices in USD per million tokens
 MODEL_PRICING: dict[str, ModelPricing] = {
-    # Anthropic Claude 4 models
-    "claude-sonnet-4-20250514": ModelPricing(
-        model_id="claude-sonnet-4-20250514",
+    # Anthropic Claude 4.5 models
+    "claude-sonnet-4-5-20250929": ModelPricing(
+        model_id="claude-sonnet-4-5-20250929",
         input_cost_per_million=3.0,
         output_cost_per_million=15.0,
-    ),
-    "claude-opus-4-20250514": ModelPricing(
-        model_id="claude-opus-4-20250514",
-        input_cost_per_million=15.0,
-        output_cost_per_million=75.0,
     ),
     "claude-opus-4-5-20251101": ModelPricing(
         model_id="claude-opus-4-5-20251101",

--- a/src/scylla/e2e/models.py
+++ b/src/scylla/e2e/models.py
@@ -483,7 +483,7 @@ class ExperimentConfig:
     task_repo: str
     task_commit: str
     task_prompt_file: Path
-    models: list[str] = field(default_factory=lambda: ["claude-sonnet-4-20250514"])
+    models: list[str] = field(default_factory=lambda: ["claude-sonnet-4-5-20250929"])
     runs_per_subtest: int = 10
     tiers_to_run: list[TierID] = field(default_factory=lambda: list(TierID))
     judge_model: str = "claude-opus-4-5-20251101"
@@ -527,7 +527,7 @@ class ExperimentConfig:
             task_repo=data["task_repo"],
             task_commit=data["task_commit"],
             task_prompt_file=Path(data["task_prompt_file"]),
-            models=data.get("models", ["claude-sonnet-4-20250514"]),
+            models=data.get("models", ["claude-sonnet-4-5-20250929"]),
             runs_per_subtest=data.get("runs_per_subtest", 10),
             tiers_to_run=[TierID.from_string(t) for t in data.get("tiers_to_run", [])],
             judge_model=data.get("judge_model", "claude-opus-4-5-20251101"),

--- a/src/scylla/executor/runner.py
+++ b/src/scylla/executor/runner.py
@@ -269,9 +269,9 @@ class EvalRunner:
         >>> summary = runner.run_test(
         ...     test_id="test-001",
         ...     tiers=["T0", "T1", "T2"],
-        ...     models=["claude-sonnet-4-20250514"],
+        ...     models=["claude-sonnet-4-5-20250929"],
         ... )
-        >>> print(f"T0 pass rate: {summary.tiers['T0']['claude-sonnet-4-20250514'].pass_rate}")
+        >>> print(f"T0 pass rate: {summary.tiers['T0']['claude-sonnet-4-5-20250929'].pass_rate}")
 
     """
 

--- a/tests/unit/adapters/test_base.py
+++ b/tests/unit/adapters/test_base.py
@@ -289,7 +289,7 @@ class TestCostCalculation:
     def test_calculate_cost_claude_sonnet(self) -> None:
         """Test cost calculation for Claude Sonnet."""
         adapter = ConcreteAdapter()
-        cost = adapter.calculate_cost(1000, 500, model="claude-sonnet-4-20250514")
+        cost = adapter.calculate_cost(1000, 500, model="claude-sonnet-4-5-20250929")
 
         # Sonnet: 0.003 per 1K input, 0.015 per 1K output
         expected = (1000 / 1000 * 0.003) + (500 / 1000 * 0.015)
@@ -298,7 +298,7 @@ class TestCostCalculation:
     def test_calculate_cost_claude_opus(self) -> None:
         """Test cost calculation for Claude Opus."""
         adapter = ConcreteAdapter()
-        cost = adapter.calculate_cost(1000, 500, model="claude-opus-4-20250514")
+        cost = adapter.calculate_cost(1000, 500, model="claude-opus-4-5-20251101")
 
         # Opus: 0.015 per 1K input, 0.075 per 1K output
         expected = (1000 / 1000 * 0.015) + (500 / 1000 * 0.075)

--- a/tests/unit/adapters/test_claude_code.py
+++ b/tests/unit/adapters/test_claude_code.py
@@ -38,7 +38,7 @@ class TestBuildCommand:
 
             adapter = ClaudeCodeAdapter()
             config = AdapterConfig(
-                model="claude-sonnet-4-20250514",
+                model="claude-sonnet-4-5-20250929",
                 prompt_file=prompt_file,
                 workspace=tmppath,
                 output_dir=tmppath,
@@ -48,7 +48,7 @@ class TestBuildCommand:
 
             assert cmd[0] == "claude"
             assert "--model" in cmd
-            assert "claude-sonnet-4-20250514" in cmd
+            assert "claude-sonnet-4-5-20250929" in cmd
             assert "--print" in cmd
             assert "--dangerously-skip-permissions" in cmd
             assert "Test prompt" == cmd[-1]
@@ -62,7 +62,7 @@ class TestBuildCommand:
 
             adapter = ClaudeCodeAdapter()
             config = AdapterConfig(
-                model="claude-sonnet-4-20250514",
+                model="claude-sonnet-4-5-20250929",
                 prompt_file=prompt_file,
                 workspace=tmppath,
                 output_dir=tmppath,
@@ -87,7 +87,7 @@ class TestBuildCommand:
 
             adapter = ClaudeCodeAdapter()
             config = AdapterConfig(
-                model="claude-sonnet-4-20250514",
+                model="claude-sonnet-4-5-20250929",
                 prompt_file=prompt_file,
                 workspace=tmppath,
                 output_dir=tmppath,
@@ -110,7 +110,7 @@ class TestBuildCommand:
 
             adapter = ClaudeCodeAdapter()
             config = AdapterConfig(
-                model="claude-sonnet-4-20250514",
+                model="claude-sonnet-4-5-20250929",
                 prompt_file=prompt_file,
                 workspace=tmppath,
                 output_dir=tmppath,
@@ -325,7 +325,7 @@ class TestRun:
 
             adapter = ClaudeCodeAdapter()
             config = AdapterConfig(
-                model="claude-sonnet-4-20250514",
+                model="claude-sonnet-4-5-20250929",
                 prompt_file=prompt_file,
                 workspace=tmppath,
                 output_dir=tmppath,
@@ -354,7 +354,7 @@ class TestRun:
 
             adapter = ClaudeCodeAdapter()
             config = AdapterConfig(
-                model="claude-sonnet-4-20250514",
+                model="claude-sonnet-4-5-20250929",
                 prompt_file=prompt_file,
                 workspace=tmppath,
                 output_dir=tmppath,
@@ -394,7 +394,7 @@ class TestRun:
 
             adapter = ClaudeCodeAdapter()
             config = AdapterConfig(
-                model="claude-sonnet-4-20250514",
+                model="claude-sonnet-4-5-20250929",
                 prompt_file=prompt_file,
                 workspace=tmppath,
                 output_dir=tmppath,
@@ -424,7 +424,7 @@ class TestRun:
 
             adapter = ClaudeCodeAdapter()
             config = AdapterConfig(
-                model="claude-sonnet-4-20250514",
+                model="claude-sonnet-4-5-20250929",
                 prompt_file=prompt_file,
                 workspace=tmppath,
                 output_dir=tmppath,
@@ -443,7 +443,7 @@ class TestRun:
 
             adapter = ClaudeCodeAdapter()
             config = AdapterConfig(
-                model="claude-sonnet-4-20250514",
+                model="claude-sonnet-4-5-20250929",
                 prompt_file=prompt_file,
                 workspace=tmppath,
                 output_dir=tmppath,
@@ -470,7 +470,7 @@ class TestRun:
 
             adapter = ClaudeCodeAdapter()
             config = AdapterConfig(
-                model="claude-sonnet-4-20250514",
+                model="claude-sonnet-4-5-20250929",
                 prompt_file=prompt_file,
                 workspace=tmppath,
                 output_dir=tmppath,

--- a/tests/unit/adapters/test_cline.py
+++ b/tests/unit/adapters/test_cline.py
@@ -38,7 +38,7 @@ class TestBuildCommand:
 
             adapter = ClineAdapter()
             config = AdapterConfig(
-                model="claude-sonnet-4-20250514",
+                model="claude-sonnet-4-5-20250929",
                 prompt_file=prompt_file,
                 workspace=tmppath,
                 output_dir=tmppath,
@@ -48,7 +48,7 @@ class TestBuildCommand:
 
             assert cmd[0] == "cline"
             assert "--model" in cmd
-            assert "claude-sonnet-4-20250514" in cmd
+            assert "claude-sonnet-4-5-20250929" in cmd
             assert "--non-interactive" in cmd
             assert "--prompt" in cmd
             assert "Test prompt" in cmd
@@ -62,7 +62,7 @@ class TestBuildCommand:
 
             adapter = ClineAdapter()
             config = AdapterConfig(
-                model="claude-sonnet-4-20250514",
+                model="claude-sonnet-4-5-20250929",
                 prompt_file=prompt_file,
                 workspace=tmppath,
                 output_dir=tmppath,
@@ -85,7 +85,7 @@ class TestBuildCommand:
 
             adapter = ClineAdapter()
             config = AdapterConfig(
-                model="claude-sonnet-4-20250514",
+                model="claude-sonnet-4-5-20250929",
                 prompt_file=prompt_file,
                 workspace=tmppath,
                 output_dir=tmppath,
@@ -253,7 +253,7 @@ class TestRun:
 
             adapter = ClineAdapter()
             config = AdapterConfig(
-                model="claude-sonnet-4-20250514",
+                model="claude-sonnet-4-5-20250929",
                 prompt_file=prompt_file,
                 workspace=tmppath,
                 output_dir=tmppath,
@@ -281,7 +281,7 @@ class TestRun:
 
             adapter = ClineAdapter()
             config = AdapterConfig(
-                model="claude-sonnet-4-20250514",
+                model="claude-sonnet-4-5-20250929",
                 prompt_file=prompt_file,
                 workspace=tmppath,
                 output_dir=tmppath,
@@ -316,7 +316,7 @@ class TestRun:
 
             adapter = ClineAdapter()
             config = AdapterConfig(
-                model="claude-sonnet-4-20250514",
+                model="claude-sonnet-4-5-20250929",
                 prompt_file=prompt_file,
                 workspace=tmppath,
                 output_dir=tmppath,
@@ -346,7 +346,7 @@ class TestRun:
 
             adapter = ClineAdapter()
             config = AdapterConfig(
-                model="claude-sonnet-4-20250514",
+                model="claude-sonnet-4-5-20250929",
                 prompt_file=prompt_file,
                 workspace=tmppath,
                 output_dir=tmppath,
@@ -365,7 +365,7 @@ class TestRun:
 
             adapter = ClineAdapter()
             config = AdapterConfig(
-                model="claude-sonnet-4-20250514",
+                model="claude-sonnet-4-5-20250929",
                 prompt_file=prompt_file,
                 workspace=tmppath,
                 output_dir=tmppath,
@@ -392,7 +392,7 @@ class TestRun:
 
             adapter = ClineAdapter()
             config = AdapterConfig(
-                model="claude-sonnet-4-20250514",
+                model="claude-sonnet-4-5-20250929",
                 prompt_file=prompt_file,
                 workspace=tmppath,
                 output_dir=tmppath,

--- a/tests/unit/config/test_pricing.py
+++ b/tests/unit/config/test_pricing.py
@@ -26,7 +26,7 @@ class TestModelPricing:
     def test_model_pricing_dict_not_empty(self) -> None:
         """MODEL_PRICING should contain known models."""
         assert len(MODEL_PRICING) > 0
-        assert "claude-sonnet-4-20250514" in MODEL_PRICING
+        assert "claude-sonnet-4-5-20250929" in MODEL_PRICING
 
     def test_pricing_values_positive(self) -> None:
         """All pricing values should be positive."""
@@ -41,8 +41,8 @@ class TestGetModelPricing:
 
     def test_known_model(self) -> None:
         """Known model should return specific pricing."""
-        pricing = get_model_pricing("claude-sonnet-4-20250514")
-        assert pricing.model_id == "claude-sonnet-4-20250514"
+        pricing = get_model_pricing("claude-sonnet-4-5-20250929")
+        assert pricing.model_id == "claude-sonnet-4-5-20250929"
         assert pricing.input_cost_per_million == 3.0
         assert pricing.output_cost_per_million == 15.0
 
@@ -66,7 +66,7 @@ class TestCalculateCost:
         cost = calculate_cost(
             tokens_input=1_000_000,
             tokens_output=1_000_000,
-            model="claude-sonnet-4-20250514",
+            model="claude-sonnet-4-5-20250929",
         )
         assert cost == pytest.approx(18.0)
 
@@ -76,7 +76,7 @@ class TestCalculateCost:
         cost = calculate_cost(
             tokens_input=1000,
             tokens_output=1000,
-            model="claude-sonnet-4-20250514",
+            model="claude-sonnet-4-5-20250929",
         )
         assert cost == pytest.approx(0.018)
 
@@ -86,7 +86,7 @@ class TestCalculateCost:
             tokens_input=1000,
             tokens_output=1000,
             tokens_cached=1000,
-            model="claude-sonnet-4-20250514",
+            model="claude-sonnet-4-5-20250929",
         )
         # Cached tokens have 0 cost by default
         assert cost == pytest.approx(0.018)
@@ -103,17 +103,17 @@ class TestBackwardCompatibility:
     def test_get_input_cost_per_1k(self) -> None:
         """get_input_cost_per_1k should convert per-million to per-1k."""
         # Sonnet: $3/M = $0.003/1k
-        cost = get_input_cost_per_1k("claude-sonnet-4-20250514")
+        cost = get_input_cost_per_1k("claude-sonnet-4-5-20250929")
         assert cost == pytest.approx(0.003)
 
     def test_get_output_cost_per_1k(self) -> None:
         """get_output_cost_per_1k should convert per-million to per-1k."""
         # Sonnet: $15/M = $0.015/1k
-        cost = get_output_cost_per_1k("claude-sonnet-4-20250514")
+        cost = get_output_cost_per_1k("claude-sonnet-4-5-20250929")
         assert cost == pytest.approx(0.015)
 
     def test_opus_pricing(self) -> None:
         """Opus should have higher pricing than Sonnet."""
-        opus_input = get_input_cost_per_1k("claude-opus-4-20250514")
-        sonnet_input = get_input_cost_per_1k("claude-sonnet-4-20250514")
+        opus_input = get_input_cost_per_1k("claude-opus-4-5-20251101")
+        sonnet_input = get_input_cost_per_1k("claude-sonnet-4-5-20250929")
         assert opus_input > sonnet_input


### PR DESCRIPTION
## Summary

Upgrades all Claude 4 model references to their Claude 4.5 equivalents across the codebase.

## Changes

**Model ID Migrations:**
- `claude-sonnet-4-20250514` → `claude-sonnet-4-5-20250929`
- `claude-opus-4-20250514` → `claude-opus-4-5-20251101`
- `claude-opus-4` → `claude-opus-4-5` (config file)

**Bug Fix:**
- Fixed `claude-haiku-4-5.yaml` which incorrectly had `model_id: "claude-opus-4-5"`
- Now correctly set to `claude-haiku-4-5-20250929`

**Cleanup:**
- Removed obsolete `claude-opus-4-20250514` entry from `pricing.py` (superseded by 4.5)

## Files Modified (17)

- **Config** (3): claude-sonnet-4.yaml, claude-opus-4.yaml, claude-haiku-4-5.yaml
- **Source** (5): pricing.py, claude_code.py, cline.py, models.py, runner.py
- **Tests** (4): test_pricing.py, test_base.py, test_claude_code.py, test_cline.py
- **Docker** (4): Dockerfile, docker-compose.yml, entrypoint.sh, README.md
- **Docs** (1): adapter-interface.md

## Test Plan

- [x] All model references found via grep search
- [x] Systematic replacement across all file types
- [x] Verified no remaining Claude 4 references
- [ ] CI tests pass with new model IDs

🤖 Generated with [Claude Code](https://claude.com/claude-code)