### PR TITLE
docs: Consolidate metrics and research documentation

### DIFF
--- a/.claude/shared/metrics-definitions.md
+++ b/.claude/shared/metrics-definitions.md
@@ -2,6 +2,10 @@
 
 Complete definitions of all metrics used in ProjectScylla evaluations.
 
+**See also:**
+- [CLAUDE.md](/CLAUDE.md#core-metrics) - Quick reference summary
+- [Research Methodology](/docs/research.md) - Application and context
+
 ## Quality Metrics
 
 ### Pass-Rate

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -168,31 +168,15 @@ Each tier is evaluated against:
 
 ## Core Metrics
 
-### Quality Metrics
+ProjectScylla evaluates agent performance across three metric categories:
 
-| Metric | Formula | Description |
-|--------|---------|-------------|
-| Pass-Rate | `correct_solutions / total_attempts` | Functional test coverage |
-| Impl-Rate | `satisfied_requirements / total_requirements` | Semantic requirement satisfaction |
-| R_Prog | `progress_steps / expected_steps` | Fine-grained advancement tracking |
-| Consistency | `std(outputs) / mean(outputs)` | Output stability across runs |
+1. **Quality Metrics**: Pass-Rate, Implementation Rate, Fine-Grained Progress
+2. **Economic Metrics**: Cost-of-Pass (CoP), Token Distribution, Change Fail Percentage
+3. **Process Metrics**: Latency, Strategic Drift, Ablation Score
 
-### Economic Metrics
-
-| Metric | Formula | Description |
-|--------|---------|-------------|
-| Cost-of-Pass (CoP) | `total_cost / pass_rate` | Expected cost per correct solution |
-| Frontier CoP | `min(CoP_tier0, ..., CoP_tier6)` | Minimum cost across all tiers |
-| Token Distribution | `tokens_by_component / total_tokens` | Component-level cost breakdown |
-| CFP | `failed_changes / total_changes` | Change Fail Percentage |
-
-### Process Metrics
-
-| Metric | Description |
-|--------|-------------|
-| Latency | Time from query to resolution |
-| Strategic Drift | Goal coherence over multi-step tasks |
-| Ablation Score | Isolated component contribution |
+**For complete metric definitions, formulas, and calculation methods, see:**
+- [Metrics Definitions](/.claude/shared/metrics-definitions.md) - Authoritative reference
+- [Research Methodology](/docs/research.md) - Context and usage
 
 ## Language Preference
 

--- a/docs/research2.md
+++ b/docs/research2.md
@@ -1,3 +1,6 @@
+> **DEPRECATED**: This is an older research document (Project Odyssey context).
+> See [research.md](research.md) for current ProjectScylla research methodology.
+
 # **Integrating Theory and Practice in Project Odyssey: A Tiered Architectural Analysis of Scalable Multi-Agent Systems**
 
 ## **I. Foundational Principles and Theoretical Context of Agentic Scaling**

--- a/docs/summary2.md
+++ b/docs/summary2.md
@@ -1,3 +1,6 @@
+> **DEPRECATED**: This is an older summary document (Project Odyssey context).
+> See [research.md](research.md) for current ProjectScylla documentation.
+
 # Project Odyssey: Comprehensive Architectural Efficacy and Economic Sustainability Blueprint
 
 ## **Executive Summary**


### PR DESCRIPTION
Closes #413, #414

## Summary
Consolidated documentation to establish single sources of truth for metrics and research methodology, eliminating duplication and improving navigation.

## Changes

### #413 - Metrics Deduplication

**Problem**: Metrics were defined in multiple places (CLAUDE.md and metrics-definitions.md), creating maintenance burden and potential inconsistency.

**Solution**: Established `.claude/shared/metrics-definitions.md` as the authoritative reference.

**CLAUDE.md changes:**
- Replaced 3 detailed metrics tables (27 lines) with brief summary (11 lines)
- Added clear links to authoritative sources:
  - Metrics Definitions (formulas and calculations)
  - Research Methodology (application context)

**metrics-definitions.md changes:**
- Added cross-references at top:
  - Link to CLAUDE.md for quick reference
  - Link to research.md for application context

**Benefits:**
- ✅ Single source of truth for metric definitions
- ✅ Easier to maintain (one place to update)
- ✅ Clear navigation between related docs

### #414 - Research Doc Consolidation

**Problem**: Multiple research documents with unclear status:
- `research.md` (current, canonical)
- `research2.md` (Project Odyssey context)
- `summary2.md` (older blueprint)

**Solution**: Clearly designated `research.md` as canonical, deprecated others.

**Changes:**
- Added deprecation headers to `research2.md` and `summary2.md`
- Each deprecated doc points to `research.md` as current source
- Preserved historical docs (not deleted) with clear status

**Benefits:**
- ✅ Clear which doc is current
- ✅ Historical context preserved
- ✅ No confusion about authoritative source

## Impact
- **Reduced duplication**: 16 fewer lines of redundant metrics tables
- **Improved clarity**: Clear doc hierarchy and navigation
- **Easier maintenance**: Single source of truth for each topic
- **Better UX**: Cross-references help users find related info

🤖 Generated with [Claude Code](https://claude.com/claude-code)