### PR TITLE
feat(e2e): Add experiment result regeneration tools

### DIFF
--- a/docs/dev/regenerate-results.md
+++ b/docs/dev/regenerate-results.md
@@ -1,0 +1,146 @@
+# Regenerate Results and Reports
+
+The `regenerate_results.py` script rebuilds `results.json` and all report files from existing `run_result.json` files without re-running agents or judges.
+
+## Use Cases
+
+1. **Fix corrupted results.json**: When the aggregation logic produces incorrect results, regenerate from source data
+2. **Re-judge failed runs**: Selectively re-run judges for runs that are missing judge results
+3. **Update report formats**: Regenerate reports after updating report templates
+4. **Recover from interruptions**: Rebuild results after experiment interruptions
+
+## Usage
+
+### Basic Regeneration
+
+Regenerate results from existing run data (no re-judging):
+
+```bash
+pixi run python scripts/regenerate_results.py /path/to/experiment/
+```
+
+### Re-judge Missing Runs
+
+Re-run judges for runs that are missing valid judge results, then regenerate:
+
+```bash
+pixi run python scripts/regenerate_results.py /path/to/experiment/ --rejudge
+```
+
+### Override Judge Model
+
+Specify a different judge model for re-judging:
+
+```bash
+pixi run python scripts/regenerate_results.py /path/to/experiment/ \
+    --rejudge --judge-model claude-opus-4-5-20251101
+```
+
+### Dry Run
+
+Preview what would be done without modifying files:
+
+```bash
+pixi run python scripts/regenerate_results.py /path/to/experiment/ \
+    --rejudge --dry-run --verbose
+```
+
+## Options
+
+- `experiment_dir`: Path to experiment directory (required)
+- `--rejudge`: Re-run judges for runs missing valid judge results
+- `--judge-model MODEL`: Override judge model (default: from config)
+- `--dry-run`: Show what would be done without modifying files
+- `-v, --verbose`: Enable verbose logging
+
+## How It Works
+
+### Scanning
+
+1. Recursively scans experiment directory for `run_result.json` files
+2. Skips `.failed/` directories (already invalidated runs)
+3. Parses directory structure: `T0/00-subtest/run_01/run_result.json`
+4. Validates each run result (checks for required fields, incomplete executions)
+
+### Re-judging (Optional)
+
+If `--rejudge` is specified:
+
+1. For each run, checks if valid judge result exists
+2. If judge is missing but agent result exists:
+   - Loads agent output from `agent/output.txt`
+   - Loads task prompt from `experiment_dir/prompt.md`
+   - Runs LLM judge using the same logic as the main pipeline
+   - Saves judge results to `judge/result.json` and `judge_NN/judgment.json`
+   - Updates `run_result.json` with new judge scores
+   - Backs up old `run_result.json` as `.pre-rejudge`
+
+### Aggregation
+
+1. Groups runs by tier and subtest
+2. Computes aggregated statistics (mean, median, stdev, pass_rate, grades)
+3. Selects best subtest per tier using existing selection algorithm
+4. Computes tier-level and experiment-level results
+5. Finds frontier tier (best cost-of-pass)
+
+### Saving
+
+1. Backs up existing `result.json` to `result.json.backup`
+2. Saves experiment-level results: `result.json`, `report.md`, `summary.md`
+3. Saves tier-level results: `T0/result.json`, `T0/report.md`, `T0/summary.md`
+4. Saves subtest-level results: `T0/00-subtest/report.md`, `T0/00-subtest/report.json`
+
+## Edge Cases
+
+- **Missing workspace**: Cannot re-judge if `run_dir/workspace/` doesn't exist
+- **Corrupted run_result.json**: Skips with warning (same as repair_checkpoint.py)
+- **Runs in .failed/ directories**: Automatically skipped
+- **Non-tier directories**: Skips entries that don't start with "T"
+- **Empty experiment**: Exits gracefully if no valid runs found
+
+## Examples
+
+### Example 1: Regenerate After Manual Fix
+
+After manually fixing a `run_result.json` file:
+
+```bash
+# Edit the file
+vim ~/fullruns/experiment/T0/00-test/run_01/run_result.json
+
+# Regenerate all results
+pixi run python scripts/regenerate_results.py ~/fullruns/experiment/
+```
+
+### Example 2: Re-judge Failed Judges
+
+After a judge timeout or failure:
+
+```bash
+# Re-run judges and regenerate
+pixi run python scripts/regenerate_results.py ~/fullruns/experiment/ \
+    --rejudge --verbose
+```
+
+### Example 3: Preview Re-judging
+
+Check what would be re-judged without making changes:
+
+```bash
+pixi run python scripts/regenerate_results.py ~/fullruns/experiment/ \
+    --rejudge --dry-run --verbose
+```
+
+## Related Tools
+
+- **repair_checkpoint.py**: Repairs checkpoint.json from run_result.json files
+- **run_e2e_experiment.py**: Main experiment runner
+
+## Implementation
+
+The regeneration logic is implemented in two files:
+
+- **src/scylla/e2e/regenerate.py**: Core regeneration logic (testable module)
+- **scripts/regenerate_results.py**: CLI wrapper (~80 lines)
+
+All aggregation logic reuses existing functions from the main pipeline to ensure consistency.

