### PR TITLE
test(analysis): Add test coverage and fix fixture schema mismatches

### DIFF
--- a/tests/unit/analysis/conftest.py
+++ b/tests/unit/analysis/conftest.py
@@ -40,19 +40,24 @@ def sample_runs_df():
                         else np.random.choice(["C", "D", "F"])
                     )
                     cost = np.random.uniform(0.01, 0.1)
-                    tokens_in = np.random.randint(1000, 10000)
-                    tokens_out = np.random.randint(500, 5000)
-                    latency = np.random.uniform(5.0, 30.0)
+
+                    # Token stats matching production schema
+                    input_tokens = np.random.randint(1000, 10000)
+                    output_tokens = np.random.randint(500, 5000)
+                    cache_creation_tokens = np.random.randint(0, 2000)
+                    cache_read_tokens = np.random.randint(0, 5000)
+                    total_tokens = (
+                        input_tokens + output_tokens + cache_creation_tokens + cache_read_tokens
+                    )
+
+                    # Duration stats matching production schema
+                    agent_duration = np.random.uniform(5.0, 25.0)
+                    judge_duration = np.random.uniform(1.0, 5.0)
+                    duration_seconds = agent_duration + judge_duration
 
                     # Calculate CoP and consistency for completeness
                     consistency = 1 - (np.random.uniform(0.05, 0.15) / score) if score > 0 else 0
                     consistency = max(0.0, min(1.0, consistency))
-
-                    # Total tokens for model_comparison
-                    total_tokens = tokens_in + tokens_out
-
-                    # Duration (alias for latency for compatibility)
-                    duration_seconds = latency
 
                     data.append(
                         {
@@ -65,12 +70,16 @@ def sample_runs_df():
                             "score": score,
                             "grade": grade,
                             "cost_usd": cost,
-                            "tokens_in": tokens_in,
-                            "tokens_out": tokens_out,
+                            "input_tokens": input_tokens,
+                            "output_tokens": output_tokens,
+                            "cache_creation_tokens": cache_creation_tokens,
+                            "cache_read_tokens": cache_read_tokens,
                             "total_tokens": total_tokens,
-                            "latency_seconds": latency,
                             "duration_seconds": duration_seconds,
+                            "agent_duration_seconds": agent_duration,
+                            "judge_duration_seconds": judge_duration,
                             "consistency": consistency,
+                            "exit_code": 0,
                         }
                     )
 
@@ -179,8 +188,9 @@ def sample_subtests_df(sample_runs_df):
                 "passed": "mean",
                 "score": ["mean", "std"],
                 "cost_usd": ["mean", "std"],
-                "tokens_in": "sum",
-                "tokens_out": "sum",
+                "input_tokens": "sum",
+                "output_tokens": "sum",
+                "total_tokens": "sum",
             }
         )
         .reset_index()
@@ -197,8 +207,9 @@ def sample_subtests_df(sample_runs_df):
         "std_score",
         "mean_cost",
         "std_cost",
-        "total_tokens_in",
-        "total_tokens_out",
+        "total_input_tokens",
+        "total_output_tokens",
+        "total_tokens",
     ]
 
     return aggregated

--- a/tests/unit/analysis/test_dataframes.py
+++ b/tests/unit/analysis/test_dataframes.py
@@ -17,9 +17,15 @@ def test_build_runs_df_structure(sample_runs_df):
         "score",
         "grade",
         "cost_usd",
-        "tokens_in",
-        "tokens_out",
-        "latency_seconds",
+        "input_tokens",
+        "output_tokens",
+        "cache_creation_tokens",
+        "cache_read_tokens",
+        "total_tokens",
+        "duration_seconds",
+        "agent_duration_seconds",
+        "judge_duration_seconds",
+        "exit_code",
     ]
 
     for col in required_cols:
@@ -44,9 +50,11 @@ def test_build_runs_df_values(sample_runs_df):
     # Cost should be positive
     assert (sample_runs_df["cost_usd"] > 0).all()
 
