### PR TITLE
fix(automation): Preserve environment when calling claude subprocess

### DIFF
--- a/scylla/automation/planner.py
+++ b/scylla/automation/planner.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import json
 import logging
+import os
 import subprocess
 import threading
 from concurrent.futures import Future, ThreadPoolExecutor, as_completed
@@ -264,13 +265,17 @@ class Planner:
 
         # Invoke Claude
         try:
+            # Preserve existing environment and set CLAUDECODE
+            env = os.environ.copy()
+            env["CLAUDECODE"] = ""
+
             result = subprocess.run(
                 cmd,
                 capture_output=True,
                 text=True,
                 check=True,
                 timeout=timeout,
-                env={"CLAUDECODE": ""},  # Avoid nested-session guard
+                env=env,  # Avoid nested-session guard
             )
 
             response = result.stdout.strip()


### PR DESCRIPTION
Fixes the `FileNotFoundError: [Errno 2] No such file or directory: 'claude'` error when running `scripts/plan_issues.py`.

## Problem

The planner's `_call_claude()` method was passing `env={"CLAUDECODE": ""}` to `subprocess.run()`, which **completely replaced** the process environment with a dict containing only `CLAUDECODE`. This removed the `PATH` variable (and all other environment variables), preventing the OS from locating the `claude` binary at `~/.local/bin/claude`.

## Solution

Changed the environment handling to preserve the existing environment:

```python
# Before (broken):
env={"CLAUDECODE": ""},  # Replaces entire env, loses PATH!

# After (fixed):
env = os.environ.copy()
env["CLAUDECODE"] = ""
```

## Verification

- ✅ Pre-commit hooks passed
- ✅ All 178 automation/planner tests passed
- ✅ Successfully planned issue #595 in live test
- ✅ Plan posted to GitHub issue comments

## Files Changed

- `scylla/automation/planner.py` - Added `os` import and fixed env handling in `_call_claude()`

🤖 Generated with [Claude Code](https://claude.com/claude-code)