### PR TITLE
feat(analysis): Add 6 new figures for paper-quality analysis (WP3)

### DIFF
--- a/scripts/generate_figures.py
+++ b/scripts/generate_figures.py
@@ -18,8 +18,18 @@ from scylla.analysis import (
     build_runs_df,
     load_all_experiments,
 )
-from scylla.analysis.figures.cost_analysis import fig06_cop_by_tier, fig08_cost_quality_pareto
+from scylla.analysis.figures.correlation import (
+    fig20_metric_correlation_heatmap,
+    fig21_cost_quality_regression,
+)
+from scylla.analysis.figures.cost_analysis import (
+    fig06_cop_by_tier,
+    fig08_cost_quality_pareto,
+    fig22_cumulative_cost,
+)
 from scylla.analysis.figures.criteria_analysis import fig09_criteria_by_tier
+from scylla.analysis.figures.diagnostics import fig23_qq_plots, fig24_score_histograms
+from scylla.analysis.figures.effect_size import fig19_effect_size_forest
 from scylla.analysis.figures.judge_analysis import (
     fig02_judge_variance,
     fig14_judge_agreement,
@@ -61,6 +71,12 @@ FIGURES = {
     "fig16_success_variance_by_test": ("variance", fig16_success_variance_by_test),
     "fig17_judge_variance_overall": ("judge", fig17_judge_variance_overall),
     "fig18_failure_rate_by_test": ("variance", fig18_failure_rate_by_test),
+    "fig19_effect_size_forest": ("effect_size", fig19_effect_size_forest),
+    "fig20_metric_correlation_heatmap": ("correlation", fig20_metric_correlation_heatmap),
+    "fig21_cost_quality_regression": ("correlation", fig21_cost_quality_regression),
+    "fig22_cumulative_cost": ("cost", fig22_cumulative_cost),
+    "fig23_qq_plots": ("diagnostics", fig23_qq_plots),
+    "fig24_score_histograms": ("diagnostics", fig24_score_histograms),
 }
 
 
@@ -159,7 +175,17 @@ def main() -> None:
 
         try:
             # Determine which DataFrame to pass
-            if category in ("variance", "tier", "cost", "token", "model", "subtest"):
+            if category in (
+                "variance",
+                "tier",
+                "cost",
+                "token",
+                "model",
+                "subtest",
+                "effect_size",
+                "correlation",
+                "diagnostics",
+            ):
                 generator_func(runs_df, output_dir, render=render)
             elif category == "judge":
                 generator_func(judges_df, output_dir, render=render)

--- a/src/scylla/analysis/figures/correlation.py
+++ b/src/scylla/analysis/figures/correlation.py
@@ -1,0 +1,269 @@
+"""Correlation analysis figures.
+
+Generates Fig 20 (metric correlation heatmap) and Fig 21 (cost vs quality regression).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import altair as alt
+import pandas as pd
+
+from scylla.analysis.figures import get_color_scale
+from scylla.analysis.figures.spec_builder import save_figure
+from scylla.analysis.stats import ols_regression, spearman_correlation
+
+
+def fig20_metric_correlation_heatmap(
+    runs_df: pd.DataFrame, output_dir: Path, render: bool = True
+) -> None:
+    """Generate Fig 20: Metric Correlation Heatmap.
+
+    Spearman correlation heatmap of score, cost, tokens, duration.
+    Annotated with coefficients. Faceted by model.
+
+    Args:
+        runs_df: Runs DataFrame
+        output_dir: Output directory
+        render: Whether to render to PNG/PDF
+
+    """
+    metrics = {
+        "score": "Score",
+        "cost_usd": "Cost (USD)",
+        "total_tokens": "Total Tokens",
+        "duration_seconds": "Duration (s)",
+    }
+
+    # Compute correlations per model
+    correlations = []
+
+    for model in sorted(runs_df["agent_model"].unique()):
+        model_data = runs_df[runs_df["agent_model"] == model]
+
+        # Compute pairwise Spearman correlations
+        for metric1_col, metric1_name in metrics.items():
+            for metric2_col, metric2_name in metrics.items():
+                if metric1_col not in model_data.columns or metric2_col not in model_data.columns:
+                    continue
+
+                data1 = model_data[metric1_col].dropna()
+                data2 = model_data[metric2_col].dropna()
+
+                # Align on common indices
+                common_idx = data1.index.intersection(data2.index)
+                if len(common_idx) < 3:
+                    continue
+
+                rho, p_value = spearman_correlation(
+                    model_data.loc[common_idx, metric1_col],
+                    model_data.loc[common_idx, metric2_col],
+                )
+
+                correlations.append(
+                    {
+                        "agent_model": model,
+                        "metric1": metric1_name,
+                        "metric2": metric2_name,
+                        "rho": rho,
+                        "p_value": p_value,
+                        "label": f"{rho:.2f}",
+                    }
+                )
+
+    corr_df = pd.DataFrame(correlations)
+
+    # Create heatmap
+    heatmap = (
+        alt.Chart(corr_df)
+        .mark_rect()
+        .encode(
+            x=alt.X("metric1:O", title="", sort=list(metrics.values())),
+            y=alt.Y("metric2:O", title="", sort=list(metrics.values())),
+            color=alt.Color(
+                "rho:Q",
+                title="Spearman ρ",
+                scale=alt.Scale(domain=[-1, 1], scheme="redblue", reverse=True),
+            ),
+            tooltip=[
+                alt.Tooltip("metric1:O", title="Metric 1"),
+                alt.Tooltip("metric2:O", title="Metric 2"),
+                alt.Tooltip("rho:Q", title="Spearman ρ", format=".3f"),
+                alt.Tooltip("p_value:Q", title="p-value", format=".4f"),
+            ],
+        )
+    )
+
+    # Add text labels
+    text = (
+        alt.Chart(corr_df)
+        .mark_text(baseline="middle")
+        .encode(
+            x=alt.X("metric1:O", sort=list(metrics.values())),
+            y=alt.Y("metric2:O", sort=list(metrics.values())),
+            text="label:N",
+            color=alt.condition(
+                alt.datum.rho > 0.5,
+                alt.value("white"),
+                alt.value("black"),
+            ),
+        )
+    )
+
+    # Facet by model if multiple models
+    if corr_df["agent_model"].nunique() > 1:
+        chart = (
+            alt.layer(heatmap, text)
+            .facet(column=alt.Column("agent_model:N", title="Agent Model"))
+            .properties(title="Metric Correlation Heatmap (Spearman ρ)")
+            .configure_view(strokeWidth=0)
+        )
+    else:
+        chart = (
+            alt.layer(heatmap, text)
+            .properties(title="Metric Correlation Heatmap (Spearman ρ)")
+            .configure_view(strokeWidth=0)
+        )
+
+    save_figure(chart, "fig20_metric_correlation_heatmap", output_dir, corr_df, render)
+
+
+def fig21_cost_quality_regression(
+    runs_df: pd.DataFrame, output_dir: Path, render: bool = True
+) -> None:
+    """Generate Fig 21: Cost vs Quality Regression.
+
+    Scatter plot + OLS regression line with R² annotation.
+    Cost vs quality at subtest level.
+
+    Args:
+        runs_df: Runs DataFrame
+        output_dir: Output directory
+        render: Whether to render to PNG/PDF
+
+    """
+    # Aggregate to subtest level (mean cost, mean score)
+    subtest_stats = (
+        runs_df.groupby(["agent_model", "tier", "subtest"])
+        .agg({"cost_usd": "mean", "score": "mean"})
+        .reset_index()
+    )
+    subtest_stats.columns = ["agent_model", "tier", "subtest", "mean_cost", "mean_score"]
+
+    # Compute regression per model
+    regressions = []
+
+    for model in sorted(subtest_stats["agent_model"].unique()):
+        model_data = subtest_stats[subtest_stats["agent_model"] == model]
+
+        # OLS regression
+        result = ols_regression(model_data["mean_cost"], model_data["mean_score"])
+
+        regressions.append(
+            {
+                "agent_model": model,
+                "slope": result["slope"],
+                "intercept": result["intercept"],
+                "r_squared": result["r_squared"],
+                "p_value": result["p_value"],
+            }
+        )
+
+        # Generate regression line points
+        cost_range = model_data["mean_cost"]
+        x_min, x_max = cost_range.min(), cost_range.max()
+
+        for x in [x_min, x_max]:
+            y = result["slope"] * x + result["intercept"]
+            regressions.append(
+                {
+                    "agent_model": model,
+                    "x": x,
+                    "y": y,
+                    "type": "regression_line",
+                }
+            )
+
+    reg_df = pd.DataFrame(regressions)
+
+    # Get dynamic color scale for models
+    models = sorted(subtest_stats["agent_model"].unique())
+    domain, range_ = get_color_scale("models", models)
+
+    # Create scatter plot
+    scatter = (
+        alt.Chart(subtest_stats)
+        .mark_circle(size=60, opacity=0.6)
+        .encode(
+            x=alt.X("mean_cost:Q", title="Mean Cost per Subtest (USD)"),
+            y=alt.Y("mean_score:Q", title="Mean Score per Subtest", scale=alt.Scale(domain=[0, 1])),
+            color=alt.Color(
+                "agent_model:N",
+                title="Agent Model",
+                scale=alt.Scale(domain=domain, range=range_),
+            ),
+            tooltip=[
+                alt.Tooltip("agent_model:N", title="Model"),
+                alt.Tooltip("tier:O", title="Tier"),
+                alt.Tooltip("subtest:O", title="Subtest"),
+                alt.Tooltip("mean_cost:Q", title="Mean Cost", format="$.4f"),
+                alt.Tooltip("mean_score:Q", title="Mean Score", format=".3f"),
+            ],
+        )
+    )
+
+    # Add regression lines
+    reg_lines_df = reg_df[reg_df["type"] == "regression_line"].copy()
+
+    regression_lines = (
+        alt.Chart(reg_lines_df)
+        .mark_line(strokeWidth=2)
+        .encode(
+            x=alt.X("x:Q"),
+            y=alt.Y("y:Q"),
+            color=alt.Color(
+                "agent_model:N",
+                scale=alt.Scale(domain=domain, range=range_),
+            ),
+        )
+    )
+
+    # Add R² annotations
+    reg_stats_df = reg_df[reg_df["type"].isna()].copy()
+    reg_stats_df["annotation"] = reg_stats_df.apply(
+        lambda row: f"R² = {row['r_squared']:.3f}, p = {row['p_value']:.4f}", axis=1
+    )
+
+    # Position annotations at top-left of chart per model
+    annotations = (
+        alt.Chart(reg_stats_df)
+        .mark_text(align="left", dx=10, dy=10, fontSize=11)
+        .encode(
+            x=alt.value(10),
+            y=alt.value(10),
+            text="annotation:N",
+            color=alt.Color(
+                "agent_model:N",
+                scale=alt.Scale(domain=domain, range=range_),
+            ),
+        )
+    )
+
+    # Facet by model if multiple models
+    if subtest_stats["agent_model"].nunique() > 1:
+        # Need to combine data for layering
+        chart = (
+            alt.layer(scatter, regression_lines, annotations, data=subtest_stats)
+            .facet(row=alt.Row("agent_model:N", title="Agent Model"))
+            .properties(title="Cost vs Quality Regression (Subtest Level)")
+            .configure_view(strokeWidth=0)
+        )
+    else:
+        chart = (
+            alt.layer(scatter, regression_lines, annotations)
+            .properties(title="Cost vs Quality Regression (Subtest Level)")
+            .configure_view(strokeWidth=0)
+        )
+
+    save_figure(chart, "fig21_cost_quality_regression", output_dir, subtest_stats, render)

--- a/src/scylla/analysis/figures/diagnostics.py
+++ b/src/scylla/analysis/figures/diagnostics.py
@@ -1,0 +1,231 @@
+"""Diagnostic figures for distribution analysis.
+
+Generates Fig 23 (Q-Q plots) and Fig 24 (score histograms with KDE).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import altair as alt
+import numpy as np
+import pandas as pd
+from scipy import stats
+
+from scylla.analysis.figures import derive_tier_order, get_color_scale
+from scylla.analysis.figures.spec_builder import save_figure
+
+
+def fig23_qq_plots(runs_df: pd.DataFrame, output_dir: Path, render: bool = True) -> None:
+    """Generate Fig 23: Q-Q Plots (Quantile-Quantile).
+
+    Q-Q plots per (model, tier) to assess normality.
+    Compares theoretical quantiles (normal distribution) vs observed quantiles.
+    Points should fall on diagonal line if data is normally distributed.
+
+    Args:
+        runs_df: Runs DataFrame
+        output_dir: Output directory
+        render: Whether to render to PNG/PDF
+
+    """
+    tier_order = derive_tier_order(runs_df)
+
+    qq_data = []
+
+    for model in sorted(runs_df["agent_model"].unique()):
+        for tier in tier_order:
+            tier_data = runs_df[(runs_df["agent_model"] == model) & (runs_df["tier"] == tier)]
+
+            if len(tier_data) < 3:
+                continue
+
+            # Get score data
+            scores = tier_data["score"].dropna().values
+
+            if len(scores) < 3:
+                continue
+
+            # Compute theoretical quantiles (standard normal)
+            theoretical_quantiles = stats.norm.ppf(
+                np.linspace(0.01, 0.99, len(scores))
+            )  # Avoid 0 and 1
+
+            # Compute observed quantiles (sorted, standardized)
+            observed_sorted = np.sort(scores)
+            observed_mean = np.mean(scores)
+            observed_std = np.std(scores)
+            observed_quantiles = (
+                (observed_sorted - observed_mean) / observed_std
+                if observed_std > 0
+                else observed_sorted
+            )
+
+            for theoretical_q, observed_q, original_score in zip(
+                theoretical_quantiles, observed_quantiles, observed_sorted
+            ):
+                qq_data.append(
+                    {
+                        "agent_model": model,
+                        "tier": tier,
+                        "theoretical_quantile": theoretical_q,
+                        "observed_quantile": observed_q,
+                        "original_score": original_score,
+                    }
+                )
+
+    qq_df = pd.DataFrame(qq_data)
+
+    if len(qq_df) == 0:
+        print("  Warning: No data for Q-Q plots")
+        return
+
+    # Create Q-Q scatter plot
+    scatter = (
+        alt.Chart(qq_df)
+        .mark_circle(size=40, opacity=0.6)
+        .encode(
+            x=alt.X("theoretical_quantile:Q", title="Theoretical Quantiles (Normal)"),
+            y=alt.Y("observed_quantile:Q", title="Observed Quantiles (Standardized Score)"),
+            color=alt.Color("tier:N", title="Tier"),
+            tooltip=[
+                alt.Tooltip("agent_model:N", title="Model"),
+                alt.Tooltip("tier:O", title="Tier"),
+                alt.Tooltip("theoretical_quantile:Q", title="Theoretical Q", format=".2f"),
+                alt.Tooltip("observed_quantile:Q", title="Observed Q", format=".2f"),
+                alt.Tooltip("original_score:Q", title="Original Score", format=".3f"),
+            ],
+        )
+    )
+
+    # Add diagonal reference line (y=x)
+    # Get extent of data
+    q_min = min(qq_df["theoretical_quantile"].min(), qq_df["observed_quantile"].min())
+    q_max = max(qq_df["theoretical_quantile"].max(), qq_df["observed_quantile"].max())
+
+    reference_line = (
+        alt.Chart(pd.DataFrame({"x": [q_min, q_max], "y": [q_min, q_max]}))
+        .mark_line(strokeDash=[5, 5], color="red")
+        .encode(x="x:Q", y="y:Q")
+    )
+
+    # Facet by (model, tier)
+    chart = (
+        alt.layer(reference_line, scatter, data=qq_df)
+        .facet(
+            column=alt.Column("tier:N", title="Tier", sort=tier_order),
+            row=alt.Row("agent_model:N", title="Agent Model"),
+        )
+        .properties(title="Q-Q Plots (Normal Distribution Assessment)")
+        .configure_view(strokeWidth=0)
+    )
+
+    save_figure(chart, "fig23_qq_plots", output_dir, qq_df, render)
+
+
+def fig24_score_histograms(runs_df: pd.DataFrame, output_dir: Path, render: bool = True) -> None:
+    """Generate Fig 24: Score Histograms with KDE Overlay.
+
+    Histograms with kernel density estimate (KDE) overlay.
+    Faceted by tier, colored by model.
+
+    Args:
+        runs_df: Runs DataFrame
+        output_dir: Output directory
+        render: Whether to render to PNG/PDF
+
+    """
+    tier_order = derive_tier_order(runs_df)
+
+    # Compute KDE for each (model, tier)
+    kde_data = []
+
+    for model in sorted(runs_df["agent_model"].unique()):
+        for tier in tier_order:
+            tier_data = runs_df[(runs_df["agent_model"] == model) & (runs_df["tier"] == tier)]
+
+            if len(tier_data) < 3:
+                continue
+
+            scores = tier_data["score"].dropna().values
+
+            if len(scores) < 3:
+                continue
+
+            # Compute KDE
+            try:
+                kde = stats.gaussian_kde(scores)
+                x_range = np.linspace(0, 1, 100)
+                kde_values = kde(x_range)
+
+                for x, density in zip(x_range, kde_values):
+                    kde_data.append(
+                        {"agent_model": model, "tier": tier, "score": x, "density": density}
+                    )
+            except Exception as e:
+                print(f"  Warning: KDE failed for {model}/{tier}: {e}")
+                continue
+
+    kde_df = pd.DataFrame(kde_data)
+
+    # Get dynamic color scale for models
+    models = sorted(runs_df["agent_model"].unique())
+    domain, range_ = get_color_scale("models", models)
+
+    # Create histogram
+    histogram = (
+        alt.Chart(runs_df)
+        .mark_bar(opacity=0.5, binSpacing=0)
+        .encode(
+            x=alt.X("score:Q", title="Score", bin=alt.Bin(maxbins=20)),
+            y=alt.Y("count():Q", title="Frequency"),
+            color=alt.Color(
+                "agent_model:N",
+                title="Agent Model",
+                scale=alt.Scale(domain=domain, range=range_),
+            ),
+            tooltip=[
+                alt.Tooltip("agent_model:N", title="Model"),
+                alt.Tooltip("count():Q", title="Count"),
+            ],
+        )
+    )
+
+    # Create KDE overlay
+    if len(kde_df) > 0:
+        # Scale KDE to match histogram frequency
+        # Get histogram counts to determine scaling factor
+        max_count = runs_df.groupby(["agent_model", "tier"]).size().max()
+
+        # Normalize KDE density to match histogram scale
+        kde_df["scaled_density"] = kde_df["density"] * (max_count / kde_df["density"].max())
+
+        kde_lines = (
+            alt.Chart(kde_df)
+            .mark_line(strokeWidth=2)
+            .encode(
+                x=alt.X("score:Q"),
+                y=alt.Y("scaled_density:Q"),
+                color=alt.Color(
+                    "agent_model:N",
+                    scale=alt.Scale(domain=domain, range=range_),
+                ),
+            )
+        )
+
+        # Facet by tier
+        chart = (
+            alt.layer(histogram, kde_lines, data=runs_df)
+            .facet(column=alt.Column("tier:N", title="Tier", sort=tier_order))
+            .properties(title="Score Distributions with KDE Overlay")
+            .configure_view(strokeWidth=0)
+        )
+    else:
+        # No KDE data, just show histogram
+        chart = (
+            histogram.facet(column=alt.Column("tier:N", title="Tier", sort=tier_order))
+            .properties(title="Score Distributions")
+            .configure_view(strokeWidth=0)
+        )
+
+    save_figure(chart, "fig24_score_histograms", output_dir, runs_df, render)

--- a/src/scylla/analysis/figures/effect_size.py
+++ b/src/scylla/analysis/figures/effect_size.py
@@ -1,0 +1,140 @@
+"""Effect size analysis figures.
+
+Generates Fig 19 (effect size forest plot with confidence intervals).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import altair as alt
+import pandas as pd
+
+from scylla.analysis.figures import derive_tier_order
+from scylla.analysis.figures.spec_builder import save_figure
+from scylla.analysis.stats import cliffs_delta_ci
+
+
+def fig19_effect_size_forest(runs_df: pd.DataFrame, output_dir: Path, render: bool = True) -> None:
+    """Generate Fig 19: Effect Size Forest Plot.
+
+    Horizontal dot plot with error bars showing Cliff's delta + 95% CI
+    for each tier transition. Vertical dashed line at delta=0.
+    Color indicates significance.
+
+    Args:
+        runs_df: Runs DataFrame
+        output_dir: Output directory
+        render: Whether to render to PNG/PDF
+
+    """
+    # Derive tier order from data
+    tier_order = derive_tier_order(runs_df)
+
+    # Compute effect sizes for consecutive tier transitions
+    effect_sizes = []
+
+    for model in sorted(runs_df["agent_model"].unique()):
+        model_runs = runs_df[runs_df["agent_model"] == model]
+
+        for i in range(len(tier_order) - 1):
+            tier1, tier2 = tier_order[i], tier_order[i + 1]
+            tier1_data = model_runs[model_runs["tier"] == tier1]
+            tier2_data = model_runs[model_runs["tier"] == tier2]
+
+            if len(tier1_data) == 0 or len(tier2_data) == 0:
+                continue
+
+            # Cliff's delta with 95% CI
+            delta, ci_low, ci_high = cliffs_delta_ci(
+                tier2_data["passed"].astype(int),
+                tier1_data["passed"].astype(int),
+                confidence=0.95,
+                n_resamples=10000,
+            )
+
+            # Determine significance (CI excludes zero)
+            is_significant = not (ci_low <= 0 <= ci_high)
+
+            effect_sizes.append(
+                {
+                    "agent_model": model,
+                    "transition": f"{tier1}→{tier2}",
+                    "tier1": tier1,
+                    "tier2": tier2,
+                    "delta": delta,
+                    "ci_low": ci_low,
+                    "ci_high": ci_high,
+                    "significant": "Yes" if is_significant else "No",
+                }
+            )
+
+    effect_df = pd.DataFrame(effect_sizes)
+
+    # Get dynamic color scale for significance
+    sig_domain = ["No", "Yes"]
+    sig_range = ["#999999", "#d62728"]  # Gray for non-sig, red for significant
+
+    # Create base points for effect sizes
+    points = (
+        alt.Chart(effect_df)
+        .mark_circle(size=100)
+        .encode(
+            y=alt.Y("transition:O", title="Tier Transition", sort=None),
+            x=alt.X(
+                "delta:Q", title="Cliff's Delta (Effect Size)", scale=alt.Scale(domain=[-1, 1])
+            ),
+            color=alt.Color(
+                "significant:N",
+                title="Significant?",
+                scale=alt.Scale(domain=sig_domain, range=sig_range),
+            ),
+            tooltip=[
+                alt.Tooltip("agent_model:N", title="Model"),
+                alt.Tooltip("transition:O", title="Transition"),
+                alt.Tooltip("delta:Q", title="Cliff's δ", format=".3f"),
+                alt.Tooltip("ci_low:Q", title="95% CI Low", format=".3f"),
+                alt.Tooltip("ci_high:Q", title="95% CI High", format=".3f"),
+                alt.Tooltip("significant:N", title="Significant"),
+            ],
+        )
+    )
+
+    # Add error bars for confidence intervals
+    error_bars = (
+        alt.Chart(effect_df)
+        .mark_errorbar()
+        .encode(
+            y=alt.Y("transition:O", sort=None),
+            x=alt.X("ci_low:Q"),
+            x2=alt.X2("ci_high:Q"),
+            color=alt.Color(
+                "significant:N",
+                scale=alt.Scale(domain=sig_domain, range=sig_range),
+            ),
+        )
+    )
+
+    # Add vertical line at delta=0 (no effect)
+    zero_line = (
+        alt.Chart(pd.DataFrame({"x": [0]}))
+        .mark_rule(strokeDash=[5, 5], color="black")
+        .encode(x="x:Q")
+    )
+
+    # Facet by model if multiple models
+    if effect_df["agent_model"].nunique() > 1:
+        chart = (
+            alt.layer(zero_line, error_bars, points, data=effect_df)
+            .facet(row=alt.Row("agent_model:N", title="Agent Model"))
+            .properties(title="Effect Size Forest Plot (Cliff's Delta with 95% CI)")
+            .configure_view(strokeWidth=0)
+        )
+    else:
+        chart = (
+            alt.layer(zero_line, error_bars, points)
+            .properties(title="Effect Size Forest Plot (Cliff's Delta with 95% CI)")
+            .configure_view(strokeWidth=0)
+        )
+
+    save_figure(chart, "fig19_effect_size_forest", output_dir, effect_df, render)

--- a/tests/unit/analysis/test_figures.py
+++ b/tests/unit/analysis/test_figures.py
@@ -240,6 +240,61 @@ def test_colors_constant():
         assert tier in COLORS["tiers"]
 
 
+def test_fig19_effect_size_forest(sample_runs_df):
+    """Test Fig 19 effect size forest plot generates without errors."""
+    from scylla.analysis.figures.effect_size import fig19_effect_size_forest
+
+    with patch("scylla.analysis.figures.effect_size.save_figure") as mock:
+        fig19_effect_size_forest(sample_runs_df, Path("/tmp"), render=False)
+        assert mock.called
+
+
+def test_fig20_metric_correlation_heatmap(sample_runs_df):
+    """Test Fig 20 correlation heatmap generates without errors."""
+    from scylla.analysis.figures.correlation import fig20_metric_correlation_heatmap
+
+    with patch("scylla.analysis.figures.correlation.save_figure") as mock:
+        fig20_metric_correlation_heatmap(sample_runs_df, Path("/tmp"), render=False)
+        assert mock.called
+
+
+def test_fig21_cost_quality_regression(sample_runs_df):
+    """Test Fig 21 regression plot generates without errors."""
+    from scylla.analysis.figures.correlation import fig21_cost_quality_regression
+
+    with patch("scylla.analysis.figures.correlation.save_figure") as mock:
+        fig21_cost_quality_regression(sample_runs_df, Path("/tmp"), render=False)
+        assert mock.called
+
+
+def test_fig22_cumulative_cost(sample_runs_df):
+    """Test Fig 22 cumulative cost curve generates without errors."""
+    from scylla.analysis.figures.cost_analysis import fig22_cumulative_cost
+
+    with patch("scylla.analysis.figures.cost_analysis.save_figure") as mock:
+        fig22_cumulative_cost(sample_runs_df, Path("/tmp"), render=False)
+        assert mock.called
+
+
+def test_fig23_qq_plots(sample_runs_df):
+    """Test Fig 23 Q-Q plots generate without errors."""
+    from scylla.analysis.figures.diagnostics import fig23_qq_plots
+
+    with patch("scylla.analysis.figures.diagnostics.save_figure"):
+        fig23_qq_plots(sample_runs_df, Path("/tmp"), render=False)
+        # Note: may not be called if insufficient data
+        # Just check it doesn't crash
+
+
+def test_fig24_score_histograms(sample_runs_df):
+    """Test Fig 24 histograms with KDE generate without errors."""
+    from scylla.analysis.figures.diagnostics import fig24_score_histograms
+
+    with patch("scylla.analysis.figures.diagnostics.save_figure") as mock:
+        fig24_score_histograms(sample_runs_df, Path("/tmp"), render=False)
+        assert mock.called
+
+
 def test_figure_module_structure():
     """Test that all figure modules exist."""
     figure_modules = [
@@ -251,6 +306,9 @@ def test_figure_module_structure():
         "judge_analysis",
         "criteria_analysis",
         "subtest_detail",
+        "effect_size",
+        "correlation",
+        "diagnostics",
     ]
 
     for module_name in figure_modules:


### PR DESCRIPTION
## Summary
Implements Work Package 3: New Figures from the analysis pipeline enhancement plan.

Adds 6 comprehensive figures for paper-quality visual analysis: effect sizes, correlations, regression, cumulative cost, and diagnostic plots.

## Changes

### WP3.1: Effect Size Forest Plot
**New file**: `src/scylla/analysis/figures/effect_size.py`
- `fig19_effect_size_forest()` - Horizontal forest plot with error bars
- Shows Cliff's delta + 95% CI for each consecutive tier transition
- Vertical dashed line at delta=0 (no effect reference)
- Color-coded by statistical significance (CI excludes zero = significant)
- Faceted by agent model for multi-model comparisons
- Uses `cliffs_delta_ci()` from WP1 for bootstrap confidence intervals

### WP3.2: Correlation and Regression
**New file**: `src/scylla/analysis/figures/correlation.py`
- `fig20_metric_correlation_heatmap()` - Spearman correlation matrix
  * Heatmap showing correlations: score, cost, tokens, duration
  * Annotated with correlation coefficients (ρ values)
  * Red-blue diverging color scale (-1 to +1)
  * Faceted by model
- `fig21_cost_quality_regression()` - Cost vs quality scatter + regression
  * Subtest-level analysis (aggregated data points)
  * OLS regression line with R² and p-value annotations
  * Uses `ols_regression()` from WP1
  * Per-model regression lines

### WP3.3: Cumulative Cost Curve
**Modified**: `src/scylla/analysis/figures/cost_analysis.py`
- `fig22_cumulative_cost()` - Cost accumulation over time
  * Line chart showing cumulative cost vs run index
  * Colored by tier (shows which tiers contribute most to total cost)
  * Faceted by model
  * Uses chronological run order

### WP3.4: Diagnostic and Distribution Plots
**New file**: `src/scylla/analysis/figures/diagnostics.py`
- `fig23_qq_plots()` - Quantile-quantile plots for normality assessment
  * Compares theoretical normal quantiles vs observed quantiles
  * Diagonal reference line (points should fall on line if normally distributed)
  * Standardized scores (z-scores)
  * Faceted by (model, tier) for per-group assessment
  * Complements table10_normality_tests
- `fig24_score_histograms()` - Distribution visualization with KDE
  * Histograms showing score distributions
  * Kernel density estimate (KDE) overlay
  * Scaled to match histogram frequency
  * Faceted by tier, colored by model

### WP3.5: Registration and Testing
**Modified**: `scripts/generate_figures.py`
- Added imports for `effect_size`, `correlation`, `diagnostics` modules
- Registered fig19-fig24 in `FIGURES` dictionary
- Updated category handling to include new categories
- Total figures: 24 (up from 18)

**Modified**: `tests/unit/analysis/test_figures.py`
- Added 6 smoke tests for new figures
- Updated `test_figure_module_structure` to include new modules
- Fixed Altair layering for faceted charts (data at top level)
- All 29 tests pass

## Test Plan
```bash
# Run figure tests
pixi run -e analysis pytest tests/unit/analysis/test_figures.py -v

# Generate new figures against real data
pixi run -e analysis python scripts/generate_figures.py \
  --figures fig19_effect_size_forest,fig20_metric_correlation_heatmap,fig21_cost_quality_regression,fig22_cumulative_cost,fig23_qq_plots,fig24_score_histograms \
  --data-dir ~/fullruns

# Verify outputs
ls docs/figures/fig{19,20,21,22,23,24}_*.{vl.json,csv,png,pdf}
```

## Test Results
**29 passed, 1 warning**
- ✓ All 6 new figure smoke tests pass
- ✓ All existing figure tests still pass
- ⚠️ Altair deprecation warning (non-blocking, theme API change)

## Dependencies
- **Depends on**: PR #273 (WP1 statistical functions - `cliffs_delta_ci`, `ols_regression`, `spearman_correlation`)
- **Depends on**: PR #274 (WP2 new tables)
- **Required by**: Paper documentation, analysis pipeline

## Technical Notes
- **Altair layering**: Faceted layered charts require `data` at top level to avoid ValueError
- **KDE scaling**: Kernel density estimates scaled to match histogram frequency for visual clarity
- **Q-Q plots**: Standardize scores (z-scores) for comparison with theoretical normal distribution
- **Effect size**: Bootstrap CIs provide uncertainty quantification beyond point estimates

🤖 Generated with [Claude Code](https://claude.com/claude-code)