### PR TITLE
refactor(e2e): Migrate all dataclasses to Pydantic BaseModel

### DIFF
--- a/scylla/e2e/checkpoint.py
+++ b/scylla/e2e/checkpoint.py
@@ -291,7 +291,7 @@ def compute_config_hash(config: ExperimentConfig) -> str:
         16-character hex hash (first 16 chars of SHA256)
 
     """
-    config_dict = config.to_dict()
+    config_dict = config.model_dump(mode="json")
 
     # Remove fields that don't affect results
     config_dict.pop("parallel_subtests", None)  # Just parallelization setting

--- a/scylla/e2e/judge_selection.py
+++ b/scylla/e2e/judge_selection.py
@@ -8,15 +8,15 @@ with an alternate LLM.
 from __future__ import annotations
 
 import json
-from dataclasses import dataclass
 from typing import TYPE_CHECKING
+
+from pydantic import BaseModel
 
 if TYPE_CHECKING:
     from scylla.e2e.models import SubTestResult
 
 
-@dataclass
-class JudgeVote:
+class JudgeVote(BaseModel):
     """A judge's vote for a sub-test.
 
     Attributes:
@@ -42,8 +42,7 @@ class JudgeVote:
         }
 
 
-@dataclass
-class JudgeSelection:
+class JudgeSelection(BaseModel):
     """Result of the judge selection process.
 
     Attributes:

--- a/scylla/e2e/llm_judge.py
+++ b/scylla/e2e/llm_judge.py
@@ -11,9 +11,10 @@ import logging
 import os
 import subprocess
 import tempfile
-from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
+
+from pydantic import BaseModel
 
 from scylla.e2e.filters import is_test_config_file
 from scylla.judge import extract_json_from_llm_response
@@ -23,8 +24,7 @@ from scylla.metrics.grading import assign_letter_grade
 logger = logging.getLogger(__name__)
 
 
-@dataclass
-class JudgeResult:
+class JudgeResult(BaseModel):
     """Result from LLM judge evaluation.
 
     Attributes:
@@ -63,8 +63,7 @@ class JudgeResult:
 _score_to_grade = assign_letter_grade
 
 
-@dataclass
-class BuildPipelineResult:
+class BuildPipelineResult(BaseModel):
     """Results from running build/lint pipeline.
 
     Attributes:

--- a/scylla/e2e/rate_limit.py
+++ b/scylla/e2e/rate_limit.py
@@ -12,10 +12,11 @@ import re
 import subprocess
 import time
 from collections.abc import Callable
-from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import TYPE_CHECKING
+
+from pydantic import BaseModel, model_validator
 
 from scylla.e2e.paths import get_agent_dir
 
@@ -25,8 +26,7 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
-@dataclass
-class RateLimitInfo:
+class RateLimitInfo(BaseModel):
     """Information about a detected rate limit.
 
     Attributes:
@@ -42,10 +42,12 @@ class RateLimitInfo:
     error_message: str
     detected_at: str
 
-    def __post_init__(self) -> None:
+    @model_validator(mode="after")
+    def validate_source(self) -> RateLimitInfo:
         """Validate source field."""
         if self.source not in ("agent", "judge"):
             raise ValueError(f"Invalid source: {self.source}. Must be 'agent' or 'judge'.")
+        return self
 
 
 class RateLimitError(Exception):

--- a/scylla/e2e/regenerate.py
+++ b/scylla/e2e/regenerate.py
@@ -12,8 +12,9 @@ import json
 import logging
 import shutil
 import statistics
-from dataclasses import dataclass
 from pathlib import Path
+
+from pydantic import BaseModel
 
 from scylla.e2e.judge_selection import select_best_subtest
 from scylla.e2e.llm_judge import run_llm_judge
