### PR TITLE
feat(skills): add judge-rerun-workspace-corruption skill

### DIFF
--- a/.claude-plugin/skills/judge-rerun-workspace-corruption/SKILL.md
+++ b/.claude-plugin/skills/judge-rerun-workspace-corruption/SKILL.md
@@ -1,0 +1,227 @@
+# Judge Rerun Workspace Corruption Fix
+
+| Field | Value |
+|-------|-------|
+| Date | 2026-02-09 |
+| Objective | Fix judge reruns that were judging against reset/empty workspaces instead of original agent work |
+| Root Cause | Judge reruns rebuilt prompts from workspace state, which was corrupted/reset by agent rerun scripts |
+| Outcome | ✅ Judges now reuse saved `judge_prompt.md` from original run; workspace recreation blocked for completed runs |
+| Files Changed | `scylla/e2e/llm_judge.py`, `rerun_judges.py`, `rerun.py`, `subtest_executor.py`, `regenerate.py` |
+
+## When to Use This Skill
+
+Use this pattern when:
+- Judge evaluations are producing incorrect results after workspace operations
+- Rerun scripts are destroying agent work before re-judging
+- You need to preserve evaluation context across multiple script invocations
+- Fallback mechanisms are masking real failures with synthetic scores
+
+## Problem Context
+
+### The Workspace Corruption Issue
+
+When running `rerun_agents.py` followed by `rerun_judges.py`:
+1. Agent rerun script recreated git worktrees, destroying agent's work
+2. Judge rerun script rebuilt judge prompts from the now-empty workspace
+3. Judges correctly gave F-grades for empty workspaces (not the original agent work)
+
+### The Fallback Judge Masking Issue
+
+When LLM judges hit rate limits or errors:
+1. Fallback judge gave blanket 0.7/grade-C scores regardless of actual work
+2. Produced 2307/3600 (64%) garbage judgments in test001-nothinking
+3. Masked the workspace corruption issue by giving passing grades to empty workspaces
+
+## Verified Architecture Pattern
+
+### 1. Save Judge Context at Execution Time
+
+**Where**: `scylla/e2e/llm_judge.py:1409`
+
+```python
+# Save the prompt to run level (shared by all judges) - write once
+run_dir = judge_dir.parent.parent
+judge_prompt_path = run_dir / "judge_prompt.md"
+if not judge_prompt_path.exists():
+    judge_prompt_path.write_text(prompt)
+```
+
+**Why**: Captures workspace state at the moment of agent execution, before any subsequent operations.
+
+### 2. Reuse Saved Context During Reruns
+
+**Where**: `scylla/e2e/rerun_judges.py:342-390`
+
+```python
+# Check if saved judge_prompt.md exists (from original run)
+saved_judge_prompt_path = run_dir / "judge_prompt.md"
+
+if saved_judge_prompt_path.exists():
+    judge_prompt = saved_judge_prompt_path.read_text()
+
+    # Call lower-level functions directly to bypass prompt rebuilding
+    from scylla.e2e.llm_judge import _call_claude_judge, _parse_judge_response
+
+    stdout, stderr, result = _call_claude_judge(judge_prompt, model, workspace)
+    judge_result = _parse_judge_response(result)
+    # ... save logs and timing
+else:
+    logger.warning("Saved judge_prompt.md not found, rebuilding (may be inaccurate)")
+    # Fallback to run_llm_judge() which rebuilds from workspace
+```
+
+**Why**: Uses original evaluation context even if workspace was subsequently modified or reset.
+
+### 3. Block Workspace Recreation for Completed Runs
+
+**Where**: `scylla/e2e/rerun.py:320-330`
+
+```python
+# Safety check: don't destroy workspaces for completed or results-only runs
+if run_info.status in (RunStatus.COMPLETED, RunStatus.RESULTS):
+    logger.error(
+        f"Refusing to rerun {tier_id}/{subtest_id}/run_{run_number:02d}: "
+        f"status is {run_info.status.value}, which should not require agent re-execution. "
+        f"Use regenerate.py for RESULTS status or rerun_judges.py for COMPLETED status."
+    )
+    return None
+```
+
+**Why**: Prevents accidental workspace destruction for runs that only need metadata regeneration or re-judging.
+
+### 4. Remove Fallback Mechanisms That Mask Failures
+
+**Where**: `scylla/e2e/llm_judge.py:886-919`
+
+```python
+# BEFORE: try/except that catches everything and falls back
+try:
+    judge_result = run_llm_judge(...)
+except Exception as e:
+    fallback_result = _fallback_judge(agent_output)  # Blanket 0.7 score
+    return fallback_result
+
+# AFTER: Let exceptions propagate for proper error handling
+stdout, stderr, result = _call_claude_judge(judge_prompt, model, workspace)
+judge_result = _parse_judge_response(result)
+# ... save logs
+return judge_result  # Exception propagates if judge fails
+```
+
+**Why**: Makes failures visible so they can be properly debugged and retried, rather than masked by synthetic scores.
+
+### 5. Add Exception Handling at Caller Sites
+
+**Where**: `scylla/e2e/subtest_executor.py:1487`, `regenerate.py:310`
+
+```python
+try:
+    judge_result = run_llm_judge(...)
+    judges.append(judge_summary)
+except Exception as e:
+    # Log error with full context
+    logger.error(f"Judge {judge_num} failed with model {model}: {e}", exc_info=True)
+
+    # Save error artifacts
+    timing_file = judge_specific_dir / "timing.json"
+    with open(timing_file, "w") as f:
+        json.dump({
+            "judge_duration_seconds": 0.0,
+            "measured_at": datetime.now(timezone.utc).isoformat(),
+            "failed": True,
+            "error": str(e),
+        }, f, indent=2)
+
+    error_file = judge_specific_dir / "error.log"
+    error_file.write_text(f"Judge failed: {e}\n")
+
+    # Re-raise to mark run as failed (subtest_executor)
+    # OR continue to next (regenerate.py)
+    raise  # or continue
+```
+
+**Why**: Saves debugging artifacts before failing, enables retry logic at appropriate level.
+
+## Failed Attempts
+
+### ❌ Adding a judge_prompt Parameter to run_llm_judge()
+
+**What we tried**: Adding an optional `judge_prompt: str | None = None` parameter to `run_llm_judge()` to accept pre-built prompts.
+
+**Why it didn't work**:
+- `run_llm_judge()` has complex logic for building prompts (workspace state, patchfile, pipeline results, rubric)
+- Adding a parameter would require threading it through multiple internal calls
+- Makes the API confusing - when would you pass a prompt vs. rebuild?
+
+**Better approach**: Call lower-level functions (`_call_claude_judge`, `_parse_judge_response`) directly when you have a pre-built prompt.
+
+### ❌ Preventing All Workspace Recreation in rerun.py
+
+**What we tried**: Checking if workspace exists and skipping `_setup_workspace()` call.
+
+**Why it didn't work**:
+- Runs with `FAILED`, `PARTIAL`, `MISSING` status genuinely need fresh workspaces
+- Only `COMPLETED` and `RESULTS` status should preserve workspaces
+- `rerun_experiment()` already has correct logic - it doesn't call `rerun_single_run()` for RESULTS status
+
+**Better approach**: Add safety check at the start of `rerun_single_run()` to reject COMPLETED/RESULTS runs with clear error message.
+
+## Results & Key Parameters
+
+### Run Status Classifications
+
+| Status | Definition | Requires Agent Rerun? | Requires Judge Rerun? |
+|--------|------------|----------------------|----------------------|
+| COMPLETED | Agent + judge + run_result.json exist | ❌ No | Maybe (if judge failed) |
+| RESULTS | Agent finished, missing result files | ❌ No (regenerate only) | ✅ Yes |
+| FAILED | Agent ran but failed (stderr, no output) | ✅ Yes | ✅ Yes (after agent) |
+| PARTIAL | Agent started but incomplete | ✅ Yes | ✅ Yes (after agent) |
+| MISSING | Run directory doesn't exist | ✅ Yes | ✅ Yes (after agent) |
+
+### File Locations
+
+| File | Purpose | Scope |
+|------|---------|-------|
+| `run_dir/judge_prompt.md` | Full judge evaluation context | Per-run (shared by all judges) |
+| `run_dir/judge/judge_01/judgment.json` | Individual judge result | Per-judge |
+| `run_dir/judge/judge_01/timing.json` | Judge execution timing + error info | Per-judge |
+| `run_dir/workspace/` | Git worktree with agent's work | Per-run |
+| `run_dir/agent/result.json` | Agent execution result | Per-run |
+
+### Script Coordination
+
+| Script | Purpose | Workspace Handling |
+|--------|---------|-------------------|
+| `rerun_agents.py` | Re-run failed/incomplete agents | Recreates workspace for FAILED/PARTIAL/MISSING |
+| `rerun_judges.py` | Re-run failed judge evaluations | Reuses existing workspace + saved judge_prompt.md |
+| `regenerate.py` | Rebuild result.json from logs | Reuses existing workspace (no recreation) |
+
+## Testing
+
+```bash
+# 1. Run e2e tests to ensure no regressions
+pixi run python -m pytest tests/unit/e2e/ -x -q
+
+# 2. Verify _fallback_judge is fully removed
+grep -r "_fallback_judge" scylla/e2e/
+
+# 3. Verify no "fallback" references remain in judge logic
+grep -rn "fallback" scylla/e2e/llm_judge.py
+```
+
+## References
+
+- Original issue: F-grade failures in `~/fullruns/test001-nothinking` from destroyed workspaces
+- Fallback judge produced 2307/3600 (64%) garbage judgments
+- Plan transcript: `/home/mvillmow/.claude/projects/-home-mvillmow-ProjectScylla/9bfdc6b7-e7ea-4558-a17e-188ded1a7188.jsonl`
+
+## Related Patterns
+
+- [Error Handling](.claude/shared/error-handling.md) - Retry strategy, timeout handling, escalation
+- [Evaluation Guidelines](.claude/shared/evaluation-guidelines.md) - Evaluation methodology best practices
+- [Metrics Definitions](.claude/shared/metrics-definitions.md) - Complete metrics definitions
+
+---
+
+**Last Updated**: 2026-02-09
+**Tested On**: Mojo 0.26.1, Python 3.12

