### PR TITLE
fix(evaluation): Add fallback to best_subtest.json in build_merged_baseline

### DIFF
--- a/src/scylla/e2e/tier_manager.py
+++ b/src/scylla/e2e/tier_manager.py
@@ -772,18 +772,24 @@ class TierManager:
         for tier_id in inherit_from_tiers:
             # 1. Load tier result.json to get best_subtest
             result_file = experiment_dir / tier_id.value / "result.json"
-            if not result_file.exists():
+            best_subtest_file = experiment_dir / tier_id.value / "best_subtest.json"
+
+            best_subtest_id = None
+            if result_file.exists():
+                with open(result_file) as f:
+                    tier_result = json.load(f)
+                best_subtest_id = tier_result.get("best_subtest")
+            elif best_subtest_file.exists():
+                with open(best_subtest_file) as f:
+                    selection = json.load(f)
+                best_subtest_id = selection.get("winning_subtest")
+
+            if not best_subtest_id:
                 raise ValueError(
-                    f"Cannot inherit from {tier_id.value}: result.json not found. "
+                    f"Cannot inherit from {tier_id.value}: neither result.json nor "
+                    f"best_subtest.json found with best subtest selection. "
                     f"Ensure tier {tier_id.value} completed before T5."
                 )
-
-            with open(result_file) as f:
-                tier_result = json.load(f)
-
-            best_subtest_id = tier_result.get("best_subtest")
-            if not best_subtest_id:
-                raise ValueError(f"Cannot inherit from {tier_id.value}: no best_subtest selected.")
 
             # 2. Load config_manifest.json from best subtest
             manifest_file = (


### PR DESCRIPTION
## Problem

When running `rerun_agents.py`, T5 subtests fail because `build_merged_baseline()` in `tier_manager.py:774` requires `<tier>/result.json` for each parent tier (T0-T4). These tier-level result files are created by `_save_tier_result()` during a normal experiment run, but are **not regenerated** by `rerun_agents.py`.

The parent tiers are actually complete — all individual agent/result.json files exist, and `best_subtest.json` exists for each tier. The data needed (`best_subtest` / `winning_subtest`) is already available.

## Root Cause

`build_merged_baseline()` only reads from `result.json` and has no fallback to `best_subtest.json` (which is always written by `save_selection()` during the normal flow and survives across reruns).

## Fix

**File**: `src/scylla/e2e/tier_manager.py:772-790`

When `result.json` is not found, fall back to reading `best_subtest.json` and extract `winning_subtest` from it. The method now:

1. Tries to read `best_subtest` from `result.json` (primary source)
2. Falls back to `winning_subtest` from `best_subtest.json` (fallback)
3. Raises an error only if neither file contains the selection

## Changes

- Modified `build_merged_baseline()` to add fallback logic
- Updated test error messages to match new behavior
- Added new test `test_fallback_to_best_subtest_json()` to verify fallback works

## Verification

✓ Dry-run test: `pixi run python scripts/rerun_agents.py ~/fullruns/test001-nothinking-haiku/2026-01-23T17-01-08-test-001/ --dry-run --tier T5`
  - No longer errors about missing result.json
  - Correctly classifies T5 runs as needing rerun

✓ All tier_manager tests pass: 34/34 tests passed