--- a/scripts/regenerate_agent_results.py
+++ b/scripts/regenerate_agent_results.py
@@ -1,0 +1,174 @@
+#!/usr/bin/env python3
+"""Regenerate agent/result.json files from existing logs.
+
+This script scans run directories for completed agents that are missing
+agent/result.json and regenerates them from the existing logs (stdout.log,
+stderr.log, command_log.json).
+
+Usage:
+    pixi run python scripts/regenerate_agent_results.py /path/to/experiment/
+
+Python Justification: File I/O, JSON parsing, and data extraction from logs.
+"""
+
+import argparse
+import json
+import logging
+import sys
+from pathlib import Path
+
+# Configure logging
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s [%(levelname)s] %(name)s: %(message)s",
+    datefmt="%Y-%m-%d %H:%M:%S",
+)
+logger = logging.getLogger(__name__)
+
+
+def regenerate_agent_result(agent_dir: Path) -> bool:
+    """Regenerate agent/result.json from existing logs.
+
+    Args:
+        agent_dir: Path to agent directory
+
+    Returns:
+        True if regenerated successfully, False otherwise
+
+    """
+    result_file = agent_dir / "result.json"
+    if result_file.exists():
+        return False  # Already exists
+
+    # Check if we have the required files
+    stdout_file = agent_dir / "stdout.log"
+    stderr_file = agent_dir / "stderr.log"
+    command_log_file = agent_dir / "command_log.json"
+
+    if not all([stdout_file.exists(), stderr_file.exists(), command_log_file.exists()]):
+        logger.warning(f"Missing required files in {agent_dir}")
+        return False
+
+    try:
+        # Read files
+        stdout = stdout_file.read_text()
+        stderr = stderr_file.read_text()
+
+        with open(command_log_file) as f:
+            cmd_log = json.load(f)
+
+        # Parse Claude Code JSON output to extract token stats and cost
+        stdout_json = json.loads(stdout.strip())
+
+        # Extract token stats from usage field
+        usage = stdout_json.get("usage", {})
+
+        # Build token_stats structure
+        token_stats = {
+            "input_tokens": usage.get("input_tokens", 0),
+            "output_tokens": usage.get("output_tokens", 0),
+            "cache_creation_input_tokens": usage.get("cache_creation_input_tokens", 0),
+            "cache_read_input_tokens": usage.get("cache_read_input_tokens", 0),
+        }
+
+        # Extract cost
+        cost_usd = stdout_json.get("total_cost_usd", 0.0)
+
+        # Get exit code from command log
+        exit_code = cmd_log["commands"][0]["exit_code"]
+
+        # Build result.json structure
+        result_data = {
+            "exit_code": exit_code,
+            "stdout": stdout,
+            "stderr": stderr,
+            "token_stats": token_stats,
+            "cost_usd": cost_usd,
+            "api_calls": 1,
+        }
+
+        # Write result.json
+        with open(result_file, "w") as f:
+            json.dump(result_data, f, indent=2)
+
+        logger.debug(f"✓ Regenerated {result_file}")
+        return True
+
+    except (json.JSONDecodeError, KeyError, IndexError) as e:
+        logger.error(f"Failed to regenerate {agent_dir}: {e}")
+        return False
+
+
+def main() -> int:
+    """Regenerate agent result.json files from existing logs."""
+    parser = argparse.ArgumentParser(
+        description="Regenerate agent/result.json files from existing logs",
+    )
+
+    parser.add_argument(
+        "experiment_dir",
+        type=Path,
+        help="Path to experiment directory",
+    )
+
+    parser.add_argument(
+        "-v",
+        "--verbose",
+        action="store_true",
+        help="Enable verbose logging",
+    )
+
+    args = parser.parse_args()
+
+    if args.verbose:
+        logging.getLogger().setLevel(logging.DEBUG)
+
+    if not args.experiment_dir.exists():
+        logger.error(f"Experiment directory not found: {args.experiment_dir}")
+        return 1
+
+    # Scan for agent directories
+    logger.info(f"Scanning {args.experiment_dir}")
+
+    regenerated = 0
+    already_exists = 0
+    failed = 0
+
+    for agent_dir in args.experiment_dir.rglob("agent"):
+        if not agent_dir.is_dir():
+            continue
+
+        result_file = agent_dir / "result.json"
+        if result_file.exists():
+            already_exists += 1
+            continue
+
+        # Check if agent completed (has output.txt)
+        output_file = agent_dir / "output.txt"
+        if not output_file.exists() or output_file.stat().st_size == 0:
+            continue
+
+        # Try to regenerate
+        if regenerate_agent_result(agent_dir):
+            regenerated += 1
+        else:
+            failed += 1
+
+    # Print summary
+    print()
+    print("=" * 60)
+    print("AGENT RESULT REGENERATION SUMMARY")
+    print("=" * 60)
+    print(f"Already exist:   {already_exists}")
+    print(f"Regenerated:     {regenerated}")
+    print(f"Failed:          {failed}")
+    print("=" * 60)
+
+    if regenerated > 0:
+        logger.info(f"✓ Successfully regenerated {regenerated} agent/result.json files")
+
+    return 0 if failed == 0 else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/regenerate_results.py
+++ b/scripts/regenerate_results.py
@@ -1,0 +1,136 @@
+#!/usr/bin/env python3
+"""Regenerate results.json and reports from existing run_result.json files.
+
+This script rebuilds experiment results without re-running agents or judges.
+It can also selectively re-run judges for runs that are missing judge results.
+
+Usage:
+    # Minimal: just regenerate from existing data
+    pixi run python scripts/regenerate_results.py /path/to/experiment/
+
+    # Re-judge missing judges first, then regenerate
+    pixi run python scripts/regenerate_results.py /path/to/experiment/ --rejudge
+
+    # Override judge model
+    pixi run python scripts/regenerate_results.py /path/to/experiment/ \
+        --rejudge --judge-model claude-opus-4-5-20251101
+
+    # Dry run to see what would be done
+    pixi run python scripts/regenerate_results.py /path/to/experiment/ \
+        --rejudge --dry-run
+
+Examples:
+    # Regenerate results after fixing run_result.json manually
+    pixi run python scripts/regenerate_results.py \
+        ~/fullruns/2026-01-29T12-00-00-experiment/
+
+    # Re-judge runs that had judge failures and regenerate
+    pixi run python scripts/regenerate_results.py \
+        ~/fullruns/2026-01-29T12-00-00-experiment/ \
+        --rejudge --verbose
+
+Python Justification: Command-line tool for result regeneration.
+
+"""
+
+import argparse
+import sys
+from pathlib import Path
+
+
+def main() -> int:
+    """Regenerate experiment results and reports from run data."""
+    parser = argparse.ArgumentParser(
+        description="Regenerate results.json and reports from existing run_result.json files",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""
+Examples:
+  # Regenerate from existing data
+  %(prog)s /path/to/experiment/
+
+  # Re-judge missing judges and regenerate
+  %(prog)s /path/to/experiment/ --rejudge
+
+  # Override judge model
+  %(prog)s /path/to/experiment/ --rejudge --judge-model claude-opus-4-5-20251101
+
+  # Dry run
+  %(prog)s /path/to/experiment/ --rejudge --dry-run
+        """,
+    )
+
+    parser.add_argument(
+        "experiment_dir",
+        type=Path,
+        help="Path to experiment directory containing run_result.json files",
+    )
+
+    parser.add_argument(
+        "--rejudge",
+        action="store_true",
+        help="Re-run judges for runs missing valid judge results",
+    )
+
+    parser.add_argument(
+        "--judge-model",
+        type=str,
+        help="Override judge model (default: from config/experiment.json)",
+    )
+
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Show what would be done without modifying files",
+    )
+
+    parser.add_argument(
+        "-v",
+        "--verbose",
+        action="store_true",
+        help="Enable verbose logging",
+    )
+
+    args = parser.parse_args()
+
+    # Validate experiment directory
+    if not args.experiment_dir.exists():
+        print(f"❌ Experiment directory not found: {args.experiment_dir}", file=sys.stderr)
+        return 1
+
+    if not args.experiment_dir.is_dir():
+        print(f"❌ Not a directory: {args.experiment_dir}", file=sys.stderr)
+        return 1
+
+    # Import here to avoid slow startup for --help
+    from scylla.e2e.regenerate import regenerate_experiment
+
+    try:
+        stats = regenerate_experiment(
+            experiment_dir=args.experiment_dir,
+            rejudge=args.rejudge,
+            judge_model=args.judge_model,
+            dry_run=args.dry_run,
+            verbose=args.verbose,
+        )
+
+        if stats.runs_valid == 0:
+            print("\n⚠️  No valid run results found", file=sys.stderr)
+            return 1
+
+        print("\n✅ Regeneration complete")
+        return 0
+
+    except FileNotFoundError as e:
+        print(f"\n❌ {e}", file=sys.stderr)
+        return 1
+    except Exception as e:
+        print(f"\n❌ Regeneration failed: {e}", file=sys.stderr)
+        if args.verbose:
+            import traceback
+
+            traceback.print_exc()
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/scylla/e2e/regenerate.py
+++ b/src/scylla/e2e/regenerate.py
@@ -1,0 +1,650 @@
+"""Regenerate results.json and reports from existing run_result.json files.
+
+This module provides functionality to rebuild experiment results without re-running
+agents or judges. It can also selectively re-run judges for runs that are missing
+judge results.
+
+Python Justification: Required for JSON manipulation, filesystem traversal,
+and integration with existing Python-based evaluation infrastructure.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import shutil
+import statistics
+from dataclasses import dataclass
+from pathlib import Path
+
+from scylla.e2e.judge_selection import select_best_subtest
+from scylla.e2e.llm_judge import run_llm_judge
+from scylla.e2e.models import (
+    ExperimentConfig,
+    ExperimentResult,
+    RunResult,
+    SubTestResult,
+    TierID,
+    TierResult,
+    TokenStats,
+)
+from scylla.e2e.run_report import (
+    generate_experiment_summary_table,
+    generate_tier_summary_table,
+    save_experiment_report,
+    save_subtest_report,
+    save_tier_report,
+)
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class RegenerateStats:
+    """Statistics from regeneration process."""
+
+    runs_found: int = 0
+    runs_valid: int = 0
+    runs_rejudged: int = 0
+    runs_skipped: int = 0
+    tiers_processed: int = 0
+    subtests_processed: int = 0
+
+
+def regenerate_experiment(
+    experiment_dir: Path,
+    rejudge: bool = False,
+    judge_model: str | None = None,
+    dry_run: bool = False,
+    verbose: bool = False,
+) -> RegenerateStats:
+    """Regenerate experiment results from existing run_result.json files.
+
+    Args:
+        experiment_dir: Path to experiment directory
+        rejudge: Whether to re-run judges for missing judge results
+        judge_model: Override judge model (default: from config)
+        dry_run: Show what would be done without modifying files
+        verbose: Enable verbose logging
+
+    Returns:
+        Statistics about the regeneration process.
+
+    """
+    if verbose:
+        logging.basicConfig(level=logging.DEBUG)
+    else:
+        logging.basicConfig(level=logging.INFO)
+
+    logger.info(f"🔍 Scanning experiment directory: {experiment_dir}")
+
+    # Load experiment config
+    config_file = experiment_dir / "config" / "experiment.json"
+    if not config_file.exists():
+        raise FileNotFoundError(f"Experiment config not found: {config_file}")
+
+    config = ExperimentConfig.load(config_file)
+    logger.info(f"✅ Loaded config for experiment: {config.experiment_id}")
+
+    # Determine judge model
+    effective_judge_model = judge_model
+    if effective_judge_model is None:
+        # Use first judge model from config (primary judge)
+        effective_judge_model = (
+            config.judge_models[0] if config.judge_models else "claude-opus-4-5-20251101"
+        )
+    logger.info(f"📊 Using judge model: {effective_judge_model}")
+
+    # Scan for run results
+    stats = RegenerateStats()
+    run_results = scan_run_results(experiment_dir, stats)
+
+    if not run_results:
+        logger.warning("⚠️  No run results found in experiment directory")
+        return stats
+
+    logger.info(
+        f"📦 Found {stats.runs_found} run_result.json files "
+        f"({stats.runs_valid} valid, {stats.runs_found - stats.runs_valid} invalid)"
+    )
+
+    # Re-judge if requested
+    if rejudge:
+        logger.info("⚖️  Re-judging runs with missing judge results...")
+        rejudge_missing_runs(
+            experiment_dir, config, run_results, effective_judge_model, dry_run, stats
+        )
+        logger.info(f"✅ Re-judged {stats.runs_rejudged} runs")
+
+    # Rebuild tier results
+    logger.info("🔨 Rebuilding tier results...")
+    tier_results = rebuild_tier_results(run_results, config, stats)
+    logger.info(f"✅ Processed {stats.tiers_processed} tiers, {stats.subtests_processed} subtests")
+
+    # Rebuild experiment result
+    logger.info("🔨 Rebuilding experiment result...")
+    experiment_result = rebuild_experiment_result(tier_results, config)
+
+    # Save all results
+    if not dry_run:
+        logger.info("💾 Saving results and reports...")
+        save_all_results(experiment_dir, experiment_result, config)
+        logger.info("✅ Results and reports saved successfully")
+    else:
+        logger.info("🔍 DRY RUN: Would save results and reports")
+
+    logger.info(
+        f"\n📊 Regeneration complete:\n"
+        f"  Runs found: {stats.runs_found}\n"
+        f"  Runs valid: {stats.runs_valid}\n"
+        f"  Runs re-judged: {stats.runs_rejudged}\n"
+        f"  Tiers processed: {stats.tiers_processed}\n"
+        f"  Subtests processed: {stats.subtests_processed}"
+    )
+
+    return stats
+
+
+def scan_run_results(
+    experiment_dir: Path,
+    stats: RegenerateStats,
+) -> dict[str, dict[str, list[RunResult]]]:
+    """Scan for run_result.json files and reconstruct RunResult objects.
+
+    Args:
+        experiment_dir: Path to experiment directory
+        stats: Statistics object to update
+
+    Returns:
+        Dict mapping tier_id -> subtest_id -> list[RunResult].
+
+    """
+    results: dict[str, dict[str, list[RunResult]]] = {}
+
+    # Find all run_result.json files
+    for run_result_file in experiment_dir.rglob("run_result.json"):
+        stats.runs_found += 1
+
+        # Skip .failed directories
+        if ".failed" in run_result_file.parts:
+            logger.debug(f"Skipping failed run: {run_result_file}")
+            stats.runs_skipped += 1
+            continue
+
+        # Parse directory structure: T0/00-subtest/run_01/run_result.json
+        try:
+            run_dir = run_result_file.parent
+            subtest_dir = run_dir.parent
+            tier_dir = subtest_dir.parent
+
+            # Extract IDs
+            tier_id = tier_dir.name
+            if not tier_id.startswith("T"):
+                logger.debug(f"Skipping non-tier directory: {tier_id}")
+                stats.runs_skipped += 1
+                continue
+
+            subtest_id = subtest_dir.name
+
+            # Load and validate run result
+            try:
+                with open(run_result_file) as f:
+                    data = json.load(f)
+
+                # Reconstruct RunResult (same logic as subtest_executor.py:659-681)
+                run_result = RunResult(
+                    run_number=data["run_number"],
+                    exit_code=data["exit_code"],
+                    token_stats=TokenStats.from_dict(data["token_stats"]),
+                    cost_usd=data["cost_usd"],
+                    duration_seconds=data["duration_seconds"],
+                    agent_duration_seconds=data.get("agent_duration_seconds", 0.0),
+                    judge_duration_seconds=data.get("judge_duration_seconds", 0.0),
+                    judge_score=data["judge_score"],
+                    judge_passed=data["judge_passed"],
+                    judge_grade=data["judge_grade"],
+                    judge_reasoning=data["judge_reasoning"],
+                    workspace_path=Path(data["workspace_path"]),
+                    logs_path=Path(data["logs_path"]),
+                    command_log_path=(
+                        Path(data["command_log_path"]) if data.get("command_log_path") else None
+                    ),
+                    criteria_scores=data.get("criteria_scores", {}),
+                )
+
+                # Add to results
+                if tier_id not in results:
+                    results[tier_id] = {}
+                if subtest_id not in results[tier_id]:
+                    results[tier_id][subtest_id] = []
+
+                results[tier_id][subtest_id].append(run_result)
+                stats.runs_valid += 1
+
+            except (json.JSONDecodeError, KeyError) as e:
+                logger.warning(f"⚠️  Invalid run_result.json: {run_result_file}: {e}")
+                stats.runs_skipped += 1
+                continue
+
+        except (IndexError, ValueError) as e:
+            logger.warning(f"⚠️  Invalid directory structure: {run_result_file}: {e}")
+            stats.runs_skipped += 1
+            continue
+
+    return results
+
+
+def rejudge_missing_runs(
+    experiment_dir: Path,
+    config: ExperimentConfig,
+    run_results: dict[str, dict[str, list[RunResult]]],
+    judge_model: str,
+    dry_run: bool,
+    stats: RegenerateStats,
+) -> None:
+    """Re-run judges for runs with missing judge results.
+
+    Args:
+        experiment_dir: Path to experiment directory
+        config: Experiment configuration
+        run_results: Dict of tier -> subtest -> runs
+        judge_model: Judge model to use
+        dry_run: If True, only show what would be done
+        stats: Statistics object to update
+
+    """
+    for tier_id, subtests in run_results.items():
+        for subtest_id, runs in subtests.items():
+            for run in runs:
+                run_dir = experiment_dir / tier_id / subtest_id / f"run_{run.run_number:02d}"
+
+                # Check if judge result exists and is valid
+                if _has_valid_judge_result(run_dir):
+                    logger.debug(f"Judge result exists for {run_dir}")
+                    continue
+
+                # Check if agent result exists
+                if not _has_valid_agent_result(run_dir):
+                    logger.warning(f"⚠️  No valid agent result for {run_dir}, cannot re-judge")
+                    continue
+
+                # Check if workspace exists
+                workspace = run_dir / "workspace"
+                if not workspace.exists():
+                    logger.warning(f"⚠️  Workspace not found for {run_dir}, cannot re-judge")
+                    continue
+
+                logger.info(f"⚖️  Re-judging: {run_dir}")
+
+                if dry_run:
+                    stats.runs_rejudged += 1
+                    continue
+
+                try:
+                    # Load agent output
+                    agent_output_file = run_dir / "agent" / "output.txt"
+                    if not agent_output_file.exists():
+                        logger.warning(f"⚠️  Agent output not found: {agent_output_file}")
+                        continue
+                    agent_output = agent_output_file.read_text()
+
+                    # Load task prompt
+                    task_prompt_file = experiment_dir / "prompt.md"
+                    if not task_prompt_file.exists():
+                        task_prompt_file = run_dir / "task_prompt.md"
+                    if not task_prompt_file.exists():
+                        logger.warning(f"⚠️  Task prompt not found for {run_dir}")
+                        continue
+                    task_prompt = task_prompt_file.read_text()
+
+                    # Backup old run_result.json
+                    run_result_file = run_dir / "run_result.json"
+                    if run_result_file.exists():
+                        backup_file = run_dir / "run_result.json.pre-rejudge"
+                        shutil.copy2(run_result_file, backup_file)
+
+                    # Run judge
+                    judge_dir = run_dir / "judge"
+                    judge_dir.mkdir(exist_ok=True)
+
+                    judge_result = run_llm_judge(
+                        workspace=workspace,
+                        task_prompt=task_prompt,
+                        agent_output=agent_output,
+                        model=judge_model,
+                        judge_dir=judge_dir,
+                        reference_patch_path=(
+                            experiment_dir / "reference.patch"
+                            if (experiment_dir / "reference.patch").exists()
+                            else None
+                        ),
+                        rubric_path=(
+                            experiment_dir / "rubric.yaml"
+                            if (experiment_dir / "rubric.yaml").exists()
+                            else None
+                        ),
+                    )
+
+                    # Update run result with new judge scores
+                    run.judge_score = judge_result.score
+                    run.judge_passed = judge_result.passed
+                    run.judge_grade = judge_result.grade
+                    run.judge_reasoning = judge_result.reasoning
+                    run.criteria_scores = judge_result.criteria_scores
+
+                    # Save updated run_result.json
+                    with open(run_result_file, "w") as f:
+                        json.dump(
+                            {
+                                "run_number": run.run_number,
+                                "exit_code": run.exit_code,
+                                "token_stats": run.token_stats.to_dict(),
+                                "cost_usd": run.cost_usd,
+                                "duration_seconds": run.duration_seconds,
+                                "agent_duration_seconds": run.agent_duration_seconds,
+                                "judge_duration_seconds": run.judge_duration_seconds,
+                                "judge_score": run.judge_score,
+                                "judge_passed": run.judge_passed,
+                                "judge_grade": run.judge_grade,
+                                "judge_reasoning": run.judge_reasoning,
+                                "workspace_path": str(run.workspace_path),
+                                "logs_path": str(run.logs_path),
+                                "command_log_path": (
+                                    str(run.command_log_path) if run.command_log_path else None
+                                ),
+                                "criteria_scores": run.criteria_scores,
+                            },
+                            f,
+                            indent=2,
+                        )
+
+                    stats.runs_rejudged += 1
+                    logger.info(f"✅ Re-judged {run_dir}: score={judge_result.score:.2f}")
+
+                except Exception as e:
+                    logger.error(f"❌ Failed to re-judge {run_dir}: {e}")
+                    continue
+
+
+def _has_valid_agent_result(run_dir: Path) -> bool:
+    """Check if a valid agent result exists (from subtest_executor.py:331)."""
+    result_file = run_dir / "agent" / "result.json"
+    if not result_file.exists():
+        return False
+
+    try:
+        data = json.loads(result_file.read_text())
+        required_fields = ["exit_code", "token_stats", "cost_usd"]
+        if not all(field in data for field in required_fields):
+            return False
+
+        # Check for incomplete execution
+        if data["exit_code"] == -1:
+            token_stats = data["token_stats"]
+            all_tokens_zero = (
+                token_stats.get("input_tokens", 0) == 0
+                and token_stats.get("output_tokens", 0) == 0
+                and token_stats.get("cache_creation_tokens", 0) == 0
+                and token_stats.get("cache_read_tokens", 0) == 0
+            )
+            if all_tokens_zero:
+                return False
+
+        return True
+    except (json.JSONDecodeError, KeyError, OSError):
+        return False
+
+
+def _has_valid_judge_result(run_dir: Path) -> bool:
+    """Check if a valid judge result exists (from subtest_executor.py:382)."""
+    judge_result_file = run_dir / "judge" / "result.json"
+    if not judge_result_file.exists():
+        return False
+
+    try:
+        data = json.loads(judge_result_file.read_text())
+        required_fields = ["score", "passed", "grade"]
+        return all(field in data for field in required_fields)
+    except (json.JSONDecodeError, KeyError, OSError):
+        return False
+
+
+def rebuild_tier_results(
+    run_results: dict[str, dict[str, list[RunResult]]],
+    config: ExperimentConfig,
+    stats: RegenerateStats,
+) -> dict[TierID, TierResult]:
+    """Rebuild tier results from run results.
+
+    Args:
+        run_results: Dict of tier -> subtest -> runs
+        config: Experiment configuration
+        stats: Statistics object to update
+
+    Returns:
+        Dict mapping TierID to TierResult.
+
+    """
+    tier_results: dict[TierID, TierResult] = {}
+
+    for tier_id_str, subtests in run_results.items():
+        try:
+            tier_id = TierID(tier_id_str)
+        except ValueError:
+            logger.warning(f"⚠️  Invalid tier ID: {tier_id_str}, skipping")
+            continue
+
+        stats.tiers_processed += 1
+
+        # Build subtest results
+        subtest_results: dict[str, SubTestResult] = {}
+        for subtest_id, runs in subtests.items():
+            stats.subtests_processed += 1
+
+            # Sort runs by run_number
+            runs.sort(key=lambda r: r.run_number)
+
+            # Aggregate results (same logic as subtest_executor.py:1519-1605)
+            subtest_result = _aggregate_results(tier_id, subtest_id, runs)
+            subtest_results[subtest_id] = subtest_result
+
+        # Select best subtest
+        if subtest_results:
+            selection = select_best_subtest(
+                subtest_results, config.judge_models, tie_threshold=0.05
+            )
+            best_subtest_id = selection.winning_subtest
+
+            # Mark best subtest
+            for subtest_id in subtest_results:
+                subtest_results[subtest_id].selected_as_best = subtest_id == best_subtest_id
+
+            best_subtest = subtest_results[best_subtest_id]
+
+            # Build tier result
+            tier_result = TierResult(
+                tier_id=tier_id,
+                subtest_results=subtest_results,
+                best_subtest=best_subtest_id,
+                best_subtest_score=best_subtest.median_score,
+                total_cost=sum(s.total_cost for s in subtest_results.values()),
+                total_runs=sum(len(s.runs) for s in subtest_results.values()),
+            )
+
+            tier_results[tier_id] = tier_result
+
+    return tier_results
+
+
+def _aggregate_results(
+    tier_id: TierID,
+    subtest_id: str,
+    runs: list[RunResult],
+) -> SubTestResult:
+    """Aggregate results from multiple runs (from subtest_executor.py:1519-1605)."""
+    if not runs:
+        return SubTestResult(
+            subtest_id=subtest_id,
+            tier_id=tier_id,
+            runs=[],
+        )
+
+    scores = [r.judge_score for r in runs]
+    costs = [r.cost_usd for r in runs]
+
+    pass_count = sum(1 for r in runs if r.judge_passed)
+    pass_rate = pass_count / len(runs)
+
+    mean_score = statistics.mean(scores)
+    median_score = statistics.median(scores)
+    std_dev = statistics.stdev(scores) if len(scores) > 1 else 0.0
+
+    # Consistency: 1 - coefficient of variation
+    cv = std_dev / mean_score if mean_score > 0 else 1.0
+    consistency = max(0.0, 1.0 - cv)
+
+    # Aggregate token stats
+    from functools import reduce
+
+    token_stats = reduce(
+        lambda a, b: a + b,
+        [r.token_stats for r in runs],
+        TokenStats(),
+    )
+
+    # Aggregate grades
+    grades = [r.judge_grade for r in runs if r.judge_grade]
+    grade_distribution: dict[str, int] | None = None
+    modal_grade: str | None = None
+    min_grade: str | None = None
+    max_grade: str | None = None
+
+    if grades:
+        # Build distribution
+        grade_distribution = {}
+        for g in grades:
+            grade_distribution[g] = grade_distribution.get(g, 0) + 1
+
+        # Modal grade (most common)
+        modal_grade = max(grade_distribution, key=grade_distribution.get)
+
+        # Grade ordering for min/max (F=worst, S=best)
+        grade_order = ["F", "D", "C", "B", "A", "S"]
+        grade_indices = [grade_order.index(g) for g in grades if g in grade_order]
+        if grade_indices:
+            min_grade = grade_order[min(grade_indices)]
+            max_grade = grade_order[max(grade_indices)]
+
+    return SubTestResult(
+        subtest_id=subtest_id,
+        tier_id=tier_id,
+        runs=runs,
+        pass_rate=pass_rate,
+        mean_score=mean_score,
+        median_score=median_score,
+        std_dev_score=std_dev,
+        mean_cost=statistics.mean(costs),
+        total_cost=sum(costs),
+        consistency=consistency,
+        token_stats=token_stats,
+        grade_distribution=grade_distribution,
+        modal_grade=modal_grade,
+        min_grade=min_grade,
+        max_grade=max_grade,
+    )
+
+
+def rebuild_experiment_result(
+    tier_results: dict[TierID, TierResult],
+    config: ExperimentConfig,
+) -> ExperimentResult:
+    """Rebuild experiment result from tier results.
+
+    Args:
+        tier_results: Dict of tier results
+        config: Experiment configuration
+
+    Returns:
+        ExperimentResult with all tier results.
+
+    """
+    # Find frontier tier (from runner.py:755-787)
+    best_tier, best_cop = _find_frontier(tier_results)
+
+    return ExperimentResult(
+        config=config,
+        tier_results=tier_results,
+        best_overall_tier=best_tier,
+        best_cost_of_pass=best_cop if best_cop != float("inf") else None,
+    )
+
+
+def _find_frontier(
+    tier_results: dict[TierID, TierResult],
+) -> tuple[TierID | None, float]:
+    """Find the frontier tier (best cost-of-pass) (from runner.py:755-787)."""
+    best_tier: TierID | None = None
+    best_cop = float("inf")
+
+    for tier_id, result in tier_results.items():
+        if not result.subtest_results:
+            continue
+
+        # Get best sub-test results
+        best_subtest = result.subtest_results.get(result.best_subtest)
+        if not best_subtest or best_subtest.pass_rate == 0:
+            continue
+
+        # Calculate cost-of-pass
+        cop = best_subtest.mean_cost / best_subtest.pass_rate
+
+        if cop < best_cop:
+            best_cop = cop
+            best_tier = tier_id
+
+    return best_tier, best_cop
+
+
+def save_all_results(
+    experiment_dir: Path,
+    result: ExperimentResult,
+    config: ExperimentConfig,
+) -> None:
+    """Save all results and reports at every level.
+
+    Args:
+        experiment_dir: Path to experiment directory
+        result: ExperimentResult to save
+        config: Experiment configuration
+
+    """
+    # Backup existing result.json
+    result_file = experiment_dir / "result.json"
+    if result_file.exists():
+        backup_file = experiment_dir / "result.json.backup"
+        shutil.copy2(result_file, backup_file)
+        logger.info(f"📦 Backed up existing result.json to {backup_file.name}")
+
+    # Save experiment-level result
+    result.save(experiment_dir)
+
+    # Save experiment-level reports
+    save_experiment_report(experiment_dir, result)
+
+    # Generate and save summary table
+    summary_md = generate_experiment_summary_table(result)
+    (experiment_dir / "summary.md").write_text(summary_md)
+
+    # Save tier-level reports
+    for tier_id, tier_result in result.tier_results.items():
+        tier_dir = experiment_dir / tier_id.value
+        save_tier_report(tier_dir, tier_id.value, tier_result)
+
+        # Generate and save tier summary
+        tier_summary_md = generate_tier_summary_table(tier_result)
+        (tier_dir / "summary.md").write_text(tier_summary_md)
+
+        # Save subtest-level reports
+        for subtest_id, subtest_result in tier_result.subtest_results.items():
+            subtest_dir = tier_dir / subtest_id
+            save_subtest_report(subtest_dir, subtest_id, subtest_result)

--- a/tests/e2e/test_regenerate.py
+++ b/tests/e2e/test_regenerate.py
@@ -1,0 +1,286 @@
+"""Tests for experiment regeneration functionality.
+
+Python Justification: Testing Python regeneration module.
+"""
+
+import json
+from pathlib import Path
+from unittest.mock import MagicMock
+
+from scylla.e2e.models import ExperimentConfig, RunResult, TierID, TokenStats
+from scylla.e2e.regenerate import (
+    RegenerateStats,
+    _aggregate_results,
+    _find_frontier,
+    _has_valid_agent_result,
+    _has_valid_judge_result,
+    rebuild_tier_results,
+    scan_run_results,
+)
+
+
+def test_has_valid_agent_result_missing_file(tmp_path: Path) -> None:
+    """Test _has_valid_agent_result with missing file."""
+    run_dir = tmp_path / "run_01"
+    run_dir.mkdir()
+    assert not _has_valid_agent_result(run_dir)
+
+
+def test_has_valid_agent_result_valid(tmp_path: Path) -> None:
+    """Test _has_valid_agent_result with valid result."""
+    run_dir = tmp_path / "run_01"
+    agent_dir = run_dir / "agent"
+    agent_dir.mkdir(parents=True)
+
+    result_data = {
+        "exit_code": 0,
+        "token_stats": {
+            "input_tokens": 100,
+            "output_tokens": 50,
+            "cache_creation_tokens": 0,
+            "cache_read_tokens": 0,
+        },
+        "cost_usd": 0.01,
+    }
+
+    (agent_dir / "result.json").write_text(json.dumps(result_data))
+
+    assert _has_valid_agent_result(run_dir)
+
+
+def test_has_valid_agent_result_incomplete_execution(tmp_path: Path) -> None:
+    """Test _has_valid_agent_result with incomplete execution (exit_code=-1, zero tokens)."""
+    run_dir = tmp_path / "run_01"
+    agent_dir = run_dir / "agent"
+    agent_dir.mkdir(parents=True)
+
+    result_data = {
+        "exit_code": -1,
+        "token_stats": {
+            "input_tokens": 0,
+            "output_tokens": 0,
+            "cache_creation_tokens": 0,
+            "cache_read_tokens": 0,
+        },
+        "cost_usd": 0.0,
+    }
+
+    (agent_dir / "result.json").write_text(json.dumps(result_data))
+
+    assert not _has_valid_agent_result(run_dir)
+
+
+def test_has_valid_judge_result_missing_file(tmp_path: Path) -> None:
+    """Test _has_valid_judge_result with missing file."""
+    run_dir = tmp_path / "run_01"
+    run_dir.mkdir()
+    assert not _has_valid_judge_result(run_dir)
+
+
+def test_has_valid_judge_result_valid(tmp_path: Path) -> None:
+    """Test _has_valid_judge_result with valid result."""
+    run_dir = tmp_path / "run_01"
+    judge_dir = run_dir / "judge"
+    judge_dir.mkdir(parents=True)
+
+    result_data = {
+        "score": 0.85,
+        "passed": True,
+        "grade": "A",
+        "reasoning": "Good work",
+    }
+
+    (judge_dir / "result.json").write_text(json.dumps(result_data))
+
+    assert _has_valid_judge_result(run_dir)
+
+
+def test_aggregate_results_empty() -> None:
+    """Test _aggregate_results with empty runs list."""
+    result = _aggregate_results(TierID.T0, "00-test", [])
+
+    assert result.subtest_id == "00-test"
+    assert result.tier_id == TierID.T0
+    assert result.runs == []
+
+
+def test_aggregate_results_single_run() -> None:
+    """Test _aggregate_results with a single run."""
+    run = RunResult(
+        run_number=1,
+        exit_code=0,
+        token_stats=TokenStats(input_tokens=100, output_tokens=50),
+        cost_usd=0.01,
+        duration_seconds=10.0,
+        agent_duration_seconds=8.0,
+        judge_duration_seconds=2.0,
+        judge_score=0.85,
+        judge_passed=True,
+        judge_grade="A",
+        judge_reasoning="Good",
+        workspace_path=Path("/tmp/workspace"),
+        logs_path=Path("/tmp/logs"),
+    )
+
+    result = _aggregate_results(TierID.T0, "00-test", [run])
+
+    assert result.subtest_id == "00-test"
+    assert result.tier_id == TierID.T0
+    assert result.pass_rate == 1.0
+    assert result.mean_score == 0.85
+    assert result.median_score == 0.85
+    assert result.mean_cost == 0.01
+    assert result.modal_grade == "A"
+
+
+def test_aggregate_results_multiple_runs() -> None:
+    """Test _aggregate_results with multiple runs."""
+    runs = [
+        RunResult(
+            run_number=1,
+            exit_code=0,
+            token_stats=TokenStats(input_tokens=100, output_tokens=50),
+            cost_usd=0.01,
+            duration_seconds=10.0,
+            agent_duration_seconds=8.0,
+            judge_duration_seconds=2.0,
+            judge_score=0.85,
+            judge_passed=True,
+            judge_grade="A",
+            judge_reasoning="Good",
+            workspace_path=Path("/tmp/workspace1"),
+            logs_path=Path("/tmp/logs1"),
+        ),
+        RunResult(
+            run_number=2,
+            exit_code=0,
+            token_stats=TokenStats(input_tokens=120, output_tokens=60),
+            cost_usd=0.012,
+            duration_seconds=12.0,
+            agent_duration_seconds=9.0,
+            judge_duration_seconds=3.0,
+            judge_score=0.75,
+            judge_passed=True,
+            judge_grade="B",
+            judge_reasoning="Good",
+            workspace_path=Path("/tmp/workspace2"),
+            logs_path=Path("/tmp/logs2"),
+        ),
+    ]
+
+    result = _aggregate_results(TierID.T0, "00-test", runs)
+
+    assert result.subtest_id == "00-test"
+    assert result.tier_id == TierID.T0
+    assert result.pass_rate == 1.0
+    assert result.mean_score == 0.80
+    assert result.median_score == 0.80
+    assert result.mean_cost == 0.011
+    assert result.modal_grade in ["A", "B"]  # Both appear once
+
+
+def test_find_frontier_empty() -> None:
+    """Test _find_frontier with empty tier results."""
+    tier_results = {}
+    best_tier, best_cop = _find_frontier(tier_results)
+
+    assert best_tier is None
+    assert best_cop == float("inf")
+
+
+def test_scan_run_results_empty_directory(tmp_path: Path) -> None:
+    """Test scan_run_results with empty directory."""
+    stats = RegenerateStats()
+    results = scan_run_results(tmp_path, stats)
+
+    assert results == {}
+    assert stats.runs_found == 0
+    assert stats.runs_valid == 0
+
+
+def test_scan_run_results_with_valid_runs(tmp_path: Path) -> None:
+    """Test scan_run_results with valid run_result.json files."""
+    # Create directory structure: T0/00-test/run_01/run_result.json
+    tier_dir = tmp_path / "T0"
+    subtest_dir = tier_dir / "00-test"
+    run_dir = subtest_dir / "run_01"
+    run_dir.mkdir(parents=True)
+
+    run_data = {
+        "run_number": 1,
+        "exit_code": 0,
+        "token_stats": {
+            "input_tokens": 100,
+            "output_tokens": 50,
+            "cache_creation_tokens": 0,
+            "cache_read_tokens": 0,
+        },
+        "cost_usd": 0.01,
+        "duration_seconds": 10.0,
+        "agent_duration_seconds": 8.0,
+        "judge_duration_seconds": 2.0,
+        "judge_score": 0.85,
+        "judge_passed": True,
+        "judge_grade": "A",
+        "judge_reasoning": "Good",
+        "workspace_path": "/tmp/workspace",
+        "logs_path": "/tmp/logs",
+        "criteria_scores": {},
+    }
+
+    (run_dir / "run_result.json").write_text(json.dumps(run_data))
+
+    stats = RegenerateStats()
+    results = scan_run_results(tmp_path, stats)
+
+    assert stats.runs_found == 1
+    assert stats.runs_valid == 1
+    assert "T0" in results
+    assert "00-test" in results["T0"]
+    assert len(results["T0"]["00-test"]) == 1
+    assert results["T0"]["00-test"][0].run_number == 1
+
+
+def test_scan_run_results_skips_failed_directories(tmp_path: Path) -> None:
+    """Test scan_run_results skips .failed directories."""
+    # Create directory structure with .failed
+    tier_dir = tmp_path / "T0"
+    subtest_dir = tier_dir / "00-test"
+    run_dir = subtest_dir / ".failed" / "run_01"
+    run_dir.mkdir(parents=True)
+
+    run_data = {
+        "run_number": 1,
+        "exit_code": -1,
+        "token_stats": {"input_tokens": 0, "output_tokens": 0},
+        "cost_usd": 0.0,
+        "duration_seconds": 0.0,
+        "judge_score": 0.0,
+        "judge_passed": False,
+        "judge_grade": "F",
+        "judge_reasoning": "Failed",
+        "workspace_path": "/tmp/workspace",
+        "logs_path": "/tmp/logs",
+    }
+
+    (run_dir / "run_result.json").write_text(json.dumps(run_data))
+
+    stats = RegenerateStats()
+    results = scan_run_results(tmp_path, stats)
+
+    assert stats.runs_found == 1
+    assert stats.runs_skipped == 1
+    assert results == {}
+
+
+def test_rebuild_tier_results_empty() -> None:
+    """Test rebuild_tier_results with empty run results."""
+    config = MagicMock(spec=ExperimentConfig)
+    config.judge_model = "claude-opus-4-5-20251101"
+    stats = RegenerateStats()
+
+    tier_results = rebuild_tier_results({}, config, stats)
+
+    assert tier_results == {}
+    assert stats.tiers_processed == 0
+    assert stats.subtests_processed == 0


### PR DESCRIPTION
## Summary
Add regeneration library and CLI scripts to rebuild results.json, reports, and agent result.json files from existing experiment run data without re-running agents or judges.

## Changes
- `src/scylla/e2e/regenerate.py`: Core regeneration library
- `scripts/regenerate_results.py`: CLI for rebuilding results.json and reports
- `scripts/regenerate_agent_results.py`: CLI for rebuilding agent result.json files
- `tests/e2e/test_regenerate.py`: Unit tests
- `docs/dev/regenerate-results.md`: Documentation

## Test plan
- [x] Pre-commit hooks pass
- [x] Unit tests included
- [ ] Test regenerate_results.py on experiment
- [ ] Test regenerate_agent_results.py on experiment

🤖 Generated with [Claude Code](https://claude.com/claude-code)