### PR TITLE
refactor(tables): Remove inline CoP duplication in table05

### DIFF
--- a/src/scylla/analysis/tables.py
+++ b/src/scylla/analysis/tables.py
@@ -1011,7 +1011,7 @@ def table05_cost_analysis(runs_df: pd.DataFrame) -> tuple[str, str]:
 
             # CoP
             pass_rate = subset["passed"].mean()
-            cop = mean_cost / pass_rate if pass_rate > 0 else float("inf")
+            cop = compute_cop(mean_cost, pass_rate)
 
             # Token breakdown
             input_tokens = subset["input_tokens"].mean()


### PR DESCRIPTION
## Summary
- Eliminates code duplication by replacing inline CoP calculation with compute_cop() call
- Maintains DRY principle
- No behavior change

## Changes
**Before**:
```python
cop = mean_cost / pass_rate if pass_rate > 0 else float("inf")
```

**After**:
```python
cop = compute_cop(mean_cost, pass_rate)
```

compute_cop() was already imported but not used in table05, causing code duplication.

## Testing
```bash
pixi run -e analysis pytest tests/unit/analysis/test_tables.py -v -k "table05"
```

Both tests pass.

## Priority
**P1 - High Priority**: Code quality and maintainability

🤖 Generated with [Claude Code](https://claude.com/claude-code)