--- a/.claude-plugin/skills/judge-rerun-workspace-corruption/plugin.json
+++ b/.claude-plugin/skills/judge-rerun-workspace-corruption/plugin.json
@@ -1,0 +1,31 @@
+{
+  "name": "judge-rerun-workspace-corruption",
+  "version": "1.0.0",
+  "description": "Fix judge reruns producing incorrect results due to workspace corruption and fallback judge masking",
+  "category": "architecture",
+  "tags": [
+    "evaluation",
+    "judging",
+    "workspace-management",
+    "error-handling",
+    "rerun-scripts"
+  ],
+  "created": "2026-02-09",
+  "tested_on": {
+    "mojo_version": "0.26.1",
+    "python_version": "3.12"
+  },
+  "related_files": [
+    "scylla/e2e/llm_judge.py",
+    "scylla/e2e/rerun_judges.py",
+    "scylla/e2e/rerun.py",
+    "scylla/e2e/subtest_executor.py",
+    "scylla/e2e/regenerate.py"
+  ],
+  "key_insights": [
+    "Save evaluation context at execution time, not rerun time",
+    "Use lower-level functions to bypass prompt rebuilding when needed",
+    "Block workspace recreation for runs that don't need re-execution",
+    "Remove fallback mechanisms that mask real failures"
+  ]
+}

