### PR TITLE
feat(e2e): implement graceful signal handling for Ctrl+C

### DIFF
--- a/scripts/run_e2e_experiment.py
+++ b/scripts/run_e2e_experiment.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 
 import argparse
 import logging
+import signal
 import sys
 from pathlib import Path
 
@@ -24,7 +25,7 @@ import yaml
 sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
 
 from scylla.e2e.models import ExperimentConfig, TierID
-from scylla.e2e.runner import run_experiment
+from scylla.e2e.runner import request_shutdown, run_experiment
 
 # Configure logging
 logging.basicConfig(
@@ -344,6 +345,14 @@ def main() -> int:
         logging.getLogger().setLevel(logging.DEBUG)
     elif args.quiet:
         logging.getLogger().setLevel(logging.ERROR)
+
+    # Register signal handlers for graceful shutdown
+    def signal_handler(signum: int, frame):
+        logger.warning(f"Received signal {signum}, initiating graceful shutdown...")
+        request_shutdown()
+
+    signal.signal(signal.SIGINT, signal_handler)
+    signal.signal(signal.SIGTERM, signal_handler)
 
     try:
         # Build configuration

--- a/src/scylla/e2e/subtest_executor.py
+++ b/src/scylla/e2e/subtest_executor.py
@@ -301,6 +301,7 @@ class RateLimitCoordinator:
         self._pause_event = manager.Event()
         self._resume_event = manager.Event()
         self._rate_limit_info = manager.dict()
+        self._shutdown_event = manager.Event()
 
     def signal_rate_limit(self, info: RateLimitInfo) -> None:
         """Signal that a rate limit was detected (called by worker).
@@ -369,6 +370,20 @@ class RateLimitCoordinator:
         self._pause_event.clear()
         self._resume_event.set()
         logger.info("Rate limit coordinator: resume signal sent to all workers")
+
+    def signal_shutdown(self) -> None:
+        """Signal all workers to stop accepting new work and exit gracefully."""
+        self._shutdown_event.set()
+        logger.info("Shutdown signal sent to all workers")
+
+    def is_shutdown_requested(self) -> bool:
+        """Check if shutdown has been requested.
+
+        Returns:
+            True if shutdown is requested, False otherwise
+
+        """
+        return self._shutdown_event.is_set()
 
 
 class SubTestExecutor:
@@ -478,6 +493,14 @@ class SubTestExecutor:
             workspace = results_dir / "workspace"
 
         for run_num in range(1, self.config.runs_per_subtest + 1):
+            # Check for shutdown before starting run
+            if coordinator and coordinator.is_shutdown_requested():
+                logger.warning(
+                    f"Shutdown requested before run {run_num} of "
+                    f"{tier_id.value}/{subtest.id}, stopping..."
+                )
+                break
+
             # Check if run already completed (checkpoint resume)
             if checkpoint and checkpoint.is_run_completed(tier_id.value, subtest.id, run_num):
                 run_dir = results_dir / f"run_{run_num:02d}"
@@ -1182,6 +1205,14 @@ def run_tier_subtests_parallel(
             subtest_id = futures[future]
             try:
                 results[subtest_id] = future.result()
+
+                # Check for shutdown request
+                from scylla.e2e.runner import is_shutdown_requested
+
+                if is_shutdown_requested():
+                    logger.warning("Shutdown requested, signaling workers to stop...")
+                    coordinator.signal_shutdown()
+                    break
 
                 # Check if rate limit was signaled during execution
                 rate_limit_info = coordinator.get_rate_limit_info()


### PR DESCRIPTION
## Summary

Implements graceful shutdown handling for SIGINT (Ctrl+C) and SIGTERM signals during E2E experiments.

**What happens on Ctrl+C:**
1. Signal handler sets global shutdown flag
2. Coordinator signals all worker processes to stop
3. Current tier/run completes (or times out)
4. Checkpoint saved with "interrupted" status
5. Partial results returned for completed tiers

## Changes

**scripts/run_e2e_experiment.py**:
- Register SIGINT and SIGTERM signal handlers
- Call `request_shutdown()` on signal reception

**src/scylla/e2e/runner.py**:
- Add global `_shutdown_requested` flag
- Add `request_shutdown()` and `is_shutdown_requested()` functions
- Check for shutdown before starting each tier
- Save checkpoint with "interrupted" status in finally block
- Return partial results when interrupted

**src/scylla/e2e/subtest_executor.py**:
- Extend `RateLimitCoordinator` with shutdown support:
  - `_shutdown_event` for cross-process signaling
  - `signal_shutdown()` to notify workers
  - `is_shutdown_requested()` for workers to check
- Check for shutdown before starting each run
- Propagate shutdown to coordinator in parallel execution loop

## Test Plan

- [x] Linting passes (`pixi run ruff check`)
- [ ] Manual test: Start E2E experiment, press Ctrl+C during execution
- [ ] Verify checkpoint saved with "interrupted" status
- [ ] Verify workers stop accepting new work
- [ ] Verify partial results are returned
- [ ] Test interruption at various stages (tier start, mid-run, between tiers)

Closes #130

🤖 Generated with [Claude Code](https://claude.com/claude-code)