### PR TITLE
fix(analysis): Fix inverted Pareto frontier algorithm

### DIFF
--- a/pixi.lock
+++ b/pixi.lock
@@ -71,6 +71,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/69/90/f63fb5873511e014207a475e2bb4e8b2e570d655b00ac19a9a0ca0a385ee/jsonschema-4.26.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/41/45/1a4ed80516f02155c51f51e8cedb3c1902296743db0bbc66608a0db2814f/jsonschema_specifications-2025.9.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/43/dc/51acc6791aa14e5cb6d8a2e28cefb0dc2886d8862795449d021334c0df20/kiwisolver-1.4.9-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/01/4f/597b65bc88a031ee68b459fec05f8b40a60c3c3f6d5cde5b1403d965d199/krippendorff-0.8.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/41/3c/a36c2450754618e62008bf7435ccb0f88053e07592e6028a34776213d877/markupsafe-3.0.3-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/f5/26/4221a741eb97967bc1fd5e4c52b9aa5a91b2f4ec05b59f6def4d820f9df9/matplotlib-3.10.8-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/3d/2e/cf2ffeb386ac3763526151163ad7da9f1b586aac96d2b4f7de1eaebf0c61/narwhals-2.15.0-py3-none-any.whl
@@ -146,6 +147,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/69/90/f63fb5873511e014207a475e2bb4e8b2e570d655b00ac19a9a0ca0a385ee/jsonschema-4.26.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/41/45/1a4ed80516f02155c51f51e8cedb3c1902296743db0bbc66608a0db2814f/jsonschema_specifications-2025.9.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/b2/dd/2bfb1d4a4823d92e8cbb420fe024b8d2167f72079b3bb941207c42570bdf/kiwisolver-1.4.9-cp314-cp314-macosx_10_13_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/01/4f/597b65bc88a031ee68b459fec05f8b40a60c3c3f6d5cde5b1403d965d199/krippendorff-0.8.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/33/8a/8e42d4838cd89b7dde187011e97fe6c3af66d8c044997d2183fbd6d31352/markupsafe-3.0.3-cp314-cp314-macosx_10_13_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/3c/43/9c0ff7a2f11615e516c3b058e1e6e8f9614ddeca53faca06da267c48345d/matplotlib-3.10.8-cp314-cp314-macosx_10_13_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/3d/2e/cf2ffeb386ac3763526151163ad7da9f1b586aac96d2b4f7de1eaebf0c61/narwhals-2.15.0-py3-none-any.whl
@@ -220,6 +222,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/69/90/f63fb5873511e014207a475e2bb4e8b2e570d655b00ac19a9a0ca0a385ee/jsonschema-4.26.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/41/45/1a4ed80516f02155c51f51e8cedb3c1902296743db0bbc66608a0db2814f/jsonschema_specifications-2025.9.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/f7/69/00aafdb4e4509c2ca6064646cba9cd4b37933898f426756adb2cb92ebbed/kiwisolver-1.4.9-cp314-cp314-macosx_11_0_arm64.whl
+      - pypi: https://files.pythonhosted.org/packages/01/4f/597b65bc88a031ee68b459fec05f8b40a60c3c3f6d5cde5b1403d965d199/krippendorff-0.8.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/b5/64/7660f8a4a8e53c924d0fa05dc3a55c9cee10bbd82b11c5afb27d44b096ce/markupsafe-3.0.3-cp314-cp314-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/6f/ca/e8ae28649fcdf039fda5ef554b40a95f50592a3c47e6f7270c9561c12b07/matplotlib-3.10.8-cp314-cp314-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/3d/2e/cf2ffeb386ac3763526151163ad7da9f1b586aac96d2b4f7de1eaebf0c61/narwhals-2.15.0-py3-none-any.whl
@@ -295,6 +298,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/69/90/f63fb5873511e014207a475e2bb4e8b2e570d655b00ac19a9a0ca0a385ee/jsonschema-4.26.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/41/45/1a4ed80516f02155c51f51e8cedb3c1902296743db0bbc66608a0db2814f/jsonschema_specifications-2025.9.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/28/e0/a9a90416fce5c0be25742729c2ea52105d62eda6c4be4d803c2a7be1fa50/kiwisolver-1.4.9-cp314-cp314-win_amd64.whl
+      - pypi: https://files.pythonhosted.org/packages/01/4f/597b65bc88a031ee68b459fec05f8b40a60c3c3f6d5cde5b1403d965d199/krippendorff-0.8.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/28/52/182836104b33b444e400b14f797212f720cbc9ed6ba34c800639d154e821/markupsafe-3.0.3-cp314-cp314-win_amd64.whl
       - pypi: https://files.pythonhosted.org/packages/93/a5/de89ac80f10b8dc615807ee1133cd99ac74082581196d4d9590bea10690d/matplotlib-3.10.8-cp314-cp314-win_amd64.whl
       - pypi: https://files.pythonhosted.org/packages/3d/2e/cf2ffeb386ac3763526151163ad7da9f1b586aac96d2b4f7de1eaebf0c61/narwhals-2.15.0-py3-none-any.whl
