### PR TITLE
fix(config): Sync model colors with authoritative figures/__init__.py values

### DIFF
--- a/src/scylla/analysis/config.yaml
+++ b/src/scylla/analysis/config.yaml
@@ -74,9 +74,10 @@ tables:
 # Color Palettes
 colors:
   # Model colors (diverging blue-red)
+  # NOTE: These values match figures/__init__.py (authoritative source)
   models:
-    "Sonnet 4.5": "#3498db"  # Blue
-    "Haiku 4.5": "#e74c3c"   # Red
+    "Sonnet 4.5": "#4C78A8"  # Blue (Vega default blue)
+    "Haiku 4.5": "#E45756"   # Red (Vega default red)
     "Opus 4.5": "#2ecc71"    # Green (reserved)
 
   # Tier colors (ColorBrewer Set2 - colorblind safe)


### PR DESCRIPTION
## Summary
- Updates config.yaml model colors to match actual values used in figures
- Eliminates confusion between documented and actual colors
- Adds clarifying comment

## Problem
config.yaml documented model colors (#3498db, #e74c3c) that differed from the actual values used in figure generation (#4C78A8, #E45756). This caused confusion about which colors were authoritative.

## Solution
Update config.yaml to match figures/__init__.py (the authoritative source):
- Sonnet 4.5: #3498db → #4C78A8 (Vega default blue)
- Haiku 4.5: #e74c3c → #E45756 (Vega default red)

## Why figures/__init__.py is authoritative
The figure generation code directly uses these values to construct Altair/Vega-Lite specs. config.yaml values were aspirational but not wired to the actual figure generation.

## Testing
```bash
pixi run -e analysis pytest tests/unit/analysis/test_config.py -v
```

All 7 config tests pass.

## Priority
**P2 - Medium Priority**: Documentation accuracy and maintainability

🤖 Generated with [Claude Code](https://claude.com/claude-code)