### PR TITLE
feat(automation): Add --issues flag to implement_issues.py

### DIFF
--- a/scripts/implement_issues.py
+++ b/scripts/implement_issues.py
@@ -44,6 +44,12 @@ Examples:
   # Implement all issues in an epic
   %(prog)s --epic 123
 
+  # Implement specific issues
+  %(prog)s --issues 595 596 597
+
+  # Implement a single issue
+  %(prog)s --issues 595
+
   # Analyze dependencies without implementing
   %(prog)s --epic 123 --analyze
 
@@ -54,13 +60,13 @@ Examples:
   %(prog)s --health-check
 
   # Dry run
-  %(prog)s --epic 123 --dry-run
+  %(prog)s --issues 595 --dry-run
 
   # Use more workers
   %(prog)s --epic 123 --max-workers 5
 
   # Don't auto-merge PRs
-  %(prog)s --epic 123 --no-auto-merge
+  %(prog)s --issues 595 --no-auto-merge
         """,
     )
 
@@ -68,6 +74,13 @@ Examples:
         "--epic",
         type=int,
         help="Epic issue number containing sub-issues",
+    )
+
+    parser.add_argument(
+        "--issues",
+        type=int,
+        nargs="+",
+        help="Specific issue numbers to implement (alternative to --epic)",
     )
 
     parser.add_argument(
@@ -137,8 +150,11 @@ Examples:
     args = parser.parse_args()
 
     # Validation
-    if not args.health_check and not args.epic:
-        parser.error("Either --epic or --health-check is required")
+    if not args.health_check and not args.epic and not args.issues:
+        parser.error("Either --epic, --issues, or --health-check is required")
+
+    if args.epic and args.issues:
+        parser.error("Cannot specify both --epic and --issues")
 
     return args
 
@@ -153,6 +169,7 @@ def main() -> int:
     # Build options
     options = ImplementerOptions(
         epic_number=args.epic or 0,
+        issues=args.issues or [],
         analyze_only=args.analyze,
         health_check=args.health_check,
         resume=args.resume,
@@ -166,6 +183,8 @@ def main() -> int:
 
     if args.health_check:
         logger.info("Running health check")
+    elif args.issues:
+        logger.info(f"Starting implementation of issues: {args.issues}")
     else:
         logger.info(f"Starting implementation of epic #{args.epic}")
 

--- a/scylla/automation/models.py
+++ b/scylla/automation/models.py
@@ -108,7 +108,8 @@ class PlannerOptions(BaseModel):
 class ImplementerOptions(BaseModel):
     """Options for the Implementer."""
 
-    epic_number: int
+    epic_number: int = 0
+    issues: list[int] = Field(default_factory=list)
     analyze_only: bool = False
     health_check: bool = False
     resume: bool = False


### PR DESCRIPTION
Fixes #595 usage issue

## Problem

The `implement_issues.py` script only supported `--epic` which required the issue to have sub-issues. When running `--epic 595`, it would fail with "Epic #595 has no sub-issues" because issue #595 is a regular issue, not an epic.

## Solution

Add `--issues` flag to support implementing specific issues directly, matching the pattern from `plan_issues.py`.

## Changes

- **scripts/implement_issues.py**:
  - Add `--issues` argument accepting list of issue numbers
  - Update validation to require either `--epic`, `--issues`, or `--health-check`
  - Prevent both `--epic` and `--issues` being specified together
  - Update examples and help text

- **scylla/automation/implementer.py**:
  - Add `_load_issues()` method to load specific issues into dependency graph
  - Handle both epic and issues modes in `run()` method
  - Import `IssueState` for closed issue filtering

- **scylla/automation/models.py**:
  - Add `issues: list[int]` field to `ImplementerOptions`
  - Make `epic_number` optional with default 0

## Usage

```bash
# Single issue
python scripts/implement_issues.py --issues 595

# Multiple issues
python scripts/implement_issues.py --issues 595 596 597

# Epic mode still works
python scripts/implement_issues.py --epic 123
```

## Validation

- ✅ All 25 unit tests pass
- ✅ Pre-commit hooks pass
- ✅ Matches `plan_issues.py` pattern for consistency

## Test Plan

- [x] Run unit tests: `pixi run python -m pytest tests/unit/automation/ -v`
- [x] Run pre-commit hooks: `pre-commit run --all-files`
- [ ] Test with real issue: `pixi run python scripts/implement_issues.py --issues 595`

🤖 Generated with [Claude Code](https://claude.com/claude-code)