### PR TITLE
refactor(judge): deduplicate JSON extraction & fix LLM judge parsing

### DIFF
--- a/scylla/judge/__init__.py
+++ b/scylla/judge/__init__.py
@@ -42,6 +42,7 @@ from scylla.judge.rubric import (
     RubricParser,
     RubricValidationError,
 )
+from scylla.judge.utils import extract_json_from_llm_response
 
 __all__ = [
     # Cleanup evaluator
@@ -77,4 +78,6 @@ __all__ = [
     "RubricError",
     "RubricParser",
     "RubricValidationError",
+    # Utils
+    "extract_json_from_llm_response",
 ]

--- a/scylla/judge/utils.py
+++ b/scylla/judge/utils.py
@@ -1,0 +1,71 @@
+"""Shared utilities for judge-related operations."""
+
+import json
+import re
+from typing import Any
+
+
+def extract_json_from_llm_response(output: str) -> dict[str, Any] | None:
+    r"""Extract a JSON object from LLM output text.
+
+    Handles multiple common LLM response formats:
+    - Raw JSON objects
+    - JSON in markdown code blocks (```json or ```)
+    - JSON wrapped in XML tags with preamble text
+    - JSON with leading/trailing text
+
+    This function uses a robust brace-matching algorithm to extract JSON
+    objects even when surrounded by explanatory text or XML tags.
+
+    Args:
+        output: Raw LLM output text that may contain JSON.
+
+    Returns:
+        Parsed JSON dictionary, or None if no valid JSON object found.
+
+    Examples:
+        >>> extract_json_from_llm_response('{"score": 5}')
+        {'score': 5}
+
+        >>> extract_json_from_llm_response('```json\n{"score": 5}\n```')
+        {'score': 5}
+
+        >>> extract_json_from_llm_response('<json>{"score": 5}</json>')
+        {'score': 5}
+
+        >>> extract_json_from_llm_response('Here is the result: {"score": 5}')
+        {'score': 5}
+
+    """
+    # Try to find JSON in code blocks first
+    json_block = re.search(r"```(?:json)?\s*(\{[\s\S]*?\})\s*```", output)
+    if json_block:
+        try:
+            return json.loads(json_block.group(1))
+        except json.JSONDecodeError:
+            pass
+
+    # Try to find raw JSON object using brace matching
+    start = output.find("{")
+    if start == -1:
+        return None
+
+    # Find matching closing brace
+    depth = 0
+    end = start
+    for i, char in enumerate(output[start:], start):
+        if char == "{":
+            depth += 1
+        elif char == "}":
+            depth -= 1
+            if depth == 0:
+                end = i + 1
+                break
+
+    if depth != 0:
+        return None
+
+    try:
+        return json.loads(output[start:end])
+    except json.JSONDecodeError:
+        return None

--- a/tests/unit/judge/test_utils.py
+++ b/tests/unit/judge/test_utils.py
@@ -1,0 +1,131 @@
+"""Tests for judge utility functions."""
+
+from scylla.judge.utils import extract_json_from_llm_response
+
+
+class TestExtractJsonFromLlmResponse:
+    """Tests for extract_json_from_llm_response utility."""
+
+    def test_raw_json_happy_path(self):
+        """Test extraction of raw JSON object."""
+        output = '{"score": 5, "passed": true}'
+        result = extract_json_from_llm_response(output)
+        assert result == {"score": 5, "passed": True}
+
+    def test_json_in_markdown_code_block_with_json_label(self):
+        """Test extraction from ```json code block."""
+        output = '```json\n{"score": 5, "passed": true}\n```'
+        result = extract_json_from_llm_response(output)
+        assert result == {"score": 5, "passed": True}
+
+    def test_json_in_markdown_code_block_without_label(self):
+        """Test extraction from ``` code block without json label."""
+        output = '```\n{"score": 5, "passed": true}\n```'
+        result = extract_json_from_llm_response(output)
+        assert result == {"score": 5, "passed": True}
+
+    def test_json_wrapped_in_xml_tags_with_preamble(self):
+        """Test extraction from XML-wrapped JSON with preamble text."""
+        output = """Here is the evaluation result:
+<json_evaluation>
+{"score": 0.8, "passed": true, "reasoning": "Good work"}
+</json_evaluation>
+"""
+        result = extract_json_from_llm_response(output)
+        assert result == {
+            "score": 0.8,
+            "passed": True,
+            "reasoning": "Good work",
+        }
+
+    def test_json_with_preamble_text_no_tags(self):
+        """Test extraction of JSON with leading preamble text."""
+        output = 'Here is the result: {"score": 5, "passed": true}'
+        result = extract_json_from_llm_response(output)
+        assert result == {"score": 5, "passed": True}
+
+    def test_json_with_trailing_text(self):
+        """Test extraction of JSON with trailing text."""
+        output = '{"score": 5, "passed": true} - This is a good result'
+        result = extract_json_from_llm_response(output)
+        assert result == {"score": 5, "passed": True}
+
+    def test_no_json_in_output(self):
+        """Test that None is returned when no JSON is found."""
+        output = "This is just plain text with no JSON"
+        result = extract_json_from_llm_response(output)
+        assert result is None
+
+    def test_malformed_json(self):
+        """Test that None is returned for malformed JSON."""
+        output = '{"score": 5, "passed": true'  # Missing closing brace
+        result = extract_json_from_llm_response(output)
+        assert result is None
+
+    def test_unbalanced_braces(self):
+        """Test that None is returned for unbalanced braces."""
+        output = '{"score": 5, "nested": {"key": "value"}'  # Missing closing brace
+        result = extract_json_from_llm_response(output)
+        assert result is None
+
+    def test_nested_json_objects(self):
+        """Test extraction of nested JSON objects."""
+        output = '{"score": 5, "metadata": {"author": "test", "version": 1}}'
+        result = extract_json_from_llm_response(output)
+        assert result == {
+            "score": 5,
+            "metadata": {"author": "test", "version": 1},
+        }
+
+    def test_json_with_arrays(self):
+        """Test extraction of JSON with arrays."""
+        output = '{"scores": [1, 2, 3], "passed": true}'
+        result = extract_json_from_llm_response(output)
+        assert result == {"scores": [1, 2, 3], "passed": True}
+
+    def test_complex_real_world_example(self):
+        """Test extraction from complex real-world LLM response."""
+        output = """I'll evaluate this submission based on the rubric.
+
+<json_evaluation>
+{
+  "score": 0.85,
+  "passed": true,
+  "reasoning": "The implementation meets most requirements with minor issues.",
+  "criteria_scores": {
+    "correctness": {"score": 0.9, "explanation": "Logic is sound"},
+    "completeness": {"score": 0.8, "explanation": "Missing edge cases"}
+  }
+}
+</json_evaluation>
+
+Let me know if you need clarification!"""
+        result = extract_json_from_llm_response(output)
+        assert result is not None
+        assert result["score"] == 0.85
+        assert result["passed"] is True
+        assert "criteria_scores" in result
+
+    def test_empty_string(self):
+        """Test that None is returned for empty string."""
+        output = ""
+        result = extract_json_from_llm_response(output)
+        assert result is None
+
+    def test_whitespace_only(self):
+        """Test that None is returned for whitespace-only input."""
+        output = "   \n\t  "
+        result = extract_json_from_llm_response(output)
+        assert result is None
+
+    def test_json_with_escaped_quotes(self):
+        """Test extraction of JSON with escaped quotes in strings."""
+        output = r'{"message": "He said \"hello\" to me"}'
+        result = extract_json_from_llm_response(output)
+        assert result == {"message": 'He said "hello" to me'}
+
+    def test_multiple_json_objects_extracts_first(self):
+        """Test that only the first JSON object is extracted."""
+        output = '{"first": 1} {"second": 2}'
+        result = extract_json_from_llm_response(output)
+        assert result == {"first": 1}


### PR DESCRIPTION
## Summary

- Fixes LLM judge parsing bug when using Haiku model
- Deduplicates 3 identical JSON extraction implementations into shared utility
- Adds comprehensive tests for JSON extraction from LLM responses

## Problem

When running e2e experiments with `--judge-model haiku`, the judge LLM returns JSON wrapped in `<json_evaluation>` XML tags with preamble text. The `_parse_judge_response()` in `llm_judge.py` only handled markdown code blocks, then fell through to `json.loads()` on the full response — which failed.

The codebase had **3 separate JSON-from-LLM-response extraction implementations**, two of which were identical copies with brace-matching that would handle this case:

| Location | Strategy | Handles XML/preamble? |
|----------|----------|----------------------|
| `scylla/e2e/llm_judge.py:1038-1084` | Markdown code blocks only | **No** (the bug) |
| `scylla/judge/parser.py:267-308` | Code blocks + brace-matching | Yes |
| `scylla/judge/evaluator.py:474-519` | Code blocks + brace-matching (identical copy) | Yes |

## Solution

Created shared `extract_json_from_llm_response()` utility in `scylla/judge/utils.py` that:
- Handles raw JSON, markdown code blocks, XML-wrapped JSON, and preamble text
- Uses robust brace-matching algorithm from existing working implementations
- Is tested with 16 comprehensive test cases

Updated all 3 consumers to use the shared utility:
- `scylla/e2e/llm_judge.py` - fixes the original bug
- `scylla/judge/parser.py` - removes duplicate code
- `scylla/judge/evaluator.py` - removes duplicate code

## Changes

- **NEW**: `scylla/judge/utils.py` - shared JSON extraction utility
- **EDIT**: `scylla/judge/__init__.py` - export new utility
- **EDIT**: `scylla/e2e/llm_judge.py` - use shared utility
- **EDIT**: `scylla/judge/parser.py` - delegate to shared utility
- **EDIT**: `scylla/judge/evaluator.py` - delegate to shared utility
- **NEW**: `tests/unit/judge/test_utils.py` - 16 test cases for utility
- **EDIT**: `tests/unit/e2e/test_subtest_executor.py` - add integration tests

## Verification

✅ New utility tests pass (16/16)
✅ Integration tests pass (5/5) including new XML/preamble cases
✅ Full test suite passes (1775/1777 - 2 pre-existing failures in executor)
✅ Pre-commit hooks pass

## Test Plan

- [x] Run `pixi run python -m pytest tests/unit/judge/test_utils.py -v`
- [x] Run `pixi run python -m pytest tests/unit/e2e/test_subtest_executor.py::TestParseJudgeResponse -v`
- [x] Run `pixi run python -m pytest tests/ -q`
- [x] Run `pre-commit run --all-files`

Closes #503

🤖 Generated with [Claude Code](https://claude.com/claude-code)