### PR TITLE
fix(stats): Add defensive guards for mann_whitney_u degenerate input

### DIFF
--- a/src/scylla/analysis/stats.py
+++ b/src/scylla/analysis/stats.py
@@ -78,14 +78,24 @@ def mann_whitney_u(
     g1 = np.array(group1)
     g2 = np.array(group2)
 
+    # Guard against degenerate input (n < 2 per group)
     if len(g1) < 2 or len(g2) < 2:
         logger.warning(
             f"Mann-Whitney U test called with sample sizes {len(g1)}, {len(g2)}. "
-            "Need at least 2 samples per group for valid results."
+            "Need at least 2 samples per group. Returning U=0, p=1.0."
         )
+        return 0.0, 1.0
 
-    statistic, pvalue = stats.mannwhitneyu(g1, g2, alternative="two-sided")
-    return float(statistic), float(pvalue)
+    try:
+        statistic, pvalue = stats.mannwhitneyu(g1, g2, alternative="two-sided")
+        return float(statistic), float(pvalue)
+    except ValueError as e:
+        # Additional guard for unexpected scipy errors
+        logger.error(
+            f"Mann-Whitney U test failed with ValueError: {e}. "
+            f"Sample sizes: {len(g1)}, {len(g2)}. Returning U=0, p=1.0."
+        )
+        return 0.0, 1.0
 
 
 def cliffs_delta(group1: pd.Series | np.ndarray, group2: pd.Series | np.ndarray) -> float:

--- a/tests/unit/analysis/test_stats.py
+++ b/tests/unit/analysis/test_stats.py
@@ -172,6 +172,36 @@ def test_mann_whitney_u_identical():
     assert p_value > 0.9
 
 
+def test_mann_whitney_u_degenerate_input():
+    """Test Mann-Whitney U with degenerate input (n < 2).
+
+    Regression test for P1 bug: ensure function doesn't raise on
+    degenerate input but returns safe defaults (U=0, p=1.0).
+    """
+    from scylla.analysis.stats import mann_whitney_u
+
+    # Single element in one group
+    g1 = [1]
+    g2 = [2, 3, 4]
+    u_stat, p_value = mann_whitney_u(g1, g2)
+    assert u_stat == 0.0
+    assert p_value == 1.0
+
+    # Single element in both groups
+    g1 = [1]
+    g2 = [2]
+    u_stat, p_value = mann_whitney_u(g1, g2)
+    assert u_stat == 0.0
+    assert p_value == 1.0
+
+    # Empty group
+    g1 = []
+    g2 = [1, 2, 3]
+    u_stat, p_value = mann_whitney_u(g1, g2)
+    assert u_stat == 0.0
+    assert p_value == 1.0
+
+
 def test_krippendorff_alpha_perfect_agreement():
     """Test Krippendorff's alpha with perfect inter-rater agreement."""
     from scylla.analysis.stats import krippendorff_alpha


### PR DESCRIPTION
## Summary
- Adds defensive guards to prevent mann_whitney_u() from raising on degenerate input
- Returns safe defaults (U=0, p=1.0) for n<2 cases
- Adds comprehensive regression test

## Problem
Previously, mann_whitney_u() logged a warning for n<2 but still called scipy.mannwhitneyu(), which could raise ValueError. This caused pipeline failures on edge cases.

## Solution
1. Early return with safe defaults when n<2
2. Try-except block around scipy call for additional robustness
3. Returns (U=0.0, p=1.0) - conservative defaults indicating no evidence of difference

## Changes
- **stats.py**: Add guards and error handling in mann_whitney_u()
- **test_stats.py**: Add test_mann_whitney_u_degenerate_input() with 3 edge cases

## Testing
```bash
pixi run -e analysis pytest tests/unit/analysis/test_stats.py::test_mann_whitney_u_degenerate_input -v
```

Test passes for single-element and empty groups.

## Priority
**P1 - High Priority**: Prevents pipeline failures on edge cases

🤖 Generated with [Claude Code](https://claude.com/claude-code)