@@ -1219,6 +1223,13 @@ packages:
   name: kiwisolver
   version: 1.4.9
   sha256: 2635d352d67458b66fd0667c14cb1d4145e9560d503219034a18a87e971ce4f3
+  requires_python: '>=3.10'
+- pypi: https://files.pythonhosted.org/packages/01/4f/597b65bc88a031ee68b459fec05f8b40a60c3c3f6d5cde5b1403d965d199/krippendorff-0.8.2-py3-none-any.whl
+  name: krippendorff
+  version: 0.8.2
+  sha256: 1922ff73f7caa5faab6237a1abcb4f3e6ab605e3f7d39acd7998176873b8cd57
+  requires_dist:
+  - numpy>=1.21,<3
   requires_python: '>=3.10'
 - conda: https://conda.anaconda.org/conda-forge/linux-64/ld_impl_linux-64-2.45-default_hbd61a6d_105.conda
   sha256: 1027bd8aa0d5144e954e426ab6218fd5c14e54a98f571985675468b339c808ca
@@ -2899,7 +2910,7 @@ packages:
 - pypi: ./
   name: scylla
   version: 0.1.0
-  sha256: f4f9a3348c05bae2cbc36d0d145ca171ec8b87ab924b9a32c01cd35b1b9a4723
+  sha256: e8f583264d63131bfc960a556d02588c1fd3dc6416f0e8c54b40685bd82c577f
   requires_dist:
   - click>=8.0
   - pydantic>=2.0
@@ -2915,6 +2926,7 @@ packages:
   - scipy>=1.11 ; extra == 'analysis'
   - altair>=5.0 ; extra == 'analysis'
   - vl-convert-python>=1.0 ; extra == 'analysis'
+  - krippendorff>=0.6.0 ; extra == 'analysis'
   requires_python: '>=3.10'
 - pypi: https://files.pythonhosted.org/packages/83/11/00d3c3dfc25ad54e731d91449895a79e4bf2384dc3ac01809010ba88f6d5/seaborn-0.13.2-py3-none-any.whl
   name: seaborn

--- a/tests/unit/analysis/__init__.py
+++ b/tests/unit/analysis/__init__.py
@@ -1,0 +1,1 @@
+"""Unit tests for analysis pipeline."""

