### PR TITLE
refactor(e2e): standardize agent/judge result paths with central helpers

### DIFF
--- a/src/scylla/e2e/paths.py
+++ b/src/scylla/e2e/paths.py
@@ -1,0 +1,64 @@
+"""Path constants and helpers for E2E experiment directory structure.
+
+This module centralizes all path logic for agent/judge result storage
+to ensure consistency across the codebase.
+"""
+
+from pathlib import Path
+
+# Directory name constants
+AGENT_DIR = "agent"
+JUDGE_DIR = "judge"
+RESULT_FILE = "result.json"
+
+
+def get_agent_dir(run_dir: Path) -> Path:
+    """Get the agent artifacts directory for a run.
+
+    Args:
+        run_dir: Path to the run directory (e.g., T0/00/run_01)
+
+    Returns:
+        Path to agent directory (e.g., T0/00/run_01/agent)
+
+    """
+    return run_dir / AGENT_DIR
+
+
+def get_judge_dir(run_dir: Path) -> Path:
+    """Get the judge artifacts directory for a run.
+
+    Args:
+        run_dir: Path to the run directory (e.g., T0/00/run_01)
+
+    Returns:
+        Path to judge directory (e.g., T0/00/run_01/judge)
+
+    """
+    return run_dir / JUDGE_DIR
+
+
+def get_agent_result_file(run_dir: Path) -> Path:
+    """Get the agent result.json file path.
+
+    Args:
+        run_dir: Path to the run directory
+
+    Returns:
+        Path to agent/result.json
+
+    """
+    return get_agent_dir(run_dir) / RESULT_FILE
+
+
+def get_judge_result_file(run_dir: Path) -> Path:
+    """Get the judge result.json file path.
+
+    Args:
+        run_dir: Path to the run directory
+
+    Returns:
+        Path to judge/result.json
+
+    """
+    return get_judge_dir(run_dir) / RESULT_FILE


### PR DESCRIPTION
## Summary
Creates a centralized paths module to ensure consistent agent/judge directory and result file handling across the E2E runner.

## Changes
- **New file**: `src/scylla/e2e/paths.py`
  - Constants: `AGENT_DIR`, `JUDGE_DIR`, `RESULT_FILE`
  - Helpers: `get_agent_dir()`, `get_judge_dir()`, `get_agent_result_file()`, `get_judge_result_file()`
- **Updated**: `src/scylla/e2e/subtest_executor.py`
  - Uses path helpers instead of hardcoded `run_dir / "agent"` and `run_dir / "judge"`
  - Uses `RESULT_FILE` constant instead of hardcoded `"result.json"` strings

## Benefits
- Prevents path inconsistencies
- Single source of truth for directory structure
- Foundation for #132 (skip completed runs validation)
- Makes refactoring easier if directory structure changes

## Testing
- Pre-commit hooks passed (ruff, ruff-format)
- No functional changes - pure refactor
- Existing tests should pass unchanged

Closes #133