### PR TITLE
feat(export): Embed pipeline_version in output files for reproducibility

### DIFF
--- a/scripts/export_data.py
+++ b/scripts/export_data.py
@@ -20,6 +20,7 @@ from scylla.analysis import (
     build_subtests_df,
     load_all_experiments,
 )
+from scylla.analysis.config import config
 from scylla.analysis.figures import derive_tier_order
 from scylla.analysis.stats import (
     cliffs_delta_ci,
@@ -54,6 +55,8 @@ def compute_statistical_results(runs_df, tier_order):
 
     """
     results = {
+        "pipeline_version": config.pipeline_version,
+        "config_version": config.config_version,
         "normality_tests": [],
         "omnibus_tests": [],
         "pairwise_comparisons": [],
@@ -304,6 +307,8 @@ def main() -> None:
 
     # Export summary statistics as JSON
     summary = {
+        "pipeline_version": config.pipeline_version,
+        "config_version": config.config_version,
         "total_experiments": len(experiments),
         "total_runs": len(runs_df),
         "total_judge_evaluations": len(judges_df),


### PR DESCRIPTION
## Summary
- Adds pipeline_version and config_version to summary.json and statistical_results.json
- Enables tracking which analysis pipeline version generated each result set
- Improves reproducibility metadata

## Changes
1. Import config from scylla.analysis.config
2. Add version fields to summary dictionary (summary.json)
3. Add version fields to statistical_results dictionary (statistical_results.json)

## Example Output
```json
{
  "pipeline_version": "1.0.0",
  "config_version": "1.0.0",
  "total_experiments": 5,
  "total_runs": 2260,
  ...
}
```

## Benefits
- Track which pipeline version generated results
- Enable version-based result filtering
- Document analysis configuration at time of export
- Support reproducibility audits

## Testing
```bash
pixi run -e analysis pytest tests/unit/analysis/test_export_data.py -v
```

Both tests pass.

## Priority
**P2 - Medium Priority**: Reproducibility and version tracking

🤖 Generated with [Claude Code](https://claude.com/claude-code)