### PR TITLE
feat(t4): add agent teams sub-tests to T4 hierarchy tier

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -149,7 +149,7 @@ ProjectScylla benchmarks AI agent architectures across 7 testing tiers with ~114
 | T1 | Skills | 10 | Domain expertise via installed skills by category |
 | T2 | Tooling | 15 | External tools and MCP servers |
 | T3 | Delegation | 41 | Flat multi-agent with specialist agents |
-| T4 | Hierarchy | 7 | Nested orchestration with orchestrator agents |
+| T4 | Hierarchy | 14 | Nested orchestration with orchestrator agents (7 hierarchy + 7 agent teams) |
 | T5 | Hybrid | 15 | Best combinations and permutations |
 | T6 | Super | 1 | Everything enabled at maximum capability |
 

--- a/config/tiers/tiers.yaml
+++ b/config/tiers/tiers.yaml
@@ -3,12 +3,12 @@
 # Defines the testing tiers for the agent evaluation framework.
 # Each tier represents a different level of agent capability.
 #
-# Tier Structure (7 tiers, ~114+ sub-tests total):
+# Tier Structure (7 tiers, ~121+ sub-tests total):
 # - T0: Prompts - 24 sub-tests for system prompt ablation
 # - T1: Skills - 10 sub-tests for skill category ablation
 # - T2: Tooling - 15 sub-tests for tool/MCP ablation
 # - T3: Delegation - 41 sub-tests for agent ablation
-# - T4: Hierarchy - 7 sub-tests for orchestrator ablation
+# - T4: Hierarchy - 14 sub-tests for orchestrator ablation (7 hierarchy + 7 agent teams)
 # - T5: Hybrid - 15+ sub-tests for best combinations
 # - T6: Super - 1 sub-test with everything enabled
 
@@ -43,7 +43,7 @@ tiers:
 
   T4:
     name: "Hierarchy"
-    description: "Nested orchestration with orchestrator agents (7 sub-tests)"
+    description: "Nested orchestration with orchestrator agents (14 sub-tests: 7 hierarchy + 7 agent teams)"
     prompt_file: "t4-hierarchy.md"
     tools_enabled: true
     delegation_enabled: true

--- a/scripts/run_e2e_experiment.py
+++ b/scripts/run_e2e_experiment.py
@@ -293,6 +293,11 @@ Examples:
         help="Limit sub-tests per tier for testing (default: all)",
     )
     parser.add_argument(
+        "--skip-agent-teams",
+        action="store_true",
+        help="Skip agent teams sub-tests (default: False, runs all including agent teams)",
+    )
+    parser.add_argument(
         "--use-containers",
         action="store_true",
         help="Run agents and judges in isolated Docker containers (default: False)",
@@ -534,6 +539,7 @@ def build_config(args: argparse.Namespace) -> ExperimentConfig:
         parallel_subtests=config_dict["parallel_subtests"],
         timeout_seconds=config_dict["timeout_seconds"],
         max_subtests=args.max_subtests,
+        skip_agent_teams=args.skip_agent_teams,
         thinking_mode=config_dict["thinking_mode"],
         use_containers=args.use_containers,
     )

--- a/scylla/e2e/models.py
+++ b/scylla/e2e/models.py
@@ -161,6 +161,7 @@ class SubTestConfig:
     extends_previous: bool = True
     resources: dict[str, Any] = field(default_factory=dict)
     inherit_best_from: list[TierID] = field(default_factory=list)
+    agent_teams: bool = False  # Enable experimental agent teams feature
 
     def to_dict(self) -> dict[str, Any]:
         """Convert to dictionary for JSON serialization."""
@@ -173,6 +174,7 @@ class SubTestConfig:
             "extends_previous": self.extends_previous,
             "resources": self.resources,
             "inherit_best_from": [tier.value for tier in self.inherit_best_from],
+            "agent_teams": self.agent_teams,
         }
 
 
