### PR TITLE
refactor(adapters): Extract BaseCliAdapter to eliminate DRY violations

### DIFF
--- a/scylla/adapters/__init__.py
+++ b/scylla/adapters/__init__.py
@@ -12,6 +12,7 @@ from scylla.adapters.base import (
     AdapterValidationError,
     BaseAdapter,
 )
+from scylla.adapters.base_cli import BaseCliAdapter
 from scylla.adapters.claude_code import ClaudeCodeAdapter
 from scylla.adapters.cline import ClineAdapter
 from scylla.adapters.openai_codex import OpenAICodexAdapter
@@ -24,6 +25,7 @@ __all__ = [
     "AdapterTimeoutError",
     "AdapterValidationError",
     "BaseAdapter",
+    "BaseCliAdapter",
     "ClaudeCodeAdapter",
     "ClineAdapter",
     "OpenAICodexAdapter",

--- a/scylla/adapters/base_cli.py
+++ b/scylla/adapters/base_cli.py
@@ -1,0 +1,238 @@
+"""Base CLI adapter for command-line agent implementations.
+
+This module provides a base class for CLI-based adapters that share common
+execution patterns, eliminating duplication across OpenAI Codex, OpenCode, and Cline.
+"""
+
+from __future__ import annotations
+
+import re
+import subprocess
+from abc import abstractmethod
+from datetime import datetime, timezone
+from typing import TYPE_CHECKING
+
+from scylla.adapters.base import (
+    AdapterConfig,
+    AdapterError,
+    AdapterResult,
+    AdapterTokenStats,
+    BaseAdapter,
+)
+
+if TYPE_CHECKING:
+    from scylla.executor.tier_config import TierConfig
+
+
+class BaseCliAdapter(BaseAdapter):
+    """Base adapter for CLI-based agent implementations.
+
+    Provides common implementation for subprocess execution, environment preparation,
+    and API call parsing. Subclasses must implement:
+    - CLI_EXECUTABLE: The command-line executable name
+    - _build_command(): Build the CLI command with specific flags
+    - _parse_token_counts(): Parse token counts from output
+
+    Optionally, subclasses can define:
+    - _api_call_fallback_pattern: Regex pattern for fallback API call detection
+
+    Example:
+        >>> class MyCliAdapter(BaseCliAdapter):
+        ...     CLI_EXECUTABLE = "mycli"
+        ...
+        ...     def _build_command(self, config, prompt, tier_config):
+        ...         return [self.CLI_EXECUTABLE, "--model", config.model, prompt]
+        ...
+        ...     def _parse_token_counts(self, stdout, stderr):
+        ...         # Parse tokens from output
+        ...         return (input_tokens, output_tokens)
+
+    """
+
+    # Subclasses must define the CLI executable name
+    CLI_EXECUTABLE: str
+
+    def run(
+        self,
+        config: AdapterConfig,
+        tier_config: TierConfig | None = None,
+    ) -> AdapterResult:
+        """Execute CLI with the given configuration.
+
+        Args:
+            config: Adapter configuration with model, prompt, workspace, etc.
+            tier_config: Optional tier-specific configuration for prompt injection.
+
+        Returns:
+            AdapterResult with execution details.
+
+        Raises:
+            AdapterError: If execution fails.
+
+        """
+        self.validate_config(config)
+
+        # Load and potentially inject tier prompt
+        task_prompt = self.load_prompt(config.prompt_file)
+        final_prompt = self.inject_tier_prompt(task_prompt, tier_config)
+
+        # Build CLI command
+        cmd = self._build_command(config, final_prompt, tier_config)
+
+        # Prepare environment with API keys
+        env = self._prepare_env(config)
+
+        # Execute
+        start_time = datetime.now(timezone.utc)
+        try:
+            result = subprocess.run(
+                cmd,
+                capture_output=True,
+                text=True,
+                timeout=config.timeout,
+                cwd=config.workspace,
+                env=env,
+            )
+
+        except subprocess.TimeoutExpired as e:
+            end_time = datetime.now(timezone.utc)
+            duration = (end_time - start_time).total_seconds()
+
+            # Write logs even on timeout
+            stdout = e.stdout.decode() if e.stdout else ""
+            stderr = e.stderr.decode() if e.stderr else ""
+            self.write_logs(config.output_dir, stdout, stderr)
+
+            return AdapterResult(
+                exit_code=-1,
+                stdout=stdout,
+                stderr=stderr,
+                duration_seconds=duration,
+                timed_out=True,
+                error_message=f"Execution timed out after {config.timeout} seconds",
+            )
+
+        except FileNotFoundError:
+            raise AdapterError(f"CLI not found. Is '{self.CLI_EXECUTABLE}' installed?")
+
+        except subprocess.SubprocessError as e:
+            raise AdapterError(f"Failed to execute {self.CLI_EXECUTABLE}: {e}") from e
+
+        end_time = datetime.now(timezone.utc)
+        duration = (end_time - start_time).total_seconds()
+
+        # Parse output for metrics
+        tokens_input, tokens_output = self._parse_token_counts(result.stdout, result.stderr)
+        api_calls = self._parse_api_calls(result.stdout, result.stderr)
+
+        # Create token stats (CLI adapters typically don't provide cache info)
+        token_stats = AdapterTokenStats(
+            input_tokens=tokens_input,
+            output_tokens=tokens_output,
+        )
+
+        # Calculate cost
+        cost = self.calculate_cost(tokens_input, tokens_output, config.model)
+
+        # Write logs
+        self.write_logs(config.output_dir, result.stdout, result.stderr)
+
+        return AdapterResult(
+            exit_code=result.returncode,
+            stdout=result.stdout,
+            stderr=result.stderr,
+            duration_seconds=duration,
+            token_stats=token_stats,
+            cost_usd=cost,
+            api_calls=api_calls,
+            timed_out=False,
+        )
+
+    @abstractmethod
+    def _build_command(
+        self,
+        config: AdapterConfig,
+        prompt: str,
+        tier_config: TierConfig | None,
+    ) -> list[str]:
+        """Build the CLI command.
+
+        Args:
+            config: Adapter configuration.
+            prompt: The prompt to send (with tier injection if applicable).
+            tier_config: Tier configuration for tool/delegation settings.
+
+        Returns:
+            Command as list of strings.
+
+        """
+        ...
+
+    def _prepare_env(self, config: AdapterConfig) -> dict[str, str]:
+        """Prepare environment variables for subprocess.
+
+        Args:
+            config: Adapter configuration with env_vars.
+
+        Returns:
+            Environment dictionary.
+
+        """
+        import os
+
+        env = os.environ.copy()
+        env.update(config.env_vars)
+        return env
+
+    @abstractmethod
+    def _parse_token_counts(self, stdout: str, stderr: str) -> tuple[int, int]:
+        """Parse token counts from CLI output.
+
+        Args:
+            stdout: Standard output from CLI.
+            stderr: Standard error from CLI.
+
+        Returns:
+            Tuple of (input_tokens, output_tokens).
+
+        """
+        ...
+
+    def _parse_api_calls(self, stdout: str, stderr: str) -> int:
+        """Parse API call count from output.
+
+        Uses common patterns across CLI tools, with optional fallback pattern
+        defined by subclasses via _api_call_fallback_pattern.
+
+        Args:
+            stdout: Standard output from CLI.
+            stderr: Standard error from CLI.
+
+        Returns:
+            Number of API calls detected.
+
+        """
+        combined = stdout + "\n" + stderr
+
+        # Pattern: "API calls: N" or "N API calls"
+        match = re.search(
+            r"(?:API\s+calls?:?\s*(\d+)|(\d+)\s+API\s+calls?)",
+            combined,
+            re.IGNORECASE,
+        )
+        if match:
+            return int(match.group(1) or match.group(2))
+
+        # Try fallback pattern if defined by subclass
+        if hasattr(self, "_api_call_fallback_pattern"):
+            fallback = getattr(self, "_api_call_fallback_pattern")
+            if fallback:
+                fallback_matches = len(re.findall(fallback, combined, re.IGNORECASE))
+                if fallback_matches > 0:
+                    return fallback_matches
+
+        # Default: assume at least 1 call if there's meaningful output
+        if len(stdout.strip()) > 100:
+            return 1
+
+        return 0

--- a/scylla/adapters/cline.py
+++ b/scylla/adapters/cline.py
@@ -2,31 +2,21 @@
 
 This module provides an adapter for running the Cline CLI
 within the Scylla evaluation framework.
-KNOWN ISSUE: This adapter shares ~80% code with openai_codex.py and opencode.py
-See GitHub Issue #479 - Consolidate copy-paste CLI adapters (DRY violation)
-TODO: Extract shared logic into BaseCliAdapter to eliminate duplication
 """
 
 from __future__ import annotations
 
 import re
-import subprocess
-from datetime import datetime, timezone
 from typing import TYPE_CHECKING
 
-from scylla.adapters.base import (
-    AdapterConfig,
-    AdapterError,
-    AdapterResult,
-    AdapterTokenStats,
-    BaseAdapter,
-)
+from scylla.adapters.base import AdapterConfig
+from scylla.adapters.base_cli import BaseCliAdapter
 
 if TYPE_CHECKING:
     from scylla.executor.tier_config import TierConfig
 
 
-class ClineAdapter(BaseAdapter):
+class ClineAdapter(BaseCliAdapter):
     """Adapter for Cline CLI.
 
     Executes the Cline CLI with the specified configuration and
@@ -48,101 +38,8 @@ class ClineAdapter(BaseAdapter):
     # Cline CLI executable
     CLI_EXECUTABLE = "cline"
 
-    def run(
-        self,
-        config: AdapterConfig,
-        tier_config: TierConfig | None = None,
-    ) -> AdapterResult:
-        """Execute Cline CLI with the given configuration.
-
-        Args:
-            config: Adapter configuration with model, prompt, workspace, etc.
-            tier_config: Optional tier-specific configuration for prompt injection.
-
-        Returns:
-            AdapterResult with execution details.
-
-        Raises:
-            AdapterError: If execution fails.
-
-        """
-        self.validate_config(config)
-
-        # Load and potentially inject tier prompt
-        task_prompt = self.load_prompt(config.prompt_file)
-        final_prompt = self.inject_tier_prompt(task_prompt, tier_config)
-
-        # Build CLI command
-        cmd = self._build_command(config, final_prompt, tier_config)
-
-        # Prepare environment with API keys
-        env = self._prepare_env(config)
-
-        # Execute
-        start_time = datetime.now(timezone.utc)
-        try:
-            result = subprocess.run(
-                cmd,
-                capture_output=True,
-                text=True,
-                timeout=config.timeout,
-                cwd=config.workspace,
-                env=env,
-            )
-
-        except subprocess.TimeoutExpired as e:
-            end_time = datetime.now(timezone.utc)
-            duration = (end_time - start_time).total_seconds()
-
-            # Write logs even on timeout
-            stdout = e.stdout.decode() if e.stdout else ""
-            stderr = e.stderr.decode() if e.stderr else ""
-            self.write_logs(config.output_dir, stdout, stderr)
-
-            return AdapterResult(
-                exit_code=-1,
-                stdout=stdout,
-                stderr=stderr,
-                duration_seconds=duration,
-                timed_out=True,
-                error_message=f"Execution timed out after {config.timeout} seconds",
-            )
-
-        except FileNotFoundError:
-            raise AdapterError(f"Cline CLI not found. Is '{self.CLI_EXECUTABLE}' installed?")
-
-        except subprocess.SubprocessError as e:
-            raise AdapterError(f"Failed to execute Cline: {e}") from e
-
-        end_time = datetime.now(timezone.utc)
-        duration = (end_time - start_time).total_seconds()
-
-        # Parse output for metrics
-        tokens_input, tokens_output = self._parse_token_counts(result.stdout, result.stderr)
-        api_calls = self._parse_api_calls(result.stdout, result.stderr)
-
-        # Create token stats (Cline doesn't provide cache info, so only basic stats)
-        token_stats = AdapterTokenStats(
-            input_tokens=tokens_input,
-            output_tokens=tokens_output,
-        )
-
-        # Calculate cost
-        cost = self.calculate_cost(tokens_input, tokens_output, config.model)
-
-        # Write logs
-        self.write_logs(config.output_dir, result.stdout, result.stderr)
-
-        return AdapterResult(
-            exit_code=result.returncode,
-            stdout=result.stdout,
-            stderr=result.stderr,
-            duration_seconds=duration,
-            token_stats=token_stats,
-            cost_usd=cost,
-            api_calls=api_calls,
-            timed_out=False,
-        )
+    # Fallback pattern for API call detection
+    _api_call_fallback_pattern = r"(?:Sending request|Request sent)"
 
     def _build_command(
         self,
@@ -183,22 +80,6 @@ class ClineAdapter(BaseAdapter):
         cmd.extend(["--prompt", prompt])
 
         return cmd
-
-    def _prepare_env(self, config: AdapterConfig) -> dict[str, str]:
-        """Prepare environment variables for subprocess.
-
-        Args:
-            config: Adapter configuration with env_vars.
-
-        Returns:
-            Environment dictionary.
-
-        """
-        import os
-
-        env = os.environ.copy()
-        env.update(config.env_vars)
-        return env
 
     def _parse_token_counts(self, stdout: str, stderr: str) -> tuple[int, int]:
         """Parse token counts from Cline output.
@@ -251,38 +132,3 @@ class ClineAdapter(BaseAdapter):
             output_tokens = int(total_match.group(2))
 
         return input_tokens, output_tokens
-
-    def _parse_api_calls(self, stdout: str, stderr: str) -> int:
-        """Parse API call count from output.
-
-        Args:
-            stdout: Standard output from CLI.
-            stderr: Standard error from CLI.
-
-        Returns:
-            Number of API calls detected.
-
-        """
-        combined = stdout + "\n" + stderr
-
-        # Pattern: "API calls: N" or "N API calls"
-        match = re.search(
-            r"(?:API\s+calls?:?\s*(\d+)|(\d+)\s+API\s+calls?)",
-            combined,
-            re.IGNORECASE,
-        )
-        if match:
-            return int(match.group(1) or match.group(2))
-
-        # Count request/response markers
-        request_count = len(
-            re.findall(r"(?:Sending request|Request sent)", combined, re.IGNORECASE)
-        )
-        if request_count > 0:
-            return request_count
-
-        # Default: assume at least 1 call if there's meaningful output
-        if len(stdout.strip()) > 100:
-            return 1
-
-        return 0

--- a/scylla/adapters/openai_codex.py
+++ b/scylla/adapters/openai_codex.py
@@ -2,32 +2,22 @@
 
 This module provides an adapter for running the OpenAI Codex CLI
 within the Scylla evaluation framework.
-KNOWN ISSUE: This adapter shares ~80% code with opencode.py and cline.py
-See GitHub Issue #479 - Consolidate copy-paste CLI adapters (DRY violation)
-TODO: Extract shared logic into BaseCliAdapter to eliminate duplication
 """
 
 from __future__ import annotations
 
 import json
 import re
-import subprocess
-from datetime import datetime, timezone
 from typing import TYPE_CHECKING
 
-from scylla.adapters.base import (
-    AdapterConfig,
-    AdapterError,
-    AdapterResult,
-    AdapterTokenStats,
-    BaseAdapter,
-)
+from scylla.adapters.base import AdapterConfig
+from scylla.adapters.base_cli import BaseCliAdapter
 
 if TYPE_CHECKING:
     from scylla.executor.tier_config import TierConfig
 
 
-class OpenAICodexAdapter(BaseAdapter):
+class OpenAICodexAdapter(BaseCliAdapter):
     """Adapter for OpenAI Codex CLI.
 
     Executes the OpenAI Codex CLI with the specified configuration and
@@ -49,101 +39,8 @@ class OpenAICodexAdapter(BaseAdapter):
     # OpenAI Codex CLI executable
     CLI_EXECUTABLE = "codex"
 
-    def run(
-        self,
-        config: AdapterConfig,
-        tier_config: TierConfig | None = None,
-    ) -> AdapterResult:
-        """Execute OpenAI Codex CLI with the given configuration.
-
-        Args:
-            config: Adapter configuration with model, prompt, workspace, etc.
-            tier_config: Optional tier-specific configuration for prompt injection.
-
-        Returns:
-            AdapterResult with execution details.
-
-        Raises:
-            AdapterError: If execution fails.
-
-        """
-        self.validate_config(config)
-
-        # Load and potentially inject tier prompt
-        task_prompt = self.load_prompt(config.prompt_file)
-        final_prompt = self.inject_tier_prompt(task_prompt, tier_config)
-
-        # Build CLI command
-        cmd = self._build_command(config, final_prompt, tier_config)
-
-        # Prepare environment with API keys
-        env = self._prepare_env(config)
-
-        # Execute
-        start_time = datetime.now(timezone.utc)
-        try:
-            result = subprocess.run(
-                cmd,
-                capture_output=True,
-                text=True,
-                timeout=config.timeout,
-                cwd=config.workspace,
-                env=env,
-            )
-
-        except subprocess.TimeoutExpired as e:
-            end_time = datetime.now(timezone.utc)
-            duration = (end_time - start_time).total_seconds()
-
-            # Write logs even on timeout
-            stdout = e.stdout.decode() if e.stdout else ""
-            stderr = e.stderr.decode() if e.stderr else ""
-            self.write_logs(config.output_dir, stdout, stderr)
-
-            return AdapterResult(
-                exit_code=-1,
-                stdout=stdout,
-                stderr=stderr,
-                duration_seconds=duration,
-                timed_out=True,
-                error_message=f"Execution timed out after {config.timeout} seconds",
-            )
-
-        except FileNotFoundError:
-            raise AdapterError(f"OpenAI Codex CLI not found. Is '{self.CLI_EXECUTABLE}' installed?")
-
-        except subprocess.SubprocessError as e:
-            raise AdapterError(f"Failed to execute OpenAI Codex: {e}") from e
-
-        end_time = datetime.now(timezone.utc)
-        duration = (end_time - start_time).total_seconds()
-
-        # Parse output for metrics
-        tokens_input, tokens_output = self._parse_token_counts(result.stdout, result.stderr)
-        api_calls = self._parse_api_calls(result.stdout, result.stderr)
-
-        # Create token stats (OpenAI Codex doesn't provide cache info, so only basic stats)
-        token_stats = AdapterTokenStats(
-            input_tokens=tokens_input,
-            output_tokens=tokens_output,
-        )
-
-        # Calculate cost
-        cost = self.calculate_cost(tokens_input, tokens_output, config.model)
-
-        # Write logs
-        self.write_logs(config.output_dir, result.stdout, result.stderr)
-
-        return AdapterResult(
-            exit_code=result.returncode,
-            stdout=result.stdout,
-            stderr=result.stderr,
-            duration_seconds=duration,
-            token_stats=token_stats,
-            cost_usd=cost,
-            api_calls=api_calls,
-            timed_out=False,
-        )
+    # Fallback pattern for API call detection
+    _api_call_fallback_pattern = r'"finish_reason"'
 
     def _build_command(
         self,
@@ -184,22 +81,6 @@ class OpenAICodexAdapter(BaseAdapter):
         cmd.append(prompt)
 
         return cmd
-
-    def _prepare_env(self, config: AdapterConfig) -> dict[str, str]:
-        """Prepare environment variables for subprocess.
-
-        Args:
-            config: Adapter configuration with env_vars.
-
-        Returns:
-            Environment dictionary.
-
-        """
-        import os
-
-        env = os.environ.copy()
-        env.update(config.env_vars)
-        return env
 
     def _parse_token_counts(self, stdout: str, stderr: str) -> tuple[int, int]:
         """Parse token counts from Codex output.
@@ -269,36 +150,3 @@ class OpenAICodexAdapter(BaseAdapter):
             output_tokens = int(combined_match.group(2))
 
         return input_tokens, output_tokens
-
-    def _parse_api_calls(self, stdout: str, stderr: str) -> int:
-        """Parse API call count from output.
-
-        Args:
-            stdout: Standard output from CLI.
-            stderr: Standard error from CLI.
-
-        Returns:
-            Number of API calls detected.
-
-        """
-        combined = stdout + "\n" + stderr
-
-        # Pattern: "API calls: N" or "N API calls"
-        match = re.search(
-            r"(?:API\s+calls?:?\s*(\d+)|(\d+)\s+API\s+calls?)",
-            combined,
-            re.IGNORECASE,
-        )
-        if match:
-            return int(match.group(1) or match.group(2))
-
-        # Count completion responses
-        response_count = len(re.findall(r'"finish_reason"', combined))
-        if response_count > 0:
-            return response_count
-
-        # Default: assume at least 1 call if there's meaningful output
-        if len(stdout.strip()) > 100:
-            return 1
-
-        return 0

--- a/scylla/adapters/opencode.py
+++ b/scylla/adapters/opencode.py
@@ -2,31 +2,21 @@
 
 This module provides an adapter for running the OpenCode CLI
 within the Scylla evaluation framework.
-KNOWN ISSUE: This adapter shares ~80% code with openai_codex.py and cline.py
-See GitHub Issue #479 - Consolidate copy-paste CLI adapters (DRY violation)
-TODO: Extract shared logic into BaseCliAdapter to eliminate duplication
 """
 
 from __future__ import annotations
 
 import re
-import subprocess
-from datetime import datetime, timezone
 from typing import TYPE_CHECKING
 
-from scylla.adapters.base import (
-    AdapterConfig,
-    AdapterError,
-    AdapterResult,
-    AdapterTokenStats,
-    BaseAdapter,
-)
+from scylla.adapters.base import AdapterConfig
+from scylla.adapters.base_cli import BaseCliAdapter
 
 if TYPE_CHECKING:
     from scylla.executor.tier_config import TierConfig
 
 
-class OpenCodeAdapter(BaseAdapter):
+class OpenCodeAdapter(BaseCliAdapter):
     """Adapter for OpenCode CLI.
 
     Executes the OpenCode CLI with the specified configuration and
@@ -48,101 +38,8 @@ class OpenCodeAdapter(BaseAdapter):
     # OpenCode CLI executable
     CLI_EXECUTABLE = "opencode"
 
-    def run(
-        self,
-        config: AdapterConfig,
-        tier_config: TierConfig | None = None,
-    ) -> AdapterResult:
-        """Execute OpenCode CLI with the given configuration.
-
-        Args:
-            config: Adapter configuration with model, prompt, workspace, etc.
-            tier_config: Optional tier-specific configuration for prompt injection.
-
-        Returns:
-            AdapterResult with execution details.
-
-        Raises:
-            AdapterError: If execution fails.
-
-        """
-        self.validate_config(config)
-
-        # Load and potentially inject tier prompt
-        task_prompt = self.load_prompt(config.prompt_file)
-        final_prompt = self.inject_tier_prompt(task_prompt, tier_config)
-
-        # Build CLI command
-        cmd = self._build_command(config, final_prompt, tier_config)
-
-        # Prepare environment with API keys
-        env = self._prepare_env(config)
-
-        # Execute
-        start_time = datetime.now(timezone.utc)
-        try:
-            result = subprocess.run(
-                cmd,
-                capture_output=True,
-                text=True,
-                timeout=config.timeout,
-                cwd=config.workspace,
-                env=env,
-            )
-
-        except subprocess.TimeoutExpired as e:
-            end_time = datetime.now(timezone.utc)
-            duration = (end_time - start_time).total_seconds()
-
-            # Write logs even on timeout
-            stdout = e.stdout.decode() if e.stdout else ""
-            stderr = e.stderr.decode() if e.stderr else ""
-            self.write_logs(config.output_dir, stdout, stderr)
-
-            return AdapterResult(
-                exit_code=-1,
-                stdout=stdout,
-                stderr=stderr,
-                duration_seconds=duration,
-                timed_out=True,
-                error_message=f"Execution timed out after {config.timeout} seconds",
-            )
-
-        except FileNotFoundError:
-            raise AdapterError(f"OpenCode CLI not found. Is '{self.CLI_EXECUTABLE}' installed?")
-
-        except subprocess.SubprocessError as e:
-            raise AdapterError(f"Failed to execute OpenCode: {e}") from e
-
-        end_time = datetime.now(timezone.utc)
-        duration = (end_time - start_time).total_seconds()
-
-        # Parse output for metrics
-        tokens_input, tokens_output = self._parse_token_counts(result.stdout, result.stderr)
-        api_calls = self._parse_api_calls(result.stdout, result.stderr)
-
-        # Create token stats (OpenCode doesn't provide cache info, so only basic stats)
-        token_stats = AdapterTokenStats(
-            input_tokens=tokens_input,
-            output_tokens=tokens_output,
-        )
-
-        # Calculate cost
-        cost = self.calculate_cost(tokens_input, tokens_output, config.model)
-
-        # Write logs
-        self.write_logs(config.output_dir, result.stdout, result.stderr)
-
-        return AdapterResult(
-            exit_code=result.returncode,
-            stdout=result.stdout,
-            stderr=result.stderr,
-            duration_seconds=duration,
-            token_stats=token_stats,
-            cost_usd=cost,
-            api_calls=api_calls,
-            timed_out=False,
-        )
+    # Fallback pattern for API call detection
+    _api_call_fallback_pattern = r"(?:completion|response):"
 
     def _build_command(
         self,
@@ -183,22 +80,6 @@ class OpenCodeAdapter(BaseAdapter):
         cmd.extend(["--message", prompt])
 
         return cmd
-
-    def _prepare_env(self, config: AdapterConfig) -> dict[str, str]:
-        """Prepare environment variables for subprocess.
-
-        Args:
-            config: Adapter configuration with env_vars.
-
-        Returns:
-            Environment dictionary.
-
-        """
-        import os
-
-        env = os.environ.copy()
-        env.update(config.env_vars)
-        return env
 
     def _parse_token_counts(self, stdout: str, stderr: str) -> tuple[int, int]:
         """Parse token counts from OpenCode output.
@@ -264,36 +145,3 @@ class OpenCodeAdapter(BaseAdapter):
             output_tokens = int(total_match.group(2))
 
         return input_tokens, output_tokens
-
-    def _parse_api_calls(self, stdout: str, stderr: str) -> int:
-        """Parse API call count from output.
-
-        Args:
-            stdout: Standard output from CLI.
-            stderr: Standard error from CLI.
-
-        Returns:
-            Number of API calls detected.
-
-        """
-        combined = stdout + "\n" + stderr
-
-        # Pattern: "API calls: N" or "N API calls"
-        match = re.search(
-            r"(?:API\s+calls?:?\s*(\d+)|(\d+)\s+API\s+calls?)",
-            combined,
-            re.IGNORECASE,
-        )
-        if match:
-            return int(match.group(1) or match.group(2))
-
-        # Count completion markers
-        completion_count = len(re.findall(r"(?:completion|response):", combined, re.IGNORECASE))
-        if completion_count > 0:
-            return completion_count
-
-        # Default: assume at least 1 call if there's meaningful output
-        if len(stdout.strip()) > 100:
-            return 1
-
-        return 0

--- a/tests/unit/adapters/conftest.py
+++ b/tests/unit/adapters/conftest.py
@@ -1,0 +1,74 @@
+"""Shared test fixtures for adapter tests."""
+
+from collections.abc import Generator
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from unittest.mock import MagicMock
+
+import pytest
+
+from scylla.adapters.base import AdapterConfig
+
+
+@pytest.fixture
+def temp_workspace() -> Generator[Path, None, None]:
+    """Create temporary workspace directory."""
+    with TemporaryDirectory() as tmpdir:
+        yield Path(tmpdir)
+
+
+@pytest.fixture
+def prompt_file(temp_workspace: Path) -> Path:
+    """Create test prompt file."""
+    prompt_file = temp_workspace / "prompt.md"
+    prompt_file.write_text("Test prompt")
+    return prompt_file
+
+
+@pytest.fixture
+def adapter_config(temp_workspace: Path, prompt_file: Path) -> AdapterConfig:
+    """Create standard adapter configuration."""
+    return AdapterConfig(
+        model="gpt-4",
+        prompt_file=prompt_file,
+        workspace=temp_workspace,
+        output_dir=temp_workspace,
+    )
+
+
+@pytest.fixture
+def tier_config_tools_disabled() -> MagicMock:
+    """Create tier config with tools disabled."""
+    tier_config = MagicMock()
+    tier_config.tools_enabled = False
+    tier_config.delegation_enabled = None
+    return tier_config
+
+
+@pytest.fixture
+def tier_config_tools_enabled() -> MagicMock:
+    """Create tier config with tools enabled."""
+    tier_config = MagicMock()
+    tier_config.tools_enabled = True
+    tier_config.delegation_enabled = None
+    return tier_config
+
+
+@pytest.fixture
+def mock_subprocess_result() -> MagicMock:
+    """Create mock subprocess result."""
+    result = MagicMock()
+    result.returncode = 0
+    result.stdout = "Success output"
+    result.stderr = ""
+    return result
+
+
+@pytest.fixture
+def mock_subprocess_result_with_tokens() -> MagicMock:
+    """Create mock subprocess result with token information."""
+    result = MagicMock()
+    result.returncode = 0
+    result.stdout = "API calls: 2\nInput tokens: 100\nOutput tokens: 200"
+    result.stderr = ""
+    return result

--- a/tests/unit/adapters/test_base_cli_adapter.py
+++ b/tests/unit/adapters/test_base_cli_adapter.py
@@ -1,0 +1,254 @@
+"""Tests for BaseCliAdapter class."""
+
+import subprocess
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from scylla.adapters.base import AdapterConfig, AdapterError
+from scylla.adapters.base_cli import BaseCliAdapter
+
+
+class TestCliAdapter(BaseCliAdapter):
+    """Concrete test implementation of BaseCliAdapter."""
+
+    CLI_EXECUTABLE = "test-cli"
+    _api_call_fallback_pattern = r"test_pattern"
+
+    def _build_command(self, config: AdapterConfig, prompt: str, tier_config) -> list[str]:
+        """Build test command."""
+        return [self.CLI_EXECUTABLE, "--model", config.model, prompt]
+
+    def _parse_token_counts(self, stdout: str, stderr: str) -> tuple[int, int]:
+        """Parse test token counts."""
+        return (100, 200)
+
+
+class TestBaseCliAdapter:
+    """Tests for BaseCliAdapter abstract class."""
+
+    def test_cannot_instantiate_abstract_class(self) -> None:
+        """Test that BaseCliAdapter cannot be instantiated directly."""
+        with pytest.raises(TypeError):
+            BaseCliAdapter()  # type: ignore
+
+    def test_concrete_implementation_instantiates(self) -> None:
+        """Test that concrete implementation can be instantiated."""
+        adapter = TestCliAdapter()
+        assert adapter is not None
+        assert adapter.CLI_EXECUTABLE == "test-cli"
+
+
+class TestRun:
+    """Tests for run() method execution flow."""
+
+    @patch("scylla.adapters.base_cli.subprocess.run")
+    def test_successful_run(self, mock_run: MagicMock, adapter_config: AdapterConfig) -> None:
+        """Test successful CLI execution."""
+        # Setup mock
+        mock_result = MagicMock()
+        mock_result.returncode = 0
+        mock_result.stdout = "Success"
+        mock_result.stderr = ""
+        mock_run.return_value = mock_result
+
+        # Execute
+        adapter = TestCliAdapter()
+        result = adapter.run(adapter_config)
+
+        # Verify
+        assert result.exit_code == 0
+        assert result.stdout == "Success"
+        assert result.stderr == ""
+        assert result.timed_out is False
+        assert result.token_stats.input_tokens == 100
+        assert result.token_stats.output_tokens == 200
+        assert result.duration_seconds > 0
+
+    @patch("scylla.adapters.base_cli.subprocess.run")
+    def test_run_with_nonzero_exit(
+        self, mock_run: MagicMock, adapter_config: AdapterConfig
+    ) -> None:
+        """Test CLI execution with non-zero exit code."""
+        # Setup mock
+        mock_result = MagicMock()
+        mock_result.returncode = 1
+        mock_result.stdout = ""
+        mock_result.stderr = "Error occurred"
+        mock_run.return_value = mock_result
+
+        # Execute
+        adapter = TestCliAdapter()
+        result = adapter.run(adapter_config)
+
+        # Verify
+        assert result.exit_code == 1
+        assert result.stderr == "Error occurred"
+        assert result.timed_out is False
+
+    @patch("scylla.adapters.base_cli.subprocess.run")
+    def test_run_timeout(self, mock_run: MagicMock, adapter_config: AdapterConfig) -> None:
+        """Test CLI execution timeout."""
+        # Setup mock to raise TimeoutExpired
+        mock_run.side_effect = subprocess.TimeoutExpired(
+            cmd=["test-cli"], timeout=3600, output=b"Partial output", stderr=b""
+        )
+
+        # Execute
+        adapter = TestCliAdapter()
+        result = adapter.run(adapter_config)
+
+        # Verify
+        assert result.exit_code == -1
+        assert result.timed_out is True
+        assert "timed out" in result.error_message.lower()
+        assert result.stdout == "Partial output"
+
+    @patch("scylla.adapters.base_cli.subprocess.run")
+    def test_run_cli_not_found(self, mock_run: MagicMock, adapter_config: AdapterConfig) -> None:
+        """Test CLI executable not found."""
+        mock_run.side_effect = FileNotFoundError()
+
+        adapter = TestCliAdapter()
+        with pytest.raises(AdapterError) as exc_info:
+            adapter.run(adapter_config)
+
+        assert "not found" in str(exc_info.value).lower()
+        assert "test-cli" in str(exc_info.value)
+
+    @patch("scylla.adapters.base_cli.subprocess.run")
+    def test_run_subprocess_error(self, mock_run: MagicMock, adapter_config: AdapterConfig) -> None:
+        """Test subprocess error handling."""
+        mock_run.side_effect = subprocess.SubprocessError("Subprocess failed")
+
+        adapter = TestCliAdapter()
+        with pytest.raises(AdapterError) as exc_info:
+            adapter.run(adapter_config)
+
+        assert "failed" in str(exc_info.value).lower()
+
+    @patch("scylla.adapters.base_cli.subprocess.run")
+    def test_run_writes_logs(self, mock_run: MagicMock, adapter_config: AdapterConfig) -> None:
+        """Test that logs are written to output directory."""
+        # Setup mock
+        mock_result = MagicMock()
+        mock_result.returncode = 0
+        mock_result.stdout = "Test stdout"
+        mock_result.stderr = "Test stderr"
+        mock_run.return_value = mock_result
+
+        # Execute
+        adapter = TestCliAdapter()
+        adapter.run(adapter_config)
+
+        # Verify logs were written
+        assert (adapter_config.output_dir / "stdout.log").exists()
+        assert (adapter_config.output_dir / "stderr.log").exists()
+        assert (adapter_config.output_dir / "stdout.log").read_text() == "Test stdout"
+        assert (adapter_config.output_dir / "stderr.log").read_text() == "Test stderr"
+
+
+class TestPrepareEnv:
+    """Tests for _prepare_env() method."""
+
+    def test_prepare_env_copies_environment(self, adapter_config: AdapterConfig) -> None:
+        """Test that _prepare_env copies os.environ."""
+        adapter = TestCliAdapter()
+        env = adapter._prepare_env(adapter_config)
+
+        # Should include system env vars
+        assert "PATH" in env
+
+    def test_prepare_env_merges_config_vars(self, temp_workspace: Path, prompt_file: Path) -> None:
+        """Test that _prepare_env merges config env_vars."""
+        config = AdapterConfig(
+            model="gpt-4",
+            prompt_file=prompt_file,
+            workspace=temp_workspace,
+            output_dir=temp_workspace,
+            env_vars={"CUSTOM_KEY": "custom_value", "API_KEY": "secret"},
+        )
+
+        adapter = TestCliAdapter()
+        env = adapter._prepare_env(config)
+
+        assert env["CUSTOM_KEY"] == "custom_value"
+        assert env["API_KEY"] == "secret"
+
+
+class TestParseApiCalls:
+    """Tests for _parse_api_calls() method."""
+
+    def test_parse_api_calls_explicit_count(self) -> None:
+        """Test parsing explicit API call count."""
+        adapter = TestCliAdapter()
+        stdout = "API calls: 5\nOther output"
+        stderr = ""
+
+        count = adapter._parse_api_calls(stdout, stderr)
+        assert count == 5
+
+    def test_parse_api_calls_count_prefix(self) -> None:
+        """Test parsing API call count with prefix."""
+        adapter = TestCliAdapter()
+        stdout = "Made 3 API calls"
+        stderr = ""
+
+        count = adapter._parse_api_calls(stdout, stderr)
+        assert count == 3
+
+    def test_parse_api_calls_fallback_pattern(self) -> None:
+        """Test parsing API calls using fallback pattern."""
+        adapter = TestCliAdapter()
+        stdout = "test_pattern\ntest_pattern\ntest_pattern"
+        stderr = ""
+
+        count = adapter._parse_api_calls(stdout, stderr)
+        assert count == 3
+
+    def test_parse_api_calls_default_for_long_output(self) -> None:
+        """Test default API call count for long output."""
+        adapter = TestCliAdapter()
+        stdout = "x" * 150  # More than 100 characters
+        stderr = ""
+
+        count = adapter._parse_api_calls(stdout, stderr)
+        assert count == 1
+
+    def test_parse_api_calls_zero_for_short_output(self) -> None:
+        """Test zero API calls for short output."""
+        adapter = TestCliAdapter()
+        stdout = "short"
+        stderr = ""
+
+        count = adapter._parse_api_calls(stdout, stderr)
+        assert count == 0
+
+
+class TestAbstractMethods:
+    """Tests for abstract method requirements."""
+
+    def test_build_command_must_be_implemented(self) -> None:
+        """Test that _build_command must be implemented."""
+
+        class IncompleteAdapter(BaseCliAdapter):
+            CLI_EXECUTABLE = "incomplete"
+
+            def _parse_token_counts(self, stdout: str, stderr: str) -> tuple[int, int]:
+                return (0, 0)
+
+        with pytest.raises(TypeError):
+            IncompleteAdapter()  # type: ignore
+
+    def test_parse_token_counts_must_be_implemented(self) -> None:
+        """Test that _parse_token_counts must be implemented."""
+
+        class IncompleteAdapter(BaseCliAdapter):
+            CLI_EXECUTABLE = "incomplete"
+
+            def _build_command(self, config: AdapterConfig, prompt: str, tier_config) -> list[str]:
+                return ["cmd"]
+
+        with pytest.raises(TypeError):
+            IncompleteAdapter()  # type: ignore


### PR DESCRIPTION
Closes #479

## Summary
- Extracted `BaseCliAdapter` with shared `run()`, `_prepare_env()`, and `_parse_api_calls()` methods
- Refactored 3 CLI adapters (OpenAI Codex, OpenCode, Cline) to inherit from `BaseCliAdapter`
- Reduced adapter code from ~300 lines to ~150 lines each (~420 lines saved)
- Added comprehensive tests for base class with 17 test cases
- Created shared test fixtures in `conftest.py`
- `ClaudeCodeAdapter` remains separate (different interface pattern)

## Test Plan
- [x] All 139 adapter tests pass
- [x] Pre-commit hooks pass
- [x] BaseCliAdapter tests cover run(), prepare_env(), parse_api_calls()
- [x] Existing adapter tests still pass with refactored implementation

🤖 Generated with [Claude Code](https://claude.com/claude-code)