### PR TITLE
fix(analysis): Guard fig11_tier_uplift against missing T0 data

### DIFF
--- a/src/scylla/analysis/figures/model_comparison.py
+++ b/src/scylla/analysis/figures/model_comparison.py
@@ -40,7 +40,13 @@ def fig11_tier_uplift(runs_df: pd.DataFrame, output_dir: Path, render: bool = Tr
     uplift_data = []
     for model in tier_stats["agent_model"].unique():
         model_data = tier_stats[tier_stats["agent_model"] == model]
-        t0_pass_rate = model_data[model_data["tier"] == "T0"]["pass_rate"].iloc[0]
+        t0_data = model_data[model_data["tier"] == "T0"]["pass_rate"]
+
+        # Skip model if no T0 baseline data
+        if len(t0_data) == 0:
+            continue
+
+        t0_pass_rate = t0_data.iloc[0]
 
         for _, row in model_data.iterrows():
             tier = row["tier"]


### PR DESCRIPTION
## Problem

`fig11_tier_uplift` uses `iloc[0]` without checking if T0 data exists:

```python
t0_pass_rate = model_data[model_data["tier"] == "T0"]["pass_rate"].iloc[0]
```

**Impact**: Unhandled `IndexError` crash if any model has no T0 baseline runs.

## Solution

- Check length of T0 data before accessing `iloc[0]`
- Skip model if no T0 baseline exists (allows other models to render)
- Prevents crash while gracefully handling missing data

## Changes

`src/scylla/analysis/figures/model_comparison.py:39-43`:
```python
t0_data = model_data[model_data["tier"] == "T0"]["pass_rate"]

# Skip model if no T0 baseline data
if len(t0_data) == 0:
    continue

t0_pass_rate = t0_data.iloc[0]
```

Closes #217