-    # Tokens should be positive integers
-    assert (sample_runs_df["tokens_in"] > 0).all()
-    assert (sample_runs_df["tokens_out"] > 0).all()
+    # Tokens should be positive integers (or zero for cache tokens)
+    assert (sample_runs_df["input_tokens"] > 0).all()
+    assert (sample_runs_df["output_tokens"] > 0).all()
+    assert (sample_runs_df["cache_creation_tokens"] >= 0).all()
+    assert (sample_runs_df["cache_read_tokens"] >= 0).all()
 
 
 def test_build_judges_df_structure(sample_judges_df):

--- a/tests/unit/analysis/test_figures.py
+++ b/tests/unit/analysis/test_figures.py
@@ -49,6 +49,129 @@ def test_fig11_tier_uplift(sample_runs_df, mock_save_figure):
     assert mock_save_figure.called
 
 
+def test_fig02_judge_variance(sample_judges_df, mock_save_figure):
+    """Test Fig 2 generates without errors."""
+    from scylla.analysis.figures.judge_analysis import fig02_judge_variance
+
+    fig02_judge_variance(sample_judges_df, Path("/tmp"), render=False)
+    assert mock_save_figure.called
+
+
+def test_fig03_failure_rate_by_tier(sample_runs_df):
+    """Test Fig 3 generates without errors."""
+    from scylla.analysis.figures.variance import fig03_failure_rate_by_tier
+
+    with patch("scylla.analysis.figures.variance.save_figure") as mock:
+        fig03_failure_rate_by_tier(sample_runs_df, Path("/tmp"), render=False)
+        assert mock.called
+
+
+def test_fig05_grade_heatmap(sample_runs_df):
+    """Test Fig 5 generates without errors."""
+    from scylla.analysis.figures.tier_performance import fig05_grade_heatmap
+
+    with patch("scylla.analysis.figures.tier_performance.save_figure") as mock:
+        fig05_grade_heatmap(sample_runs_df, Path("/tmp"), render=False)
+        assert mock.called
+
+
+def test_fig07_token_distribution(sample_runs_df, mock_save_figure):
+    """Test Fig 7 generates without errors."""
+    from scylla.analysis.figures.token_analysis import fig07_token_distribution
+
+    fig07_token_distribution(sample_runs_df, Path("/tmp"), render=False)
+    assert mock_save_figure.called
+
+
+def test_fig08_cost_quality_pareto(sample_runs_df):
+    """Test Fig 8 generates without errors."""
+    from scylla.analysis.figures.cost_analysis import fig08_cost_quality_pareto
+
+    with patch("scylla.analysis.figures.cost_analysis.save_figure") as mock:
+        fig08_cost_quality_pareto(sample_runs_df, Path("/tmp"), render=False)
+        assert mock.called
+
+
+def test_fig09_criteria_by_tier(sample_criteria_df, mock_save_figure):
+    """Test Fig 9 generates without errors."""
+    from scylla.analysis.figures.criteria_analysis import fig09_criteria_by_tier
+
+    fig09_criteria_by_tier(sample_criteria_df, Path("/tmp"), render=False)
+    assert mock_save_figure.called
+
+
+def test_fig10_score_violin(sample_runs_df):
+    """Test Fig 10 generates without errors."""
+    from scylla.analysis.figures.tier_performance import fig10_score_violin
+
+    with patch("scylla.analysis.figures.tier_performance.save_figure") as mock:
+        fig10_score_violin(sample_runs_df, Path("/tmp"), render=False)
+        assert mock.called
+
+
+def test_fig12_consistency(sample_runs_df):
+    """Test Fig 12 generates without errors."""
+    from scylla.analysis.figures.model_comparison import fig12_consistency
+
+    with patch("scylla.analysis.figures.model_comparison.save_figure") as mock:
+        fig12_consistency(sample_runs_df, Path("/tmp"), render=False)
+        assert mock.called
+
+
+def test_fig13_latency(sample_runs_df):
+    """Test Fig 13 generates without errors."""
+    from scylla.analysis.figures.subtest_detail import fig13_latency
+
+    with patch("scylla.analysis.figures.subtest_detail.save_figure") as mock:
+        fig13_latency(sample_runs_df, Path("/tmp"), render=False)
+        assert mock.called
+
+
+def test_fig14_judge_agreement(sample_judges_df):
+    """Test Fig 14 generates without errors."""
+    from scylla.analysis.figures.judge_analysis import fig14_judge_agreement
+
+    with patch("scylla.analysis.figures.judge_analysis.save_figure") as mock:
+        fig14_judge_agreement(sample_judges_df, Path("/tmp"), render=False)
+        assert mock.called
+
+
+def test_fig15_subtest_heatmap(sample_runs_df):
+    """Test Fig 15 generates without errors."""
+    from scylla.analysis.figures.subtest_detail import fig15_subtest_heatmap
+
+    with patch("scylla.analysis.figures.subtest_detail.save_figure") as mock:
+        fig15_subtest_heatmap(sample_runs_df, Path("/tmp"), render=False)
+        assert mock.called
+
+
+def test_fig16_success_variance_by_test(sample_runs_df):
+    """Test Fig 16 generates without errors."""
+    from scylla.analysis.figures.variance import fig16_success_variance_by_test
+
+    with patch("scylla.analysis.figures.variance.save_figure") as mock:
+        fig16_success_variance_by_test(sample_runs_df, Path("/tmp"), render=False)
+        assert mock.called
+
+
+def test_fig17_judge_variance_overall(sample_judges_df):
+    """Test Fig 17 generates without errors."""
+    from scylla.analysis.figures.judge_analysis import fig17_judge_variance_overall
+
+    with patch("scylla.analysis.figures.judge_analysis.save_figure") as mock:
+        fig17_judge_variance_overall(sample_judges_df, Path("/tmp"), render=False)
+        assert mock.called
+
+
+def test_fig18_failure_rate_by_test(sample_runs_df):
+    """Test Fig 18 generates without errors."""
+    from scylla.analysis.figures.variance import fig18_failure_rate_by_test
+
+    with patch("scylla.analysis.figures.variance.save_figure") as mock:
+        fig18_failure_rate_by_test(sample_runs_df, Path("/tmp"), render=False)
+        assert mock.called
+
+
 def test_publication_theme():
     """Test publication theme is applied correctly."""
     from scylla.analysis.figures.spec_builder import apply_publication_theme


