### PR TITLE
feat(e2e): add TestFixture dataclass and ExperimentConfig grading paths

### DIFF
--- a/scripts/run_e2e_experiment.py
+++ b/scripts/run_e2e_experiment.py
@@ -421,7 +421,7 @@ def load_test_config(tiers_dir: Path) -> dict | None:
             "tiers": fixture.tiers,
             "language": fixture.language,
         }
-    except (FileNotFoundError, ValueError) as e:
+    except (FileNotFoundError, ValueError):
         # Fallback to old parsing for backward compatibility
         with open(test_yaml) as f:
             config = yaml.safe_load(f) or {}

--- a/scylla/e2e/models.py
+++ b/scylla/e2e/models.py
@@ -753,8 +753,10 @@ class ExperimentConfig:
         language: Programming language for build pipeline ('python' or 'mojo')
         thinking_mode: Thinking mode for agent execution (None, Low, High, UltraThink)
         use_containers: Run agents and judges in isolated Docker containers (default: False)
-        criteria_file: Optional explicit path to criteria.md (default: tiers_dir/../expected/criteria.md)
-        rubric_file: Optional explicit path to rubric.yaml (default: tiers_dir/../expected/rubric.yaml)
+        criteria_file: Optional path to criteria.md
+            (default: tiers_dir/../expected/criteria.md)
+        rubric_file: Optional path to rubric.yaml
+            (default: tiers_dir/../expected/rubric.yaml)
 
     """
 


### PR DESCRIPTION
## Summary

Formalize test fixture schema with `TestFixture` dataclass and add optional grading material paths to `ExperimentConfig` for dynamic generation support.

**Phase 2.3-2.4 of dynamic benchmark preparation plan.**

## Changes

### `scylla/e2e/models.py`

**New: TestFixture Dataclass**
Complete test fixture definition that generators must produce:

```python
@dataclass
class TestFixture:
    id: str                    # "test-001"
    name: str                  # Human-readable name
    description: str           # Test description
    language: str              # "python" or "mojo"
    source_repo: str           # Git repo URL
    source_hash: str           # Git commit hash
    task_prompt: str           # prompt.md content
    criteria: str              # criteria.md content
    rubric: dict[str, Any]     # Parsed rubric.yaml
    tiers: list[str]           # ["T0", "T1", ...]
    timeout_seconds: int = 3600

    @classmethod
    def from_directory(cls, path: Path) -> TestFixture
    
    def to_directory(self, path: Path) -> None
```

**Methods:**
- `from_directory()` - Load from standard layout (test.yaml, prompt.md, expected/)
- `to_directory()` - Write to standard layout

**ExperimentConfig New Fields:**
```python
criteria_file: Path | None = None  # Override criteria.md location
rubric_file: Path | None = None    # Override rubric.yaml location
```

### `scripts/run_e2e_experiment.py`

**Updated: load_test_config()**
- Now uses `TestFixture.from_directory()` for structured loading
- Falls back to old YAML parsing for backward compatibility
- Cleaner, type-safe fixture loading

## Example Usage

```python
# Load existing fixture
fixture = TestFixture.from_directory(Path("tests/fixtures/tests/test-001"))

# Create new fixture programmatically (future generator)
fixture = TestFixture(
    id="test-dynamic-001",
    name="Generated Test",
    description="Dynamically generated benchmark",
    language="python",
    source_repo="https://github.com/user/repo",
    source_hash="abc123",
    task_prompt="Implement feature X...",
    criteria="Success criteria...",
    rubric={"categories": {...}},
    tiers=["T0", "T1", "T2"],
)

# Write to disk
fixture.to_directory(Path("output/test-dynamic-001"))

# Round-trip verification
loaded = TestFixture.from_directory(Path("output/test-dynamic-001"))
assert loaded.id == fixture.id
```

## Impact

- **Backward Compatible**: Falls back to old parsing if TestFixture loading fails
- **Formalizes Contract**: Clear schema for what generators must produce
- **Round-Trip Capable**: Load and save preserves all data
- **Type Safe**: Structured dataclass instead of raw dicts

## Test Plan
- [x] Verify imports work
- [ ] Test TestFixture.from_directory() on existing fixtures
- [ ] Test round-trip: from_directory() → to_directory() → from_directory()

## Related
- Phase 2.3-2.4 of dynamic benchmark generator preparation

🤖 Generated with [Claude Code](https://claude.com/claude-code)