### PR TITLE
fix(automation): Enable retrospective by default in implement_issues.py

### DIFF
--- a/scripts/implement_issues.py
+++ b/scripts/implement_issues.py
@@ -116,9 +116,9 @@ Examples:
     )
 
     parser.add_argument(
-        "--retrospective",
+        "--no-retrospective",
         action="store_true",
-        help="Run /retrospective after implementation to capture learnings as skills",
+        help="Disable /retrospective after implementation (enabled by default)",
     )
 
     parser.add_argument(
@@ -160,7 +160,7 @@ def main() -> int:
         skip_closed=not args.no_skip_closed,
         auto_merge=not args.no_auto_merge,
         dry_run=args.dry_run,
-        enable_retrospective=args.retrospective,
+        enable_retrospective=not args.no_retrospective,
         enable_follow_up=not args.no_follow_up,
     )
 

--- a/scylla/automation/models.py
+++ b/scylla/automation/models.py
@@ -116,7 +116,7 @@ class ImplementerOptions(BaseModel):
     skip_closed: bool = True
     auto_merge: bool = True
     dry_run: bool = False
-    enable_retrospective: bool = False
+    enable_retrospective: bool = True
     enable_follow_up: bool = True
 
 

--- a/tests/unit/automation/test_implementer.py
+++ b/tests/unit/automation/test_implementer.py
@@ -18,7 +18,7 @@ def mock_options():
         epic_number=123,
         dry_run=False,
         max_workers=1,
-        enable_retrospective=False,
+        enable_retrospective=False,  # Explicitly disable for most tests
         enable_follow_up=False,  # Disable for most tests
     )
 


### PR DESCRIPTION
Closes #595

## Summary

Makes retrospective enabled by default in `implement_issues.py`, with a `--no-retrospective` flag to disable it (mirroring the `--no-follow-up` pattern).

## Changes

- **scripts/implement_issues.py**: Replace `--retrospective` flag with `--no-retrospective`
- **scylla/automation/models.py**: Change `enable_retrospective` default from `False` to `True`
- **tests/unit/automation/test_implementer.py**: Add clarifying comment for explicit test behavior

## Behavior

**Before:**
```bash
# Retrospective disabled by default
python scripts/implement_issues.py --epic 595

# Must opt-in to enable
python scripts/implement_issues.py --epic 595 --retrospective
```

**After:**
```bash
# Retrospective enabled by default
python scripts/implement_issues.py --epic 595

# Can opt-out to disable
python scripts/implement_issues.py --epic 595 --no-retrospective
```

## Validation

- ✅ All 25 unit tests pass
- ✅ Pre-commit hooks pass (ruff, formatting)
- ✅ Follows existing pattern (`--no-follow-up`)

## Test plan

- [x] Run existing tests: `pixi run python -m pytest tests/unit/automation/ -v`
- [x] Run pre-commit hooks: `pre-commit run --all-files`
- [ ] Health check: `python scripts/implement_issues.py --health-check`
- [ ] Dry run: `python scripts/implement_issues.py --epic 595 --dry-run --verbose --no-retrospective --no-follow-up`
- [ ] Real run: `python scripts/implement_issues.py --epic 595 --max-workers 1 --verbose`

🤖 Generated with [Claude Code](https://claude.com/claude-code)