### PR TITLE
fix(analysis): Save CSV data for fig08, fix integration test (5 failing tests)

### DIFF
--- a/scylla/analysis/figures/cost_analysis.py
+++ b/scylla/analysis/figures/cost_analysis.py
@@ -201,6 +201,10 @@ def fig08_cost_quality_pareto(runs_df: pd.DataFrame, output_dir: Path, render: b
 
     save_figure(chart, "fig08_cost_quality_pareto", output_dir, render)
 
+    # Save tier stats with Pareto classification to CSV for analysis
+    csv_path = output_dir / "fig08_cost_quality_pareto.csv"
+    tier_stats.to_csv(csv_path, index=False)
+
 
 def fig22_cumulative_cost(runs_df: pd.DataFrame, output_dir: Path, render: bool = True) -> None:
     """Generate Fig 22: Cumulative Cost Curve.

--- a/tests/unit/analysis/test_integration.py
+++ b/tests/unit/analysis/test_integration.py
@@ -19,6 +19,7 @@ def test_e2e_pipeline_with_sample_data(sample_runs_df):
     3. Figures can be generated
     4. No exceptions raised during processing
     """
+    from scylla.analysis.figures.cost_analysis import fig08_cost_quality_pareto
     from scylla.analysis.figures.tier_performance import fig04_pass_rate_by_tier
     from scylla.analysis.tables.summary import table01_tier_summary
 
@@ -42,14 +43,15 @@ def test_e2e_pipeline_with_sample_data(sample_runs_df):
         assert "Tier" in table_md
         assert r"\begin{table}" in table_tex or r"\begin{longtable}" in table_tex
 
-        # Generate figure (smoke test)
+        # Generate figures (smoke test - test both CSV-generating and non-CSV figures)
         fig04_pass_rate_by_tier(sample_runs_df, output_dir, render=False)
+        fig08_cost_quality_pareto(sample_runs_df, output_dir, render=False)
 
         # Verify outputs exist
         vl_files = list(output_dir.glob("*.vl.json"))
         csv_files = list(output_dir.glob("*.csv"))
         assert len(vl_files) > 0, "Expected Vega-Lite spec files"
-        assert len(csv_files) > 0, "Expected CSV data files"
+        assert len(csv_files) > 0, "Expected CSV data files from fig08"
 
 
 def test_e2e_empty_dataframe_handling():


### PR DESCRIPTION
## Summary

Fixes 5 failing tests in the analysis module that were blocking PRs #493 and #494 from merging.

## Problem

### Failing Tests
1. **4 tests in test_apareto.py** - All failed with `FileNotFoundError`
   - `test_pareto_frontier_basic`
   - `test_pareto_frontier_multiple_efficient`
   - `test_pareto_frontier_tied_points`
   - `test_pareto_frontier_single_point`
   
2. **1 test in test_integration.py**
   - `test_e2e_pipeline_with_sample_data` - AssertionError: Expected CSV data files

### Root Cause
- `fig08_cost_quality_pareto()` was not saving the tier statistics DataFrame to CSV
- Tests expected to read and verify Pareto classification from CSV file
- Integration test called `fig04` which doesn't save CSV, but asserted CSV files exist

## Solution

### 1. scylla/analysis/figures/cost_analysis.py
Added CSV export after the figure generation:
```python
# Save tier stats with Pareto classification to CSV for analysis
csv_path = output_dir / "fig08_cost_quality_pareto.csv"
tier_stats.to_csv(csv_path, index=False)
```

### 2. tests/unit/analysis/test_integration.py
Updated integration test to call a figure that actually saves CSV:
```python
# Generate figures (smoke test - test both CSV-generating and non-CSV figures)
fig04_pass_rate_by_tier(sample_runs_df, output_dir, render=False)
fig08_cost_quality_pareto(sample_runs_df, output_dir, render=False)  # This saves CSV
```

## Impact

### Before
- 5 tests failing ❌
- PRs #493 and #494 blocked from merging
- CI checks failing

### After
- All 5 tests passing ✅
- CSV data enables Pareto frontier verification
- Integration test properly validates CSV-generating figures

## Testing

```bash
# Run locally
pixi run python -m pytest tests/unit/analysis/test_apareto.py -v
pixi run python -m pytest tests/unit/analysis/test_integration.py::test_e2e_pipeline_with_sample_data -v

# Results
tests/unit/analysis/test_apareto.py::test_pareto_frontier_basic PASSED
tests/unit/analysis/test_apareto.py::test_pareto_frontier_multiple_efficient PASSED
tests/unit/analysis/test_apareto.py::test_pareto_frontier_tied_points PASSED
tests/unit/analysis/test_apareto.py::test_pareto_frontier_single_point PASSED
tests/unit/analysis/test_integration.py::test_e2e_pipeline_with_sample_data PASSED

5 passed in 0.88s ✓
```

## Files Changed

- `scylla/analysis/figures/cost_analysis.py` - Added CSV export (3 lines)
- `tests/unit/analysis/test_integration.py` - Updated test to use CSV-generating figure (3 lines)

## Related Issues

**Unblocks**:
- PR #493 (Issue #490 - Consolidate calculate_cost)
- PR #494 (Issue #480 - Add core/discovery tests)

**Note**: These test failures were pre-existing in the main branch, not introduced by our new PRs.

## Pre-commit Checks

✅ All pre-commit hooks pass
- Security (shell=True check)
- Ruff format
- Ruff lint
- Trailing whitespace
- EOF newlines
- Large files
- Mixed line endings

🤖 Generated with [Claude Code](https://claude.com/claude-code)