### PR TITLE
docs: Remove Python justification docstrings

### DIFF
--- a/scylla/cli/main.py
+++ b/scylla/cli/main.py
@@ -1,7 +1,4 @@
-"""Command-line interface for ProjectScylla.
-
-Python justification: Click library for CLI parsing and subprocess orchestration.
-"""
+"""Command-line interface for ProjectScylla."""
 
 import json
 import statistics

--- a/scylla/cli/progress.py
+++ b/scylla/cli/progress.py
@@ -1,7 +1,4 @@
-"""Progress display for test execution.
-
-Python justification: Terminal output formatting and progress tracking.
-"""
+"""Progress display for test execution."""
 
 import sys
 from dataclasses import dataclass, field

--- a/scylla/executor/tier_config.py
+++ b/scylla/executor/tier_config.py
@@ -2,8 +2,6 @@
 
 This module provides the TierConfigLoader class for loading tier definitions
 from YAML and their associated prompt templates from markdown files.
-
-Python justification: Required for YAML parsing, file I/O, and Pydantic validation.
 """
 
 from pathlib import Path

--- a/scylla/orchestrator.py
+++ b/scylla/orchestrator.py
@@ -1,7 +1,4 @@
-"""Test orchestrator for agent evaluations.
-
-Python justification: Required for subprocess orchestration and file I/O.
-"""
+"""Test orchestrator for agent evaluations."""
 
 from __future__ import annotations
 

--- a/scylla/reporting/markdown.py
+++ b/scylla/reporting/markdown.py
@@ -1,7 +1,4 @@
-"""Markdown report generator for evaluation results.
-
-Python justification: String templating and file I/O for report generation.
-"""
+"""Markdown report generator for evaluation results."""
 
 from dataclasses import dataclass, field
 from datetime import datetime, timezone

--- a/scylla/reporting/result.py
+++ b/scylla/reporting/result.py
@@ -1,7 +1,4 @@
-"""Result writer for per-run evaluation results.
-
-Python justification: JSON serialization and file I/O for result persistence.
-"""
+"""Result writer for per-run evaluation results."""
 
 import json
 from dataclasses import asdict, dataclass

--- a/scylla/reporting/scorecard.py
+++ b/scylla/reporting/scorecard.py
@@ -1,7 +1,4 @@
-"""Scorecard generator for model-level result aggregation.
-
-Python justification: JSON serialization and file I/O for scorecard persistence.
-"""
+"""Scorecard generator for model-level result aggregation."""
 
 import json
 from dataclasses import dataclass, field

--- a/scylla/reporting/summary.py
+++ b/scylla/reporting/summary.py
@@ -1,7 +1,4 @@
-"""Summary generator for test-level result aggregation.
-
-Python justification: JSON serialization and file I/O for summary persistence.
-"""
+"""Summary generator for test-level result aggregation."""
 
 import json
 from dataclasses import dataclass, field

--- a/tests/unit/adapters/test_base.py
+++ b/tests/unit/adapters/test_base.py
@@ -1,7 +1,4 @@
-"""Tests for base adapter class.
-
-Python justification: Required for pytest testing framework.
-"""
+"""Tests for base adapter class."""
 
 from pathlib import Path
 from tempfile import TemporaryDirectory

--- a/tests/unit/adapters/test_claude_code.py
+++ b/tests/unit/adapters/test_claude_code.py
@@ -1,7 +1,4 @@
-"""Tests for Claude Code CLI adapter.
-
-Python justification: Required for pytest testing framework.
-"""
+"""Tests for Claude Code CLI adapter."""
 
 from pathlib import Path
 from tempfile import TemporaryDirectory

--- a/tests/unit/adapters/test_cline.py
+++ b/tests/unit/adapters/test_cline.py
@@ -1,7 +1,4 @@
-"""Tests for Cline CLI adapter.
-
-Python justification: Required for pytest testing framework.
-"""
+"""Tests for Cline CLI adapter."""
 
 from pathlib import Path
 from tempfile import TemporaryDirectory

--- a/tests/unit/adapters/test_openai_codex.py
+++ b/tests/unit/adapters/test_openai_codex.py
@@ -1,7 +1,4 @@
-"""Tests for OpenAI Codex CLI adapter.
-
-Python justification: Required for pytest testing framework.
-"""
+"""Tests for OpenAI Codex CLI adapter."""
 
 from pathlib import Path
 from tempfile import TemporaryDirectory

--- a/tests/unit/adapters/test_opencode.py
+++ b/tests/unit/adapters/test_opencode.py
@@ -1,7 +1,4 @@
-"""Tests for OpenCode CLI adapter.
-
-Python justification: Required for pytest testing framework.
-"""
+"""Tests for OpenCode CLI adapter."""
 
 from pathlib import Path
 from tempfile import TemporaryDirectory

--- a/tests/unit/cli/test_cli.py
+++ b/tests/unit/cli/test_cli.py
@@ -1,7 +1,4 @@
-"""Tests for CLI commands.
-
-Python justification: Required for pytest testing framework and Click testing.
-"""
+"""Tests for CLI commands."""
 
 from click.testing import CliRunner
 

--- a/tests/unit/cli/test_progress.py
+++ b/tests/unit/cli/test_progress.py
@@ -1,7 +1,4 @@
-"""Tests for progress display.
-
-Python justification: Required for pytest testing framework.
-"""
+"""Tests for progress display."""
 
 import sys
 from datetime import datetime, timedelta, timezone

--- a/tests/unit/config/test_models.py
+++ b/tests/unit/config/test_models.py
@@ -1,7 +1,4 @@
-"""Tests for Pydantic configuration models.
-
-Python justification: Required for pytest testing framework.
-"""
+"""Tests for Pydantic configuration models."""
 
 import pytest
 from pydantic import ValidationError

--- a/tests/unit/config/test_pricing.py
+++ b/tests/unit/config/test_pricing.py
@@ -1,7 +1,4 @@
-"""Tests for centralized pricing configuration.
-
-Python justification: Required for pytest testing framework.
-"""
+"""Tests for centralized pricing configuration."""
 
 import pytest
 

--- a/tests/unit/core/test_results.py
+++ b/tests/unit/core/test_results.py
@@ -1,7 +1,4 @@
-"""Tests for scylla.core.results module.
-
-Python justification: Required for pytest testing framework.
-"""
+"""Tests for scylla.core.results module."""
 
 from scylla.core.results import BaseExecutionInfo, BaseRunMetrics, BaseRunResult
 

--- a/tests/unit/discovery/test_agents.py
+++ b/tests/unit/discovery/test_agents.py
@@ -1,7 +1,4 @@
-"""Tests for scylla.discovery.agents module.
-
-Python justification: Required for pytest testing framework.
-"""
+"""Tests for scylla.discovery.agents module."""
 
 from pathlib import Path
 

--- a/tests/unit/discovery/test_blocks.py
+++ b/tests/unit/discovery/test_blocks.py
@@ -1,7 +1,4 @@
-"""Tests for scylla.discovery.blocks module.
-
-Python justification: Required for pytest testing framework.
-"""
+"""Tests for scylla.discovery.blocks module."""
 
 from pathlib import Path
 

--- a/tests/unit/discovery/test_skills.py
+++ b/tests/unit/discovery/test_skills.py
@@ -1,7 +1,4 @@
-"""Tests for scylla.discovery.skills module.
-
-Python justification: Required for pytest testing framework.
-"""
+"""Tests for scylla.discovery.skills module."""
 
 from pathlib import Path
 

--- a/tests/unit/e2e/test_orchestrator.py
+++ b/tests/unit/e2e/test_orchestrator.py
@@ -1,7 +1,4 @@
-"""Integration tests for test orchestrator.
-
-Python justification: Required for pytest testing framework.
-"""
+"""Integration tests for test orchestrator."""
 
 from pathlib import Path
 

--- a/tests/unit/executor/test_capture.py
+++ b/tests/unit/executor/test_capture.py
@@ -1,7 +1,4 @@
-"""Tests for log and metrics capture.
-
-Python justification: Required for pytest testing framework.
-"""
+"""Tests for log and metrics capture."""
 
 import json
 from pathlib import Path

--- a/tests/unit/executor/test_judge_container.py
+++ b/tests/unit/executor/test_judge_container.py
@@ -1,7 +1,4 @@
-"""Tests for judge container orchestration.
-
-Python justification: Required for pytest testing framework.
-"""
+"""Tests for judge container orchestration."""
 
 from pathlib import Path
 from unittest.mock import MagicMock, patch

--- a/tests/unit/executor/test_runner.py
+++ b/tests/unit/executor/test_runner.py
@@ -1,7 +1,4 @@
-"""Tests for test runner orchestration.
-
-Python justification: Required for pytest testing framework.
-"""
+"""Tests for test runner orchestration."""
 
 from pathlib import Path
 from tempfile import TemporaryDirectory

--- a/tests/unit/executor/test_tier_config.py
+++ b/tests/unit/executor/test_tier_config.py
@@ -1,7 +1,4 @@
-"""Tests for tier configuration loading.
-
-Python justification: Required for pytest testing framework.
-"""
+"""Tests for tier configuration loading."""
 
 from pathlib import Path
 from tempfile import TemporaryDirectory

--- a/tests/unit/judge/test_cleanup_evaluator.py
+++ b/tests/unit/judge/test_cleanup_evaluator.py
@@ -1,7 +1,4 @@
-"""Tests for cleanup script evaluation.
-
-Python justification: Required for pytest testing framework.
-"""
+"""Tests for cleanup script evaluation."""
 
 from pathlib import Path
 

--- a/tests/unit/judge/test_evaluator.py
+++ b/tests/unit/judge/test_evaluator.py
@@ -1,7 +1,4 @@
-"""Tests for judge evaluator.
-
-Python justification: Required for pytest testing framework.
-"""
+"""Tests for judge evaluator."""
 
 from pathlib import Path
 from tempfile import TemporaryDirectory

--- a/tests/unit/judge/test_parser.py
+++ b/tests/unit/judge/test_parser.py
@@ -1,7 +1,4 @@
-"""Tests for judgment parser.
-
-Python justification: Required for pytest testing framework.
-"""
+"""Tests for judgment parser."""
 
 import json
 from pathlib import Path

--- a/tests/unit/judge/test_prompts.py
+++ b/tests/unit/judge/test_prompts.py
@@ -1,7 +1,4 @@
-"""Tests for judge prompt templates.
-
-Python justification: Required for pytest testing framework.
-"""
+"""Tests for judge prompt templates."""
 
 import pytest
 

--- a/tests/unit/judge/test_rubric.py
+++ b/tests/unit/judge/test_rubric.py
@@ -1,7 +1,4 @@
-"""Tests for rubric parser.
-
-Python justification: Required for pytest testing framework.
-"""
+"""Tests for rubric parser."""
 
 from pathlib import Path
 from tempfile import TemporaryDirectory

--- a/tests/unit/metrics/test_ablation.py
+++ b/tests/unit/metrics/test_ablation.py
@@ -1,7 +1,4 @@
-"""Tests for ablation score metrics.
-
-Python justification: Required for pytest testing framework.
-"""
+"""Tests for ablation score metrics."""
 
 import pytest
 

--- a/tests/unit/metrics/test_aggregator.py
+++ b/tests/unit/metrics/test_aggregator.py
@@ -1,7 +1,4 @@
-"""Tests for run aggregation.
-
-Python justification: Required for pytest testing framework.
-"""
+"""Tests for run aggregation."""
 
 import pytest
 

--- a/tests/unit/metrics/test_cross_tier.py
+++ b/tests/unit/metrics/test_cross_tier.py
@@ -1,7 +1,4 @@
-"""Tests for cross-tier analysis.
-
-Python justification: Required for pytest testing framework.
-"""
+"""Tests for cross-tier analysis."""
 
 import pytest
 

--- a/tests/unit/metrics/test_grading.py
+++ b/tests/unit/metrics/test_grading.py
@@ -1,7 +1,4 @@
-"""Tests for grading calculations.
-
-Python justification: Required for pytest testing framework.
-"""
+"""Tests for grading calculations."""
 
 import math
 

--- a/tests/unit/metrics/test_latency.py
+++ b/tests/unit/metrics/test_latency.py
@@ -1,7 +1,4 @@
-"""Tests for latency metrics.
-
-Python justification: Required for pytest testing framework.
-"""
+"""Tests for latency metrics."""
 
 from datetime import datetime, timedelta
 

--- a/tests/unit/metrics/test_process.py
+++ b/tests/unit/metrics/test_process.py
@@ -1,7 +1,4 @@
-"""Tests for process metrics calculations.
-
-Python justification: Required for pytest testing framework.
-"""
+"""Tests for process metrics calculations."""
 
 import pytest
 

--- a/tests/unit/metrics/test_statistics.py
+++ b/tests/unit/metrics/test_statistics.py
@@ -1,7 +1,4 @@
-"""Tests for statistical calculations.
-
-Python justification: Required for pytest testing framework.
-"""
+"""Tests for statistical calculations."""
 
 import math
 

--- a/tests/unit/metrics/test_token_tracking.py
+++ b/tests/unit/metrics/test_token_tracking.py
@@ -1,7 +1,4 @@
-"""Tests for component-level token tracking.
-
-Python justification: Required for pytest testing framework.
-"""
+"""Tests for component-level token tracking."""
 
 import math
 

--- a/tests/unit/reporting/test_markdown.py
+++ b/tests/unit/reporting/test_markdown.py
@@ -1,7 +1,4 @@
-"""Tests for Markdown report generator.
-
-Python justification: Required for pytest testing framework.
-"""
+"""Tests for Markdown report generator."""
 
 import tempfile
 from pathlib import Path

--- a/tests/unit/reporting/test_result.py
+++ b/tests/unit/reporting/test_result.py
@@ -1,7 +1,4 @@
-"""Tests for result.json writer.
-
-Python justification: Required for pytest testing framework.
-"""
+"""Tests for result.json writer."""
 
 import json
 import tempfile

--- a/tests/unit/reporting/test_scorecard.py
+++ b/tests/unit/reporting/test_scorecard.py
@@ -1,7 +1,4 @@
-"""Tests for scorecard.json generator.
-
-Python justification: Required for pytest testing framework.
-"""
+"""Tests for scorecard.json generator."""
 
 import json
 import tempfile

--- a/tests/unit/reporting/test_summary.py
+++ b/tests/unit/reporting/test_summary.py
@@ -1,7 +1,4 @@
-"""Tests for summary.json generator.
-
-Python justification: Required for pytest testing framework.
-"""
+"""Tests for summary.json generator."""
 
 import json
 import tempfile


### PR DESCRIPTION
Closes #426

Removes 'Python justification:' lines incorrectly ported from ProjectOdyssey.

## Changes
- Removed justification lines from 8 source files
- Removed justification lines from 35 test files
- Module docstrings remain otherwise intact

## Testing
- Ran `pixi run pytest tests/ -v` - 1775/1777 tests passed (2 pre-existing failures unrelated to changes)
- Ran `pre-commit run --all-files` - all checks passed