### PR DESCRIPTION
## Summary

Phase 3: P2 Test Coverage improvements

### 1. Fix Fixture Schema Mismatches (`conftest.py`)

**Problem:**
- Test fixtures used `tokens_in`, `tokens_out`, `latency_seconds`
- Production code expects `input_tokens`, `output_tokens`, `duration_seconds`, etc.
- Missing columns: `cache_creation_tokens`, `cache_read_tokens`, `agent_duration_seconds`, `judge_duration_seconds`, `exit_code`

**Fix:**
- Updated `sample_runs_df` fixture to match production schema from `build_runs_df()`
- Updated `sample_subtests_df` to use correct column names
- All test fixtures now match production data structure

### 2. Add Smoke Tests for 14 Missing Figures

**Problem:**
- Only 4 of 18 figures had tests (22% coverage)
- Missing: fig02, fig03, fig05, fig07-fig10, fig12-fig18

**Fix:**
- Added smoke tests for all 14 missing figures
- Each test verifies figure generates without errors
- Proper mocking to avoid file I/O during tests
- Coverage: 18/18 figures (100%)

### 3. Update Existing Dataframe Tests

**Problem:**
- `test_build_runs_df_structure` expected old column names
- `test_build_runs_df_values` validated old columns

**Fix:**
- Updated to expect production column names
- Added validation for cache tokens >= 0

## Test Coverage Improvements

**Before:**
- Figures: 4/18 tested (22%)
- Fixture schema: Mismatched production

**After:**
- Figures: 18/18 tested (100%)
- Fixture schema: Matches production
- All 65 tests pass

## Verification

```bash
# Run tests
pixi run -e analysis pytest tests/unit/analysis/ -v
# 65 passed, 3 skipped

# Run linting
pre-commit run --all-files
```

## Related Issues

Part of analysis pipeline code review (Phase 3: P2 Test Coverage).

Depends on: #270 (P1 fixes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)