### PR TITLE
test(resume): Remove tiebreaker_model from test fixture

### DIFF
--- a/tests/unit/e2e/test_resume.py
+++ b/tests/unit/e2e/test_resume.py
@@ -29,7 +29,6 @@ def experiment_config() -> ExperimentConfig:
         runs_per_subtest=2,
         tiers_to_run=[TierID.T0],
         judge_models=["claude-opus-4-5-20251101"],
-        tiebreaker_model="claude-opus-4-5-20251101",
         parallel_subtests=2,
         timeout_seconds=300,
     )


### PR DESCRIPTION
## Summary

Removes `tiebreaker_model` parameter from ExperimentConfig test fixture in test_resume.py, completing the cleanup from PR #163.

## Changes

- Remove `tiebreaker_model="claude-opus-4-5-20251101"` line from experiment_config fixture

## Test Plan

- [x] Syntax checks pass
- [ ] CI unit tests pass

Fixes the last remaining test failure from tiebreaker_model removal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)