### PR TITLE
test(evaluation): Fix order-sensitive assertion in test_fallback_to_best_subtest_json

### DIFF
--- a/tests/unit/e2e/test_tier_manager.py
+++ b/tests/unit/e2e/test_tier_manager.py
@@ -834,7 +834,7 @@ class TestBuildMergedBaseline:
 
         # Should succeed by reading from best_subtest.json
         merged = manager.build_merged_baseline([TierID.T0], experiment_dir)
-        assert merged == {"tools": {"enabled": ["bash", "read"]}}
+        assert set(merged["tools"]["enabled"]) == {"bash", "read"}
 
 
 class TestResourceSuffixInClaudeMd:


### PR DESCRIPTION
## Problem

The test `test_fallback_to_best_subtest_json` introduced in PR #312 is failing due to order-sensitivity. It compares lists directly, but the tool order in the enabled list is not deterministic.

```python
assert merged == {"tools": {"enabled": ["bash", "read"]}}  # Fails when order is ["read", "bash"]
```

## Fix

Changed the assertion to compare sets instead of lists since the order of tools is not semantically significant:

```python
assert set(merged["tools"]["enabled"]) == {"bash", "read"}
```

## Verification

✓ Test now passes: `pixi run python -m pytest tests/unit/e2e/test_tier_manager.py::TestBuildMergedBaseline::test_fallback_to_best_subtest_json -v`