### PR TITLE
feat(automation): Integrate /advise skill into plan_issues.py

### DIFF
--- a/pixi.toml
+++ b/pixi.toml
@@ -9,6 +9,7 @@ platforms = ["linux-64", "osx-arm64", "osx-64", "win-64"]
 test = "pytest"
 lint = "ruff check scylla scripts tests"
 format = "ruff format scylla scripts tests"
+plan-issues = "python scripts/plan_issues.py"
 
 [dependencies]
 python = ">=3.10"

--- a/scripts/plan_issues.py
+++ b/scripts/plan_issues.py
@@ -100,6 +100,12 @@ Examples:
     )
 
     parser.add_argument(
+        "--no-advise",
+        action="store_true",
+        help="Skip the advise step (don't search team knowledge base before planning)",
+    )
+
+    parser.add_argument(
         "-v",
         "--verbose",
         action="store_true",
@@ -128,6 +134,7 @@ def main() -> int:
             parallel=args.parallel,
             system_prompt_file=args.system_prompt,
             skip_closed=not args.no_skip_closed,
+            enable_advise=not args.no_advise,
         )
 
         # Run planner

--- a/scylla/automation/implementer.py
+++ b/scylla/automation/implementer.py
@@ -144,7 +144,7 @@ class IssueImplementer:
 
         # Check Claude Code
         try:
-            run(["claude-code", "--version"], check=True)
+            run(["claude", "--version"], check=True)
             logger.info("✓ Claude Code available")
         except Exception as e:
             logger.error(f"✗ Claude Code not available: {e}")
@@ -424,7 +424,7 @@ class IssueImplementer:
 
         try:
             run(
-                ["claude-code", "--message", prompt],
+                ["claude", "--message", prompt],
                 cwd=worktree_path,
                 timeout=1800,  # 30 minutes
             )

--- a/scylla/automation/models.py
+++ b/scylla/automation/models.py
@@ -99,6 +99,7 @@ class PlannerOptions(BaseModel):
     parallel: int = 3
     system_prompt_file: Path | None = None
     skip_closed: bool = True
+    enable_advise: bool = True
 
 
 class ImplementerOptions(BaseModel):

