### PR TITLE
fix(analysis): Replace custom Krippendorff alpha with krippendorff package

### DIFF
--- a/pixi.toml
+++ b/pixi.toml
@@ -31,6 +31,7 @@ seaborn = ">=0.13"
 scipy = ">=1.11"
 altair = ">=5.0"
 vl-convert-python = ">=1.0"
+krippendorff = ">=0.6.0"
 
 [environments]
 default = { features = ["dev"], solve-group = "default" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,6 +48,7 @@ analysis = [
     "scipy>=1.11",
     "altair>=5.0",
     "vl-convert-python>=1.0",
+    "krippendorff>=0.6.0",
 ]
 
 [project.urls]

--- a/src/scylla/analysis/tables.py
+++ b/src/scylla/analysis/tables.py
@@ -341,7 +341,7 @@ def table03_judge_agreement(judges_df: pd.DataFrame) -> tuple[str, str]:
         else:
             md_lines.append(f"| {row['Judge Pair']} | — | — | — |")
 
-    md_lines.append(f"\n**Krippendorff's α** (ordinal): {alpha:.3f}")
+    md_lines.append(f"\n**Krippendorff's α** (interval): {alpha:.3f}")
 
     markdown = "\n".join(md_lines)
 


### PR DESCRIPTION
## Problem

The custom `krippendorff_alpha()` implementation had critical correctness issues:

1. **No interval branch**: `level="interval"` fell through to the `else` (nominal) branch
2. **Float equality on continuous data**: Nominal branch used `valid[i] == valid[j]` on continuous [0,1] scores, treating 0.45 vs 0.46 as full disagreement
3. **Wrong formula**: Nominal branch implemented Scott's pi `(P_o - P_e)/(1 - P_e)` instead of Krippendorff's alpha `1 - (D_o / D_e)`
4. **Mislabeled**: Table 3 markdown said "(ordinal)" but code called `level="interval"`

**Impact**: Table 3's reported Krippendorff's alpha value is scientifically invalid.

## Solution

- Replace 114-line custom implementation with thin wrapper calling `krippendorff` package
- Add `krippendorff>=0.6.0` to `pixi.toml` and `pyproject.toml` dependencies
- Fix Table 3 markdown label from "(ordinal)" to "(interval)"
- LaTeX label was already correct at line 372

## Changes

- `src/scylla/analysis/stats.py`: Removed lines 184-297, replaced with 10-line wrapper
- `src/scylla/analysis/tables.py:344`: Fixed label "(ordinal)" → "(interval)"
- `pixi.toml`, `pyproject.toml`: Added `krippendorff>=0.6.0` dependency

## Verification

After regenerating Table 3, verify alpha value against direct package call:

```python
import krippendorff
import numpy as np

# Sample judge ratings
ratings = judge_pivot[["judge_1", "judge_2", "judge_3"]].values.T
alpha = krippendorff.alpha(reliability_data=ratings, level_of_measurement="interval")
print(f"Alpha: {alpha:.3f}")
```

Closes #215