@@ -37,8 +38,7 @@ from scylla.e2e.run_report import (
 logger = logging.getLogger(__name__)
 
 
-@dataclass
-class RegenerateStats:
+class RegenerateStats(BaseModel):
     """Statistics from regeneration process."""
 
     runs_found: int = 0

--- a/scylla/e2e/rerun.py
+++ b/scylla/e2e/rerun.py
@@ -14,11 +14,12 @@ from __future__ import annotations
 
 import logging
 import os
-from dataclasses import dataclass
 from datetime import datetime, timezone
 from enum import Enum
 from pathlib import Path
 from typing import TYPE_CHECKING
+
+from pydantic import BaseModel, ConfigDict
 
 from scylla.e2e.checkpoint import load_checkpoint, save_checkpoint
 from scylla.e2e.models import ExperimentConfig, RunResult, TierBaseline, TierID
@@ -43,8 +44,7 @@ class RunStatus(Enum):
     RESULTS = "results"  # Agent finished, but run_result.json or agent/result.json missing
 
 
-@dataclass
-class RerunStats:
+class RerunStats(BaseModel):
     """Statistics from rerun process."""
 
     total_expected_runs: int = 0
@@ -79,9 +79,10 @@ class RerunStats:
         print("=" * 70)
 
 
-@dataclass
-class RunToRerun:
+class RunToRerun(BaseModel):
     """A single run that needs re-running."""
+
+    model_config = ConfigDict(arbitrary_types_allowed=True)
 
     tier_id: str  # e.g., "T0"
     subtest_id: str  # e.g., "00"

--- a/scylla/e2e/rerun_base.py
+++ b/scylla/e2e/rerun_base.py
@@ -7,9 +7,10 @@ including config loading, tiers directory detection, and dry-run output formatti
 from __future__ import annotations
 
 import logging
-from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING
+
+from pydantic import BaseModel, ConfigDict
 
 from scylla.e2e.models import ExperimentConfig
 from scylla.e2e.tier_manager import TierManager
@@ -20,9 +21,10 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
-@dataclass
-class RerunContext:
+class RerunContext(BaseModel):
     """Shared context for rerun operations."""
+
+    model_config = ConfigDict(arbitrary_types_allowed=True)
 
     experiment_dir: Path
     config: ExperimentConfig

--- a/tests/unit/e2e/test_judge_selection.py
+++ b/tests/unit/e2e/test_judge_selection.py
@@ -41,8 +41,8 @@ class TestJudgeSelection:
             winning_subtest="01",
             winning_score=0.85,
             votes=[
-                JudgeVote("01", 0.85, 0.9, "Good"),
-                JudgeVote("02", 0.80, 0.8, "Okay"),
+                JudgeVote(subtest_id="01", score=0.85, confidence=0.9, reasoning="Good"),
+                JudgeVote(subtest_id="02", score=0.80, confidence=0.8, reasoning="Okay"),
             ],
             margin=0.05,
             tiebreaker_needed=False,


### PR DESCRIPTION
## Summary

Complete migration of all 24 e2e dataclasses to Pydantic BaseModel, following the pattern established in commit 086e0b4. This completes the migration that was started earlier and left `scylla/e2e/` dataclasses untouched.

## Changes

### Migrated Classes (24 total)

**scylla/e2e/models.py (12 classes):**
- `TokenStats`, `SubTestConfig`, `TierConfig`, `JudgeResultSummary`
- `RunResult`, `SubTestResult`, `TierBaseline`, `ResourceManifest`
- `TierResult`, `TestFixture`, `ExperimentConfig`, `ExperimentResult`

**scylla/e2e/rate_limit.py (1 class):**
- `RateLimitInfo` (converted `__post_init__` → `@model_validator`)

**scylla/e2e/judge_selection.py (2 classes):**
- `JudgeVote`, `JudgeSelection`

**scylla/e2e/llm_judge.py (2 classes):**
- `JudgeResult`, `BuildPipelineResult`

**scylla/e2e/rerun.py (2 classes):**
- `RerunStats`, `RunToRerun`

**scylla/e2e/rerun_judges.py (3 classes):**
- `RerunJudgeStats`, `JudgeSlotToRerun`, `_JudgeSlotResult`

**scylla/e2e/regenerate.py (1 class):**
- `RegenerateStats`

**scylla/e2e/rerun_base.py (1 class):**
- `RerunContext`

### Migration Patterns

1. **Class declaration:** `@dataclass` decorator removed, `class Foo(BaseModel):`
2. **Field defaults:** `field(default_factory=...)` → `Field(default_factory=...)`
3. **Model config:** Added `ConfigDict(arbitrary_types_allowed=True)` for Path/Enum fields
4. **Validation:** `__post_init__` → `@model_validator(mode='after')` or `Field(default_factory=...)`
5. **Forward references:** `RateLimitInfo` in `SubTestResult` resolved with string annotation + `model_rebuild()`

### Fixes

- ✅ Reverted `checkpoint.py:294` workaround: `config.to_dict()` → `config.model_dump(mode="json")`
- ✅ Fixed `test_judge_selection.py`: positional arguments → keyword arguments for Pydantic models

### Custom Methods Preserved

All custom methods work with Pydantic:
- `to_dict()`, `from_dict()` - kept for custom serialization (Path→str, Enum→value)
- `@property` decorators - work as-is
- `__add__` dunder methods - work as-is
- Class methods (`load()`, `save()`, `from_directory()`) - work as-is

## Testing

- ✅ 430 e2e unit tests pass
- ✅ 2,044 total tests pass
- ✅ Pre-commit hooks pass (formatting applied)
- ✅ Both `model_dump()` and `to_dict()` work correctly

## Verification

```bash
# Run e2e tests
pixi run python -m pytest tests/unit/e2e/ -v

# Run full test suite
pixi run python -m pytest tests/ -v

# Verify model_dump() works
python -c "from scylla.e2e.models import ExperimentConfig; from pathlib import Path; c = ExperimentConfig(experiment_id='test', task_repo='r', task_commit='c', task_prompt_file=Path('p'), language='python'); print(c.model_dump())"
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)