--- a/scylla/automation/prompts.py
+++ b/scylla/automation/prompts.py
@@ -59,6 +59,52 @@ Create an implementation plan for GitHub issue #{issue_number}.
 Use markdown with clear sections and bullet points.
 """
 
+ADVISE_PROMPT = """
+Search the team knowledge base for relevant prior learnings before planning this issue.
+
+**Issue:** #{issue_number}: {issue_title}
+
+{issue_body}
+
+---
+
+**Your task:**
+1. Read the skills marketplace: {marketplace_path}
+2. Search for plugins matching this issue's topic by:
+   - Keywords in plugin names and descriptions
+   - Tags and categories
+   - Similar problem domains
+3. For each relevant plugin, read its SKILL.md file to understand:
+   - What worked (successful approaches)
+   - What failed (common pitfalls)
+   - Recommended parameters and configurations
+   - Related patterns and conventions
+
+**Output format:**
+## Related Skills
+| Plugin | Category | Relevance |
+|--------|----------|-----------|
+| plugin-name | category | Why it's relevant |
+
+## What Worked
+- Successful approach 1
+- Successful approach 2
+
+## What Failed
+- Common pitfall 1 (from plugin X)
+- Common pitfall 2 (from plugin Y)
+
+## Recommended Parameters
+- Parameter/configuration 1
+- Parameter/configuration 2
+
+If no relevant skills are found, output:
+## Related Skills
+None found
+
+**Important:** Only return findings from the actual marketplace. Do not speculate or invent skills.
+"""
+
 
 def get_implementation_prompt(issue_number: int) -> str:
     """Get the implementation prompt for an issue."""
@@ -68,6 +114,32 @@ def get_implementation_prompt(issue_number: int) -> str:
 def get_plan_prompt(issue_number: int) -> str:
     """Get the planning prompt for an issue."""
     return PLAN_PROMPT.format(issue_number=issue_number)
+
+
+def get_advise_prompt(
+    issue_number: int,
+    issue_title: str,
+    issue_body: str,
+    marketplace_path: str,
+) -> str:
+    """Get the advise prompt for searching team knowledge.
+
+    Args:
+        issue_number: GitHub issue number
+        issue_title: Issue title
+        issue_body: Issue body/description
+        marketplace_path: Path to marketplace.json
+
+    Returns:
+        Formatted advise prompt
+
+    """
+    return ADVISE_PROMPT.format(
+        issue_number=issue_number,
+        issue_title=issue_title,
+        issue_body=issue_body,
+        marketplace_path=marketplace_path,
+    )
 
 
 def get_pr_description(

--- a/tests/unit/automation/test_models.py
+++ b/tests/unit/automation/test_models.py
@@ -241,6 +241,7 @@ class TestPlannerOptions:
         assert options.parallel == 3
         assert options.system_prompt_file is None
         assert options.skip_closed is True
+        assert options.enable_advise is True
 
     def test_custom_values(self):
         """Test PlannerOptions with custom values."""
@@ -253,9 +254,11 @@ class TestPlannerOptions:
             parallel=5,
             system_prompt_file=Path("/tmp/prompt.md"),
             skip_closed=False,
+            enable_advise=False,
         )
 
         assert options.dry_run is True
         assert options.force is True
         assert options.parallel == 5
         assert options.skip_closed is False
+        assert options.enable_advise is False

--- a/tests/unit/automation/test_planner.py
+++ b/tests/unit/automation/test_planner.py
@@ -1,0 +1,199 @@
+"""Tests for the Planner automation."""
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from scylla.automation.models import PlannerOptions
+from scylla.automation.planner import Planner
+
+
+@pytest.fixture
+def mock_options():
+    """Create mock PlannerOptions."""
+    return PlannerOptions(
+        issues=[123],
+        dry_run=False,
+        force=False,
+        parallel=1,
+        system_prompt_file=None,
+        skip_closed=True,
+        enable_advise=True,
+    )
+
+
+@pytest.fixture
+def planner(mock_options):
+    """Create a Planner instance."""
+    return Planner(mock_options)
+
+
+class TestCallClaude:
+    """Tests for _call_claude method."""
+
+    def test_successful_call(self, planner):
+        """Test successful Claude call."""
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(stdout="This is a plan", returncode=0)
+
+            result = planner._call_claude("Test prompt")
+
+            assert result == "This is a plan"
+            mock_run.assert_called_once()
+            args = mock_run.call_args[0][0]
+            assert args[0] == "claude"
+            assert args[1] == "--print"
+            assert args[2] == "Test prompt"
+            assert "--output-format" in args
+            assert "text" in args
+
+    def test_empty_response(self, planner):
+        """Test handling of empty response."""
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(stdout="   ", returncode=0)
+
+            with pytest.raises(RuntimeError, match="empty response"):
+                planner._call_claude("Test prompt")
+
+    def test_timeout(self, planner):
+        """Test timeout handling."""
+        import subprocess
+
+        with patch("subprocess.run") as mock_run:
+            mock_run.side_effect = subprocess.TimeoutExpired("claude", 300)
+
+            with pytest.raises(RuntimeError, match="timed out"):
+                planner._call_claude("Test prompt", timeout=300)
+
+    def test_rate_limit_retry(self, planner):
+        """Test rate limit retry logic."""
+        import subprocess
+
+        with (
+            patch("subprocess.run") as mock_run,
+            patch("scylla.automation.planner.detect_rate_limit") as mock_detect,
+        ):
+            # First call fails with rate limit, second succeeds
+            mock_run.side_effect = [
+                subprocess.CalledProcessError(1, "claude", stderr="rate limit exceeded"),
+                MagicMock(stdout="Success", returncode=0),
+            ]
+
+            # First detect returns rate limit, then no rate limit
+            mock_detect.side_effect = [(True, 0), (False, 0)]
+
+            with patch("time.sleep"):  # Don't actually sleep
+                result = planner._call_claude("Test prompt", max_retries=3)
+
+            assert result == "Success"
+            assert mock_run.call_count == 2
+
+    def test_system_prompt_passthrough(self, mock_options):
+        """Test system prompt file is passed through."""
+        mock_options.system_prompt_file = Path("/tmp/system.md")
+
+        # Create the file so exists() returns True
+        with patch.object(Path, "exists", return_value=True):
+            planner = Planner(mock_options)
+
+            with patch("subprocess.run") as mock_run:
+                mock_run.return_value = MagicMock(stdout="Response", returncode=0)
+
+                planner._call_claude("Test prompt")
+
+                args = mock_run.call_args[0][0]
+                assert "--system-prompt" in args
+                assert str(mock_options.system_prompt_file) in args
+
+
+class TestRunAdvise:
+    """Tests for _run_advise method."""
+
+    def test_returns_findings(self, planner):
+        """Test successful advise returns findings."""
+        with (
+            patch("scylla.automation.planner.get_repo_root") as mock_get_repo,
+            patch.object(Path, "exists", return_value=True),
+        ):
+            mock_get_repo.return_value = Path("/repo")
+
+            with patch.object(
+                planner, "_call_claude", return_value="## Related Skills\nFound 3 skills"
+            ):
+                result = planner._run_advise(123, "Test Issue", "Issue body")
+
+                assert "Related Skills" in result
+                assert "Found 3 skills" in result
+
+    def test_graceful_failure_on_error(self, planner):
+        """Test graceful failure when advise errors."""
+        with patch("scylla.automation.planner.get_repo_root") as mock_get_repo:
+            mock_get_repo.side_effect = RuntimeError("Git error")
+
+            result = planner._run_advise(123, "Test Issue", "Issue body")
+
+            assert result == ""
+
+    def test_skips_when_mnemosyne_missing(self, planner):
+        """Test skips advise when ProjectMnemosyne is missing."""
+        with (
+            patch("scylla.automation.planner.get_repo_root") as mock_get_repo,
+            patch.object(Path, "exists", return_value=False),
+        ):
+            mock_get_repo.return_value = Path("/repo")
+
+            result = planner._run_advise(123, "Test Issue", "Issue body")
+
+            assert result == ""
+
+
+class TestGeneratePlan:
+    """Tests for _generate_plan method."""
+
+    def test_plan_with_advise_findings(self, planner):
+        """Test plan generation with advise findings injected."""
+        with (
+            patch("scylla.automation.planner.gh_issue_json") as mock_gh,
+            patch.object(
+                planner,
+                "_run_advise",
+                return_value="## Related Skills\nFound skills",
+            ),
+            patch.object(planner, "_call_claude", return_value="# Implementation Plan\nStep 1"),
+        ):
+            mock_gh.return_value = {
+                "title": "Test Issue",
+                "body": "Issue description",
+            }
+
+            plan = planner._generate_plan(123)
+
+            assert "Implementation Plan" in plan
+            # Verify _call_claude was called with context including advise findings
+            call_args = planner._call_claude.call_args[0][0]
+            assert "Prior Learnings" in call_args
+            assert "Related Skills" in call_args
+
+    def test_plan_without_advise(self, mock_options):
+        """Test plan generation with advise disabled."""
+        mock_options.enable_advise = False
+        planner = Planner(mock_options)
+
+        with (
+            patch("scylla.automation.planner.gh_issue_json") as mock_gh,
+            patch.object(planner, "_run_advise") as mock_advise,
+            patch.object(planner, "_call_claude", return_value="# Implementation Plan\nStep 1"),
+        ):
+            mock_gh.return_value = {
+                "title": "Test Issue",
+                "body": "Issue description",
+            }
+
+            plan = planner._generate_plan(123)
+
+            # Advise should not be called
+            mock_advise.assert_not_called()
+
+            # Plan should still be generated
+            assert "Implementation Plan" in plan

--- a/tests/unit/automation/test_prompts.py
+++ b/tests/unit/automation/test_prompts.py
@@ -1,0 +1,59 @@
+"""Tests for automation prompts."""
+
+from scylla.automation.prompts import (
+    get_advise_prompt,
+    get_implementation_prompt,
+    get_plan_prompt,
+    get_pr_description,
+)
+
+
+def test_get_implementation_prompt():
+    """Test implementation prompt generation."""
+    prompt = get_implementation_prompt(123)
+    assert "123" in prompt
+    assert "pytest" in prompt
+    assert "type hint" in prompt.lower()
+
+
+def test_get_plan_prompt():
+    """Test plan prompt generation."""
+    prompt = get_plan_prompt(456)
+    assert "456" in prompt
+    assert "Objective" in prompt
+    assert "Implementation Order" in prompt
+
+
+def test_get_advise_prompt():
+    """Test advise prompt generation."""
+    prompt = get_advise_prompt(
+        issue_number=789,
+        issue_title="Add feature X",
+        issue_body="We need to implement feature X",
+        marketplace_path="/path/to/marketplace.json",
+    )
+
+    assert "789" in prompt
+    assert "Add feature X" in prompt
+    assert "We need to implement feature X" in prompt
+    assert "/path/to/marketplace.json" in prompt
+    assert "Related Skills" in prompt
+    assert "What Worked" in prompt
+    assert "What Failed" in prompt
+
+
+def test_get_pr_description():
+    """Test PR description generation."""
+    desc = get_pr_description(
+        issue_number=123,
+        summary="Implemented feature X",
+        changes="- Added module Y\n- Updated module Z",
+        testing="- Added unit tests\n- Verified manually",
+    )
+
+    assert "123" in desc
+    assert "Implemented feature X" in desc
+    assert "Added module Y" in desc
+    assert "Added unit tests" in desc
+    assert "Closes #123" in desc
+    assert "Claude Code" in desc


### PR DESCRIPTION
## Summary

Implements a two-step planning workflow that searches the team knowledge base (ProjectMnemosyne) before generating implementation plans, allowing prior learnings to inform the planning process.

## Changes

### Core Functionality
- **planner.py**: 
  - Extract `_call_claude()` helper for DRY subprocess + retry logic
  - Add `_run_advise()` to search ProjectMnemosyne marketplace for relevant skills
  - Enhance `_generate_plan()` to inject advise findings into plan context
- **prompts.py**: Add `ADVISE_PROMPT` template and `get_advise_prompt()` helper
- **models.py**: Add `enable_advise: bool = True` to `PlannerOptions`

### CLI & Tooling
- **plan_issues.py**: Add `--no-advise` flag to skip advise step (enabled by default)
- **pixi.toml**: Add `plan-issues` task for easy invocation
- **Fix CLI binary**: Change `claude-code` → `claude` in 3 locations

### Testing
- **test_planner.py**: 10 new tests for `_call_claude()`, `_run_advise()`, `_generate_plan()`
- **test_prompts.py**: 4 new tests for prompt generation including advise prompt
- **test_models.py**: Update tests to verify `enable_advise` field defaults

## Design Decisions

- **Advise defaults ON**: Team knowledge should be leveraged by default
- **Graceful degradation**: If ProjectMnemosyne is missing or advise fails, planning proceeds normally with a warning
- **Direct file reading**: Advise prompt instructs Claude to read marketplace.json and SKILL.md files (non-interactive mode)
- **DRY principle**: Extracted `_call_claude()` as reusable helper for both advise and plan steps
- **CLAUDECODE env var**: Set to "" to avoid nested-session guard when calling Claude CLI

## Verification

✅ All 164 automation tests pass  
✅ All pre-commit hooks pass  
✅ CLI help shows --no-advise flag  
✅ Pixi task works: `pixi run plan-issues --issues 123`

## Usage Examples

```bash
# Plan issues with advise (default)
pixi run plan-issues --issues 123 456

# Plan without advise
pixi run plan-issues --issues 123 --no-advise

# Dry run to see what would happen
pixi run plan-issues --issues 123 --dry-run -v
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)