### PR TITLE
fix(automation): Fix implement_issues.py Claude Code integration

### DIFF
--- a/scylla/automation/github_api.py
+++ b/scylla/automation/github_api.py
@@ -413,6 +413,7 @@ def fetch_issue_info(issue_number: int) -> IssueInfo:
     return IssueInfo(
         number=issue_data["number"],
         title=issue_data["title"],
+        body=issue_data.get("body", ""),
         state=IssueState(issue_data["state"]),
         labels=[label["name"] for label in issue_data.get("labels", [])],
         dependencies=parse_issue_dependencies(issue_data.get("body", "")),

--- a/scylla/automation/models.py
+++ b/scylla/automation/models.py
@@ -27,6 +27,7 @@ class IssueInfo(BaseModel):
 
     number: int
     title: str
+    body: str = ""
     state: IssueState = IssueState.OPEN
     labels: list[str] = Field(default_factory=list)
     dependencies: list[int] = Field(default_factory=list)

--- a/scylla/automation/prompts.py
+++ b/scylla/automation/prompts.py
@@ -9,7 +9,19 @@ Contains templates for:
 IMPLEMENTATION_PROMPT = """
 Implement GitHub issue #{issue_number}.
 
-Follow the project's Python conventions and type hint all function signatures.
+**Working Directory:** {worktree_path}
+**Branch:** {branch_name}
+
+**Issue Title:** {issue_title}
+
+**Issue Description:**
+{issue_body}
+
+---
+
+**Implementation Context:**
+- Run `gh issue view {issue_number} --comments` to read the full plan and any comments
+- Follow the project's Python conventions and type hint all function signatures
 
 **Critical Requirements:**
 1. Read the issue description and any existing plan carefully
@@ -152,9 +164,33 @@ to verify end-to-end behavior with real GitHub API.",
 """
 
 
-def get_implementation_prompt(issue_number: int) -> str:
-    """Get the implementation prompt for an issue."""
-    return IMPLEMENTATION_PROMPT.format(issue_number=issue_number)
+def get_implementation_prompt(
+    issue_number: int,
+    issue_title: str = "",
+    issue_body: str = "",
+    branch_name: str = "",
+    worktree_path: str = "",
+) -> str:
+    """Get the implementation prompt for an issue.
+
+    Args:
+        issue_number: GitHub issue number
+        issue_title: Issue title (optional, for backward compatibility)
+        issue_body: Issue body/description (optional, for backward compatibility)
+        branch_name: Git branch name (optional, for backward compatibility)
+        worktree_path: Working directory path (optional, for backward compatibility)
+
+    Returns:
+        Formatted implementation prompt
+
+    """
+    return IMPLEMENTATION_PROMPT.format(
+        issue_number=issue_number,
+        issue_title=issue_title,
+        issue_body=issue_body,
+        branch_name=branch_name,
+        worktree_path=worktree_path,
+    )
 
 
 def get_plan_prompt(issue_number: int) -> str:

--- a/tests/unit/automation/test_implementer.py
+++ b/tests/unit/automation/test_implementer.py
@@ -70,6 +70,11 @@ class TestRunClaudeCode:
             assert ".claude-prompt-123.md" in args[1]
             assert "--output-format" in args
             assert "json" in args
+            # Verify permission mode and allowed tools
+            assert "--permission-mode" in args
+            assert "dontAsk" in args
+            assert "--allowedTools" in args
+            assert "Read,Write,Edit,Glob,Grep,Bash" in args
 
     def test_graceful_failure_on_json_parse_error(self, implementer):
         """Test graceful handling when JSON parse fails."""

--- a/tests/unit/automation/test_models.py
+++ b/tests/unit/automation/test_models.py
@@ -27,6 +27,7 @@ class TestIssueInfo:
 
         assert issue.number == 123
         assert issue.title == "Test issue"
+        assert issue.body == ""
         assert issue.state == IssueState.OPEN
         assert issue.labels == []
         assert issue.dependencies == []

--- a/tests/unit/automation/test_prompts.py
+++ b/tests/unit/automation/test_prompts.py
@@ -10,11 +10,30 @@ from scylla.automation.prompts import (
 
 
 def test_get_implementation_prompt():
-    """Test implementation prompt generation."""
+    """Test implementation prompt generation with backward compatibility."""
+    # Test backward compatibility - should work with just issue_number
     prompt = get_implementation_prompt(123)
     assert "123" in prompt
     assert "pytest" in prompt
     assert "type hint" in prompt.lower()
+
+
+def test_get_implementation_prompt_with_context():
+    """Test implementation prompt with full context."""
+    prompt = get_implementation_prompt(
+        issue_number=123,
+        issue_title="Add feature X",
+        issue_body="Implement feature X with Y and Z",
+        branch_name="123-add-feature-x",
+        worktree_path="/tmp/worktree",
+    )
+
+    assert "123" in prompt
+    assert "Add feature X" in prompt
+    assert "Implement feature X with Y and Z" in prompt
+    assert "123-add-feature-x" in prompt
+    assert "/tmp/worktree" in prompt
+    assert "gh issue view" in prompt
 
 
 def test_get_plan_prompt():


### PR DESCRIPTION
## Summary

Fixes the `implement_issues.py` automation pipeline by adding critical CLI flags and context that were causing Claude Code to hang on permission prompts or fail to write files. Implementation based on comparison with working ProjectOdyssey version.

## Changes

### CLI Flags (scylla/automation/implementer.py)
- ✅ Add `--permission-mode dontAsk` to prevent hanging on permission prompts
- ✅ Add `--allowedTools Read,Write,Edit,Glob,Grep,Bash` to explicitly grant permissions

### Context Enhancement
- ✅ Add `body` field to `IssueInfo` model (scylla/automation/models.py)
- ✅ Populate `body` in `fetch_issue_info()` (scylla/automation/github_api.py)
- ✅ Enhance `IMPLEMENTATION_PROMPT` with working directory, branch name, issue title/body (scylla/automation/prompts.py)
- ✅ Pass full context to `get_implementation_prompt()` (scylla/automation/implementer.py)

### Commit Logic Fixes
- ✅ Refactor `_commit_changes()` to use single `git status --porcelain` parse
- ✅ Handle renamed files, quoted filenames, and all change types
- ✅ Improve error messages with issue number and actionable suggestions

### Diagnostics
- ✅ Add warning when no changes detected after Claude session
- ✅ Include session_id for easier debugging

## Testing

```bash
# All automation tests pass
pixi run python -m pytest tests/unit/automation/ -v
# 199 passed in 11.00s

# All pre-commit hooks pass
pre-commit run --all-files
# All checks passed
```

## Root Cause

The Scylla version was missing CLI flags that the working Odyssey version includes, causing:
1. Claude to hang waiting for permission prompts (no `--permission-mode dontAsk`)
2. Claude to lack explicit tool permissions (no `--allowedTools`)
3. Claude to lack context about what to implement (no issue body/title in prompt)

🤖 Generated with [Claude Code](https://claude.com/claude-code)