### PR TITLE
feat(analysis): Add three new tables for paper-quality output (WP2)

### DIFF
--- a/scripts/generate_tables.py
+++ b/scripts/generate_tables.py
@@ -27,6 +27,9 @@ from scylla.analysis.tables import (
     table05_cost_analysis,
     table06_model_comparison,
     table07_subtest_detail,
+    table08_summary_statistics,
+    table09_experiment_config,
+    table10_normality_tests,
 )
 
 
@@ -106,6 +109,9 @@ def main() -> None:
             "tab07_subtest_detail",
             lambda: table07_subtest_detail(runs_df, subtests_df),
         ),
+        ("Table 8", "tab08_summary_statistics", lambda: table08_summary_statistics(runs_df)),
+        ("Table 9", "tab09_experiment_config", lambda: table09_experiment_config(runs_df)),
+        ("Table 10", "tab10_normality_tests", lambda: table10_normality_tests(runs_df)),
     ]
 
     success_count = 0
@@ -125,7 +131,7 @@ def main() -> None:
 
     # Summary
     print(f"\n{'='*70}")
-    print(f"Summary: {success_count}/7 tables generated successfully")
+    print(f"Summary: {success_count}/{len(tables)} tables generated successfully")
     if failed:
         print(f"\nFailed tables ({len(failed)}):")
         for table_name, error in failed:

--- a/tests/unit/analysis/test_tables.py
+++ b/tests/unit/analysis/test_tables.py
@@ -43,6 +43,9 @@ def test_table_function_signatures():
         "table05_cost_analysis",
         "table06_model_comparison",
         "table07_subtest_detail",
+        "table08_summary_statistics",
+        "table09_experiment_config",
+        "table10_normality_tests",
     ]
 
     for func_name in table_functions:
@@ -129,3 +132,96 @@ def test_table01_uses_compute_cop():
 
     # Verify that inf appears in output (compute_cop returns inf for zero pass rate)
     assert "inf" in markdown.lower() or "∞" in markdown
+
+
+def test_table08_summary_statistics():
+    """Test Table 8 summary statistics smoke test."""
+    import pandas as pd
+
+    from scylla.analysis.tables import table08_summary_statistics
+
+    # Create minimal test data
+    test_data = pd.DataFrame(
+        {
+            "agent_model": ["Sonnet 4.5"] * 20,
+            "tier": ["T0"] * 20,
+            "score": [0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0] * 2,
+            "cost_usd": [1.0, 1.5, 2.0, 2.5, 3.0] * 4,
+            "duration_seconds": [10, 20, 30, 40, 50] * 4,
+            "total_tokens": [1000, 2000, 3000, 4000, 5000] * 4,
+        }
+    )
+
+    markdown, latex = table08_summary_statistics(test_data)
+
+    # Verify tables generated
+    assert isinstance(markdown, str)
+    assert isinstance(latex, str)
+    assert len(markdown) > 0
+    assert len(latex) > 0
+
+    # Verify contains statistics headers
+    assert "Mean" in markdown
+    assert "Median" in markdown
+    assert "Skew" in markdown
+    assert "Kurt" in markdown
+
+
+def test_table09_experiment_config():
+    """Test Table 9 experiment configuration smoke test."""
+    import pandas as pd
+
+    from scylla.analysis.tables import table09_experiment_config
+
+    # Create minimal test data
+    test_data = pd.DataFrame(
+        {
+            "agent_model": ["Sonnet 4.5"] * 10,
+            "tier": ["T0"] * 5 + ["T1"] * 5,
+            "subtest": ["test1", "test2", "test1", "test2", "test1"] * 2,
+        }
+    )
+
+    markdown, latex = table09_experiment_config(test_data)
+
+    # Verify tables generated
+    assert isinstance(markdown, str)
+    assert isinstance(latex, str)
+    assert len(markdown) > 0
+    assert len(latex) > 0
+
+    # Verify contains configuration headers
+    assert "Agent Models" in markdown
+    assert "Tiers" in markdown
+    assert "Total Runs" in markdown
+
+
+def test_table10_normality_tests():
+    """Test Table 10 normality tests smoke test."""
+    import pandas as pd
+
+    from scylla.analysis.tables import table10_normality_tests
+
+    # Create test data with sufficient samples for Shapiro-Wilk (need N >= 3)
+    test_data = pd.DataFrame(
+        {
+            "agent_model": ["Sonnet 4.5"] * 10,
+            "tier": ["T0"] * 10,
+            "score": [0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0],
+            "cost_usd": [1.0, 1.5, 2.0, 2.5, 3.0, 3.5, 4.0, 4.5, 5.0, 5.5],
+        }
+    )
+
+    markdown, latex = table10_normality_tests(test_data)
+
+    # Verify tables generated
+    assert isinstance(markdown, str)
+    assert isinstance(latex, str)
+    assert len(markdown) > 0
+    assert len(latex) > 0
+
+    # Verify contains normality test headers
+    assert "Shapiro-Wilk" in markdown
+    assert "Normal?" in markdown
+    assert "W" in markdown
+    assert "p-value" in markdown


