### PR TITLE
feat(judge): Create judge.runner CLI module

### DIFF
--- a/scylla/judge/runner.py
+++ b/scylla/judge/runner.py
@@ -1,0 +1,350 @@
+"""Judge runner CLI module.
+
+This module provides a command-line interface for running judge evaluations
+in containerized environments. It's designed to be invoked as:
+
+    python -m scylla.judge.runner --workspace <path> --output <path> --model <id> --prompt <path>
+
+The runner reads the task prompt, evaluates the workspace, and writes the
+judgment output to the specified output directory.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import sys
+from pathlib import Path
+from typing import Any
+
+from scylla.judge.evaluator import (
+    Judgment,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class RunnerError(Exception):
+    """Base exception for runner errors."""
+
+    pass
+
+
+class RunnerValidationError(RunnerError):
+    """Raised when validation of arguments fails."""
+
+    pass
+
+
+def parse_args() -> argparse.Namespace:
+    """Parse command-line arguments.
+
+    Returns:
+        Parsed arguments namespace.
+
+    """
+    parser = argparse.ArgumentParser(
+        description="Judge runner for containerized evaluation",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+
+    parser.add_argument(
+        "--workspace",
+        type=Path,
+        required=True,
+        help="Path to workspace directory to evaluate (read-only)",
+    )
+
+    parser.add_argument(
+        "--output",
+        type=Path,
+        required=True,
+        help="Path to output directory for results",
+    )
+
+    parser.add_argument(
+        "--model",
+        type=str,
+        required=True,
+        help="Model ID to use for evaluation (e.g., claude-opus-4-5-20251101)",
+    )
+
+    parser.add_argument(
+        "--prompt",
+        type=Path,
+        required=True,
+        help="Path to task prompt file",
+    )
+
+    parser.add_argument(
+        "--timeout",
+        type=int,
+        default=300,
+        help="Timeout for evaluation in seconds (default: 300)",
+    )
+
+    parser.add_argument(
+        "--verbose",
+        "-v",
+        action="store_true",
+        help="Enable verbose logging",
+    )
+
+    return parser.parse_args()
+
+
+def validate_arguments(args: argparse.Namespace) -> None:
+    """Validate command-line arguments.
+
+    Args:
+        args: Parsed arguments.
+
+    Raises:
+        RunnerValidationError: If validation fails.
+
+    """
+    # Validate workspace exists
+    if not args.workspace.exists():
+        raise RunnerValidationError(f"Workspace does not exist: {args.workspace}")
+
+    if not args.workspace.is_dir():
+        raise RunnerValidationError(f"Workspace is not a directory: {args.workspace}")
+
+    # Validate prompt file exists
+    if not args.prompt.exists():
+        raise RunnerValidationError(f"Prompt file does not exist: {args.prompt}")
+
+    if not args.prompt.is_file():
+        raise RunnerValidationError(f"Prompt is not a file: {args.prompt}")
+
+    # Validate output directory or create it
+    if not args.output.exists():
+        try:
+            args.output.mkdir(parents=True, exist_ok=True)
+        except OSError as e:
+            raise RunnerValidationError(f"Failed to create output directory: {e}")
+
+    if not args.output.is_dir():
+        raise RunnerValidationError(f"Output is not a directory: {args.output}")
+
+    # Validate timeout
+    if args.timeout <= 0:
+        raise RunnerValidationError(f"Timeout must be positive: {args.timeout}")
+
+
+def load_task_prompt(prompt_file: Path) -> str:
+    """Load task prompt from file.
+
+    Args:
+        prompt_file: Path to prompt file.
+
+    Returns:
+        Task prompt content.
+
+    Raises:
+        RunnerError: If loading fails.
+
+    """
+    try:
+        return prompt_file.read_text()
+    except Exception as e:
+        raise RunnerError(f"Failed to load prompt file: {e}")
+
+
+def collect_workspace_state(workspace: Path) -> str:
+    """Collect workspace state for evaluation context.
+
+    Args:
+        workspace: Path to workspace directory.
+
+    Returns:
+        Human-readable summary of workspace contents.
+
+    """
+    # List files in workspace (non-recursive for now)
+    files = []
+    try:
+        for item in sorted(workspace.iterdir()):
+            if item.is_file():
+                files.append(f"- {item.name}")
+            elif item.is_dir():
+                files.append(f"- {item.name}/ (directory)")
+    except Exception as e:
+        logger.warning(f"Failed to list workspace contents: {e}")
+        return f"Error listing workspace: {e}"
+
+    if not files:
+        return "Workspace is empty"
+
+    return "Workspace contents:\n" + "\n".join(files)
+
+
+def run_evaluation(
+    workspace: Path,
+    prompt: str,
+    model: str,
+    timeout: int,
+) -> Judgment:
+    """Run judge evaluation.
+
+    Args:
+        workspace: Path to workspace to evaluate.
+        prompt: Task prompt.
+        model: Model ID to use.
+        timeout: Timeout in seconds.
+
+    Returns:
+        Judgment from evaluation.
+
+    Raises:
+        RunnerError: If evaluation fails.
+
+    """
+    # For now, we'll create a simple judgment without using an adapter
+    # since we're in a containerized environment and don't have full access
+    # to the adapter system. This is a minimal implementation.
+    # TODO: Implement full adapter integration when needed.
+    # The model and timeout parameters will be used when adapter integration is added.
+
+    # Collect workspace state
+    workspace_state = collect_workspace_state(workspace)
+
+    # Create a basic judgment for now
+    # This is a placeholder implementation
+    logger.warning("Using placeholder judgment - full adapter integration not yet implemented")
+
+    judgment = Judgment()
+    judgment.qualitative_feedback = (
+        f"Workspace evaluated with model {model}. "
+        f"Task: {prompt[:100]}... "
+        f"State: {workspace_state[:100]}..."
+    )
+
+    return judgment
+
+
+def write_output(judgment: Judgment, output_dir: Path) -> None:
+    """Write judgment to output directory.
+
+    Args:
+        judgment: Judgment to write.
+        output_dir: Output directory.
+
+    Raises:
+        RunnerError: If writing fails.
+
+    """
+    try:
+        # Write judgment as JSON
+        output_file = output_dir / "judgment.json"
+
+        # Convert judgment to dict
+        judgment_dict: dict[str, Any] = {
+            "requirements": {
+                req_id: {
+                    "score": score.score,
+                    "confidence": score.confidence,
+                    "notes": score.notes,
+                }
+                for req_id, score in judgment.requirements.items()
+            },
+            "categories": {
+                cat_name: {
+                    "score": score.score,
+                    "confidence": score.confidence,
+                    "notes": score.notes,
+                }
+                for cat_name, score in judgment.categories.items()
+            },
+            "summary": (
+                {
+                    "weighted_score": judgment.summary.weighted_score,
+                    "passed": judgment.summary.passed,
+                    "letter_grade": judgment.summary.letter_grade,
+                    "overall_confidence": judgment.summary.overall_confidence,
+                    "strengths": judgment.summary.strengths,
+                    "weaknesses": judgment.summary.weaknesses,
+                }
+                if judgment.summary
+                else None
+            ),
+            "exploratory_testing": (
+                {
+                    "commands_run": judgment.exploratory_testing.commands_run,
+                    "observations": judgment.exploratory_testing.observations,
+                    "failures": judgment.exploratory_testing.failures,
+                }
+                if judgment.exploratory_testing
+                else None
+            ),
+            "qualitative_feedback": judgment.qualitative_feedback,
+        }
+
+        output_file.write_text(json.dumps(judgment_dict, indent=2))
+        logger.info(f"Judgment written to {output_file}")
+
+    except Exception as e:
+        raise RunnerError(f"Failed to write output: {e}")
+
+
+def main() -> int:
+    """Execute judge runner.
+
+    Returns:
+        Exit code (0 for success, 1 for error).
+
+    """
+    # Parse arguments
+    try:
+        args = parse_args()
+    except SystemExit:
+        return 1
+
+    # Configure logging
+    logging.basicConfig(
+        level=logging.DEBUG if args.verbose else logging.INFO,
+        format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+    )
+
+    logger.info("Judge runner starting")
+    logger.info(f"Workspace: {args.workspace}")
+    logger.info(f"Output: {args.output}")
+    logger.info(f"Model: {args.model}")
+    logger.info(f"Prompt: {args.prompt}")
+
+    try:
+        # Validate arguments
+        validate_arguments(args)
+
+        # Load task prompt
+        prompt = load_task_prompt(args.prompt)
+        logger.info(f"Loaded prompt ({len(prompt)} chars)")
+
+        # Run evaluation
+        judgment = run_evaluation(
+            workspace=args.workspace,
+            prompt=prompt,
+            model=args.model,
+            timeout=args.timeout,
+        )
+
+        # Write output
+        write_output(judgment, args.output)
+
+        logger.info("Judge evaluation completed successfully")
+        return 0
+
+    except RunnerError as e:
+        logger.error(f"Runner error: {e}")
+        print(f"Error: {e}", file=sys.stderr)
+        return 1
+
+    except Exception as e:
+        logger.exception(f"Unexpected error: {e}")
+        print(f"Unexpected error: {e}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/unit/judge/test_runner.py
+++ b/tests/unit/judge/test_runner.py
@@ -1,0 +1,458 @@
+"""Tests for judge runner CLI module.
+
+Python justification: Required for pytest testing framework.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from scylla.judge.evaluator import JudgeScore, JudgeSummary, Judgment
+from scylla.judge.runner import (
+    RunnerError,
+    RunnerValidationError,
+    collect_workspace_state,
+    load_task_prompt,
+    main,
+    parse_args,
+    run_evaluation,
+    validate_arguments,
+    write_output,
+)
+
+
+class TestParseArgs:
+    """Tests for argument parsing."""
+
+    def test_parse_args_all_required(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Test parsing all required arguments."""
+        monkeypatch.setattr(
+            "sys.argv",
+            [
+                "runner.py",
+                "--workspace",
+                "/workspace",
+                "--output",
+                "/output",
+                "--model",
+                "claude-opus-4-5-20251101",
+                "--prompt",
+                "/prompt/task.md",
+            ],
+        )
+
+        args = parse_args()
+        assert args.workspace == Path("/workspace")
+        assert args.output == Path("/output")
+        assert args.model == "claude-opus-4-5-20251101"
+        assert args.prompt == Path("/prompt/task.md")
+        assert args.timeout == 300  # default
+        assert args.verbose is False
+
+    def test_parse_args_with_optional(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Test parsing with optional arguments."""
+        monkeypatch.setattr(
+            "sys.argv",
+            [
+                "runner.py",
+                "--workspace",
+                "/workspace",
+                "--output",
+                "/output",
+                "--model",
+                "claude-sonnet-4-5-20250929",
+                "--prompt",
+                "/prompt/task.md",
+                "--timeout",
+                "600",
+                "--verbose",
+            ],
+        )
+
+        args = parse_args()
+        assert args.timeout == 600
+        assert args.verbose is True
+
+    def test_parse_args_missing_required(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Test parsing fails when required arguments are missing."""
+        monkeypatch.setattr("sys.argv", ["runner.py"])
+
+        with pytest.raises(SystemExit):
+            parse_args()
+
+
+class TestValidateArguments:
+    """Tests for argument validation."""
+
+    def test_validate_valid_arguments(self, tmp_path: Path) -> None:
+        """Test validation with valid arguments."""
+        workspace = tmp_path / "workspace"
+        workspace.mkdir()
+
+        output = tmp_path / "output"
+        output.mkdir()
+
+        prompt = tmp_path / "prompt.md"
+        prompt.write_text("Test task prompt")
+
+        args = MagicMock()
+        args.workspace = workspace
+        args.output = output
+        args.prompt = prompt
+        args.timeout = 300
+
+        # Should not raise
+        validate_arguments(args)
+
+    def test_validate_creates_output_dir(self, tmp_path: Path) -> None:
+        """Test validation creates output directory if missing."""
+        workspace = tmp_path / "workspace"
+        workspace.mkdir()
+
+        output = tmp_path / "output"
+        # Don't create output directory
+
+        prompt = tmp_path / "prompt.md"
+        prompt.write_text("Test task prompt")
+
+        args = MagicMock()
+        args.workspace = workspace
+        args.output = output
+        args.prompt = prompt
+        args.timeout = 300
+
+        validate_arguments(args)
+
+        # Output directory should now exist
+        assert output.exists()
+        assert output.is_dir()
+
+    def test_validate_workspace_not_exists(self, tmp_path: Path) -> None:
+        """Test validation fails if workspace doesn't exist."""
+        workspace = tmp_path / "nonexistent"
+        output = tmp_path / "output"
+        prompt = tmp_path / "prompt.md"
+
+        args = MagicMock()
+        args.workspace = workspace
+        args.output = output
+        args.prompt = prompt
+        args.timeout = 300
+
+        with pytest.raises(RunnerValidationError, match="Workspace does not exist"):
+            validate_arguments(args)
+
+    def test_validate_workspace_not_directory(self, tmp_path: Path) -> None:
+        """Test validation fails if workspace is not a directory."""
+        workspace = tmp_path / "workspace_file"
+        workspace.write_text("not a directory")
+
+        output = tmp_path / "output"
+        prompt = tmp_path / "prompt.md"
+
+        args = MagicMock()
+        args.workspace = workspace
+        args.output = output
+        args.prompt = prompt
+        args.timeout = 300
+
+        with pytest.raises(RunnerValidationError, match="Workspace is not a directory"):
+            validate_arguments(args)
+
+    def test_validate_prompt_not_exists(self, tmp_path: Path) -> None:
+        """Test validation fails if prompt file doesn't exist."""
+        workspace = tmp_path / "workspace"
+        workspace.mkdir()
+
+        output = tmp_path / "output"
+        output.mkdir()
+
+        prompt = tmp_path / "nonexistent.md"
+
+        args = MagicMock()
+        args.workspace = workspace
+        args.output = output
+        args.prompt = prompt
+        args.timeout = 300
+
+        with pytest.raises(RunnerValidationError, match="Prompt file does not exist"):
+            validate_arguments(args)
+
+    def test_validate_prompt_not_file(self, tmp_path: Path) -> None:
+        """Test validation fails if prompt is not a file."""
+        workspace = tmp_path / "workspace"
+        workspace.mkdir()
+
+        output = tmp_path / "output"
+        output.mkdir()
+
+        prompt = tmp_path / "prompt_dir"
+        prompt.mkdir()
+
+        args = MagicMock()
+        args.workspace = workspace
+        args.output = output
+        args.prompt = prompt
+        args.timeout = 300
+
+        with pytest.raises(RunnerValidationError, match="Prompt is not a file"):
+            validate_arguments(args)
+
+    def test_validate_negative_timeout(self, tmp_path: Path) -> None:
+        """Test validation fails with negative timeout."""
+        workspace = tmp_path / "workspace"
+        workspace.mkdir()
+
+        output = tmp_path / "output"
+        output.mkdir()
+
+        prompt = tmp_path / "prompt.md"
+        prompt.write_text("Test prompt")
+
+        args = MagicMock()
+        args.workspace = workspace
+        args.output = output
+        args.prompt = prompt
+        args.timeout = -10
+
+        with pytest.raises(RunnerValidationError, match="Timeout must be positive"):
+            validate_arguments(args)
+
+
+class TestLoadTaskPrompt:
+    """Tests for loading task prompts."""
+
+    def test_load_task_prompt_success(self, tmp_path: Path) -> None:
+        """Test loading task prompt successfully."""
+        prompt_file = tmp_path / "task.md"
+        prompt_content = "# Task\n\nConvert Justfile to Makefile"
+        prompt_file.write_text(prompt_content)
+
+        result = load_task_prompt(prompt_file)
+        assert result == prompt_content
+
+    def test_load_task_prompt_file_not_found(self, tmp_path: Path) -> None:
+        """Test loading non-existent prompt file."""
+        prompt_file = tmp_path / "nonexistent.md"
+
+        with pytest.raises(RunnerError, match="Failed to load prompt file"):
+            load_task_prompt(prompt_file)
+
+
+class TestCollectWorkspaceState:
+    """Tests for collecting workspace state."""
+
+    def test_collect_empty_workspace(self, tmp_path: Path) -> None:
+        """Test collecting state from empty workspace."""
+        workspace = tmp_path / "workspace"
+        workspace.mkdir()
+
+        result = collect_workspace_state(workspace)
+        assert result == "Workspace is empty"
+
+    def test_collect_workspace_with_files(self, tmp_path: Path) -> None:
+        """Test collecting state from workspace with files."""
+        workspace = tmp_path / "workspace"
+        workspace.mkdir()
+
+        (workspace / "file1.txt").write_text("content1")
+        (workspace / "file2.py").write_text("content2")
+        (workspace / "subdir").mkdir()
+
+        result = collect_workspace_state(workspace)
+        assert "Workspace contents:" in result
+        assert "- file1.txt" in result
+        assert "- file2.py" in result
+        assert "- subdir/ (directory)" in result
+
+    def test_collect_workspace_nonexistent(self, tmp_path: Path) -> None:
+        """Test collecting state from non-existent workspace."""
+        workspace = tmp_path / "nonexistent"
+
+        result = collect_workspace_state(workspace)
+        assert "Error listing workspace:" in result
+
+
+class TestRunEvaluation:
+    """Tests for running evaluation."""
+
+    def test_run_evaluation_basic(self, tmp_path: Path) -> None:
+        """Test basic evaluation run."""
+        workspace = tmp_path / "workspace"
+        workspace.mkdir()
+
+        prompt = "Convert Justfile to Makefile"
+        model = "claude-opus-4-5-20251101"
+        timeout = 300
+
+        judgment = run_evaluation(workspace, prompt, model, timeout)
+
+        assert isinstance(judgment, Judgment)
+        assert prompt[:50] in judgment.qualitative_feedback
+        assert model in judgment.qualitative_feedback
+
+
+class TestWriteOutput:
+    """Tests for writing output."""
+
+    def test_write_output_basic_judgment(self, tmp_path: Path) -> None:
+        """Test writing basic judgment output."""
+        output_dir = tmp_path / "output"
+        output_dir.mkdir()
+
+        judgment = Judgment()
+        judgment.qualitative_feedback = "Test feedback"
+
+        write_output(judgment, output_dir)
+
+        output_file = output_dir / "judgment.json"
+        assert output_file.exists()
+
+        data = json.loads(output_file.read_text())
+        assert data["qualitative_feedback"] == "Test feedback"
+        assert data["requirements"] == {}
+        assert data["categories"] == {}
+        assert data["summary"] is None
+        assert data["exploratory_testing"] is None
+
+    def test_write_output_complete_judgment(self, tmp_path: Path) -> None:
+        """Test writing complete judgment with all fields."""
+        output_dir = tmp_path / "output"
+        output_dir.mkdir()
+
+        judgment = Judgment()
+        judgment.requirements["R1"] = JudgeScore(score=0.8, confidence=0.9, notes="Good")
+        judgment.categories["completeness"] = JudgeScore(score=0.7, confidence=0.8, notes="OK")
+        judgment.summary = JudgeSummary(
+            weighted_score=0.75,
+            passed=True,
+            letter_grade="B",
+            overall_confidence=0.85,
+            strengths=["Clear code"],
+            weaknesses=["Missing tests"],
+        )
+        judgment.qualitative_feedback = "Overall good work"
+
+        write_output(judgment, output_dir)
+
+        output_file = output_dir / "judgment.json"
+        data = json.loads(output_file.read_text())
+
+        assert data["requirements"]["R1"]["score"] == 0.8
+        assert data["requirements"]["R1"]["confidence"] == 0.9
+        assert data["categories"]["completeness"]["score"] == 0.7
+        assert data["summary"]["weighted_score"] == 0.75
+        assert data["summary"]["passed"] is True
+        assert data["summary"]["letter_grade"] == "B"
+        assert data["summary"]["strengths"] == ["Clear code"]
+
+    def test_write_output_nonexistent_directory(self, tmp_path: Path) -> None:
+        """Test writing to non-existent directory fails."""
+        output_dir = tmp_path / "nonexistent"
+
+        judgment = Judgment()
+
+        with pytest.raises(RunnerError, match="Failed to write output"):
+            write_output(judgment, output_dir)
+
+
+class TestMain:
+    """Tests for main entry point."""
+
+    def test_main_success(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Test successful main execution."""
+        workspace = tmp_path / "workspace"
+        workspace.mkdir()
+        (workspace / "test.txt").write_text("test content")
+
+        output = tmp_path / "output"
+
+        prompt_file = tmp_path / "prompt.md"
+        prompt_file.write_text("# Task\nTest task")
+
+        monkeypatch.setattr(
+            "sys.argv",
+            [
+                "runner.py",
+                "--workspace",
+                str(workspace),
+                "--output",
+                str(output),
+                "--model",
+                "claude-opus-4-5-20251101",
+                "--prompt",
+                str(prompt_file),
+            ],
+        )
+
+        exit_code = main()
+
+        assert exit_code == 0
+        assert (output / "judgment.json").exists()
+
+    def test_main_validation_error(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Test main with validation error."""
+        workspace = tmp_path / "nonexistent"
+        output = tmp_path / "output"
+        prompt_file = tmp_path / "prompt.md"
+
+        monkeypatch.setattr(
+            "sys.argv",
+            [
+                "runner.py",
+                "--workspace",
+                str(workspace),
+                "--output",
+                str(output),
+                "--model",
+                "claude-opus-4-5-20251101",
+                "--prompt",
+                str(prompt_file),
+            ],
+        )
+
+        exit_code = main()
+
+        assert exit_code == 1
+
+    def test_main_missing_arguments(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Test main with missing arguments."""
+        monkeypatch.setattr("sys.argv", ["runner.py"])
+
+        exit_code = main()
+
+        assert exit_code == 1
+
+    def test_main_verbose_mode(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Test main with verbose logging enabled."""
+        workspace = tmp_path / "workspace"
+        workspace.mkdir()
+
+        output = tmp_path / "output"
+
+        prompt_file = tmp_path / "prompt.md"
+        prompt_file.write_text("# Task\nTest task")
+
+        monkeypatch.setattr(
+            "sys.argv",
+            [
+                "runner.py",
+                "--workspace",
+                str(workspace),
+                "--output",
+                str(output),
+                "--model",
+                "claude-opus-4-5-20251101",
+                "--prompt",
+                str(prompt_file),
+                "--verbose",
+            ],
+        )
+
+        exit_code = main()
+
+        assert exit_code == 0


### PR DESCRIPTION
Closes #340

Creates missing judge.runner module referenced by Docker and executor.

## Changes
- New scylla/judge/runner.py with CLI interface
- Test coverage in tests/unit/judge/test_runner.py
- Supports --workspace, --output, --model, --prompt args
- Proper error handling and logging
- 23 tests passing, pre-commit hooks passing

## Implementation Details
- CLI argument parser using argparse
- Validates workspace, prompt file, and output directory
- Placeholder evaluation logic (TODO: full adapter integration)
- Writes judgment JSON to output directory
- Main entry point for `python -m scylla.judge.runner`

## Testing
```bash
pixi run pytest tests/unit/judge/test_runner.py -v
# 23 passed in 0.15s

python -m scylla.judge.runner --help
# Shows usage information

pre-commit run --all-files
# All checks passing
```

## Related Files
- docker/entrypoint.sh:319 - References this module
- scylla/executor/judge_container.py:261,291 - Uses this module