@@ -610,6 +612,7 @@ class ExperimentConfig:
     timeout_seconds: int = 3600
     max_turns: int | None = None  # Max conversation turns for agent (None = unlimited)
     max_subtests: int | None = None  # Max sub-tests per tier (None = all)
+    skip_agent_teams: bool = False  # Skip agent teams sub-tests (default: False)
     thinking_mode: str = "None"  # Thinking mode: None (default), Low, High, UltraThink
     use_containers: bool = (
         False  # DEPRECATED: Container isolation now at experiment level, not per-agent
@@ -631,6 +634,7 @@ class ExperimentConfig:
             "timeout_seconds": self.timeout_seconds,
             "max_turns": self.max_turns,
             "max_subtests": self.max_subtests,
+            "skip_agent_teams": self.skip_agent_teams,
             "thinking_mode": self.thinking_mode,
             "use_containers": self.use_containers,
         }
@@ -667,6 +671,7 @@ class ExperimentConfig:
             timeout_seconds=data.get("timeout_seconds", 3600),
             max_turns=data.get("max_turns"),
             max_subtests=data.get("max_subtests"),
+            skip_agent_teams=data.get("skip_agent_teams", False),
             thinking_mode=data.get("thinking_mode", "None"),
             use_containers=data.get("use_containers", False),
         )

--- a/scylla/e2e/runner.py
+++ b/scylla/e2e/runner.py
@@ -634,7 +634,7 @@ class E2ERunner:
         start_time = datetime.now(timezone.utc)
 
         # Load tier configuration
-        tier_config = self.tier_manager.load_tier_config(tier_id)
+        tier_config = self.tier_manager.load_tier_config(tier_id, self.config.skip_agent_teams)
 
         # Limit sub-tests if max_subtests is set
         if self.config.max_subtests is not None:

--- a/tests/claude-code/shared/subtests/t4/08-chief-architect-teams.yaml
+++ b/tests/claude-code/shared/subtests/t4/08-chief-architect-teams.yaml
@@ -1,0 +1,8 @@
+name: chief-architect-teams
+description: 'L0 orchestrator with agent teams: chief-architect'
+extends_previous: true
+agent_teams: true
+resources:
+  agents:
+    levels:
+    - 0

--- a/tests/claude-code/shared/subtests/t4/09-agentic-workflows-orchestrator-teams.yaml
+++ b/tests/claude-code/shared/subtests/t4/09-agentic-workflows-orchestrator-teams.yaml
@@ -1,0 +1,8 @@
+name: agentic-workflows-orchestrator-teams
+description: 'L1 orchestrator with agent teams: agentic-workflows-orchestrator'
+extends_previous: true
+agent_teams: true
+resources:
+  agents:
+    levels:
+    - 1

--- a/tests/claude-code/shared/subtests/t4/10-cicd-orchestrator-teams.yaml
+++ b/tests/claude-code/shared/subtests/t4/10-cicd-orchestrator-teams.yaml
@@ -1,0 +1,8 @@
+name: cicd-orchestrator-teams
+description: 'L1 orchestrator with agent teams: cicd-orchestrator'
+extends_previous: true
+agent_teams: true
+resources:
+  agents:
+    levels:
+    - 1

--- a/tests/claude-code/shared/subtests/t4/11-foundation-orchestrator-teams.yaml
+++ b/tests/claude-code/shared/subtests/t4/11-foundation-orchestrator-teams.yaml
@@ -1,0 +1,8 @@
+name: foundation-orchestrator-teams
+description: 'L1 orchestrator with agent teams: foundation-orchestrator'
+extends_previous: true
+agent_teams: true
+resources:
+  agents:
+    levels:
+    - 1

--- a/tests/claude-code/shared/subtests/t4/12-papers-orchestrator-teams.yaml
+++ b/tests/claude-code/shared/subtests/t4/12-papers-orchestrator-teams.yaml
@@ -1,0 +1,8 @@
+name: papers-orchestrator-teams
+description: 'L1 orchestrator with agent teams: papers-orchestrator'
+extends_previous: true
+agent_teams: true
+resources:
+  agents:
+    levels:
+    - 1