### PR DESCRIPTION
## Summary
Implements Work Package 2: New Tables from the analysis pipeline enhancement plan.

Adds three essential tables for paper-quality analysis: summary statistics, experiment configuration, and normality tests.

## Changes

### WP2.1: table08_summary_statistics
Comprehensive descriptive statistics for all key metrics:
- **Statistics**: N, Mean, Median, Min, Max, Q1, Q3, StdDev, Skewness, Kurtosis
- **Metrics**: score, cost_usd, duration_seconds, total_tokens
- **Grouping**: Per (agent_model, metric)
- Uses `scipy.stats.skew()` and `scipy.stats.kurtosis()` for distribution shape

### WP2.2: table09_experiment_config
Data-derived experimental setup (no hardcoded values):
- **Configuration**: Agent models, tiers, tier IDs from actual data
- **Subtests/tier**: Min-max range derived from data
- **Runs/subtest**: Mode of run counts across all subtests
- **Other**: Total runs, judge models
- Supports multi-experiment datasets via `experiment` column

### WP2.3: table10_normality_tests
Shapiro-Wilk normality tests justifying statistical test choices:
- **Tests**: score and cost_usd distributions per (model, tier)
- **Results**: W statistic, p-value, Normal? (α=0.05)
- **Summary**: Reports X/Y (Z%) distributions that pass normality
- **Requirements**: N >= 3 samples per group

### WP2.4: Registration
- Updated `scripts/generate_tables.py` to generate tables 8-10
- Added smoke tests to `tests/unit/analysis/test_tables.py`
- Updated `__all__` exports in `src/scylla/analysis/tables.py`

## Test Plan
```bash
# Run table tests
pixi run -e analysis pytest tests/unit/analysis/test_tables.py -v

# Generate tables against real data
pixi run -e analysis python scripts/generate_tables.py --data-dir ~/fullruns

# Verify outputs
ls docs/tables/tab{08,09,10}_{summary_statistics,experiment_config,normality_tests}.{md,tex}
```

## Test Results
**7 passed, 1 skipped, 2 warnings**
- ✓ `test_table08_summary_statistics` - Generates valid output with stats headers
- ✓ `test_table09_experiment_config` - Derives configuration from data
- ✓ `test_table10_normality_tests` - Runs Shapiro-Wilk on test data

## Dependencies
- **Depends on**: PR #273 (WP1 statistical functions)
- **Required by**: WP5 (enhanced exports), paper documentation

## References
- Plan: Enhancement plan for paper-quality analysis pipeline
- Statistical methodology: Standard descriptive statistics + normality testing

🤖 Generated with [Claude Code](https://claude.com/claude-code)