### PR TITLE
feat(e2e): Add parallel execution to rerun_judges

### DIFF
--- a/scripts/rerun_judges.py
+++ b/scripts/rerun_judges.py
@@ -169,6 +169,14 @@ Examples:
     )
 
     parser.add_argument(
+        "--parallel",
+        type=int,
+        default=1,
+        metavar="N",
+        help="Number of judge slots to run in parallel (default: 1, sequential)",
+    )
+
+    parser.add_argument(
         "-v",
         "--verbose",
         action="store_true",
@@ -236,6 +244,7 @@ def main() -> int:
             status_filter=status_filter,
             judge_model=args.judge_model,
             regenerate_only=args.regenerate_only,
+            parallel=args.parallel,
         )
 
         # Summary already printed by rerun_judges_experiment()


### PR DESCRIPTION
## Summary
Add per-judge-slot classification and parallel execution to `rerun_judges.py` for efficient judge rerun workflows.

## Changes
- Per-judge-slot status classification (completed/failed/partial/missing)
- `--parallel N` flag for concurrent judge slot execution via ThreadPoolExecutor
- Default `parallel=1` preserves sequential behavior

## Test plan
- [x] Pre-commit hooks pass
- [ ] Test sequential execution (`--parallel 1`)
- [ ] Test parallel execution (`--parallel 4`)
- [ ] Verify no pool poisoning on errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)