### PR TITLE
Split fig16 into per-subtest and aggregate variance views

### DIFF
--- a/scripts/generate_figures.py
+++ b/scripts/generate_figures.py
@@ -56,7 +56,8 @@ from scylla.analysis.figures.token_analysis import fig07_token_distribution
 from scylla.analysis.figures.variance import (
     fig01_score_variance_by_tier,
     fig03_failure_rate_by_tier,
-    fig16_success_variance_by_test,
+    fig16a_success_variance_per_subtest,
+    fig16b_success_variance_aggregate,
     fig18a_failure_rate_per_subtest,
     fig18b_failure_rate_aggregate,
 )
@@ -79,7 +80,8 @@ FIGURES = {
     "fig15a_subtest_run_heatmap": ("subtest", fig15a_subtest_run_heatmap),
     "fig15b_subtest_best_heatmap": ("subtest", fig15b_subtest_best_heatmap),
     "fig15c_tier_summary_heatmap": ("subtest", fig15c_tier_summary_heatmap),
-    "fig16_success_variance_by_test": ("variance", fig16_success_variance_by_test),
+    "fig16a_success_variance_per_subtest": ("variance", fig16a_success_variance_per_subtest),
+    "fig16b_success_variance_aggregate": ("variance", fig16b_success_variance_aggregate),
     "fig17_judge_variance_overall": ("judge", fig17_judge_variance_overall),
     "fig18a_failure_rate_per_subtest": ("variance", fig18a_failure_rate_per_subtest),
     "fig18b_failure_rate_aggregate": ("variance", fig18b_failure_rate_aggregate),

--- a/tests/unit/analysis/test_figures.py
+++ b/tests/unit/analysis/test_figures.py
@@ -131,12 +131,20 @@ def test_fig15c_tier_summary_heatmap(sample_runs_df, tmp_path):
     assert (tmp_path / "fig15c_tier_summary_heatmap.vl.json").exists()
 
 
-def test_fig16_success_variance_by_test(sample_runs_df, tmp_path):
-    """Test Fig 16 generates files correctly."""
-    from scylla.analysis.figures.variance import fig16_success_variance_by_test
+def test_fig16a_success_variance_per_subtest(sample_runs_df, tmp_path):
+    """Test Fig 16a generates files correctly."""
+    from scylla.analysis.figures.variance import fig16a_success_variance_per_subtest
 
-    fig16_success_variance_by_test(sample_runs_df, tmp_path, render=False)
-    assert (tmp_path / "fig16_success_variance_by_test.vl.json").exists()
+    fig16a_success_variance_per_subtest(sample_runs_df, tmp_path, render=False)
+    assert (tmp_path / "fig16a_success_variance_per_subtest.vl.json").exists()
+
+
+def test_fig16b_success_variance_aggregate(sample_runs_df, tmp_path):
+    """Test Fig 16b generates files correctly."""
+    from scylla.analysis.figures.variance import fig16b_success_variance_aggregate
+
+    fig16b_success_variance_aggregate(sample_runs_df, tmp_path, render=False)
+    assert (tmp_path / "fig16b_success_variance_aggregate.vl.json").exists()
 
 
 def test_fig17_judge_variance_overall(sample_judges_df, tmp_path):


### PR DESCRIPTION
## Summary

Splits fig16_success_variance_by_test into two separate figures:
- **fig16a_success_variance_per_subtest**: Per-tier variance for each subtest separately (heatmap view)
- **fig16b_success_variance_aggregate**: Per-tier aggregate variance across all subtests combined (bar chart view)

## Changes

1. **scylla/analysis/figures/variance.py**:
   - Replaced `fig16_success_variance_by_test()` with two new functions
   - `fig16a`: Maintains original heatmap visualization with per-subtest detail
   - `fig16b`: New aggregate view using bar charts for tier-level comparison

2. **scripts/generate_figures.py**:
   - Updated imports to include both fig16a and fig16b
   - Updated figure registry to register both figures

3. **tests/unit/analysis/test_figures.py**:
   - Replaced single fig16 test with separate tests for fig16a and fig16b
   - Both tests verify correct file generation

## Rationale

- **Per-subtest view (fig16a)**: Preserves detailed variance patterns for identifying which specific subtests have high variance
- **Aggregate view (fig16b)**: Provides tier-level summary by pooling all subtest runs, useful for comparing overall tier stability
- **Bar charts for aggregate**: More appropriate than heatmaps for comparing aggregate values across tiers
- **Dual-panel structure**: Both figures maintain pass variance + score std dev panels for consistency

## Test Plan

- [x] Unit tests pass for both fig16a and fig16b
- [x] Pre-commit hooks pass
- [x] All variance-related tests pass

## Related

Closes #386 task #11

🤖 Generated with [Claude Code](https://claude.com/claude-code)