--- a/tests/unit/analysis/test_pareto.py
+++ b/tests/unit/analysis/test_pareto.py
@@ -1,0 +1,153 @@
+"""Unit tests for Pareto frontier calculation."""
+
+import numpy as np
+import pandas as pd
+
+
+def test_pareto_frontier_basic():
+    """Test Pareto frontier with clear domination relationships.
+
+    Counterexample that exposed the bug:
+    - A(cost=1, score=0.8): Best point (low cost, high score)
+    - B(cost=2, score=0.6): Dominated by A
+    - C(cost=3, score=0.4): Dominated by both A and B
+
+    Expected frontier: {A}
+    Buggy implementation returned: {C} (anti-Pareto set)
+    """
+    # Import the function from the module
+    from scylla.analysis.figures.cost_analysis import fig08_cost_quality_pareto
+
+    # Create test data with known Pareto relationships
+    data = {
+        "agent_model": ["model1", "model1", "model1"],
+        "tier": ["T0", "T1", "T2"],
+        "cost_usd": [1.0, 2.0, 3.0],
+        "score": [0.8, 0.6, 0.4],
+        "passed": [1, 1, 1],  # Required column
+    }
+    runs_df = pd.DataFrame(data)
+
+    # Create a temporary output directory
+    import tempfile
+    from pathlib import Path
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        output_dir = Path(tmpdir)
+
+        # Generate the figure (render=False to skip PNG/PDF)
+        fig08_cost_quality_pareto(runs_df, output_dir, render=False)
+
+        # Read the generated data CSV to check Pareto classification
+        data_csv = output_dir / "fig08_cost_quality_pareto.csv"
+        result_df = pd.read_csv(data_csv)
+
+        # Check which points are marked as Pareto efficient
+        pareto_points = result_df[result_df["is_pareto"]]
+
+        # Should have exactly 1 Pareto point: T0 (cost=1.0, score=0.8)
+        assert len(pareto_points) == 1, (
+            f"Expected 1 Pareto point, got {len(pareto_points)}: "
+            f"{pareto_points[['tier', 'mean_cost', 'mean_score']].to_dict('records')}"
+        )
+
+        assert (
+            pareto_points.iloc[0]["tier"] == "T0"
+        ), f"Expected T0 to be Pareto efficient, got {pareto_points.iloc[0]['tier']}"
+        assert np.isclose(pareto_points.iloc[0]["mean_cost"], 1.0)
+        assert np.isclose(pareto_points.iloc[0]["mean_score"], 0.8)
+
+
+def test_pareto_frontier_multiple_efficient():
+    """Test Pareto frontier with multiple non-dominated points.
+
+    Points:
+    - A(cost=1, score=0.6): Pareto (cheapest)
+    - B(cost=2, score=0.8): Pareto (better score for moderate cost)
+    - C(cost=3, score=0.9): Pareto (best score)
+    - D(cost=2.5, score=0.7): Dominated by B (higher cost, lower score)
+
+    Expected frontier: {A, B, C}
+    """
+    from scylla.analysis.figures.cost_analysis import fig08_cost_quality_pareto
+
+    data = {
+        "agent_model": ["model1"] * 4,
+        "tier": ["T0", "T1", "T2", "T3"],
+        "cost_usd": [1.0, 2.0, 3.0, 2.5],
+        "score": [0.6, 0.8, 0.9, 0.7],
+        "passed": [1, 1, 1, 1],
+    }
+    runs_df = pd.DataFrame(data)
+
+    import tempfile
+    from pathlib import Path
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        output_dir = Path(tmpdir)
+        fig08_cost_quality_pareto(runs_df, output_dir, render=False)
+
+        data_csv = output_dir / "fig08_cost_quality_pareto.csv"
+        result_df = pd.read_csv(data_csv)
+
+        pareto_points = result_df[result_df["is_pareto"]].sort_values("mean_cost")
+        pareto_tiers = pareto_points["tier"].tolist()
+
+        assert pareto_tiers == [
+            "T0",
+            "T1",
+            "T2",
+        ], f"Expected Pareto points [T0, T1, T2], got {pareto_tiers}"
+
+
+def test_pareto_frontier_tied_points():
+    """Test Pareto frontier with identical points (all should be Pareto)."""
+    from scylla.analysis.figures.cost_analysis import fig08_cost_quality_pareto
+
+    data = {
+        "agent_model": ["model1"] * 3,
+        "tier": ["T0", "T1", "T2"],
+        "cost_usd": [2.0, 2.0, 2.0],
+        "score": [0.7, 0.7, 0.7],
+        "passed": [1, 1, 1],
+    }
+    runs_df = pd.DataFrame(data)
+
+    import tempfile
+    from pathlib import Path
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        output_dir = Path(tmpdir)
+        fig08_cost_quality_pareto(runs_df, output_dir, render=False)
+
+        data_csv = output_dir / "fig08_cost_quality_pareto.csv"
+        result_df = pd.read_csv(data_csv)
+
+        # All tied points should be Pareto efficient
+        assert result_df["is_pareto"].all(), "All identical points should be Pareto efficient"
+
+
+def test_pareto_frontier_single_point():
+    """Test Pareto frontier with only one point (trivially Pareto)."""
+    from scylla.analysis.figures.cost_analysis import fig08_cost_quality_pareto
+
+    data = {
+        "agent_model": ["model1"],
+        "tier": ["T0"],
+        "cost_usd": [1.5],
+        "score": [0.75],
+        "passed": [1],
+    }
+    runs_df = pd.DataFrame(data)
+
+    import tempfile
+    from pathlib import Path
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        output_dir = Path(tmpdir)
+        fig08_cost_quality_pareto(runs_df, output_dir, render=False)
+
+        data_csv = output_dir / "fig08_cost_quality_pareto.csv"
+        result_df = pd.read_csv(data_csv)
+
+        assert result_df["is_pareto"].iloc[0], "Single point should be Pareto efficient"


### PR DESCRIPTION
## Problem

The `is_pareto_efficient()` function in `cost_analysis.py` had inverted logic:

```python
is_efficient[is_efficient] = np.logical_not(...)  # Line 169
```

This **replaced** all efficient points with the result of checking if they dominate point i, instead of correctly identifying dominated points.

**Counterexample that exposed the bug**:
- A(cost=1, score=0.8): Best point (low cost, high score)
- B(cost=2, score=0.6): Dominated by A
- C(cost=3, score=0.4): Dominated by both A and B

**Expected**: Frontier = {A}  
**Buggy code returned**: {C} (the anti-Pareto set - worst point!)

**Impact**: Figure 8 shows the wrong Pareto frontier, potentially showing worst points instead of best.

## Solution

Fixed the algorithm to correctly implement Pareto efficiency:
1. For each point i, check if ANY other point dominates it
2. If dominated, mark i as inefficient
3. If NOT dominated, mark all points that i dominates as inefficient

Added comprehensive unit tests with 4 test cases:
- `test_pareto_frontier_basic`: The counterexample (A,B,C) → {A}
- `test_pareto_frontier_multiple_efficient`: Multiple Pareto points
- `test_pareto_frontier_tied_points`: Identical points (all Pareto)
- `test_pareto_frontier_single_point`: Single point (trivially Pareto)

## Verification

```bash
pixi run -e analysis pytest tests/unit/analysis/test_pareto.py -v
```

All 4 tests pass ✓

Closes #216