### PR TITLE
fix(tests): Add missing mocks to implementer tests

### DIFF
--- a/tests/unit/automation/test_implementer.py
+++ b/tests/unit/automation/test_implementer.py
@@ -8,7 +8,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from scylla.automation.implementer import IssueImplementer
-from scylla.automation.models import ImplementerOptions
+from scylla.automation.models import ImplementerOptions, IssueInfo
 
 
 @pytest.fixture
@@ -242,8 +242,11 @@ class TestImplementIssuePipeline:
                 patch.object(implementer, "_get_or_create_state") as mock_state,
                 patch.object(implementer, "_has_plan", return_value=True),
                 patch.object(implementer, "_run_claude_code", return_value="session123"),
-                patch.object(implementer, "_commit_changes"),
-                patch.object(implementer, "_create_pr", return_value=456),
+                patch.object(implementer, "_ensure_pr_created", return_value=456),
+                patch(
+                    "scylla.automation.implementer.fetch_issue_info",
+                    return_value=IssueInfo(number=123, title="Test issue", body="Test body"),
+                ),
                 patch.object(implementer, "_run_retrospective") as mock_retro,
                 patch.object(implementer, "_save_state"),
                 patch.object(implementer.worktree_manager, "create_worktree"),
@@ -275,8 +278,11 @@ class TestImplementIssuePipeline:
                 patch.object(implementer, "_get_or_create_state") as mock_state,
                 patch.object(implementer, "_has_plan", return_value=True),
                 patch.object(implementer, "_run_claude_code", return_value="session123"),
-                patch.object(implementer, "_commit_changes"),
-                patch.object(implementer, "_create_pr", return_value=456),
+                patch.object(implementer, "_ensure_pr_created", return_value=456),
+                patch(
+                    "scylla.automation.implementer.fetch_issue_info",
+                    return_value=IssueInfo(number=123, title="Test issue", body="Test body"),
+                ),
                 patch.object(implementer, "_run_retrospective") as mock_retro,
                 patch.object(implementer, "_save_state"),
                 patch.object(implementer.worktree_manager, "create_worktree"),
@@ -307,8 +313,11 @@ class TestImplementIssuePipeline:
                 patch.object(implementer, "_get_or_create_state") as mock_state,
                 patch.object(implementer, "_has_plan", return_value=True),
                 patch.object(implementer, "_run_claude_code", return_value=None),
-                patch.object(implementer, "_commit_changes"),
-                patch.object(implementer, "_create_pr", return_value=456),
+                patch.object(implementer, "_ensure_pr_created", return_value=456),
+                patch(
+                    "scylla.automation.implementer.fetch_issue_info",
+                    return_value=IssueInfo(number=123, title="Test issue", body="Test body"),
+                ),
                 patch.object(implementer, "_run_retrospective") as mock_retro,
                 patch.object(implementer, "_save_state"),
                 patch.object(implementer.worktree_manager, "create_worktree"),
@@ -518,8 +527,11 @@ class TestImplementIssuePipelineFollowUp:
                 patch.object(implementer, "_get_or_create_state") as mock_state,
                 patch.object(implementer, "_has_plan", return_value=True),
                 patch.object(implementer, "_run_claude_code", return_value="session789"),
-                patch.object(implementer, "_commit_changes"),
-                patch.object(implementer, "_create_pr", return_value=456),
+                patch.object(implementer, "_ensure_pr_created", return_value=456),
+                patch(
+                    "scylla.automation.implementer.fetch_issue_info",
+                    return_value=IssueInfo(number=123, title="Test issue", body="Test body"),
+                ),
                 patch.object(implementer, "_run_follow_up_issues") as mock_follow_up,
                 patch.object(implementer, "_save_state"),
                 patch.object(implementer.worktree_manager, "create_worktree"),
@@ -555,8 +567,11 @@ class TestImplementIssuePipelineFollowUp:
                 patch.object(implementer, "_get_or_create_state") as mock_state,
                 patch.object(implementer, "_has_plan", return_value=True),
                 patch.object(implementer, "_run_claude_code", return_value="session789"),
-                patch.object(implementer, "_commit_changes"),
-                patch.object(implementer, "_create_pr", return_value=456),
+                patch.object(implementer, "_ensure_pr_created", return_value=456),
+                patch(
+                    "scylla.automation.implementer.fetch_issue_info",
+                    return_value=IssueInfo(number=123, title="Test issue", body="Test body"),
+                ),
                 patch.object(implementer, "_run_follow_up_issues") as mock_follow_up,
                 patch.object(implementer, "_save_state"),
                 patch.object(implementer.worktree_manager, "create_worktree"),
@@ -592,8 +607,11 @@ class TestImplementIssuePipelineFollowUp:
                 patch.object(implementer, "_get_or_create_state") as mock_state,
                 patch.object(implementer, "_has_plan", return_value=True),
                 patch.object(implementer, "_run_claude_code", return_value=None),
-                patch.object(implementer, "_commit_changes"),
-                patch.object(implementer, "_create_pr", return_value=456),
+                patch.object(implementer, "_ensure_pr_created", return_value=456),
+                patch(
+                    "scylla.automation.implementer.fetch_issue_info",
+                    return_value=IssueInfo(number=123, title="Test issue", body="Test body"),
+                ),
                 patch.object(implementer, "_run_follow_up_issues") as mock_follow_up,
                 patch.object(implementer, "_save_state"),
                 patch.object(implementer.worktree_manager, "create_worktree"),


### PR DESCRIPTION
## Summary

Fixed all 6 failing tests in `test_implementer.py` that were causing CI failures on main branch.

## Root Cause

The `_implement_issue` pipeline was recently refactored to add:
- `fetch_issue_info()` at line 365 
- `_ensure_pr_created()` at line 387

Tests were not updated to mock these new calls, causing real `gh issue view` subprocess calls that failed in CI with exit status 4.

## Changes

**File: `tests/unit/automation/test_implementer.py`**

1. Added `IssueInfo` import from `scylla.automation.models`
2. Added `fetch_issue_info` mock to all 6 failing tests returning `IssueInfo(number=123, title="Test issue", body="Test body")`
3. Replaced stale `_commit_changes` and `_create_pr` mocks with `_ensure_pr_created` to match refactored implementation

## Tests Fixed

**TestImplementIssuePipeline** (3 tests):
- ✅ `test_retrospective_phase_when_enabled`
- ✅ `test_retrospective_phase_when_disabled`
- ✅ `test_retrospective_skipped_when_no_session_id`

**TestImplementIssuePipelineFollowUp** (3 tests):
- ✅ `test_follow_up_enabled_runs_phase`
- ✅ `test_follow_up_disabled_skips_phase`
- ✅ `test_no_session_id_skips_follow_up`

## Verification

- ✅ All 6 previously failing tests now pass
- ✅ Full unit test suite: **2082 passed**, 2 skipped, 7 warnings
- ✅ All pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)