### PR TITLE
fix(templates): Remove Python-only patterns from Mojo template

### DIFF
--- a/tests/claude-code/shared/skills/mojo/mojo-build-package/templates/package_init.mojo
+++ b/tests/claude-code/shared/skills/mojo/mojo-build-package/templates/package_init.mojo
@@ -13,14 +13,3 @@ Example usage:
 # Import modules to re-export
 # from .module1 import Class1, function1
 # from .module2 import Class2, function2
-
-# Define public API
-__all__ = [
-    # "Class1",
-    # "Class2",
-    # "function1",
-    # "function2",
-]
-
-# Package version
-__version__ = "0.1.0"


### PR DESCRIPTION
Fixes #435

## Changes
- Removed `__all__` (Python-specific module export pattern)
- Removed `__version__` (not a Mojo convention)
- Kept valid Mojo imports and docstring

## Test Plan
- [ ] Template file syntax is valid Mojo
- [ ] No Python-only patterns remain