### PR TITLE
fix(automation): Use temp file instead of --message flag for Claude Code

### DIFF
--- a/tests/unit/automation/test_implementer.py
+++ b/tests/unit/automation/test_implementer.py
@@ -49,7 +49,11 @@ class TestRunClaudeCode:
             }
         )
 
-        with patch("scylla.automation.implementer.run") as mock_run:
+        with (
+            patch("scylla.automation.implementer.run") as mock_run,
+            patch.object(Path, "write_text"),
+            patch.object(Path, "unlink"),
+        ):
             mock_run.return_value = mock_result
 
             session_id = implementer._run_claude_code(
@@ -62,7 +66,8 @@ class TestRunClaudeCode:
             mock_run.assert_called_once()
             args = mock_run.call_args[0][0]
             assert args[0] == "claude"
-            assert "--message" in args
+            # Should now pass a file path, not --message
+            assert ".claude-prompt-123.md" in args[1]
             assert "--output-format" in args
             assert "json" in args
 
@@ -74,6 +79,8 @@ class TestRunClaudeCode:
         with (
             patch("scylla.automation.implementer.run") as mock_run,
             patch("scylla.automation.implementer.logger") as mock_logger,
+            patch.object(Path, "write_text"),
+            patch.object(Path, "unlink"),
         ):
             mock_run.return_value = mock_result
 
@@ -97,7 +104,11 @@ class TestRunClaudeCode:
             }
         )
 
-        with patch("scylla.automation.implementer.run") as mock_run:
+        with (
+            patch("scylla.automation.implementer.run") as mock_run,
+            patch.object(Path, "write_text"),
+            patch.object(Path, "unlink"),
+        ):
             mock_run.return_value = mock_result
 
             session_id = implementer._run_claude_code(
@@ -111,7 +122,11 @@ class TestRunClaudeCode:
 
     def test_timeout_raises_runtime_error(self, implementer):
         """Test timeout handling."""
-        with patch("scylla.automation.implementer.run") as mock_run:
+        with (
+            patch("scylla.automation.implementer.run") as mock_run,
+            patch.object(Path, "write_text"),
+            patch.object(Path, "unlink"),
+        ):
             mock_run.side_effect = subprocess.TimeoutExpired("claude", 1800)
 
             with pytest.raises(RuntimeError, match="timed out"):


### PR DESCRIPTION
## Problem

The `implement_issues.py` script was failing with error "no --message flag" because Claude Code doesn't accept `--message` as a command-line flag.

## Solution

Write prompts to temporary files in the worktree and pass the file path to Claude Code instead of using `--message`.

## Changes

- **scylla/automation/implementer.py**:
  - `_run_claude_code`: Write prompt to `.claude-prompt-{issue}.md` file, pass file path to `claude` command
  - `_run_follow_up_issues`: Write prompt to `.claude-followup-{issue}.md` file, pass file path to `claude --resume`
  - Both methods clean up temp files in `finally` blocks

- **tests/unit/automation/test_implementer.py**:
  - Mock `Path.write_text` and `Path.unlink` in all `_run_claude_code` tests
  - Update assertions to check for file path argument instead of `--message` flag

## Validation

- ✅ All 25 unit tests pass
- ✅ Pre-commit hooks pass
- ✅ Follows Claude Code CLI conventions

## Before

```python
run(["claude", "--message", prompt, "--output-format", "json"])
# Error: claude: unknown flag: --message
```

## After

```python
prompt_file = worktree_path / f".claude-prompt-{issue_number}.md"
prompt_file.write_text(prompt)
run(["claude", str(prompt_file), "--output-format", "json"])
```

## Test Plan

- [x] Run unit tests: `pixi run python -m pytest tests/unit/automation/ -v`
- [x] Run pre-commit hooks: `pre-commit run --all-files`
- [ ] Test with real issue (requires running from normal shell, not nested Claude Code)

🤖 Generated with [Claude Code](https://claude.com/claude-code)