### PR TITLE
refactor(e2e): Change language defaults from mojo to python

### DIFF
--- a/scylla/e2e/llm_judge.py
+++ b/scylla/e2e/llm_judge.py
@@ -534,7 +534,7 @@ def _run_python_pipeline(workspace: Path) -> BuildPipelineResult:
     return BuildPipelineResult(**results)
 
 
-def _run_build_pipeline(workspace: Path, language: str = "mojo") -> BuildPipelineResult:
+def _run_build_pipeline(workspace: Path, language: str = "python") -> BuildPipelineResult:
     """Run build/lint pipeline and capture results.
 
     Routes to language-specific pipeline based on language parameter.
@@ -772,7 +772,7 @@ def run_llm_judge(
     include_patchfile: bool = True,
     run_build_pipeline: bool = True,
     judge_run_number: int = 1,
-    language: str = "mojo",
+    language: str = "python",
 ) -> JudgeResult:
     """Run LLM judge evaluation on agent's work.
 
@@ -1069,7 +1069,7 @@ def _parse_judge_response(response: str) -> JudgeResult:
     )
 
 
-def _save_pipeline_commands(run_dir: Path, workspace: Path, language: str = "mojo") -> None:
+def _save_pipeline_commands(run_dir: Path, workspace: Path, language: str = "python") -> None:
     """Save all build/lint/test commands as reproducible bash scripts.
 
     Creates individual scripts for each tool in run_dir/commands/ directory,
@@ -1333,7 +1333,7 @@ echo "=== All checks completed ==="
 
 
 def _save_pipeline_outputs(
-    run_dir: Path, result: BuildPipelineResult, language: str = "mojo"
+    run_dir: Path, result: BuildPipelineResult, language: str = "python"
 ) -> None:
     """Save outputs from each pipeline step for debugging.
 
@@ -1368,7 +1368,7 @@ def _save_judge_logs(
     workspace: Path | None = None,
     raw_stdout: str = "",
     raw_stderr: str = "",
-    language: str = "mojo",
+    language: str = "python",
 ) -> None:
     """Save judge evaluation logs and generate replay script.
 

--- a/scylla/e2e/subtest_executor.py
+++ b/scylla/e2e/subtest_executor.py
@@ -1462,7 +1462,7 @@ class SubTestExecutor:
         task_prompt: str,
         stdout: str,
         judge_dir: Path,
-        language: str = "mojo",
+        language: str = "python",
         rubric_path: Path | None = None,
     ) -> tuple[dict, list[JudgeResultSummary]]:
         """Run LLM judge evaluation(s) on the result.


### PR DESCRIPTION
Closes #401 (Priority 1)

## Summary
Changed default language parameter from `"mojo"` to `"python"` in all general-purpose e2e functions, completing the second phase of Mojo vestige cleanup.

## Changes
Updated 6 function signatures in `scylla/e2e/`:

**llm_judge.py (5 functions):**
- `_run_build_pipeline()` - line 537
- `run_llm_judge()` - line 775
- `_save_pipeline_commands()` - line 1072
- `_save_pipeline_outputs()` - line 1336
- `_save_judge_logs()` - line 1371

**subtest_executor.py (1 function):**
- `_run_single_subtest()` - line 1465

All changed from `language: str = "mojo"` → `language: str = "python"`

## What Was NOT Changed
**Preserved Mojo-specific functions:**
- `_run_mojo_build_pipeline()` - This function is specifically for Mojo builds and correctly hardcodes `"mojo"` in its result dictionary
- This is intentional and correct

## Verification
✅ `grep 'language.*=.*"mojo"' scylla/e2e/*.py` returns no general-purpose matches  
✅ Only Mojo-specific functions retain `"mojo"` hardcoding  
✅ Pre-commit hooks pass  
✅ No functional changes - Python is now the default

## Related PRs
- PR #509: Deleted Mojo guides, rewrote agents (#401 P0) ✅ merged
- PR #510: Removed Python Justification docstrings (#401 P2) ✅ merged

🤖 Generated with [Claude Code](https://claude.com/claude-code)