### PR TITLE
refactor(e2e): Consolidate rerun.py and rerun_judges.py shared patterns

### DIFF
--- a/scylla/e2e/rerun_base.py
+++ b/scylla/e2e/rerun_base.py
@@ -1,0 +1,137 @@
+"""Shared infrastructure for rerun.py and rerun_judges.py.
+
+This module consolidates common patterns for re-running agents and judges,
+including config loading, tiers directory detection, and dry-run output formatting.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from scylla.e2e.models import ExperimentConfig
+from scylla.e2e.tier_manager import TierManager
+
+if TYPE_CHECKING:
+    pass
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class RerunContext:
+    """Shared context for rerun operations."""
+
+    experiment_dir: Path
+    config: ExperimentConfig
+    tier_manager: TierManager
+    tiers_dir: Path
+
+
+def load_rerun_context(experiment_dir: Path) -> RerunContext:
+    """Load experiment config and auto-detect tiers directory.
+
+    Args:
+        experiment_dir: Path to experiment directory
+
+    Returns:
+        RerunContext with loaded configuration
+
+    Raises:
+        FileNotFoundError: If config or tiers directory not found
+
+    """
+    logger.info(f"Scanning experiment directory: {experiment_dir}")
+
+    # Load experiment config
+    config_file = experiment_dir / "config" / "experiment.json"
+    if not config_file.exists():
+        raise FileNotFoundError(f"Experiment config not found: {config_file}")
+
+    config = ExperimentConfig.load(config_file)
+    logger.info(f"Loaded config: {config.experiment_id}")
+
+    # Auto-detect tiers_dir: look for tests/fixtures/tests/ in parent directories
+    current = experiment_dir
+    tiers_dir = None
+    for _ in range(5):  # Search up to 5 levels up
+        candidate = current / "tests" / "fixtures" / "tests"
+        if candidate.exists() and candidate.is_dir():
+            # Find test-NNN directory
+            test_dirs = [
+                d for d in candidate.iterdir() if d.is_dir() and d.name.startswith("test-")
+            ]
+            if test_dirs:
+                tiers_dir = sorted(test_dirs)[0]  # Use first test dir
+                break
+        current = current.parent
+        if current == current.parent:  # Reached root
+            break
+
+    if not tiers_dir:
+        # Fallback: try ProjectScylla root
+        project_root = Path(__file__).parent.parent.parent
+        candidate = project_root / "tests" / "fixtures" / "tests"
+        if candidate.exists():
+            test_dirs = [
+                d for d in candidate.iterdir() if d.is_dir() and d.name.startswith("test-")
+            ]
+            if test_dirs:
+                tiers_dir = sorted(test_dirs)[0]
+
+    if not tiers_dir:
+        raise FileNotFoundError(
+            "Could not auto-detect tiers directory. Please ensure the experiment was created "
+            "with a valid test fixture directory."
+        )
+
+    logger.info(f"Using tiers directory: {tiers_dir}")
+
+    # Create tier manager
+    tier_manager = TierManager(tiers_dir)
+
+    return RerunContext(
+        experiment_dir=experiment_dir,
+        config=config,
+        tier_manager=tier_manager,
+        tiers_dir=tiers_dir,
+    )
+
+
+def print_dry_run_summary(
+    items_by_status: dict,
+    status_names: dict,
+    max_preview: int = 10,
+) -> None:
+    """Print dry-run summary for runs or judge slots.
+
+    Args:
+        items_by_status: Dictionary mapping status enum to list of items
+        status_names: Dictionary mapping status enum to display name
+        max_preview: Maximum number of items to preview per status (default: 10)
+
+    """
+    print("\n" + "=" * 70)
+    print("DRY RUN MODE - No changes will be made")
+    print("=" * 70)
+
+    for status, items in items_by_status.items():
+        if items:
+            display_name = status_names.get(status, status.value.upper())
+            print(f"\n{display_name} ({len(items)} items):")
+            for item in items[:max_preview]:
+                # Format item based on its attributes
+                if hasattr(item, "judge_number"):
+                    # Judge slot format
+                    print(
+                        f"  - {item.tier_id}/{item.subtest_id}/run_{item.run_number:02d} "
+                        f"judge_{item.judge_number:02d} ({item.judge_model}): {item.reason}"
+                    )
+                else:
+                    # Run format
+                    run_id = f"{item.tier_id}/{item.subtest_id}/run_{item.run_number:02d}"
+                    print(f"  - {run_id}: {item.reason}")
+            if len(items) > max_preview:
+                print(f"  ... and {len(items) - max_preview} more")

--- a/tests/unit/e2e/test_rerun_base.py
+++ b/tests/unit/e2e/test_rerun_base.py
@@ -1,0 +1,237 @@
+"""Tests for rerun_base.py shared infrastructure."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+from pathlib import Path
+
+import pytest
+
+from scylla.e2e.rerun_base import load_rerun_context, print_dry_run_summary
+
+
+class _TestStatus(Enum):
+    """Test status enum for dry-run testing."""
+
+    COMPLETE = "complete"
+    FAILED = "failed"
+    MISSING = "missing"
+
+
+@dataclass
+class _TestRunItem:
+    """Test run item for dry-run testing."""
+
+    tier_id: str
+    subtest_id: str
+    run_number: int
+    reason: str
+
+
+@dataclass
+class _TestJudgeItem:
+    """Test judge item for dry-run testing."""
+
+    tier_id: str
+    subtest_id: str
+    run_number: int
+    judge_number: int
+    judge_model: str
+    reason: str
+
+
+def test_load_rerun_context_success(tmp_path: Path):
+    """Test successful loading of rerun context."""
+    # Create experiment directory structure
+    experiment_dir = tmp_path / "experiment"
+    config_dir = experiment_dir / "config"
+    config_dir.mkdir(parents=True)
+
+    # Create minimal config
+    config_file = config_dir / "experiment.json"
+    config_file.write_text(
+        """{
+        "experiment_id": "test-001",
+        "tiers_to_run": ["T0"],
+        "runs_per_subtest": 3,
+        "judge_models": ["claude-sonnet-4"],
+        "task_repo": "test-repo",
+        "task_commit": "abc123",
+        "task_prompt_file": "prompt.md",
+        "language": "python"
+    }"""
+    )
+
+    # Create tiers directory
+    tiers_dir = tmp_path / "tests" / "fixtures" / "tests" / "test-001"
+    tiers_dir.mkdir(parents=True)
+
+    # Create T0 config
+    t0_dir = tiers_dir / "T0"
+    t0_dir.mkdir()
+    (t0_dir / "config.yaml").write_text(
+        """subtests:
+  - id: "00"
+    name: "Test subtest"
+"""
+    )
+
+    # Load context
+    context = load_rerun_context(experiment_dir)
+
+    # Verify
+    assert context.experiment_dir == experiment_dir
+    assert context.config.experiment_id == "test-001"
+    assert context.tiers_dir == tiers_dir
+    assert context.tier_manager is not None
+
+
+def test_load_rerun_context_missing_config(tmp_path: Path):
+    """Test error when config file is missing."""
+    experiment_dir = tmp_path / "experiment"
+    experiment_dir.mkdir()
+
+    with pytest.raises(FileNotFoundError, match="Experiment config not found"):
+        load_rerun_context(experiment_dir)
+
+
+def test_load_rerun_context_missing_tiers_dir(tmp_path: Path, monkeypatch):
+    """Test error when tiers directory cannot be found."""
+    # Create experiment directory with config but no tiers
+    experiment_dir = tmp_path / "experiment"
+    config_dir = experiment_dir / "config"
+    config_dir.mkdir(parents=True)
+
+    config_file = config_dir / "experiment.json"
+    config_file.write_text(
+        """{
+        "experiment_id": "test-001",
+        "tiers_to_run": ["T0"],
+        "runs_per_subtest": 3,
+        "judge_models": ["claude-sonnet-4"],
+        "task_repo": "test-repo",
+        "task_commit": "abc123",
+        "task_prompt_file": "prompt.md",
+        "language": "python"
+    }"""
+    )
+
+    # Mock __file__ to prevent fallback from finding real tiers directory
+    fake_module_path = tmp_path / "fake_module.py"
+    monkeypatch.setattr("scylla.e2e.rerun_base.__file__", str(fake_module_path))
+
+    with pytest.raises(FileNotFoundError, match="Could not auto-detect tiers directory"):
+        load_rerun_context(experiment_dir)
+
+
+def test_print_dry_run_summary_runs(capsys):
+    """Test dry-run summary for run items."""
+    # Create test items
+    failed_runs = [
+        _TestRunItem("T0", "00", 1, "Agent failed"),
+        _TestRunItem("T0", "00", 2, "Agent failed"),
+    ]
+    missing_runs = [
+        _TestRunItem("T0", "01", 1, "Never started"),
+    ]
+
+    items_by_status = {
+        _TestStatus.FAILED: failed_runs,
+        _TestStatus.MISSING: missing_runs,
+        _TestStatus.COMPLETE: [],
+    }
+
+    status_names = {
+        _TestStatus.FAILED: "FAILED",
+        _TestStatus.MISSING: "MISSING",
+        _TestStatus.COMPLETE: "COMPLETE",
+    }
+
+    print_dry_run_summary(items_by_status, status_names)
+
+    captured = capsys.readouterr()
+    assert "DRY RUN MODE - No changes will be made" in captured.out
+    assert "FAILED (2 items):" in captured.out
+    assert "T0/00/run_01: Agent failed" in captured.out
+    assert "T0/00/run_02: Agent failed" in captured.out
+    assert "MISSING (1 items):" in captured.out
+    assert "T0/01/run_01: Never started" in captured.out
+
+
+def test_print_dry_run_summary_judges(capsys):
+    """Test dry-run summary for judge items."""
+    # Create test items
+    failed_slots = [
+        _TestJudgeItem("T0", "00", 1, 1, "claude-sonnet-4", "Judge failed"),
+        _TestJudgeItem("T0", "00", 1, 2, "claude-opus-4", "Judge failed"),
+    ]
+    missing_slots = [
+        _TestJudgeItem("T0", "00", 2, 1, "claude-sonnet-4", "Never ran"),
+    ]
+
+    items_by_status = {
+        _TestStatus.FAILED: failed_slots,
+        _TestStatus.MISSING: missing_slots,
+        _TestStatus.COMPLETE: [],
+    }
+
+    status_names = {
+        _TestStatus.FAILED: "FAILED",
+        _TestStatus.MISSING: "MISSING",
+        _TestStatus.COMPLETE: "COMPLETE",
+    }
+
+    print_dry_run_summary(items_by_status, status_names)
+
+    captured = capsys.readouterr()
+    assert "DRY RUN MODE - No changes will be made" in captured.out
+    assert "FAILED (2 items):" in captured.out
+    assert "T0/00/run_01 judge_01 (claude-sonnet-4): Judge failed" in captured.out
+    assert "T0/00/run_01 judge_02 (claude-opus-4): Judge failed" in captured.out
+    assert "MISSING (1 items):" in captured.out
+    assert "T0/00/run_02 judge_01 (claude-sonnet-4): Never ran" in captured.out
+
+
+def test_print_dry_run_summary_truncation(capsys):
+    """Test that dry-run summary truncates long lists."""
+    # Create 15 failed runs
+    failed_runs = [_TestRunItem("T0", f"{i:02d}", 1, "Failed") for i in range(15)]
+
+    items_by_status = {
+        _TestStatus.FAILED: failed_runs,
+    }
+
+    status_names = {
+        _TestStatus.FAILED: "FAILED",
+    }
+
+    print_dry_run_summary(items_by_status, status_names, max_preview=10)
+
+    captured = capsys.readouterr()
+    assert "FAILED (15 items):" in captured.out
+    assert "... and 5 more" in captured.out
+
+
+def test_print_dry_run_summary_empty(capsys):
+    """Test dry-run summary with no items."""
+    items_by_status = {
+        _TestStatus.FAILED: [],
+        _TestStatus.MISSING: [],
+        _TestStatus.COMPLETE: [],
+    }
+
+    status_names = {
+        _TestStatus.FAILED: "FAILED",
+        _TestStatus.MISSING: "MISSING",
+        _TestStatus.COMPLETE: "COMPLETE",
+    }
+
+    print_dry_run_summary(items_by_status, status_names)
+
+    captured = capsys.readouterr()
+    assert "DRY RUN MODE - No changes will be made" in captured.out
+    # Should not show any status sections since all are empty
+    assert "FAILED" not in captured.out
+    assert "MISSING" not in captured.out
+    assert "COMPLETE" not in captured.out


### PR DESCRIPTION
## Summary
- Created `scylla/e2e/rerun_base.py` with shared infrastructure (~120 lines)
- Extracted `load_rerun_context()` - config loading and tiers directory auto-detection
- Extracted `print_dry_run_summary()` - dry-run output formatting
- Refactored `rerun.py` to use shared infrastructure
- Refactored `rerun_judges.py` to use shared infrastructure
- Added comprehensive tests in `tests/unit/e2e/test_rerun_base.py` (~240 lines)

## Test plan
- [x] All unit tests pass: `pixi run python -m pytest tests/unit/e2e/ -v` (431 passed, 1 skipped)
- [x] Pre-commit hooks pass: `pre-commit run --all-files`
- [x] No functional changes - only refactoring to reduce duplication

Closes #488

🤖 Generated with [Claude Code](https://claude.com/claude-code)