### PR TITLE
feat(automation): Add follow-up issue filing and advise-to-plan linking

### DIFF
--- a/scripts/implement_issues.py
+++ b/scripts/implement_issues.py
@@ -122,6 +122,12 @@ Examples:
     )
 
     parser.add_argument(
+        "--no-follow-up",
+        action="store_true",
+        help="Disable automatic filing of follow-up issues (enabled by default)",
+    )
+
+    parser.add_argument(
         "-v",
         "--verbose",
         action="store_true",
@@ -155,6 +161,7 @@ def main() -> int:
         auto_merge=not args.no_auto_merge,
         dry_run=args.dry_run,
         enable_retrospective=args.retrospective,
+        enable_follow_up=not args.no_follow_up,
     )
 
     if args.health_check:

--- a/scylla/automation/models.py
+++ b/scylla/automation/models.py
@@ -53,6 +53,7 @@ class ImplementationPhase(str, Enum):
     PUSHING = "pushing"
     CREATING_PR = "creating_pr"
     RETROSPECTIVE = "retrospective"
+    FOLLOW_UP_ISSUES = "follow_up_issues"
     COMPLETED = "completed"
     FAILED = "failed"
 
@@ -116,6 +117,7 @@ class ImplementerOptions(BaseModel):
     auto_merge: bool = True
     dry_run: bool = False
     enable_retrospective: bool = False
+    enable_follow_up: bool = True
 
 
 class DependencyGraph(BaseModel):

--- a/scylla/automation/prompts.py
+++ b/scylla/automation/prompts.py
@@ -47,7 +47,8 @@ Create an implementation plan for GitHub issue #{issue_number}.
 4. **Files to Modify** - Existing files to change with specific changes
 5. **Implementation Order** - Numbered sequence of steps
 6. **Verification** - How to test and verify the implementation
-7. **Skills Used** - List skills invoked during planning (e.g., /explore, /search)
+7. **Skills Used** - List skills invoked during planning AND any team
+   knowledge base skills referenced in the Prior Learnings section above
 
 **Guidelines:**
 - Be specific about file paths and function names
@@ -55,6 +56,8 @@ Create an implementation plan for GitHub issue #{issue_number}.
 - Include test file creation in the plan
 - Consider dependencies and integration points
 - Keep the plan focused on the issue requirements
+- In the Skills Used section, include both skills you invoked directly
+  and any team knowledge base skills provided in the Prior Learnings
 - Document which skills you used during planning so implementers know what context was gathered
 
 **Format:**