--- a/.claude-plugin/skills/judge-rerun-workspace-corruption/references/notes.md
+++ b/.claude-plugin/skills/judge-rerun-workspace-corruption/references/notes.md
@@ -1,0 +1,218 @@
+# Technical Notes: Judge Rerun Workspace Corruption Fix
+
+## Session Context
+
+**Date**: 2026-02-09
+**Objective**: Fix judge reruns producing incorrect F-grades due to workspace corruption
+**Investigation**: `~/fullruns/test001-nothinking` revealed 64% fallback judge usage masking workspace issues
+
+## Root Cause Analysis
+
+### Problem 1: Workspace Corruption Chain
+1. User runs `rerun_agents.py` to retry failed runs
+2. Script calls `rerun_single_run()` which moves old `run_dir` to `.failed/`
+3. Script recreates workspace with `_setup_workspace()` - fresh git worktree
+4. Agent runs successfully (or fails), workspace now has new state
+5. User runs `rerun_judges.py` to re-evaluate
+6. Judge rerun rebuilds prompt from **current** workspace state, not original
+7. If workspace was reset, judge sees empty workspace → correct F-grade for empty workspace
+8. But F-grade is incorrect for the **original** agent work that was destroyed
+
+### Problem 2: Fallback Judge Masking
+1. LLM judge hits rate limit or timeout
+2. Exception caught by try/except in `run_llm_judge()` (lines 886-953)
+3. `_fallback_judge()` called, returns blanket 0.7/grade-C
+4. In test001-nothinking: 2307/3600 judgments were fallback (64%)
+5. These passing grades masked the workspace corruption issue
+
+## Code Structure Discovery
+
+### Judge Prompt Storage Location
+```
+run_dir/
+├── judge_prompt.md          # Saved once during original execution
+├── judge/
+│   ├── judge_01/
+│   │   ├── judgment.json    # Individual judge result
+│   │   ├── timing.json      # Execution timing
+│   │   ├── response.txt     # LLM response
+│   │   └── error.log        # Error details (new)
+│   ├── judge_02/
+│   └── judge_03/
+└── workspace/               # Git worktree (may be reset by rerun scripts)
+```
+
+### Function Call Hierarchy
+
+```
+run_llm_judge()
+├── _get_workspace_state()
+├── _get_patchfile()
+├── _run_build_pipeline()
+├── build_task_prompt()      # Builds judge prompt from current workspace state
+├── _call_claude_judge()     # Low-level: calls Claude CLI with prompt string
+└── _parse_judge_response()  # Parses JSON response
+```
+
+**Key Insight**: `_call_claude_judge()` and `_parse_judge_response()` are low-level functions that can be called directly if you already have a pre-built judge prompt. This is what `rerun_judges.py` now does.
+
+### Run Status State Machine
+
+```
+MISSING → PARTIAL → FAILED/RESULTS → COMPLETED
+   ↓         ↓          ↓                ↓
+  Rerun   Rerun    Rerun/Regen      No action
+```
+
+- `MISSING`: No run_dir exists → needs full agent execution
+- `PARTIAL`: Agent started but incomplete → needs full agent execution
+- `FAILED`: Agent ran but failed (stderr, no output) → needs full agent execution
+- `RESULTS`: Agent finished, missing result files → needs regeneration only (no agent rerun)
+- `COMPLETED`: All files exist → no action needed (unless re-judging)
+
+**Important**: `rerun_experiment()` never calls `rerun_single_run()` for RESULTS status. RESULTS goes through separate regeneration path.
+
+## Implementation Details
+
+### Change 1: Remove Fallback Judge
+
+**File**: `scylla/e2e/llm_judge.py`
+
+Before (lines 886-953):
+```python
+try:
+    stdout, stderr, result = _call_claude_judge(judge_prompt, model, workspace)
+    judge_result = _parse_judge_response(result)
+    # ... save logs
+    return judge_result
+except Exception as e:
+    logger.warning(f"LLM judge failed, using fallback: {e}")
+    fallback_result = _fallback_judge(agent_output)  # 0.7/C score
+    # ... save fallback timing
+    return fallback_result
+```
+
+After (lines 886-919):
+```python
+stdout, stderr, result = _call_claude_judge(judge_prompt, model, workspace)
+judge_result = _parse_judge_response(result)
+# ... save logs
+return judge_result
+# Exception propagates to caller
+```
+
+Also deleted `_fallback_judge()` function (was lines 1123-1169).
+
+### Change 2: Reuse Saved Judge Prompt
+
+**File**: `scylla/e2e/rerun_judges.py`
+
+Added logic at line 342:
+```python
+saved_judge_prompt_path = run_dir / "judge_prompt.md"
+
+if saved_judge_prompt_path.exists():
+    judge_prompt = saved_judge_prompt_path.read_text()
+
+    # Bypass run_llm_judge() which would rebuild prompt
+    from scylla.e2e.llm_judge import _call_claude_judge, _parse_judge_response, _save_judge_logs
+
+    stdout, stderr, result = _call_claude_judge(judge_prompt, model, workspace)
+    judge_result = _parse_judge_response(result)
+
+    # Save logs with rerun flag
+    _save_judge_logs(actual_judge_dir, judge_prompt, result, ...)
+else:
+    logger.warning("Rebuilding from workspace (may be inaccurate)")
+    judge_result = run_llm_judge(...)  # Old behavior as fallback
+```
+
+### Change 3: Block Workspace Recreation for Completed Runs
+
+**File**: `scylla/e2e/rerun.py`
+
+Added at line 320 (before workspace operations):
+```python
+if run_info.status in (RunStatus.COMPLETED, RunStatus.RESULTS):
+    logger.error(
+        f"Refusing to rerun: status is {run_info.status.value}. "
+        f"Use regenerate.py for RESULTS or rerun_judges.py for COMPLETED."
+    )
+    return None
+```
+
+**Note**: This is a safety check. Normal operation already filters these out in `rerun_experiment()`.
+
+### Change 4: Exception Handling at Caller Sites
+
+**Files**: `scylla/e2e/subtest_executor.py:1487`, `scylla/e2e/regenerate.py:310`
+
+Both now wrap `run_llm_judge()` in try/except that:
+1. Logs error with full context
+2. Saves error artifacts (timing.json with `failed: true`, error.log)
+3. Either re-raises (subtest_executor) or continues to next (regenerate)
+
+## Testing Results
+
+```bash
+$ pixi run python -m pytest tests/unit/e2e/ -x -q
+188 passed, 1 skipped in 1.43s
+
+$ grep -r "_fallback_judge" scylla/e2e/
+scylla/e2e/__pycache__/llm_judge.cpython-312.pyc: binary file matches  # OK - will regenerate
+
+$ grep -n "fallback" scylla/e2e/llm_judge.py
+# No output - all fallback judge code removed
+
+$ grep -n "fallback" scylla/e2e/*.py | wc -l
+7  # All unrelated (rate limit fallback, legacy compatibility, etc.)
+```
+
+## Coordination Between Scripts
+
+### Correct Usage Pattern
+
+For a run with failed judge:
+```bash
+# 1. If agent also failed, rerun agent first
+pixi run python scripts/rerun_agents.py ~/experiment/ --status failed
+
+# 2. Then rerun judges (will use saved judge_prompt.md)
+pixi run python scripts/rerun_judges.py ~/experiment/
+```
+
+For a run with missing result files:
+```bash
+# Use regenerate, not rerun_agents (no need to re-execute agent)
+pixi run python scripts/regenerate.py ~/experiment/ --status results
+```
+
+### Why This Matters
+
+Before this fix:
+1. Running `rerun_agents.py` would destroy workspace
+2. Running `rerun_judges.py` would judge the empty workspace
+3. Fallback judge would give passing grades, masking the issue
+
+After this fix:
+1. `rerun_judges.py` uses saved `judge_prompt.md` (original workspace state)
+2. No fallback judge - failures are visible
+3. Safety check prevents accidental workspace destruction
+
+## Performance Impact
+
+- **No performance change** for normal execution path
+- **Slightly faster** judge reruns (skips workspace state collection and prompt rebuilding)
+- **Better debuggability** due to saved error artifacts
+
+## Related Issues Prevented
+
+This fix also prevents:
+- Judges evaluating against partial/incomplete agent work if agent was interrupted
+- Judges evaluating against wrong git branch if workspace was reset
+- Silently passing broken runs due to fallback judge
+- Lost debugging information when judges fail
+
+---
+
+**Session Transcript**: `/home/mvillmow/.claude/projects/-home-mvillmow-ProjectScylla/9bfdc6b7-e7ea-4558-a17e-188ded1a7188.jsonl`

