### PR TITLE
refactor(analysis): Move correlation metric pairs to config.yaml

### DIFF
--- a/src/scylla/analysis/config.py
+++ b/src/scylla/analysis/config.py
@@ -125,6 +125,20 @@ class AnalysisConfig:
         return self.get("colors", "grade_order", default=["S", "A", "B", "C", "D", "F"])
 
     @property
+    def correlation_metrics(self) -> dict[str, str]:
+        """Metric pairs for correlation analysis (column_name: display_name)."""
+        return self.get(
+            "figures",
+            "correlation_metrics",
+            default={
+                "score": "Score",
+                "cost_usd": "Cost (USD)",
+                "total_tokens": "Total Tokens",
+                "duration_seconds": "Duration (s)",
+            },
+        )
+
+    @property
     def pipeline_version(self) -> str:
         """Analysis pipeline version."""
         return self.get("reproducibility", "pipeline_version", default="1.0.0")

--- a/src/scylla/analysis/config.yaml
+++ b/src/scylla/analysis/config.yaml
@@ -44,6 +44,13 @@ figures:
   # Performance thresholds
   pass_threshold: 0.60  # Reference line for acceptable pass-rate
 
+  # Correlation analysis metric pairs
+  correlation_metrics:
+    score: "Score"
+    cost_usd: "Cost (USD)"
+    total_tokens: "Total Tokens"
+    duration_seconds: "Duration (s)"
+
   # Font settings
   fonts:
     family: "serif"

--- a/src/scylla/analysis/figures/correlation.py
+++ b/src/scylla/analysis/figures/correlation.py
@@ -10,6 +10,7 @@ from pathlib import Path
 import altair as alt
 import pandas as pd
 
+from scylla.analysis.config import config
 from scylla.analysis.figures import get_color_scale
 from scylla.analysis.figures.spec_builder import save_figure
 from scylla.analysis.stats import holm_bonferroni_correction, ols_regression, spearman_correlation
@@ -29,12 +30,8 @@ def fig20_metric_correlation_heatmap(
         render: Whether to render to PNG/PDF
 
     """
-    metrics = {
-        "score": "Score",
-        "cost_usd": "Cost (USD)",
-        "total_tokens": "Total Tokens",
-        "duration_seconds": "Duration (s)",
-    }
+    # Get metrics from centralized config
+    metrics = config.correlation_metrics
 
     # Compute correlations per model
     correlations = []


### PR DESCRIPTION
## Summary

Centralize correlation analysis metric pairs in config.yaml for better maintainability and configurability.

## Changes

- Add  section to config.yaml with metric pairs (score, cost_usd, total_tokens, duration_seconds)
- Add  property to AnalysisConfig
- Update  to use 

## Benefits

- Easier to modify metric pairs without code changes
- Consistent with other centralized config (pass_threshold, grade_order)
- Supports experiment-specific metric combinations

## Testing

- All existing correlation tests pass
- Configuration integration verified

Addresses **P2-3** from publication readiness assessment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)