@@ -107,6 +110,45 @@ None found
 **Important:** Only return findings from the actual marketplace. Do not speculate or invent skills.
 """
 
+FOLLOW_UP_PROMPT = """
+Review your work on issue #{issue_number} and identify any follow-up tasks,
+enhancements, or edge cases discovered during implementation.
+
+**Output format:**
+Return a JSON array of follow-up items (max 5). Each item must have:
+- `title`: Brief, specific title (under 70 characters)
+- `body`: Detailed description of the follow-up work
+- `labels`: Array of relevant labels from:
+  ["enhancement", "bug", "test", "docs", "refactor", "research"]
+
+If there are no follow-up items, return an empty array: `[]`
+
+**Example:**
+```json
+[
+  {{
+    "title": "Add edge case handling for empty input",
+    "body": "During implementation, discovered that empty input returns
+misleading error. Should add validation and specific error message.",
+    "labels": ["enhancement", "bug"]
+  }},
+  {{
+    "title": "Add integration tests for new feature",
+    "body": "Current tests only cover unit level. Need integration tests
+to verify end-to-end behavior with real GitHub API.",
+    "labels": ["test"]
+  }}
+]
+```
+
+**Guidelines:**
+- Only include concrete, actionable items discovered during this implementation
+- Don't include speculative future features
+- Keep descriptions concise but specific enough for another developer
+- Max 5 items - prioritize the most important
+- Return `[]` if no follow-ups needed
+"""
+
 
 def get_implementation_prompt(issue_number: int) -> str:
     """Get the implementation prompt for an issue."""
@@ -142,6 +184,19 @@ def get_advise_prompt(
         issue_body=issue_body,
         marketplace_path=marketplace_path,
     )
+
+
+def get_follow_up_prompt(issue_number: int) -> str:
+    """Get the follow-up prompt for identifying future work.
+
+    Args:
+        issue_number: GitHub issue number
+
+    Returns:
+        Formatted follow-up prompt
+
+    """
+    return FOLLOW_UP_PROMPT.format(issue_number=issue_number)
 
 
 def get_pr_description(

--- a/tests/unit/automation/test_models.py
+++ b/tests/unit/automation/test_models.py
@@ -119,6 +119,17 @@ class TestImplementationState:
         )
         assert state.phase == ImplementationPhase.RETROSPECTIVE
 
+    def test_follow_up_issues_phase(self):
+        """Test FOLLOW_UP_ISSUES phase in ImplementationPhase enum."""
+        assert ImplementationPhase.FOLLOW_UP_ISSUES == "follow_up_issues"
+
+        # Verify it can be used in state
+        state = ImplementationState(
+            issue_number=123,
+            phase=ImplementationPhase.FOLLOW_UP_ISSUES,
+        )
+        assert state.phase == ImplementationPhase.FOLLOW_UP_ISSUES
+
 
 class TestDependencyGraph:
     """Tests for DependencyGraph model."""
@@ -296,6 +307,7 @@ class TestImplementerOptions:
         assert options.auto_merge is True
         assert options.dry_run is False
         assert options.enable_retrospective is False
+        assert options.enable_follow_up is True  # Enabled by default
 
     def test_custom_values(self):
         """Test ImplementerOptions with custom values."""
@@ -309,6 +321,7 @@ class TestImplementerOptions:
             auto_merge=False,
             dry_run=True,
             enable_retrospective=True,
+            enable_follow_up=True,
         )
 
         assert options.epic_number == 456
@@ -320,3 +333,4 @@ class TestImplementerOptions:
         assert options.auto_merge is False
         assert options.dry_run is True
         assert options.enable_retrospective is True
+        assert options.enable_follow_up is True

--- a/tests/unit/automation/test_prompts.py
+++ b/tests/unit/automation/test_prompts.py
@@ -2,6 +2,7 @@
 
 from scylla.automation.prompts import (
     get_advise_prompt,
+    get_follow_up_prompt,
     get_implementation_prompt,
     get_plan_prompt,
     get_pr_description,
@@ -22,6 +23,8 @@ def test_get_plan_prompt():
     assert "456" in prompt
     assert "Objective" in prompt
     assert "Implementation Order" in prompt
+    # Verify it references advise findings
+    assert "Prior Learnings" in prompt or "knowledge base" in prompt
 
 
 def test_get_advise_prompt():
@@ -40,6 +43,19 @@ def test_get_advise_prompt():
     assert "Related Skills" in prompt
     assert "What Worked" in prompt
     assert "What Failed" in prompt
+
+
+def test_get_follow_up_prompt():
+    """Test follow-up prompt generation."""
+    prompt = get_follow_up_prompt(789)
+    assert "789" in prompt
+    assert "JSON" in prompt
+    assert "title" in prompt
+    assert "body" in prompt
+    assert "labels" in prompt
+    assert "enhancement" in prompt
+    assert "bug" in prompt
+    assert "test" in prompt
 
 
 def test_get_pr_description():


### PR DESCRIPTION
## Summary

Implements two automation enhancements to improve the issue implementation pipeline:

1. **Follow-up issue filing** - Automatically captures and files follow-up work identified during implementation
2. **Advise-to-plan linking** - Connects team knowledge base findings to the plan's Skills Used section

## Changes

### Follow-up Issue Filing

**Pipeline Flow:**
```
... CREATING_PR → [RETROSPECTIVE] → [FOLLOW_UP_ISSUES] → COMPLETED
```

**Implementation:**
- Added `FOLLOW_UP_ISSUES` phase to `ImplementationPhase` enum
- Added `enable_follow_up: bool = True` to `ImplementerOptions` (enabled by default)
- Added `FOLLOW_UP_PROMPT` template that requests JSON array of follow-up items
- Added `gh_issue_create(title, body, labels)` to GitHub API utilities
- Added `_parse_follow_up_items(text)` method to extract JSON from Claude responses
- Added `_run_follow_up_issues(session_id, worktree_path, issue_number)` pipeline method
- Added `--no-follow-up` CLI flag to disable (enabled by default per user request)

**Features:**
- Resumes Claude session after PR creation to identify follow-up work
- Parses JSON response (handles code blocks, bare JSON, invalid input)
- Creates GitHub issues with labels (caps at 5 items)
- Posts summary comment on parent issue linking to created issues
- Gracefully handles errors (non-blocking, logs warnings)

### Advise-to-Plan Linking

**Change:**
- Updated `PLAN_PROMPT` section 7 to explicitly reference "Prior Learnings from Team Knowledge Base"
- Added guidance to include both directly invoked skills AND team knowledge base skills from advise findings

**Why:**
The planner already injects advise findings as "Prior Learnings" in the context. This change tells Claude to reference them in the "Skills Used" section of the plan, creating the connection between `/advise` output and plan documentation.

## Testing

- All 198 automation tests pass
- Added 14 new tests:
  - `TestParseFollowUpItems` (7 tests): JSON parsing edge cases
  - `TestRunFollowUpIssues` (4 tests): Issue creation and error handling
  - `TestImplementIssuePipelineFollowUp` (3 tests): Pipeline integration
- Pre-commit hooks pass (formatting, linting)

## Verification

```bash
# Test models
pixi run python -m pytest tests/unit/automation/test_models.py -v -k "ImplementerOptions or ImplementationPhase"

# Test prompts
pixi run python -m pytest tests/unit/automation/test_prompts.py -v

# Test GitHub API
pixi run python -m pytest tests/unit/automation/test_github_api.py::TestGhIssueCreate -v

# Test implementer
pixi run python -m pytest tests/unit/automation/test_implementer.py -v -k "FollowUp"

# All automation tests
pixi run python -m pytest tests/unit/automation/ -v

# Verify CLI
pixi run python scripts/implement_issues.py --help | grep -A 2 "follow-up"

# Verify plan prompt
pixi run python -c "from scylla.automation.prompts import get_plan_prompt; print(get_plan_prompt(1))" | grep -i "prior\|knowledge"
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)