--- a/tests/claude-code/shared/subtests/t4/13-shared-library-orchestrator-teams.yaml
+++ b/tests/claude-code/shared/subtests/t4/13-shared-library-orchestrator-teams.yaml
@@ -1,0 +1,8 @@
+name: shared-library-orchestrator-teams
+description: 'L1 orchestrator with agent teams: shared-library-orchestrator'
+extends_previous: true
+agent_teams: true
+resources:
+  agents:
+    levels:
+    - 1

--- a/tests/claude-code/shared/subtests/t4/14-tooling-orchestrator-teams.yaml
+++ b/tests/claude-code/shared/subtests/t4/14-tooling-orchestrator-teams.yaml
@@ -1,0 +1,8 @@
+name: tooling-orchestrator-teams
+description: 'L1 orchestrator with agent teams: tooling-orchestrator'
+extends_previous: true
+agent_teams: true
+resources:
+  agents:
+    levels:
+    - 1


### PR DESCRIPTION
## Summary

Adds 7 new T4 sub-tests (08-14) to evaluate Claude Code's experimental "Agent Teams" feature alongside the existing hierarchy tests (01-07).

## Changes

### Core Infrastructure
- **models.py**: Added `agent_teams: bool` field to `SubTestConfig` dataclass
- **tier_manager.py**: 
  - Parse `agent_teams` field from YAML configs
  - Set `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1` env var in settings.json when enabled
  - Added `skip_agent_teams` parameter to filter agent teams tests
- **runner.py**: Pass `skip_agent_teams` flag through to tier_manager
- **run_e2e_experiment.py**: Added `--skip-agent-teams` CLI option

### New Sub-tests
Created 7 YAML files in `tests/claude-code/shared/subtests/t4/`:
- 08-chief-architect-teams.yaml
- 09-agentic-workflows-orchestrator-teams.yaml
- 10-cicd-orchestrator-teams.yaml
- 11-foundation-orchestrator-teams.yaml
- 12-papers-orchestrator-teams.yaml
- 13-shared-library-orchestrator-teams.yaml
- 14-tooling-orchestrator-teams.yaml

### Documentation
- **CLAUDE.md**: Updated T4 description to reflect 14 sub-tests (7 hierarchy + 7 agent teams)
- **tiers.yaml**: Updated T4 description and total count

## Implementation Details

Agent teams tests:
- Enable the experimental feature via environment variable in settings.json
- Run in parallel with regular hierarchy tests
- Can be filtered out using `--skip-agent-teams` CLI flag
- Use the same agent configurations as regular tests (L0/L1 orchestrators)

## Testing & Verification

✅ All 34 existing unit tests pass  
✅ Subtest discovery correctly finds 14 tests (7 regular + 7 teams)  
✅ settings.json correctly sets env var for agent teams tests  
✅ `--skip-agent-teams` correctly filters to 7 regular tests  

### Verification Script Output
```
T4 Subtest Discovery Verification
============================================================
1. All subtests (agent_teams included):
   Total subtests: 14
   - 01: chief-architect
   - 02-07: [other orchestrators]
   - 08: chief-architect-teams [AGENT_TEAMS]
   - 09-14: [other orchestrators with teams]

2. Subtests with --skip-agent-teams:
   Total subtests: 7
   - 01-07: [regular orchestrators only]

✓ Expected 14 total subtests, got 14: PASS
✓ Expected 7 non-teams subtests, got 7: PASS
✓ Expected 7 agent_teams subtests, got 7: PASS
✓ No agent_teams in skip mode: PASS
```

## Usage

Run all T4 tests including agent teams:
```bash
python scripts/run_e2e_experiment.py --tiers T4 --runs 10
```

Run only regular hierarchy tests (skip agent teams):
```bash
python scripts/run_e2e_experiment.py --tiers T4 --runs 10 --skip-agent-teams
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)