### PR TITLE
feat(tables): Add degrees of freedom to Kruskal-Wallis omnibus tests

### DIFF
--- a/src/scylla/analysis/tables.py
+++ b/src/scylla/analysis/tables.py
@@ -192,7 +192,8 @@ def table02_tier_comparison(runs_df: pd.DataFrame) -> tuple[str, str]:
             continue
 
         h_stat, omnibus_p = kruskal_wallis(*tier_groups)
-        omnibus_results.append((model, h_stat, omnibus_p))
+        dof = len(tier_groups) - 1  # Degrees of freedom for Kruskal-Wallis
+        omnibus_results.append((model, h_stat, omnibus_p, dof))
 
         # Step 2: Only proceed to pairwise tests if omnibus is significant
         proceed_to_pairwise = omnibus_p < ALPHA
@@ -305,9 +306,9 @@ def table02_tier_comparison(runs_df: pd.DataFrame) -> tuple[str, str]:
 
     # Add omnibus results to header
     md_lines.append("**Omnibus Test Results (Kruskal-Wallis):**")
-    for model, h_stat, omnibus_p in omnibus_results:
+    for model, h_stat, omnibus_p, dof in omnibus_results:
         sig_str = "✓ (proceed to pairwise)" if omnibus_p < ALPHA else "✗ (skip pairwise)"
-        md_lines.append(f"- {model}: H={h_stat:.2f}, p={omnibus_p:.4f} {sig_str}")
+        md_lines.append(f"- {model}: H({dof})={h_stat:.2f}, p={omnibus_p:.4f} {sig_str}")
     md_lines.append("")
 
     md_lines.append(
@@ -360,10 +361,10 @@ def table02_tier_comparison(runs_df: pd.DataFrame) -> tuple[str, str]:
         ]
     )
 
-    for model, h_stat, omnibus_p in omnibus_results:
+    for model, h_stat, omnibus_p, dof in omnibus_results:
         sig_str = rf"$p < {ALPHA}$" if omnibus_p < ALPHA else rf"$p \geq {ALPHA}$ (n.s.)"
         latex_lines.append(
-            rf"\multicolumn{{7}}{{l}}{{{model}: $H={h_stat:.2f}$, "
+            rf"\multicolumn{{7}}{{l}}{{{model}: $H({dof})={h_stat:.2f}$, "
             rf"$p={omnibus_p:.4f}$ {sig_str}}} \\"
         )
 
@@ -439,7 +440,8 @@ def table02b_impl_rate_comparison(runs_df: pd.DataFrame) -> tuple[str, str]:
             continue
 
         h_stat, omnibus_p = kruskal_wallis(*tier_groups)
-        omnibus_results.append((model, h_stat, omnibus_p))
+        dof = len(tier_groups) - 1  # Degrees of freedom for Kruskal-Wallis
+        omnibus_results.append((model, h_stat, omnibus_p, dof))
 
         # Step 2: Only proceed to pairwise tests if omnibus is significant
         proceed_to_pairwise = omnibus_p < ALPHA
@@ -549,9 +551,9 @@ def table02b_impl_rate_comparison(runs_df: pd.DataFrame) -> tuple[str, str]:
 
     # Add omnibus results to header
     md_lines.append("**Omnibus Test Results (Kruskal-Wallis):**")
-    for model, h_stat, omnibus_p in omnibus_results:
+    for model, h_stat, omnibus_p, dof in omnibus_results:
         sig_str = "✓ (proceed to pairwise)" if omnibus_p < ALPHA else "✗ (skip pairwise)"
-        md_lines.append(f"- {model}: H={h_stat:.2f}, p={omnibus_p:.4f} {sig_str}")
+        md_lines.append(f"- {model}: H({dof})={h_stat:.2f}, p={omnibus_p:.4f} {sig_str}")
     md_lines.append("")
 
     md_lines.append(
@@ -635,10 +637,10 @@ def table02b_impl_rate_comparison(runs_df: pd.DataFrame) -> tuple[str, str]:
         ]
     )
 
-    for model, h_stat, omnibus_p in omnibus_results:
+    for model, h_stat, omnibus_p, dof in omnibus_results:
         sig_str = rf"$p < {ALPHA}$" if omnibus_p < ALPHA else rf"$p \geq {ALPHA}$ (n.s.)"
         latex_lines.append(
-            rf"\multicolumn{{7}}{{l}}{{{model}: $H={h_stat:.2f}$, "
+            rf"\multicolumn{{7}}{{l}}{{{model}: $H({dof})={h_stat:.2f}$, "
             rf"$p={omnibus_p:.4f}$ {sig_str}}} \\"
         )
 


### PR DESCRIPTION
## Summary
- Adds degrees of freedom (df) to Kruskal-Wallis omnibus test reporting
- Meets APA statistical reporting standards
- Updates both markdown and LaTeX output formats

## Changes
**Calculation**: df = k - 1 (where k = number of groups/tiers)

**Before**:
```
- Sonnet 4.5: H=42.35, p=0.0001 ✓
```

**After**:
```
- Sonnet 4.5: H(6)=42.35, p=0.0001 ✓
```

## APA Compliance
APA Publication Manual requires reporting degrees of freedom for all hypothesis tests. For Kruskal-Wallis H-test, df = k - 1 where k is the number of independent groups.

## Implementation Details
- Calculates df when running Kruskal-Wallis test
- Stores df in omnibus_results tuple
- Updates both markdown and LaTeX output formatting
- Uses 'dof' variable name to avoid conflict with DataFrame 'df'

## Testing
```bash
pixi run -e analysis pytest tests/unit/analysis/test_tables.py -v -k "table02"
```

All 7 tests pass.

## Priority
**P3 - Low Priority**: Publication standards compliance

🤖 Generated with [Claude Code](https://claude.com/claude-code)