### PR TITLE
fix(analysis): Fix remaining figure generation bugs

### DIFF
--- a/scylla/analysis/figures/cost_analysis.py
+++ b/scylla/analysis/figures/cost_analysis.py
@@ -210,8 +210,8 @@ def fig08_cost_quality_pareto(runs_df: pd.DataFrame, output_dir: Path, render: b
     shape_options = ["circle", "square", "triangle-up", "diamond", "cross"]
     shape_range = [shape_options[i % len(shape_options)] for i in range(len(models))]
 
-    # Compute dynamic domain for score axis
-    score_domain = compute_dynamic_domain(tier_stats["mean_score"])
+    # Compute dynamic domain for score axis with increased padding for text labels
+    score_domain = compute_dynamic_domain(tier_stats["mean_score"], padding_fraction=0.15)
 
     # Create scatter plot
     scatter = (

--- a/scylla/analysis/figures/criteria_analysis.py
+++ b/scylla/analysis/figures/criteria_analysis.py
@@ -11,7 +11,7 @@ import altair as alt
 import pandas as pd
 
 from scylla.analysis.figures import derive_tier_order, get_color_scale
-from scylla.analysis.figures.spec_builder import save_figure
+from scylla.analysis.figures.spec_builder import compute_dynamic_domain, save_figure
 
 
 def fig09_criteria_by_tier(
@@ -52,9 +52,9 @@ def fig09_criteria_by_tier(
     criterion_labels_list = [criterion_labels[c] for c in criterion_order]
     _, criterion_colors = get_color_scale("criteria", criterion_order)
 
-    # Use full [0, 1] domain for criterion scores to show complete bar heights
-    # (dynamic domain would clip to 0.9-1.0 and break the bars)
-    score_domain = [0, 1]
+    # Dynamic domain rounded to nearest 0.1 for clean axis labels
+    raw_domain = compute_dynamic_domain(criteria_agg["criterion_score"])
+    score_domain = [round(raw_domain[0] / 0.1) * 0.1, round(raw_domain[1] / 0.1) * 0.1]
 
     # Create grouped bar chart
     chart = (

--- a/scylla/analysis/figures/judge_analysis.py
+++ b/scylla/analysis/figures/judge_analysis.py
@@ -39,8 +39,8 @@ def fig02_judge_variance(judges_df: pd.DataFrame, output_dir: Path, render: bool
     # Get dynamic color scale
     domain, range_ = get_color_scale("judges", judge_order)
 
-    # Compute dynamic domain for judge score axis
-    score_domain = compute_dynamic_domain(data["judge_score"])
+    # Compute dynamic domain for judge score axis with increased padding for boxplot whiskers
+    score_domain = compute_dynamic_domain(data["judge_score"], padding_fraction=0.15)
 
     # Create violin plot with box plot overlay
     base = alt.Chart(data).encode(
@@ -214,8 +214,8 @@ def fig17_judge_variance_overall(
     # Get dynamic color scale
     domain, range_ = get_color_scale("judges", judge_order)
 
-    # Compute dynamic domain for judge score axis
-    score_domain = compute_dynamic_domain(data["judge_score"])
+    # Compute dynamic domain for judge score axis with increased padding for boxplot whiskers
+    score_domain = compute_dynamic_domain(data["judge_score"], padding_fraction=0.15)
 
     # Panel A: Box plot of score distributions
     boxplot = (

--- a/scylla/analysis/figures/tier_performance.py
+++ b/scylla/analysis/figures/tier_performance.py
@@ -72,9 +72,13 @@ def fig04_pass_rate_by_tier(
     models = sorted(stats_df["agent_model"].unique())
     domain, range_ = get_color_scale("models", models)
 
-    # Compute dynamic domain for pass rate axis - include CI bounds
+    # Compute dynamic domain for pass rate axis - include CI bounds and pass_threshold
+    # Include pass_threshold so the reference line is always visible
+    threshold_series = pd.Series([pass_threshold])
     pass_rate_domain = compute_dynamic_domain_with_ci(
-        stats_df["pass_rate"], stats_df["ci_low"], stats_df["ci_high"]
+        pd.concat([stats_df["pass_rate"], threshold_series]),
+        pd.concat([stats_df["ci_low"], threshold_series]),
+        pd.concat([stats_df["ci_high"], threshold_series]),
     )
 
     # Create grouped bar chart

--- a/scylla/analysis/figures/variance.py
+++ b/scylla/analysis/figures/variance.py
@@ -38,8 +38,8 @@ def fig01_score_variance_by_tier(
     models = sorted(data["agent_model"].unique())
     domain, range_ = get_color_scale("models", models)
 
-    # Compute dynamic domain for score axis
-    score_domain = compute_dynamic_domain(data["score"])
+    # Compute dynamic domain for score axis with increased padding for boxplot whiskers
+    score_domain = compute_dynamic_domain(data["score"], padding_fraction=0.15)
 
     # Create base chart with faceting
     base = alt.Chart(data).encode(


### PR DESCRIPTION
## Summary

Fixes remaining figure generation bugs identified after PR #322 (commit 39db7e0). Addresses:
- Data rendered outside graph bounds (boxplots, text labels)
- Regression lines at wrong ranges (extrapolation)
- Static domains compressing data (fig09)
- Reference lines falling outside visible domain (fig04)

## Changes

### Phase 1: Boxplot Domain Padding
- **Files**: `variance.py`, `judge_analysis.py`, `impl_rate_analysis.py`
- **Fix**: Increased `padding_fraction` from 0.10 to 0.15 for boxplot figures
- **Impact**: Prevents whiskers/outliers from rendering outside bounds in fig01, fig02, fig17, fig27

### Phase 2: Threshold Line Visibility (fig04)
- **File**: `tier_performance.py`
- **Fix**: Include `pass_threshold` value in domain computation
- **Impact**: Ensures 0.60 threshold reference line is always visible

### Phase 3: DataFrame Refactoring (fig21)
- **File**: `correlation.py`
- **Fix**: Split mixed DataFrame into `reg_stats_df` and `reg_lines_df`
- **Impact**: Removes fragile `type.isna()` pattern, improves maintainability

### Phase 4: Manual Regression Line (fig26)
- **File**: `impl_rate_analysis.py`
- **Fix**: Replace `transform_regression` with manual OLS computation
- **Impact**: Prevents regression line extrapolation beyond data range

### Phase 5: Text Label Headroom (fig08)
- **File**: `cost_analysis.py`
- **Fix**: Increased padding for score domain to accommodate tier labels
- **Impact**: Prevents label clipping at domain boundaries

### Phase 6: Dynamic Domain (fig09)
- **File**: `criteria_analysis.py`
- **Fix**: Replace static `[0, 1]` domain with dynamic domain (0.1 rounding)
- **Impact**: Prevents data compression when scores cluster at high values

## Test Plan

- [x] All 45 unit tests pass (`pytest tests/unit/analysis/test_figures.py`)
- [x] Pre-commit hooks pass
- [x] Regenerated all 26 figures successfully
- [x] Visually inspected baseline vs fixed figures

## Breaking Changes

None - all changes maintain backward compatibility.

🤖 Generated with [Claude Code](https://claude.com/claude-code)