--- a/scylla/e2e/rerun.py
+++ b/scylla/e2e/rerun.py
@@ -316,6 +316,17 @@ def rerun_single_run(
         workspace_manager=workspace_manager,
     )
 
+    # Safety check: don't destroy workspaces for completed or results-only runs
+    # These should be handled by regenerate or rerun_judges, not full agent rerun
+    if run_info.status in (RunStatus.COMPLETED, RunStatus.RESULTS):
+        logger.error(
+            f"Refusing to rerun {run_info.tier_id}/{run_info.subtest_id}/"
+            f"run_{run_info.run_number:02d}: status is {run_info.status.value}, "
+            f"which should not require agent re-execution. "
+            f"Use regenerate.py for RESULTS status or rerun_judges.py for COMPLETED status."
+        )
+        return None
+
     # If run_dir exists with old data, move it to .failed/
     if run_info.run_dir.exists():
         failed_dir = run_info.run_dir.parent / ".failed"


### PR DESCRIPTION
## Summary

Documents architectural fix for judge reruns producing incorrect results due to workspace corruption and fallback judge masking failures.

## Problem Context

Investigation of F-grade failures in `~/fullruns/test001-nothinking` revealed two critical issues:

1. **Judge reruns against destroyed workspaces** — `rerun_agents.py` recreated git worktrees (destroying agent work), then `rerun_judges.py` rebuilt judge prompts from the reset workspaces, causing correct F grades for empty workspaces instead of the original agent work.

