### PR TITLE
fix(e2e): Complete Pydantic migration to fix all E2E test crashes

### DIFF
--- a/scripts/run_e2e_batch.py
+++ b/scripts/run_e2e_batch.py
@@ -536,14 +536,8 @@ Analyze the results of running all 47 E2E tests and file summaries to GitHub.
 
 ## Configuration
 - Date: {date}
-<<<<<<< HEAD
-- Model: {config["model"]} | Judge: {config["judge_model"]}
-- Runs: {config["runs"]} | Max Subtests: {config["max_subtests"]}
-- Thinking: {config["thinking"]}
-=======
 - Model: {config["model"]} | Judge: {config["judge_model"]} | Runs: {config["runs"]}
 - Max Subtests: {config["max_subtests"]} | Thinking: {config["thinking"]}
->>>>>>> 14b6d9a (fix(batch-runner): Fix crashes, terminal corruption, and improve UX)
 - Tiers: {", ".join(config["tiers"])}
 - Results directory: {results_dir}/
 

--- a/scylla/e2e/rerun.py
+++ b/scylla/e2e/rerun.py
@@ -356,7 +356,7 @@ def rerun_single_run(
 
     executor._setup_workspace(
         workspace,
-        CommandLogger(run_dir),
+        CommandLogger(log_dir=run_dir),
         tier_id,
         subtest_config.id,
         run_number=run_info.run_number,

--- a/scylla/e2e/subtest_executor.py
+++ b/scylla/e2e/subtest_executor.py
@@ -345,7 +345,7 @@ class SubTestExecutor:
                 # Setup workspace with git worktree
                 _setup_workspace(
                     workspace=workspace,
-                    command_logger=CommandLogger(run_dir),
+                    command_logger=CommandLogger(log_dir=run_dir),
                     tier_id=tier_id,
                     subtest_id=subtest.id,
                     run_number=run_num,
@@ -492,7 +492,7 @@ class SubTestExecutor:
         judge_dir.chmod(0o777)
 
         # Agent command logger outputs to agent/
-        command_logger = CommandLogger(agent_dir)
+        command_logger = CommandLogger(log_dir=agent_dir)
 
         # Resource suffix is now handled in CLAUDE.md by tier_manager.prepare_workspace()
         # Task prompt stays clean - just symlink to experiment-level copy for deduplication

--- a/scylla/e2e/tier_manager.py
+++ b/scylla/e2e/tier_manager.py
@@ -190,9 +190,7 @@ class TierManager:
                         final_merged = temp_merged
 
             # Create temporary SubTestConfig for resource suffix generation
-            from dataclasses import replace
-
-            temp_subtest = replace(subtest, resources=final_merged)
+            temp_subtest = subtest.model_copy(update={"resources": final_merged})
             resource_suffix = self.build_resource_suffix(temp_subtest)
 
             # Apply merged resources with suffix
@@ -200,9 +198,7 @@ class TierManager:
         # Normal baseline extension for other tiers
         elif baseline and subtest.extends_previous:
             # Build resource suffix from baseline
-            from dataclasses import replace
-
-            temp_subtest = replace(subtest, resources=baseline.resources)
+            temp_subtest = subtest.model_copy(update={"resources": baseline.resources})
             resource_suffix = self.build_resource_suffix(temp_subtest)
             self._apply_baseline(workspace, baseline, resource_suffix)
         else:


### PR DESCRIPTION
## Summary

Completes the Pydantic migration started in 38a3df1 by fixing three critical issues that caused all 47 E2E tests to crash with 0% pass rate before any Claude Code invocation.

## Changes

### 1. Fixed CommandLogger Positional Arguments (3 call sites)
CommandLogger is now a Pydantic BaseModel requiring keyword args, but 3 call sites still passed positional args:
- `scylla/e2e/subtest_executor.py:348` - Changed `CommandLogger(run_dir)` → `CommandLogger(log_dir=run_dir)`
- `scylla/e2e/subtest_executor.py:495` - Changed `CommandLogger(agent_dir)` → `CommandLogger(log_dir=agent_dir)`
- `scylla/e2e/rerun.py:359` - Changed `CommandLogger(run_dir)` → `CommandLogger(log_dir=run_dir)`

### 2. Resolved Merge Conflict in run_e2e_batch.py
- Removed conflict markers at lines 539-546
- Kept newer single-line formatting for model/judge/runs configuration

### 3. Replaced dataclasses.replace() with Pydantic model_copy()
SubTestConfig is now a Pydantic BaseModel, so `dataclasses.replace()` no longer works:
- `scylla/e2e/tier_manager.py:193-195` - Changed to `model_copy(update={"resources": final_merged})`
- `scylla/e2e/tier_manager.py:203-205` - Changed to `model_copy(update={"resources": baseline.resources})`

## Impact

**Before**: All 47 E2E tests crashed immediately with TypeError on framework initialization
**After**: Framework initializes correctly and tests can execute against Claude Code

## Verification

✅ Pre-commit hooks pass (ruff, formatting, etc.)
✅ 2044 unit tests pass, 6 skipped
✅ CommandLogger correctly requires keyword arguments
✅ Pydantic model_copy works with SubTestConfig
✅ All E2E modules import successfully

## Test Plan

```bash
# Pre-commit validation
pre-commit run --all-files

# Unit tests
pixi run python -m pytest tests/ -v

# Smoke test E2E framework initialization
python scripts/run_e2e_batch.py --threads 1 --tiers T0 --max-subtests 1
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)