### PR TITLE
feat(analysis): split fig15 into 3-level heatmap breakdown

### DIFF
--- a/scripts/generate_figures.py
+++ b/scripts/generate_figures.py
@@ -42,7 +42,12 @@ from scylla.analysis.figures.judge_analysis import (
 )
 from scylla.analysis.figures.model_comparison import fig11_tier_uplift, fig12_consistency
 from scylla.analysis.figures.spec_builder import apply_publication_theme
-from scylla.analysis.figures.subtest_detail import fig13_latency, fig15_subtest_heatmap
+from scylla.analysis.figures.subtest_detail import (
+    fig13_latency,
+    fig15a_subtest_run_heatmap,
+    fig15b_subtest_best_heatmap,
+    fig15c_tier_summary_heatmap,
+)
 from scylla.analysis.figures.tier_performance import (
     fig04_pass_rate_by_tier,
     fig05_grade_heatmap,
@@ -70,7 +75,9 @@ FIGURES = {
     "fig12_consistency": ("model", fig12_consistency),
     "fig13_latency": ("cost", fig13_latency),
     "fig14_judge_agreement": ("judge", fig14_judge_agreement),
-    "fig15_subtest_heatmap": ("subtest", fig15_subtest_heatmap),
+    "fig15a_subtest_run_heatmap": ("subtest", fig15a_subtest_run_heatmap),
+    "fig15b_subtest_best_heatmap": ("subtest", fig15b_subtest_best_heatmap),
+    "fig15c_tier_summary_heatmap": ("subtest", fig15c_tier_summary_heatmap),
     "fig16_success_variance_by_test": ("variance", fig16_success_variance_by_test),
     "fig17_judge_variance_overall": ("judge", fig17_judge_variance_overall),
     "fig18_failure_rate_by_test": ("variance", fig18_failure_rate_by_test),

--- a/scylla/analysis/figures/subtest_detail.py
+++ b/scylla/analysis/figures/subtest_detail.py
@@ -1,6 +1,6 @@
 """Detailed subtest analysis figures.
 
-Generates Fig 13 (latency breakdown) and Fig 15 (subtest heatmap).
+Generates Fig 13 (latency breakdown) and Fig 15a/b/c (subtest heatmaps).
 """
 
 from __future__ import annotations
@@ -84,10 +84,13 @@ def fig13_latency(runs_df: pd.DataFrame, output_dir: Path, render: bool = True) 
     save_figure(chart, "fig13_latency", output_dir, render)
 
 
-def fig15_subtest_heatmap(runs_df: pd.DataFrame, output_dir: Path, render: bool = True) -> None:
-    """Generate Fig 15: Subtest Performance Heatmap.
+def fig15a_subtest_run_heatmap(
+    runs_df: pd.DataFrame, output_dir: Path, render: bool = True
+) -> None:
+    """Generate Fig 15a: Per-Tier Subtest/Run Heatmap (All Runs).
 
     Large heatmap showing all subtests × runs, color-coded by score.
+    Maximum granularity - shows performance variation across all runs.
 
     Args:
         runs_df: Runs DataFrame
@@ -144,7 +147,7 @@ def fig15_subtest_heatmap(runs_df: pd.DataFrame, output_dir: Path, render: bool 
             .properties(
                 width=300,
                 height=1200,  # Large height to accommodate all subtests
-                title=f"{model} - All Subtests Performance",
+                title=f"{model} - All Runs (Max Granularity)",
             )
         )
 
@@ -153,4 +156,157 @@ def fig15_subtest_heatmap(runs_df: pd.DataFrame, output_dir: Path, render: bool 
     # Concatenate horizontally
     chart = alt.hconcat(*charts).resolve_scale(color="shared")
 
-    save_figure(chart, "fig15_subtest_heatmap", output_dir, render)
+    save_figure(chart, "fig15a_subtest_run_heatmap", output_dir, render)
+
+
+def fig15b_subtest_best_heatmap(
+    runs_df: pd.DataFrame, output_dir: Path, render: bool = True
+) -> None:
+    """Generate Fig 15b: Per-Tier Subtest Heatmap (Best Run Only).
+
+    Shows only the best-performing run for each subtest.
+    Mid-level granularity - removes run variance, focuses on capability ceiling.
+
+    Args:
+        runs_df: Runs DataFrame
+        output_dir: Output directory
+        render: Whether to render to PNG/PDF
+
+    """
+    # For each (agent_model, tier, subtest), keep only the run with highest score
+    best_runs = (
+        runs_df.sort_values("score", ascending=False)
+        .groupby(["agent_model", "tier", "subtest"])
+        .first()
+        .reset_index()
+    )
+
+    # Prepare data
+    heatmap_data = best_runs[["agent_model", "tier", "subtest", "run_number", "score"]].copy()
+
+    # Create subtest labels combining tier and subtest ID
+    heatmap_data["subtest_label"] = heatmap_data["tier"] + "/" + heatmap_data["subtest"]
+
+    # Derive tier order and sort subtests
+    tier_order = derive_tier_order(heatmap_data)
+    heatmap_data["tier_sort"] = heatmap_data["tier"].map({t: i for i, t in enumerate(tier_order)})
+    heatmap_data["subtest_num"] = heatmap_data["subtest"].astype(int)
+    heatmap_data = heatmap_data.sort_values(["tier_sort", "subtest_num"])
+
+    # Get sorted subtest labels
+    sorted_subtests = heatmap_data["subtest_label"].unique().tolist()
+
+    # Create heatmap per model (no x-axis since only 1 run per subtest)
+    charts = []
+    for model in heatmap_data["agent_model"].unique():
+        model_data = heatmap_data[heatmap_data["agent_model"] == model]
+
+        heatmap = (
+            alt.Chart(model_data)
+            .mark_rect()
+            .encode(
+                x=alt.X(
+                    "agent_model:N",
+                    title=None,
+                    axis=alt.Axis(labels=False, ticks=False),
+                ),
+                y=alt.Y(
+                    "subtest_label:N",
+                    title="Tier/Subtest",
+                    sort=sorted_subtests,
+                    axis=alt.Axis(labelFontSize=8),
+                ),
+                color=alt.Color(
+                    "score:Q",
+                    title="Score",
+                    scale=alt.Scale(
+                        scheme="redyellowgreen",
+                        domain=[0, 1],
+                    ),
+                ),
+                tooltip=[
+                    alt.Tooltip("tier:O", title="Tier"),
+                    alt.Tooltip("subtest:O", title="Subtest"),
+                    alt.Tooltip("run_number:O", title="Best Run"),
+                    alt.Tooltip("score:Q", title="Score", format=".3f"),
+                ],
+            )
+            .properties(
+                width=100,
+                height=1200,
+                title=f"{model} - Best Run Per Subtest",
+            )
+        )
+
+        charts.append(heatmap)
+
+    # Concatenate horizontally
+    chart = alt.hconcat(*charts).resolve_scale(color="shared")
+
+    save_figure(chart, "fig15b_subtest_best_heatmap", output_dir, render)
+
+
+def fig15c_tier_summary_heatmap(
+    runs_df: pd.DataFrame, output_dir: Path, render: bool = True
+) -> None:
+    """Generate Fig 15c: Per-Tier Summary Heatmap (Aggregated).
+
+    Aggregates scores across all subtests within each tier.
+    Minimum granularity - focuses on tier-level performance patterns.
+
+    Args:
+        runs_df: Runs DataFrame
+        output_dir: Output directory
+        render: Whether to render to PNG/PDF
+
+    """
+    # Aggregate scores by (agent_model, tier, run_number)
+    tier_summary = (
+        runs_df.groupby(["agent_model", "tier", "run_number"])["score"].mean().reset_index()
+    )
+
+    # Derive tier order
+    tier_order = derive_tier_order(tier_summary)
+
+    # Create heatmap per model
+    charts = []
+    for model in tier_summary["agent_model"].unique():
+        model_data = tier_summary[tier_summary["agent_model"] == model]
+
+        heatmap = (
+            alt.Chart(model_data)
+            .mark_rect()
+            .encode(
+                x=alt.X("run_number:O", title="Run Number", axis=alt.Axis(labelAngle=0)),
+                y=alt.Y(
+                    "tier:O",
+                    title="Tier",
+                    sort=tier_order,
+                ),
+                color=alt.Color(
+                    "score:Q",
+                    title="Mean Score",
+                    scale=alt.Scale(
+                        scheme="redyellowgreen",
+                        domain=[0, 1],
+                    ),
+                ),
+                tooltip=[
+                    alt.Tooltip("tier:O", title="Tier"),
+                    alt.Tooltip("run_number:O", title="Run"),
+                    alt.Tooltip("score:Q", title="Mean Score", format=".3f"),
+                ],
+            )
+            .properties(
+                width=300,
+                height=200,
+                title=f"{model} - Tier Summary (Mean Across Subtests)",
+            )
+        )
+
+        charts.append(heatmap)
+
+    # Concatenate horizontally
+    chart = alt.hconcat(*charts).resolve_scale(color="shared")
+
+    save_figure(chart, "fig15c_tier_summary_heatmap", output_dir, render)

--- a/tests/unit/analysis/test_figures.py
+++ b/tests/unit/analysis/test_figures.py
@@ -107,12 +107,28 @@ def test_fig14_judge_agreement(sample_judges_df, tmp_path):
     assert (tmp_path / "fig14_judge_agreement.vl.json").exists()
 
 
-def test_fig15_subtest_heatmap(sample_runs_df, tmp_path):
-    """Test Fig 15 generates files correctly."""
-    from scylla.analysis.figures.subtest_detail import fig15_subtest_heatmap
+def test_fig15a_subtest_run_heatmap(sample_runs_df, tmp_path):
+    """Test Fig 15a generates files correctly."""
+    from scylla.analysis.figures.subtest_detail import fig15a_subtest_run_heatmap
 
-    fig15_subtest_heatmap(sample_runs_df, tmp_path, render=False)
-    assert (tmp_path / "fig15_subtest_heatmap.vl.json").exists()
+    fig15a_subtest_run_heatmap(sample_runs_df, tmp_path, render=False)
+    assert (tmp_path / "fig15a_subtest_run_heatmap.vl.json").exists()
+
+
+def test_fig15b_subtest_best_heatmap(sample_runs_df, tmp_path):
+    """Test Fig 15b generates files correctly."""
+    from scylla.analysis.figures.subtest_detail import fig15b_subtest_best_heatmap
+
+    fig15b_subtest_best_heatmap(sample_runs_df, tmp_path, render=False)
+    assert (tmp_path / "fig15b_subtest_best_heatmap.vl.json").exists()
+
+
+def test_fig15c_tier_summary_heatmap(sample_runs_df, tmp_path):
+    """Test Fig 15c generates files correctly."""
+    from scylla.analysis.figures.subtest_detail import fig15c_tier_summary_heatmap
+
+    fig15c_tier_summary_heatmap(sample_runs_df, tmp_path, render=False)
+    assert (tmp_path / "fig15c_tier_summary_heatmap.vl.json").exists()
 
 
 def test_fig16_success_variance_by_test(sample_runs_df, tmp_path):


### PR DESCRIPTION
## Summary

Splits `fig15_subtest_heatmap` into three separate figures with different granularity levels:

- **fig15a_subtest_run_heatmap**: Maximum granularity (tier/subtest × run_number)
  - Shows all subtests × all runs
  - Reveals performance variation across individual runs
  - Identifies which subtests have high run-to-run variance

- **fig15b_subtest_best_heatmap**: Mid-level granularity (tier/subtest × best_run)
  - Shows only the best-performing run for each subtest
  - Removes run variance to focus on capability ceiling
  - Answers "What's the best we can do on each subtest?"

- **fig15c_tier_summary_heatmap**: Minimum granularity (tier × run_number)
  - Aggregates scores across all subtests within each tier
  - Reveals tier-level performance patterns
  - Simplifies comparison across tiers

## Rationale

The 3-level breakdown improves interpretability by separating concerns:
1. Run variance (15a) vs capability ceiling (15b) vs tier trends (15c)
2. Easier to identify where variance occurs (within-run, within-tier, between-tier)
3. Aligns with ablation study framework (T0-T6 tier structure)
4. Each figure focuses on answering one specific question

## Implementation Details

- All three functions use consistent color scales (`redyellowgreen`, domain=[0,1])
- Tier ordering derived from data using `derive_tier_order()`
- fig15b uses `.groupby().first()` after sorting by score descending
- fig15c uses `.groupby().mean()` to aggregate within tiers
- Added comprehensive tests for all three figures (all passing)

## Test Plan

- [x] Run unit tests for fig15a/b/c (all pass)
- [x] Verify figure generation script includes all three figures
- [x] Confirm consistent color scales across figures
- [x] Check tier ordering logic

Related to #386 task #10.

Generated with [Claude Code](https://claude.com/claude-code)