### PR TITLE
test(judge_selection): Fix unit tests for judge_models parameter change

### DIFF
--- a/tests/unit/e2e/test_judge_selection.py
+++ b/tests/unit/e2e/test_judge_selection.py
@@ -114,8 +114,7 @@ class TestSelectBestSubtest:
                 mean_cost=0.10,
                 token_stats=TokenStats(
                     input_tokens=8000,
-                    output_tokens=2000,
-                    total_tokens=10000,  # More tokens
+                    output_tokens=2000,  # total_tokens will be 10000
                 ),
             ),
             "02": SubTestResult(
@@ -129,8 +128,7 @@ class TestSelectBestSubtest:
                 mean_cost=0.08,
                 token_stats=TokenStats(
                     input_tokens=6000,
-                    output_tokens=1500,
-                    total_tokens=7500,  # Fewer tokens - should win tiebreaker
+                    output_tokens=1500,  # total_tokens will be 7500 - fewer tokens, should win
                 ),
             ),
         }


### PR DESCRIPTION
## Summary

Fixes unit tests that broke due to PR #163 changing the `select_best_subtest()` signature to require `judge_models` parameter.

## Changes

- Add `judge_models` parameter to all `select_best_subtest()` test calls
- Update tiebreaker test to use token-based tiebreaking instead of composite score
- Add `TokenStats` with different token counts to verify token-based tiebreaker
- Fix `TokenStats` constructor calls (total_tokens is a computed property)

## Test Plan

- [x] All unit tests pass locally via `pixi run pytest`
- [ ] CI tests pass

Fixes the test failures introduced by #163.

🤖 Generated with [Claude Code](https://claude.com/claude-code)