### PR TITLE
feat(metrics): Integrate Impl-Rate into statistical tests

### DIFF
--- a/docs/paper-readiness-audit.md
+++ b/docs/paper-readiness-audit.md
@@ -1,0 +1,393 @@
+# Paper-Readiness Completeness Assessment
+
+**Date**: 2026-02-01
+**Status**: Data gaps identified, analysis pipeline mostly complete
+**Recommendation**: Methodology paper feasible with 5-7 weeks additional work
+
+---
+
+## Executive Summary
+
+ProjectScylla has **substantial evaluation infrastructure** in place with 2,245 completed runs across 2 models (Sonnet 4.5, Haiku 4.5) and 7 tiers (T0-T6), but faces **critical data quality issues** in the Haiku experiment that block paper readiness. The analysis pipeline is 80% complete with 24 figures and 11 tables generated, but several key metrics are not yet integrated into statistical tests.
+
+**Primary Blockers**:
+1. 15 aborted runs in Haiku T5 (never executed)
+2. 218 missing judge_01 evaluations in Haiku T4/T5 (systematic failure)
+3. Missing figure renders (0 PNG/PDF outputs from 24 Vega-Lite specs)
+4. Incomplete metrics integration (Impl-Rate, CoP, process metrics not in statistical tests)
+
+**Estimated time to paper-ready**: 5-7 weeks (assuming methodology paper scope)
+
+---
+
+## 1. Data Completeness Audit
+
+### Experiment Inventory
+
+| Experiment | Model | Subtests | Runs/Subtest | Total Runs | Status |
+|---|---|---|---|---|---|
+| test001-dryrun | Sonnet 4.5 | 7 (1 per tier) | 1 | 7 | ✅ Clean (dry run only) |
+| test001-nothinking | Sonnet 4.5 (no thinking) | 113 | 10 | 1,130 | ✅ **CLEAN** |
+| test001-nothinking-haiku | Haiku 4.5 (no thinking) | 113 | 10 | 1,130 | ⚠️ **HAS ISSUES** |
+
+### test001-nothinking (Sonnet): 100% Complete ✅
+- 1,130/1,130 runs have `run_result.json`
+- 1,130/1,130 runs have 3/3 judges with `judgment.json`
+- 113/113 subtests have `report.json`
+- 7/7 tiers have `report.json` and `best_subtest.json`
+- 0 null judge scores, 0 non-zero exit codes
+- **Pass rate: 94.2%** (1,064/1,130)
+
+### test001-nothinking-haiku (Haiku): Data Quality Issues ⚠️
+
+| Issue | Count | Severity | Issue # |
+|---|---|---|---|
+| Missing `run_result.json` | 16 runs | 🔴 HIGH | #319 |
+| Aborted runs (never executed) | 15 runs | 🔴 HIGH | #319 |
+| Incomplete judges (2/3) | 204 runs | 🟡 MEDIUM | #320 |
+| Incomplete judges (1/3) | 1 run | 🟡 MEDIUM | #320 |
+| Missing subtest report.json | 1 | 🟢 LOW | #321 |
+| Missing tier-level reports | 1 tier | 🟢 LOW | #321 |
+| Non-zero exit codes | 5 runs | 🟢 LOW | -- |
+| judge_passed=false | 296 runs | ℹ️ INFO | (expected) |
+
+**Critical finding**: judge_01 is **systematically missing** in 218 runs -- the entire T4 tier (70 runs) and most of T5 (126+ runs) in the Haiku experiment only have 2 of 3 judges. This is a systematic judge failure, not random.
+
+### Failure Rates by Tier and Model
+
+| Tier | Sonnet Pass Rate | Haiku Pass Rate | Delta | Significance |
+|------|-----------------|----------------|-------|--------------|
+| T0 | 92.9% | 73.8% | **-19.1pp** | Large effect |
+| T1 | 97.0% | 71.0% | **-26.0pp** | Large effect |
+| T2 | 98.7% | 73.3% | **-25.4pp** | Large effect |
+| T3 | 93.4% | 71.7% | **-21.7pp** | Large effect |
+| T4 | 98.6% | 72.9% | **-25.7pp** | Large effect |
+| T5 | 89.3% | 70.7% | **-18.6pp** | Large effect |
+| T6 | 100.0% | 90.0% | **-10.0pp** | Moderate effect |
+| **Overall** | **94.2%** | **72.4%** | **-21.8pp** | **Large effect** |
+
+---
+
+## 2. Analysis Pipeline Output Verification
+
+### Data Files: All Present ✅
+
+| File | Rows | Columns | Status |
+|---|---|---|---|
+| `runs.csv` | 2,245 | 19 | ✅ OK |
+| `judges.csv` | 6,606 | 13 | ⚠️ OK (74 more than summary.json reports) |
+| `criteria.csv` | 32,499 | 11 | ✅ OK |
+| `subtests.csv` | 233 | 23 | ✅ OK |
+| `summary.json` | -- | -- | ✅ OK (3 experiments, 2 models, 7 tiers) |
+| `statistical_results.json` | -- | -- | ✅ OK (5 sections, 62 entries) |
+
+**Discrepancy**: summary.json reports 6,532 judge evaluations but judges.csv has 6,606 rows (delta = 74). Likely invalid judges included in CSV but excluded from summary count. See issue #323.
+
+### Figures: 24 Vega-Lite specs, 0 renders ⚠️
+
+| Format | Count | Status |
+|---|---|---|
+| `.vl.json` (Vega-Lite specs) | 24 | ✅ Present |
+| `.csv` (data files) | 27 | ✅ OK (3 extra are supplementary data) |
+| `.png` (renders) | **0** | 🔴 **NOT GENERATED** (Issue #322) |
+| `.pdf` (renders) | **0** | 🔴 **NOT GENERATED** (Issue #322) |
+
+**Critical**: Zero PNG/PDF rendered outputs. The rendering step (`--no-render=false`) has not been executed. Paper requires rendered figures. See issue #322.
+
+### Tables: 11/11 Complete ✅
+
+All 11 tables present in both Markdown (`.md`) and LaTeX (`.tex`):
+- tab01_tier_summary
+- tab02_tier_comparison
+- tab02b_impl_rate_comparison
+- tab03_judge_agreement
+- tab04_criteria_performance
+- tab05_cost_analysis
+- tab06_model_comparison
+- tab07_subtest_detail
+- tab08_summary_statistics
+- tab09_experiment_config
+- tab10_normality_tests
+
+---
+
+## 3. Statistical Rigor Assessment
+
+### Configuration
+
+| Parameter | Value |
+|---|---|
+| Significance level (alpha) | 0.05 |
+| Bootstrap resamples | 10,000 |
+| Bootstrap method | BCa |
+| Random state | 42 |
+| Confidence level | 0.95 |
+
+### Statistical Results Coverage
+
+| Section | Entries | Description |
+|---|---|---|
+| normality_tests | 28 | Shapiro-Wilk per (model, tier, metric) |
+| omnibus_tests | 2 | Kruskal-Wallis H per model |
+| pairwise_comparisons | 12 | Mann-Whitney U for adjacent tier pairs |
+| effect_sizes | 12 | Cliff's delta with CIs |
+| correlations | 8 | Spearman between metric pairs |
+
+### Missing Statistical Analyses
+
+| Analysis | Status | Priority | Issue # |
+|---|---|---|---|
+| Power analysis | ❌ NOT IMPLEMENTED | 🟡 P2 | #328 |
+| Interaction effects (model x tier) | ❌ NOT IMPLEMENTED | 🟡 P2 | #329 |
+| Impl-Rate statistical tests | ⚠️ PARTIAL | 🟡 P1 | #324 |
+| CoP statistical tests | ⚠️ PARTIAL | 🟡 P1 | #325 |
+| Process metrics integration | ❌ NOT IMPLEMENTED | 🟡 P1 | #326 |
+
+---
+
+## 4. Coverage Gap Analysis
+
+### Task Diversity: CRITICAL GAP
+
+**Only test-001 (Hello World) has full runs.** This is a trivial "create hello.py that prints Hello World" task.
+
+**Assessment**: A single trivial task is **insufficient for a general-purpose publication** about agent architecture ablation. However, it could support a:
+- **Methodology paper** (evaluation framework design) ✅ Feasible
+- **Technical report** (proof-of-concept demonstration) ✅ Feasible
+- **Results paper** (agent capabilities across tasks) ❌ Requires test-002+
+
+**Recommendation**: Frame as **methodology paper** focusing on:
+- Evaluation framework design
+- Statistical methodology for agent evaluation
+- Ablation study approach demonstration
+- Proof-of-concept with single task
+
+### Model Coverage: ADEQUATE FOR INITIAL PAPER
+
+| Model | Thinking | Status |
+|---|---|---|
+| Sonnet 4.5 (no thinking) | OFF | ✅ Full data (1,130 runs) |
+| Haiku 4.5 (no thinking) | OFF | ⚠️ Full data (1,130 runs, with gaps) |
+| Sonnet 4.5 (thinking) | ON | ❌ **NOT TESTED** |
+| Haiku 4.5 (thinking) | ON | ❌ **NOT TESTED** |
+| Opus 4.5 | -- | ❌ **NOT TESTED** |
+
+Two models provide meaningful comparison (high-capability vs cost-efficient). Thinking variants and Opus would strengthen the paper but are not strictly required for methodology paper.
+
+### Metric Coverage
+
+| Metric | Computed | In Statistical Tests | Status | Issue # |
+|---|---|---|---|---|
+| Pass-Rate | ✅ | ✅ | ✅ READY | -- |
+| Impl-Rate | ✅ | ❌ | ⚠️ NEEDS INTEGRATION | #324 |
+| CoP (Cost-of-Pass) | ✅ | ❌ | ⚠️ NEEDS INTEGRATION | #325 |
+| Frontier CoP | ✅ (cross_tier.py) | ❌ | ⚠️ NEEDS INTEGRATION | #325 |
+| Consistency | ✅ (subtests_df) | ❌ | ⚠️ NEEDS INTEGRATION | -- |
+| R_Prog | ✅ (code exists) | ❌ | ❌ NOT INTEGRATED | #326 |
+| CFP | ✅ (code exists) | ❌ | ❌ NOT INTEGRATED | #326 |
+| Strategic Drift | ✅ (code exists) | ❌ | ❌ NOT INTEGRATED | #326 |
+| Latency | ⚠️ (duration_seconds) | ❌ | ⚠️ PARTIAL | #327 |
+| Judge Agreement | ✅ | ✅ (tables) | ✅ READY | -- |
+
+---
+
+## 5. Paper-Readiness Checklist
+
+### ✅ READY (data exists, analysis complete, figures/tables generated)
+
+- [x] Pass-Rate comparison across tiers and models (tab01, tab02, fig04)
+- [x] Score distributions and variance (fig01, fig10)
+- [x] Grade distributions (fig03, fig05)
+- [x] Judge agreement analysis (tab03, fig14)
+- [x] Criteria-level performance (tab04, fig09)
+- [x] Cost analysis and CoP (tab05, fig06, fig08)
+- [x] Model comparison (tab06)
+- [x] Subtest detail (tab07, fig15)
+- [x] Normality tests justifying non-parametric methods (tab10, fig23, fig24)
+- [x] Effect sizes with CIs for tier transitions (fig19)
+- [x] Metric correlations (fig20, fig21)
+- [x] Summary statistics (tab08)
+- [x] Experiment configuration documentation (tab09)
+- [x] Statistical results export (statistical_results.json)
+- [x] All 11 tables in Markdown + LaTeX
+- [x] 309 passing unit tests
+
+### ⚠️ NEEDS REGENERATION (data exists but outputs stale/incomplete)
+
+- [ ] **Render PNG/PDF figures** -- 0 of 24 figures have rendered outputs (#322)
+- [ ] **Fix judge evaluation count discrepancy** -- summary.json vs judges.csv (#323)
+- [ ] **Regenerate nothinking-haiku T6 reports** -- missing at subtest and tier level (#321)
+
+### 🔴 NEEDS ADDITIONAL RUNS (critical data gaps)
+
+- [ ] **Haiku T5 aborted runs** -- 15 runs never executed (#319)
+- [ ] **Haiku judge_01 retries** -- 218 runs missing judge_01 in T4/T5 (#320)
+- [ ] *(Optional)* Additional tasks beyond test-001 for generalizability claims
+- [ ] *(Optional)* Thinking-enabled model variants
+
+### ⚠️ NEEDS IMPLEMENTATION (code exists but not integrated)
+
+- [ ] **Integrate Impl-Rate into statistical tests** (#324)
+- [ ] **Integrate CoP/Frontier CoP into statistical tests** (#325)
+- [ ] **Integrate process metrics** (R_Prog, CFP, Strategic Drift) (#326)
+- [ ] **Add interaction effects analysis** (model x tier) (#329)
+- [ ] **Add power analysis** (#328)
+- [ ] **Fix Issue #316** -- P0 blocker: pytest.approx usage
+
+### 🔵 OUT OF SCOPE (future work)
+
+- Bayesian statistical methods
+- Outlier detection
+- Learning curves across runs
+- Multi-task generalization (test-002 through test-047)
+- Opus model testing
+- Thinking-enabled variants
+- Detailed latency tracking (TTFT, phase-level)
+- Token distribution analysis at component level
+
+---
+
+## 6. Recommended Minimum Path to Paper
+
+### Phase 1: Fix Data Gaps (1-2 weeks) - P0 🔴
+
+1. **Re-run 15 aborted Haiku T5 runs** (#319)
+   - T5/14 run_04-10, T5/15 run_03-10
+   - Use experiment-recovery-tools skill for selective re-execution
+2. **Re-run judge_01 for 218 Haiku runs** (#320)
+   - Entire T4 tier (70 runs) + most of T5
+   - Use experiment-recovery-tools for selective judge re-execution
+3. **Regenerate T6/01 subtest report.json** (#321)
+   - Tier-level aggregation for nothinking-haiku
+
+### Phase 2: Regenerate Analysis Outputs (1 week) - P1 🟡
+
+4. **Re-run analysis pipeline** after fixing data gaps
+   ```bash
+   pixi run -e analysis python scripts/generate_all_results.py \
+     --data-dir ~/fullruns --output-dir results/analysis \
+     --exclude test001-dryrun
+   ```
+5. **Enable figure rendering** (#322)
+   - Add `--no-render=false` flag
+   - Generates PNG (300 DPI) and PDF for all 24 figures
+   - Generates LaTeX inclusion snippets
+
+### Phase 3: Integrate Missing Metrics (1 week) - P1 🟡
+
+6. **Add Impl-Rate to statistical_results.json** (#324)
+   - Normality tests, pairwise comparisons, effect sizes
+7. **Add CoP to statistical testing** (#325)
+   - Tier-level descriptive statistics and comparisons
+8. **Integrate Frontier CoP** from cross_tier.py into main summary (#325)
+
+### Phase 4: Strengthen Statistical Analysis (1 week) - P2 🟡
+
+9. **Add post-hoc power analysis** (#328)
+   - Compute achieved power for observed effect sizes with n=10
+10. **Add model x tier interaction test** (#329)
+    - Two-way non-parametric test (Scheirer-Ray-Hare)
+11. **Fix Issue #316** (P0 pytest.approx blocker)
+
+### Phase 5: Paper Framing and Writing (2-3 weeks)
+
+12. **Decide paper scope**:
+    - **Option A (Methodology paper)**: Focus on evaluation framework, statistical methodology, proof-of-concept with test-001. Single-task is acceptable for demonstrating methodology. ✅ **RECOMMENDED**
+    - **Option B (Results paper)**: Requires additional tasks (test-002+) and possibly more models. Significantly more experiment time needed. ⏸️ Future work
+
+**Estimated timeline to submission**: 5-7 weeks (assuming Option A: methodology paper)
+
+---
+
+## 7. Risk Assessment
+
+### High Risk (Likely to Block Paper)
+
+1. **Haiku data quality** (#319, #320, #321)
+   - 16 missing run_result.json
+   - 218 missing judge_01 evaluations
+   - May require 1-2 weeks to re-run
+
+2. **Figure rendering** (#322)
+   - Zero PNG/PDF outputs
+   - May reveal visualization issues not visible in Vega-Lite specs
+   - LaTeX integration testing required
+
+### Medium Risk (May Delay Paper)
+
+3. **Metrics integration** (#324, #325, #326)
+   - Code exists but not integrated
+   - May reveal data dependencies or missing artifacts
+   - Statistical tests may show unexpected patterns
+
+4. **Statistical rigor** (#328, #329)
+   - Power analysis may show underpowered comparisons
+   - Interaction effects may complicate interpretation
+
+### Low Risk (Unlikely to Block)
+
+5. **Process metrics** (#326)
+   - Code exists but may require artifacts not in current runs
+   - Can be deferred to future work if artifacts missing
+
+6. **Judge count discrepancy** (#323)
+   - Likely just invalid judges excluded
+   - Low impact on conclusions
+
+---
+
+## 8. Success Criteria for Paper Submission
+
+### Minimum Requirements (Must Have)
+
+- [x] Complete data for 2 models across 7 tiers (after fixing #319, #320, #321)
+- [ ] All 24 figures rendered as PNG/PDF (#322)
+- [ ] All 11 tables in LaTeX format
+- [x] Statistical tests for Pass-Rate (complete)
+- [ ] Statistical tests for Impl-Rate (#324)
+- [ ] Statistical tests for CoP (#325)
+- [x] Judge agreement analysis (complete)
+- [ ] Power analysis showing adequate power for main effects (#328)
+- [x] Unit tests passing (309/309)
+- [ ] Reproducible analysis pipeline
+
+### Desirable (Should Have)
+
+- [ ] Process metrics integrated (#326)
+- [ ] Model x tier interaction analysis (#329)
+- [ ] Latency breakdown by phase (#327)
+- [ ] Consistency metric statistical tests
+- [ ] Frontier CoP in summary tables (#325)
+
+### Future Work (Nice to Have)
+
+- Additional tasks (test-002+)
+- Thinking-enabled model variants
+- Opus model testing
+- Bayesian statistical methods
+- Token distribution component analysis
+
+---
+
+## 9. Conclusion
+
+ProjectScylla has **substantial evaluation infrastructure** with 2,245 completed runs and a comprehensive analysis pipeline producing 24 figures and 11 tables. However, **critical data quality issues in the Haiku experiment** (15 aborted runs, 218 missing judge evaluations) and **incomplete metrics integration** (Impl-Rate, CoP, process metrics not in statistical tests) block immediate paper submission.
+
+**Recommendation**: Pursue **Option A (Methodology Paper)** focusing on the evaluation framework design and statistical methodology, using test-001 as proof-of-concept. This is feasible with **5-7 weeks** of additional work to:
+1. Fix data gaps (P0 issues #319, #320, #321)
+2. Regenerate analysis with figure rendering (P1 issue #322)
+3. Integrate missing metrics (P1 issues #324, #325, #326)
+4. Strengthen statistical rigor (P2 issues #328, #329)
+
+The current single-task dataset is **insufficient for broad claims** about agent capabilities across task complexity, but is **adequate for demonstrating the ablation study methodology** and establishing the evaluation framework.
+
+**Next Steps**: Prioritize P0 data gap fixes (#319, #320, #321) immediately, then proceed through phases 1-5 as outlined in section 6.
+
+---
+
+## Related Issues
+
+**Tracking**: #330 (Paper scope and readiness tracking)
+**P0 Data Gaps**: #319, #320, #321
+**P1 Analysis**: #322, #323, #324, #325, #326
+**P2 Statistical**: #316, #327, #328, #329


### PR DESCRIPTION
Closes #324

## Summary

Integrates Implementation Rate (Impl-Rate) into all statistical tests alongside Pass-Rate (score), providing comprehensive analysis of both binary success (pass/fail) and granular requirement satisfaction (impl_rate).

## Changes

### Statistical Tests Integration (`scripts/export_data.py`)

Added impl_rate to all 5 statistical test categories:

1. **Normality Tests** (Shapiro-Wilk)
   - Tests impl_rate distribution per (model, tier) pair
   - Justifies non-parametric methods for impl_rate comparisons

2. **Omnibus Tests** (Kruskal-Wallis H)
   - Tests for differences in impl_rate across all tiers per model
   - Establishes whether tier effect exists before pairwise tests

3. **Pairwise Comparisons** (Mann-Whitney U)
   - Compares impl_rate between consecutive tiers
   - Applies Holm-Bonferroni correction per model
   - Identifies which tier transitions are significant

4. **Effect Sizes** (Cliff's delta with bootstrap CIs)
   - Quantifies magnitude of impl_rate improvement per tier transition
   - Provides uncertainty quantification via BCa bootstrap

5. **Correlations** (Spearman rank)
   - Added 3 new correlations:
     - `score` ↔ `impl_rate` (quality metrics relationship)
     - `impl_rate` ↔ `cost_usd` (cost-quality trade-off)
     - `impl_rate` ↔ `duration_seconds` (efficiency analysis)

### Structural Improvements

- Added `"metric"` field to `pairwise_comparisons` entries (distinguishes `pass_rate` vs `impl_rate`)
- Added `"metric"` field to `effect_sizes` entries (parallel structure)

### Test Coverage (`tests/unit/analysis/test_export_data.py`)

- New test: `test_impl_rate_integration()` verifies impl_rate appears in all 5 sections
- Updated assertions to expect `"metric"` field in pairwise/effect tests
- Fixed test fixtures to include `impl_rate` column

## Impact on statistical_results.json

| Section | Before | After | Added |
|---------|--------|-------|-------|
| normality_tests | 28 | 42 | +14 (impl_rate per model/tier) |
| omnibus_tests | 2 | 4 | +2 (impl_rate per model) |
| pairwise_comparisons | 12 | 24 | +12 (impl_rate per tier transition) |
| effect_sizes | 12 | 24 | +12 (impl_rate per tier transition) |
| correlations | 4 | 7 | +3 (impl_rate pairs) |
| **Total entries** | **62** | **101** | **+39 (+63%)** |

## Testing

All 9 tests pass in `test_export_data.py`:
```bash
pixi run -e analysis pytest tests/unit/analysis/test_export_data.py -v
# 9 passed in 3.62s
```

Key test: `test_impl_rate_integration()` verifies impl_rate present in all sections.

## Next Steps

After merging:
1. Re-run analysis pipeline to generate updated `statistical_results.json`
2. Update tables and figures to reference impl_rate statistical tests
3. Integrate CoP metrics (#325)
4. Integrate process metrics (#326)

## Related

- Part of paper-readiness metrics integration (see #330)
- Follows same pattern as score/pass_rate statistical tests
- Enables complete dual-metric analysis (binary pass + granular impl_rate)