### PR TITLE
feat(automation): Add Skills Used section to plan prompt

### DIFF
--- a/scylla/automation/prompts.py
+++ b/scylla/automation/prompts.py
@@ -47,6 +47,7 @@ Create an implementation plan for GitHub issue #{issue_number}.
 4. **Files to Modify** - Existing files to change with specific changes
 5. **Implementation Order** - Numbered sequence of steps
 6. **Verification** - How to test and verify the implementation
+7. **Skills Used** - List skills invoked during planning (e.g., /explore, /search)
 
 **Guidelines:**
 - Be specific about file paths and function names
@@ -54,6 +55,7 @@ Create an implementation plan for GitHub issue #{issue_number}.
 - Include test file creation in the plan
 - Consider dependencies and integration points
 - Keep the plan focused on the issue requirements
+- Document which skills you used during planning so implementers know what context was gathered
 
 **Format:**
 Use markdown with clear sections and bullet points.


### PR DESCRIPTION
Enhances the planning prompt to request documentation of which skills were invoked during plan creation.

## Motivation

When implementers receive plans, they need to understand what context was gathered and which tools/skills were used during planning. This helps them:
- Know what research has already been done
- Avoid duplicating exploration work
- Understand the depth of analysis
- Verify that appropriate tools were used

## Changes

Updated `PLAN_PROMPT` in `scylla/automation/prompts.py`:
- Added "**Skills Used**" as item #7 in the plan structure
- Added guideline: "Document which skills you used during planning so implementers know what context was gathered"
- Example skills: `/explore`, `/search`, etc.

## Example Output

Plans generated with this prompt will now include a section like:

```markdown
## Skills Used
- `/explore` - Searched codebase for existing test patterns
- `/search` - Located related implementation in scylla/metrics/
```

## Testing

- ✅ All prompt tests pass (`tests/unit/automation/test_prompts.py`)
- ✅ Pre-commit hooks pass
- ✅ Verified prompt output format is correct

## Future Work

This sets the foundation for:
- Skill usage analytics in automation
- Quality metrics for plan thoroughness
- Automated validation that required skills were used

🤖 Generated with [Claude Code](https://claude.com/claude-code)