### PR TITLE
feat(skills): add deduplicate-llm-json-extraction skill

### DIFF
--- a/.claude-plugin/skills/deduplicate-llm-json-extraction/SKILL.md
+++ b/.claude-plugin/skills/deduplicate-llm-json-extraction/SKILL.md
@@ -1,0 +1,429 @@
+# Skill: Deduplicate LLM JSON Extraction
+
+## Overview
+
+| Field | Value |
+|-------|-------|
+| **Date** | 2026-02-12 |
+| **Objective** | Fix LLM judge parsing bug with Haiku model + deduplicate 3 identical JSON extraction implementations |
+| **Outcome** | ✅ SUCCESS - Bug fixed, code deduplicated, 16 tests added, all quality checks passed |
+| **Issue** | #503 |
+| **PR** | #505 |
+| **Category** | Refactoring |
+
+## When to Use This Skill
+
+Apply this pattern when you encounter:
+
+1. **Identical or near-identical code** in multiple modules (3+ occurrences)
+2. **Bug exists in one implementation** but not others with same logic
+3. **Copy-paste propagation risk** - when fixing one, others get missed
+4. **Maintenance burden** - need to update logic in multiple places
+5. **Missing test coverage** - implementations lack comprehensive tests
+
+**Trigger signals**:
+- Finding same regex patterns in multiple files
+- Same algorithm (e.g., brace-matching) duplicated across modules
+- Bug report affects one consumer but identical code exists elsewhere
+- Code review comments about "we have this same logic in X, Y, Z"
+
+## Problem Context
+
+When running e2e experiments with `--judge-model haiku`, the LLM judge returned JSON wrapped in `<json_evaluation>` XML tags with preamble text. The parser in `scylla/e2e/llm_judge.py` only handled markdown code blocks, causing failures.
+
+**Root cause discovered**: The codebase had **3 separate implementations** of JSON extraction from LLM responses:
+
+| Location | Strategy | Handles XML? | Bug? |
+|----------|----------|--------------|------|
+| `scylla/e2e/llm_judge.py:1038-1084` | Markdown code blocks only | ❌ | **YES** |
+| `scylla/judge/parser.py:267-308` | Code blocks + brace-matching | ✅ | No |
+| `scylla/judge/evaluator.py:474-519` | Code blocks + brace-matching | ✅ | No |
+
+Two implementations had the robust solution, one didn't. Classic deduplication opportunity.
+
+## Verified Workflow
+
+### Step 1: Identify Duplicate Implementations
+
+**Tools**: `grep`, `Grep` tool
+
+```bash
+# Search for similar patterns
+grep -r "json.loads" scylla/
+grep -r "```json" scylla/
+grep -r "re.search.*json" scylla/
+```
+
+**What to look for**:
+- Same regex patterns (e.g., `` r"```(?:json)?\s*(\{[\s\S]*?\})\s*```" ``)
+- Same algorithmic structure (find opening brace, match depth, extract substring)
+- Same error handling patterns
+- Comments describing same functionality
+
+### Step 2: Choose the Best Implementation as Source
+
+**Selection criteria** (in order):
+1. ✅ **Most robust** - handles the most edge cases
+2. ✅ **Best tested** - has existing test coverage
+3. ✅ **Most recent** - likely to have latest fixes
+4. ✅ **Clearest code** - easiest to understand and maintain
+
+In this case: `parser.py:267-308` was chosen (identical to `evaluator.py`, both more robust than `llm_judge.py`)
+
+### Step 3: Extract to Shared Utility Module
+
+**File naming pattern**: `<module>/utils.py` for module-level utilities
+
+**Created**: `scylla/judge/utils.py`
+
+**Key decisions**:
+- ✅ Use descriptive name: `extract_json_from_llm_response()`
+- ✅ Add comprehensive docstring with examples
+- ✅ Include all edge cases in docstring
+- ✅ Keep same signature as original functions
+
+**Template**:
+```python
+"""Shared utilities for <module>-related operations."""
+
+import <required-imports>
+
+
+def extract_json_from_llm_response(output: str) -> dict[str, Any] | None:
+    r"""Extract a JSON object from LLM output text.
+
+    Handles multiple common LLM response formats:
+    - Raw JSON objects
+    - JSON in markdown code blocks (```json or ```)
+    - JSON wrapped in XML tags with preamble text
+    - JSON with leading/trailing text
+
+    This function uses a robust brace-matching algorithm to extract JSON
+    objects even when surrounded by explanatory text or XML tags.
+
+    Args:
+        output: Raw LLM output text that may contain JSON.
+
+    Returns:
+        Parsed JSON dictionary, or None if no valid JSON object found.
+
+    Examples:
+        >>> extract_json_from_llm_response('{"score": 5}')
+        {'score': 5}
+
+        >>> extract_json_from_llm_response('```json\n{"score": 5}\n```')
+        {'score': 5}
+
+    """
+    # [Paste the most robust implementation here]
+```
+
+**Critical**: Use `r"""` for docstrings with backslashes (ruff will complain otherwise)
+
+### Step 4: Update Module Exports
+
+**Edit**: `<module>/__init__.py`
+
+```python
+from <module>.utils import extract_json_from_llm_response
+
+__all__ = [
+    # ... existing exports ...
+    # Utils
+    "extract_json_from_llm_response",
+]
+```
+
+### Step 5: Update All Consumers
+
+**Pattern for each consumer**:
+
+**Before** (full implementation):
+```python
+def _extract_json(self, output: str) -> dict[str, Any] | None:
+    """Extract JSON object from output text."""
+    # 40+ lines of duplicate logic
+    json_block = re.search(r"```(?:json)?\s*(\{[\s\S]*?\})\s*```", output)
+    # ... brace matching ...
+    # ... error handling ...
+    return json.loads(output[start:end])
+```
+
+**After** (delegation):
+```python
+from <module>.utils import extract_json_from_llm_response
+
+def _extract_json(self, output: str) -> dict[str, Any] | None:
+    """Extract JSON object from output text."""
+    return extract_json_from_llm_response(output)
+```
+
+**For standalone functions** (like `_parse_judge_response`):
+```python
+# Before: 40+ lines of extraction + validation
+# After:
+data = extract_json_from_llm_response(response)
+if data is None:
+    raise ValueError("Judge response does not contain valid JSON...")
+# ... keep existing validation logic ...
+```
+
+### Step 6: Write Comprehensive Tests
+
+**Create**: `tests/unit/<module>/test_utils.py`
+
+**Test coverage checklist**:
+- ✅ Raw JSON (happy path)
+- ✅ JSON in markdown code blocks (`` ```json `` and `` ``` ``)
+- ✅ JSON wrapped in XML tags with preamble
+- ✅ JSON with preamble text (no tags)
+- ✅ JSON with trailing text
+- ✅ No JSON in output (returns None)
+- ✅ Malformed JSON (returns None)
+- ✅ Unbalanced braces (returns None)
+- ✅ Nested JSON objects
+- ✅ JSON with arrays
+- ✅ Complex real-world LLM responses
+- ✅ Empty string
+- ✅ Whitespace only
+- ✅ Escaped quotes in strings
+- ✅ Multiple JSON objects (extracts first)
+
+**Template**:
+```python
+"""Tests for <module> utility functions."""
+
+import pytest
+from <module>.utils import extract_json_from_llm_response
+
+
+class TestExtractJsonFromLlmResponse:
+    """Tests for extract_json_from_llm_response utility."""
+
+    def test_raw_json_happy_path(self):
+        """Test extraction of raw JSON object."""
+        output = '{"score": 5, "passed": true}'
+        result = extract_json_from_llm_response(output)
+        assert result == {"score": 5, "passed": True}
+
+    def test_json_wrapped_in_xml_tags_with_preamble(self):
+        """Test extraction from XML-wrapped JSON with preamble text."""
+        output = """Here is the evaluation result:
+<json_evaluation>
+{"score": 0.8, "passed": true, "reasoning": "Good work"}
+</json_evaluation>
+"""
+        result = extract_json_from_llm_response(output)
+        assert result == {
+            "score": 0.8,
+            "passed": True,
+            "reasoning": "Good work",
+        }
+```
+
+### Step 7: Add Integration Tests
+
+**Update**: `tests/unit/<module>/test_<consumer>.py`
+
+Add tests for the **originally failing case**:
+
+```python
+def test_parse_judge_response_handles_xml_wrapped_json(self) -> None:
+    """Test _parse_judge_response handles XML-wrapped JSON with preamble text."""
+    response = """Here is the evaluation result:
+<json_evaluation>
+{"score": 0.8, "passed": true, "reasoning": "Good work"}
+</json_evaluation>
+"""
+    result = _parse_judge_response(response)
+    assert result.score == 0.8
+    assert result.passed is True
+    assert result.reasoning == "Good work"
+```
+
+### Step 8: Verification Checklist
+
+Run in this exact order:
+
+```bash
+# 1. New utility tests
+pixi run python -m pytest tests/unit/<module>/test_utils.py -v
+
+# 2. Integration tests (updated consumer tests)
+pixi run python -m pytest tests/unit/<module>/test_<consumer>.py::<TestClass> -v
+
+# 3. Full test suite (ensure no regressions)
+pixi run python -m pytest tests/ -q
+
+# 4. Pre-commit hooks (code quality)
+pre-commit run --files <changed-files>
+```
+
+**Expected results**:
+- ✅ All new tests pass
+- ✅ All integration tests pass (including new cases)
+- ✅ Full test suite passes (or pre-existing failures documented)
+- ✅ Pre-commit hooks pass (ruff, black, mypy)
+
+### Step 9: Commit and PR
+
+**Commit message format**:
+```
+refactor(<module>): deduplicate <functionality> & fix <bug>
+
+## Problem
+[Description of bug + duplication discovery]
+
+## Solution
+Created shared `<utility_function>()` utility in `<module>/utils.py` that:
+- [Feature 1]
+- [Feature 2]
+- [Feature 3]
+
+Updated all N consumers to use the shared utility:
+- `<file1>` - fixes the original bug
+- `<file2>` - removes duplicate code
+- `<file3>` - removes duplicate code
+
+## Changes
+- NEW: <new files>
+- EDIT: <modified files>
+
+## Verification
+✓ New utility tests pass (X/X)
+✓ Integration tests pass (Y/Y)
+✓ Full test suite passes (Z/total)
+✓ Pre-commit hooks pass
+
+Closes #<issue>
+
+Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>
+```
+
+**PR workflow**:
+```bash
+git checkout -b fix-<description>
+git add <files>
+git commit -m "..."
+git push -u origin fix-<description>
+gh pr create --title "..." --body "..." --label "bug,refactor"
+gh pr merge --auto --rebase
+```
+
+## Failed Attempts & Lessons Learned
+
+### ❌ Attempt 1: Fix Only the Broken Implementation
+
+**What we tried**: Initially considered just fixing the bug in `llm_judge.py` by copying the brace-matching logic.
+
+**Why it failed**: Would have created a **4th** duplicate implementation. Future bugs would require fixing 4 places instead of 1.
+
+**Lesson**: When you find duplicate code during bug fixing, **always deduplicate first** rather than propagating the fix.
+
+### ⚠️ Pitfall: Updating Error Messages Without Checking Tests
+
+**What happened**: Changed error message from `"Judge response is not valid JSON"` to `"Judge response does not contain valid JSON"`.
+
+**Impact**: Broke existing test that expected the old message.
+
+**Fix**: Updated test expectations in `test_subtest_executor.py:220` to match new message.
+
+**Lesson**: When changing error messages, always grep for tests that assert on those messages:
+```bash
+grep -r "Judge response is not valid JSON" tests/
+```
+
+### ⚠️ Pitfall: Docstring Backslashes Without Raw String
+
+**What happened**: Linter (ruff) failed with `D301 Use r""" if any backslashes in a docstring`.
+
+**Why**: Docstring had `` `\n` `` in examples without using raw string prefix.
+
+**Fix**: Changed `"""` to `r"""` for the docstring.
+
+**Lesson**: Always use `r"""` for docstrings containing backslashes, even in examples.
+
+### ✅ Success: Identifying Pre-existing Test Failures
+
+**What happened**: Full test suite showed 2 failures in `executor/test_agent_container.py`.
+
+**Investigation**: Stashed changes, ran tests on main branch → same failures.
+
+**Conclusion**: Pre-existing failures unrelated to our changes.
+
+**Lesson**: Always verify test failures by checking if they exist on main branch:
+```bash
+git stash
+pixi run python -m pytest <failing-test> -q
+git stash pop
+```
+
+## Results & Parameters
+
+### Files Created
+
+| File | Lines | Purpose |
+|------|-------|---------|
+| `scylla/judge/utils.py` | 68 | Shared JSON extraction utility |
+| `tests/unit/judge/test_utils.py` | 149 | Comprehensive test suite |
+
+### Files Modified
+
+| File | Lines Changed | Purpose |
+|------|---------------|---------|
+| `scylla/judge/__init__.py` | +2 | Export new utility |
+| `scylla/e2e/llm_judge.py` | -24, +11 | Use shared utility (fixes bug) |
+| `scylla/judge/parser.py` | -41, +1 | Delegate to shared utility |
+| `scylla/judge/evaluator.py` | -46, +1 | Delegate to shared utility |
+| `tests/unit/e2e/test_subtest_executor.py` | +22 | Add integration tests |
+
+**Net change**: +273 additions, -113 deletions (160 net lines)
+
+### Test Results
+
+```
+✅ New utility tests: 16/16 passed
+✅ Integration tests: 5/5 passed
+✅ Full test suite: 1775/1777 passed
+   ⚠️  2 pre-existing failures in executor (unrelated)
+✅ Pre-commit hooks: All passed
+```
+
+### Deduplication Metrics
+
+| Metric | Value |
+|--------|-------|
+| **Duplicate implementations removed** | 2 |
+| **Lines of duplicate code removed** | ~87 lines |
+| **New shared utility** | 1 function |
+| **Test coverage added** | 16 tests |
+| **Consumers updated** | 3 |
+
+## Key Takeaways
+
+1. **Bug in one → Check for duplicates**: When fixing a bug, always search for duplicate implementations that may have the same issue (or the fix).
+
+2. **Deduplicate during bug fix**: Don't just fix the bug in one place — consolidate the logic to prevent future drift.
+
+3. **Choose the most robust implementation**: When deduplicating, pick the version that handles the most edge cases.
+
+4. **Write tests for the bug**: The originally failing case (XML-wrapped JSON) became a test case to prevent regression.
+
+5. **Document what each format handles**: The docstring explicitly lists all supported formats (raw JSON, markdown, XML, preamble).
+
+6. **Verify pre-existing failures**: Don't assume test failures are your fault — check if they exist on main.
+
+7. **Use raw strings for backslashes**: Always use `r"""` for docstrings containing backslash examples.
+
+## Related Skills
+
+- `find-duplicate-code` - Techniques for identifying code duplication
+- `extract-utility-functions` - Creating shared utilities
+- `comprehensive-test-coverage` - Writing thorough test suites
+- `pre-commit-hook-workflow` - Running and fixing pre-commit checks
+
+## References
+
+- Issue: https://github.com/HomericIntelligence/ProjectScylla/issues/503
+- PR: https://github.com/HomericIntelligence/ProjectScylla/pull/505
+- Commit: `cfa6869`

--- a/.claude-plugin/skills/deduplicate-llm-json-extraction/references/notes.md
+++ b/.claude-plugin/skills/deduplicate-llm-json-extraction/references/notes.md
@@ -1,0 +1,263 @@
+# Session Notes: Deduplicate LLM JSON Extraction
+
+## Session Context
+
+**Date**: 2026-02-12
+**Session ID**: 95550d04-f8cc-43b3-abac-40cd64149abd
+**Issue**: #503
+**PR**: #505
+
+## Problem Discovery
+
+Initial bug report: LLM judge failing with Haiku model when JSON wrapped in XML tags.
+
+Error was in `scylla/e2e/llm_judge.py:_parse_judge_response()` which only handled:
+- Markdown code blocks (`` ```json `` or `` ``` ``)
+- Raw JSON via `json.loads()`
+
+**Did NOT handle**:
+- XML-wrapped JSON: `<json_evaluation>{"score": 0.8}</json_evaluation>`
+- Preamble text before JSON: `Here is the result: {"score": 0.8}`
+
+## Code Search Findings
+
+Searched for similar JSON extraction logic:
+
+```bash
+grep -r "json.loads" scylla/
+grep -r '```json' scylla/
+grep -r 're.search.*json' scylla/
+```
+
+**Found 3 implementations**:
+
+1. **scylla/e2e/llm_judge.py:1038-1084** (BROKEN)
+   - String manipulation for markdown blocks
+   - No brace matching
+   - Fails on XML/preamble
+
+2. **scylla/judge/parser.py:267-308** (WORKING)
+   - Markdown code blocks regex
+   - Brace-matching algorithm
+   - Handles XML/preamble
+
+3. **scylla/judge/evaluator.py:474-519** (WORKING)
+   - **IDENTICAL** to parser.py
+   - Same regex, same algorithm
+   - Copy-paste from parser.py
+
+## Implementation Strategy
+
+Chose to:
+1. Extract proven implementation to shared utility
+2. Update all 3 consumers
+3. Add comprehensive tests
+
+**Why this approach**:
+- Fixes the bug in llm_judge.py
+- Removes duplicate code (113 lines removed)
+- Prevents future drift
+- Single source of truth for testing
+
+## Key Code Snippets
+
+### Original Broken Implementation (llm_judge.py)
+
+```python
+# Handle markdown code blocks
+if "```json" in response:
+    start = response.find("```json") + 7
+    end = response.find("```", start)
+    response = response[start:end].strip()
+elif "```" in response:
+    start = response.find("```") + 3
+    end = response.find("```", start)
+    response = response[start:end].strip()
+
+try:
+    data = json.loads(response)  # Fails on XML/preamble
+except json.JSONDecodeError as e:
+    raise ValueError(...)
+```
+
+### Working Implementation (parser.py)
+
+```python
+# Try to find JSON in code blocks first
+json_block = re.search(r"```(?:json)?\s*(\{[\s\S]*?\})\s*```", output)
+if json_block:
+    try:
+        return json.loads(json_block.group(1))
+    except json.JSONDecodeError:
+        pass
+
+# Try to find raw JSON object (brace matching)
+start = output.find("{")
+if start == -1:
+    return None
+
+# Find matching closing brace
+depth = 0
+end = start
+for i, char in enumerate(output[start:], start):
+    if char == "{":
+        depth += 1
+    elif char == "}":
+        depth -= 1
+        if depth == 0:
+            end = i + 1
+            break
+
+if depth != 0:
+    return None
+
+try:
+    return json.loads(output[start:end])
+except json.JSONDecodeError:
+    return None
+```
+
+### New Shared Utility (judge/utils.py)
+
+Exact copy of working implementation, now in `extract_json_from_llm_response()`.
+
+## Test Strategy
+
+### Unit Tests (test_utils.py)
+
+16 test cases covering:
+- Happy paths (raw JSON, code blocks)
+- Edge cases (XML tags, preamble, trailing text)
+- Error cases (no JSON, malformed, unbalanced braces)
+- Real-world examples (complex nested JSON with XML wrapper)
+
+### Integration Tests (test_subtest_executor.py)
+
+Added 3 tests for `_parse_judge_response()`:
+1. XML-wrapped JSON (the original bug)
+2. Preamble text
+3. Markdown code block
+
+**Important**: Had to update error message expectation from `"Judge response is not valid JSON"` to `"Judge response does not contain valid JSON"`.
+
+## Pitfalls Encountered
+
+### 1. Test Grade Expectations
+
+Initial tests expected:
+- 0.8 → "B" grade
+- 0.7 → "C" grade
+
+Actual grading scale:
+- 0.8 → "A" grade
+- 0.7 → "B" grade
+
+**Fix**: Checked actual `_score_to_grade()` function and updated test assertions.
+
+### 2. Docstring Backslashes
+
+Ruff error: `D301 Use r""" if any backslashes in a docstring`
+
+**Why**: Examples had `\n` in docstring without raw string prefix.
+
+**Fix**: Changed `"""` to `r"""` and actual `\n` in examples (not escaped).
+
+### 3. Pre-existing Test Failures
+
+Full test suite showed 2 failures in `tests/unit/executor/test_agent_container.py`.
+
+**Investigation**:
+```bash
+git stash
+pixi run python -m pytest tests/unit/executor/test_agent_container.py::test_build_volumes_without_claude_md -q
+# Still fails on main branch
+git stash pop
+```
+
+**Conclusion**: Unrelated to our changes, pre-existing failures.
+
+## Verification Commands
+
+```bash
+# Unit tests
+pixi run python -m pytest tests/unit/judge/test_utils.py -v
+
+# Integration tests
+pixi run python -m pytest tests/unit/e2e/test_subtest_executor.py::TestParseJudgeResponse -v
+
+# Full suite
+pixi run python -m pytest tests/ -q
+
+# Pre-commit
+pre-commit run --files scylla/judge/utils.py scylla/judge/__init__.py scylla/judge/parser.py scylla/judge/evaluator.py scylla/e2e/llm_judge.py tests/unit/judge/test_utils.py tests/unit/e2e/test_subtest_executor.py
+```
+
+## Git Workflow
+
+```bash
+# Create branch
+git checkout -b fix-llm-judge-json-parsing
+
+# Create issue
+gh issue create --title "..." --body "..." --label "bug,refactor"
+# → Issue #503
+
+# Make changes
+# ...
+
+# Stage files
+git add scylla/judge/utils.py scylla/judge/__init__.py scylla/judge/parser.py scylla/judge/evaluator.py scylla/e2e/llm_judge.py tests/unit/judge/test_utils.py tests/unit/e2e/test_subtest_executor.py
+
+# Commit
+git commit -m "refactor(judge): deduplicate JSON extraction & fix LLM judge parsing
+
+[Full commit message with problem, solution, changes, verification]
+
+Closes #503
+
+Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>"
+
+# Push
+git push -u origin fix-llm-judge-json-parsing
+
+# Create PR
+gh pr create --title "..." --body "..." --label "bug,refactor"
+# → PR #505
+
+# Enable auto-merge
+gh pr merge --auto --rebase 505
+
+# Comment on issue
+gh issue comment 503 --body "Implementation Complete ✅..."
+```
+
+## Metrics
+
+### Code Changes
+
+- **Files created**: 2 (utils.py, test_utils.py)
+- **Files modified**: 5
+- **Lines added**: 273
+- **Lines deleted**: 113
+- **Net change**: +160 lines
+
+### Deduplication Impact
+
+- **Duplicate implementations**: 3 → 1
+- **Lines of duplicate code removed**: ~87
+- **Consumers updated**: 3
+- **Tests added**: 16 unit + 3 integration
+
+### Test Results
+
+- **New utility tests**: 16/16 ✅
+- **Integration tests**: 5/5 ✅
+- **Full test suite**: 1775/1777 ✅ (2 pre-existing failures)
+- **Pre-commit hooks**: All passed ✅
+
+## Links
+
+- **Issue**: https://github.com/HomericIntelligence/ProjectScylla/issues/503
+- **PR**: https://github.com/HomericIntelligence/ProjectScylla/pull/505
+- **Commit**: cfa6869
+- **Branch**: fix-llm-judge-json-parsing


### PR DESCRIPTION
## Summary

Captures learnings from successfully deduplicating 3 identical JSON extraction implementations and fixing the LLM judge parsing bug.

## Skill Details

**Category**: Refactoring  
**Pattern**: Identify and consolidate duplicate code by creating shared utilities

**Session**: 95550d04-f8cc-43b3-abac-40cd64149abd  
**Related Issue**: #503  
**Related PR**: #505

## When to Use This Skill

Apply this pattern when:
- 3+ identical or near-identical implementations exist
- Bug exists in one but not others with same logic
- Risk of copy-paste propagation
- Maintenance burden from updating multiple places

## Key Workflow Steps

1. **Identify duplicates** - grep for similar patterns
2. **Choose best implementation** - most robust, best tested
3. **Extract to shared utility** - descriptive name, comprehensive docs
4. **Update module exports** - add to `__all__`
5. **Update all consumers** - delegate to shared function
6. **Write comprehensive tests** - 15+ edge cases
7. **Add integration tests** - test originally failing case
8. **Verify** - unit tests, integration, full suite, pre-commit

## Results from Session

✅ **Bug fixed** - Haiku model JSON parsing now works  
✅ **Code deduplicated** - 87 lines of duplicate code removed  
✅ **Tests added** - 16 comprehensive unit tests + 3 integration tests  
✅ **Consumers updated** - 3 files now use shared utility  
✅ **Quality checks** - All tests pass, pre-commit hooks pass

## Failed Attempts Documented

- ❌ Fixing only broken implementation (would create 4th duplicate)
- ⚠️ Updating error messages without checking tests
- ⚠️ Docstring backslashes without raw string prefix
- ✅ Identifying pre-existing test failures

## Files

- `SKILL.md` - Complete workflow with step-by-step guide
- `references/notes.md` - Raw session details and code snippets

## Test Plan

- [x] SKILL.md is comprehensive and actionable
- [x] References include all key code snippets
- [x] Failed attempts documented for learning
- [x] Workflow can be followed independently

🤖 Generated with [Claude Code](https://claude.com/claude-code)