### PR TITLE
docs(tables): Add correction method footnotes to statistical tables

### DIFF
--- a/src/scylla/analysis/tables.py
+++ b/src/scylla/analysis/tables.py
@@ -367,6 +367,12 @@ def table02_tier_comparison(runs_df: pd.DataFrame) -> tuple[str, str]:
             rf"$p={omnibus_p:.4f}$ {sig_str}}} \\"
         )
 
+    # Add correction method footnote
+    latex_lines.append(
+        r"\multicolumn{7}{l}{\footnotesize "
+        r"Pairwise p-values corrected with Holm-Bonferroni method.} \\"
+    )
+
     latex_lines.extend(
         [
             r"\bottomrule",
@@ -635,6 +641,12 @@ def table02b_impl_rate_comparison(runs_df: pd.DataFrame) -> tuple[str, str]:
             rf"\multicolumn{{7}}{{l}}{{{model}: $H={h_stat:.2f}$, "
             rf"$p={omnibus_p:.4f}$ {sig_str}}} \\"
         )
+
+    # Add correction method footnote
+    latex_lines.append(
+        r"\multicolumn{7}{l}{\footnotesize "
+        r"Pairwise p-values corrected with Holm-Bonferroni method.} \\"
+    )
 
     latex_lines.extend(
         [
@@ -977,6 +989,13 @@ def table04_criteria_performance(
             f"{criterion} & {criteria_weights[criterion]:.2f} & "
             f"{model_cols} & {pvalue_str} & {winner_str} \\\\"
         )
+
+    # Add correction method footnote
+    latex_lines.append(r"\midrule")
+    latex_lines.append(
+        r"\multicolumn{" + str(len(models) + 4) + r"}{l}{\footnotesize "
+        r"p-values corrected with Holm-Bonferroni method.} \\"
+    )
 
     latex_lines.extend([r"\bottomrule", r"\end{tabular}", r"\end{table}"])
 
@@ -1388,6 +1407,14 @@ def table06_model_comparison(runs_df: pd.DataFrame) -> tuple[str, str]:
                 f"{row['Pair']} & {row['Metric']} & {val1_str} & {val2_str} & "
                 f"{delta_str} & {pval_str} \\\\"
             )
+
+    # Add correction method footnote
+    latex_lines.append(r"\midrule")
+    num_cols = 5 if len(models) == 2 else 6
+    latex_lines.append(
+        rf"\multicolumn{{{num_cols}}}{{l}}{{\footnotesize "
+        r"p-values corrected with Holm-Bonferroni method.}} \\"
+    )
 
     latex_lines.extend([r"\bottomrule", r"\end{tabular}", r"\end{table}"])
 


### PR DESCRIPTION
## Summary
- Adds explicit Holm-Bonferroni correction method footnotes to 4 statistical tables
- Improves transparency and meets APA reporting standards
- No behavior change

## Changes
Added footnotes to:
1. **Table 02** (Tier Pairwise Comparison): After omnibus test results
2. **Table 02b** (Impl-Rate Tier Comparison): After omnibus test results
3. **Table 04** (Criteria Performance): Before table end, dynamic column count
4. **Table 06** (Model Comparison): Before table end, handles 2-model and N-model layouts

## Example Output
```latex
\multicolumn{7}{l}{\footnotesize 
Pairwise p-values corrected with Holm-Bonferroni method.} \\
\bottomrule
```

## Why This Matters
- **Transparency**: Readers know which correction method was applied
- **APA Standards**: Statistical reporting best practices
- **Reproducibility**: Documents the correction method used

## Testing
```bash
pixi run -e analysis pytest tests/unit/analysis/test_tables.py -v -k "table02 or table04 or table06"
```

All 13 tests pass.

## Priority
**P2 - Medium Priority**: Documentation and reporting standards

🤖 Generated with [Claude Code](https://claude.com/claude-code)