2. **Fallback judge masking failures** — When LLM judges hit rate limits, `_fallback_judge()` gave blanket 0.7/grade-C scores instead of failing. This produced 2307/3600 (64%) garbage fallback judgments that masked the workspace issue.

## Changes

### Core Architecture Fixes

- **Remove `_fallback_judge` function** — Let exceptions propagate so callers can handle retry logic
- **Reuse saved `judge_prompt.md`** — Judge reruns use original workspace state instead of rebuilding from current (potentially corrupted) workspace
- **Block workspace recreation** — Safety check prevents accidental destruction of completed run workspaces
- **Add exception handling** — Save error artifacts (timing.json, error.log) before failing

### Files Modified

| File | Change |
|------|--------|
| `scylla/e2e/llm_judge.py` | Remove `_fallback_judge` function and try/except that caught all exceptions |
| `scylla/e2e/rerun_judges.py` | Reuse original `judge_prompt.md` when available |
| `scylla/e2e/rerun.py` | Add safety check to prevent workspace recreation for completed runs |
| `scylla/e2e/subtest_executor.py` | Add exception handling to save error artifacts before re-raising |
| `scylla/e2e/regenerate.py` | Add exception handling to save error artifacts before continuing |

## Impact

- ✅ **Eliminates garbage judgments** — No more blanket 0.7/grade-C scores masking real failures
- ✅ **Accurate reruns** — Judges evaluate original workspace state, not reset/empty workspaces
- ✅ **Proper failure handling** — Judge failures are now visible and can be retried
- ✅ **Better debugging** — Error artifacts saved for all judge failures

## Testing

```bash
# All e2e tests pass
$ pixi run python -m pytest tests/unit/e2e/ -x -q
188 passed, 1 skipped in 1.43s

# Fallback judge completely removed
$ grep -r "_fallback_judge" scylla/e2e/
# (no matches except bytecode cache)

# No fallback references in judge logic
$ grep -n "fallback" scylla/e2e/llm_judge.py
# (no matches)
```

## Related

- Skill documentation: `.claude-plugin/skills/judge-rerun-workspace-corruption/SKILL.md`
- Technical notes: `.claude-plugin/skills/judge-rerun-workspace-corruption/references/notes.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)