### PR TITLE
feat(analysis): split fig18 into per-subtest and aggregate failure rate views

### DIFF
--- a/scripts/generate_figures.py
+++ b/scripts/generate_figures.py
@@ -52,7 +52,8 @@ from scylla.analysis.figures.variance import (
     fig01_score_variance_by_tier,
     fig03_failure_rate_by_tier,
     fig16_success_variance_by_test,
-    fig18_failure_rate_by_test,
+    fig18a_failure_rate_per_subtest,
+    fig18b_failure_rate_aggregate,
 )
 
 # Figure registry mapping names to generator functions
@@ -73,7 +74,8 @@ FIGURES = {
     "fig15_subtest_heatmap": ("subtest", fig15_subtest_heatmap),
     "fig16_success_variance_by_test": ("variance", fig16_success_variance_by_test),
     "fig17_judge_variance_overall": ("judge", fig17_judge_variance_overall),
-    "fig18_failure_rate_by_test": ("variance", fig18_failure_rate_by_test),
+    "fig18a_failure_rate_per_subtest": ("variance", fig18a_failure_rate_per_subtest),
+    "fig18b_failure_rate_aggregate": ("variance", fig18b_failure_rate_aggregate),
     "fig19_effect_size_forest": ("effect_size", fig19_effect_size_forest),
     "fig20_metric_correlation_heatmap": ("correlation", fig20_metric_correlation_heatmap),
     "fig21_cost_quality_regression": ("correlation", fig21_cost_quality_regression),

--- a/tests/unit/analysis/test_figures.py
+++ b/tests/unit/analysis/test_figures.py
@@ -131,12 +131,20 @@ def test_fig17_judge_variance_overall(sample_judges_df, tmp_path):
     assert (tmp_path / "fig17_judge_variance_overall.vl.json").exists()
 
 
-def test_fig18_failure_rate_by_test(sample_runs_df, tmp_path):
-    """Test Fig 18 generates files correctly."""
-    from scylla.analysis.figures.variance import fig18_failure_rate_by_test
+def test_fig18a_failure_rate_per_subtest(sample_runs_df, tmp_path):
+    """Test Fig 18a generates files correctly."""
+    from scylla.analysis.figures.variance import fig18a_failure_rate_per_subtest
 
-    fig18_failure_rate_by_test(sample_runs_df, tmp_path, render=False)
-    assert (tmp_path / "fig18_failure_rate_by_test.vl.json").exists()
+    fig18a_failure_rate_per_subtest(sample_runs_df, tmp_path, render=False)
+    assert (tmp_path / "fig18a_failure_rate_per_subtest.vl.json").exists()
+
+
+def test_fig18b_failure_rate_aggregate(sample_runs_df, tmp_path):
+    """Test Fig 18b generates files correctly."""
+    from scylla.analysis.figures.variance import fig18b_failure_rate_aggregate
+
+    fig18b_failure_rate_aggregate(sample_runs_df, tmp_path, render=False)
+    assert (tmp_path / "fig18b_failure_rate_aggregate.vl.json").exists()
 
 
 def test_publication_theme():


### PR DESCRIPTION
## Summary

Split fig18_failure_rate_by_test into two figures with different aggregation levels for better clarity:

- **fig18a_failure_rate_per_subtest**: Detailed per-subtest failure rates
  - Shows individual subtest performance within each tier
  - Color-coded by tier with `Tier-Subtest` label format
  - Provides granular view of failure patterns across subtests

- **fig18b_failure_rate_aggregate**: Summary aggregate failure rates by tier
  - Shows overall tier performance across all subtests
  - Aggregates pass/fail metrics across all subtests within each tier
  - Provides high-level tier-to-tier comparison
  - Includes n_subtests in tooltip for context

**Visual Distinction**:
- Detailed (18a): Y-axis shows "Tier-Subtest" labels (e.g., "T0-subtest1")
- Summary (18b): Y-axis shows only "Tier" labels (e.g., "T0")

## Changes

- `/home/mvillmow/worktree-fig18/scylla/analysis/figures/variance.py`: Replaced fig18 with fig18a and fig18b
- `/home/mvillmow/worktree-fig18/scripts/generate_figures.py`: Updated imports and figure registry
- `/home/mvillmow/worktree-fig18/tests/unit/analysis/test_figures.py`: Added tests for both new figures

## Test Plan

- [x] Verified Python syntax for all modified files
- [x] Verified function definitions in variance.py
- [x] Verified imports in generate_figures.py
- [x] Verified figure registry entries
- [x] Verified test function definitions
- [ ] CI will validate full test suite passes

Closes #386 task #12

Generated with [Claude Code](https://claude.com/claude-code)