### PR TITLE
fix(e2e): correct parameter names and function calls in regenerate_results

### DIFF
--- a/scylla/e2e/regenerate.py
+++ b/scylla/e2e/regenerate.py
@@ -468,7 +468,6 @@ def rebuild_tier_results(
                 best_subtest=best_subtest_id,
                 best_subtest_score=best_subtest.median_score,
                 total_cost=sum(s.total_cost for s in subtest_results.values()),
-                total_runs=sum(len(s.runs) for s in subtest_results.values()),
             )
 
             tier_results[tier_id] = tier_result
@@ -575,7 +574,8 @@ def rebuild_experiment_result(
         config=config,
         tier_results=tier_results,
         best_overall_tier=best_tier,
-        best_cost_of_pass=best_cop if best_cop != float("inf") else None,
+        frontier_cop=best_cop,
+        frontier_cop_tier=best_tier,
     )
 
 
@@ -626,13 +626,13 @@ def save_all_results(
         logger.info(f"📦 Backed up existing result.json to {backup_file.name}")
 
     # Save experiment-level result
-    result.save(experiment_dir)
+    result.save(experiment_dir / "result.json")
 
     # Save experiment-level reports
     save_experiment_report(experiment_dir, result)
 
     # Generate and save summary table
-    summary_md = generate_experiment_summary_table(result)
+    summary_md = generate_experiment_summary_table(result.tier_results)
     (experiment_dir / "summary.md").write_text(summary_md)
 
     # Save tier-level reports
@@ -641,7 +641,7 @@ def save_all_results(
         save_tier_report(tier_dir, tier_id.value, tier_result)
 
         # Generate and save tier summary
-        tier_summary_md = generate_tier_summary_table(tier_result)
+        tier_summary_md = generate_tier_summary_table(tier_id.value, tier_result.subtest_results)
         (tier_dir / "summary.md").write_text(tier_summary_md)
 
         # Save subtest-level reports


### PR DESCRIPTION
## Summary

Fixed multiple critical bugs in `scylla/e2e/regenerate.py` that prevented successful report regeneration from existing run results.

## Root Cause

The `regenerate_results.py` script had parameter mismatches with the data models in `models.py`:
- Using field names that don't exist in dataclasses
- Passing wrong argument types to functions
- Missing required function parameters

## Changes

1. **TierResult initialization** - Removed invalid `total_runs` parameter (not a field in TierResult)
2. **ExperimentResult initialization** - Fixed parameter names (`best_cost_of_pass` → `frontier_cop`, added `frontier_cop_tier`)
3. **result.save() call** - Added filename to path (`experiment_dir / "result.json"`)
4. **generate_experiment_summary_table()** - Pass `result.tier_results` instead of `result`
5. **generate_tier_summary_table()** - Pass both `tier_id.value` and `tier_result.subtest_results`

## Testing

Successfully regenerated Haiku experiment reports:
- 1133 run_result.json files → All tier reports + top-level reports
- T6/report.json created (was missing)
- summary.md, report.json, tier_comparison.json all generated

## Impact

- Enables report regeneration without re-running expensive experiments
- Critical for fixing interrupted experiments where runs completed but reports weren't generated
- Used to complete test001-nothinking-haiku experiment for analysis paper

🤖 Generated with [Claude Code](https://claude.com/claude-code)