### PR TITLE
feat(ci): Add coverage thresholds to prevent regression

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,9 +37,9 @@ jobs:
           # Install package in dev mode for unit tests
           if [[ "$TEST_PATH" == "tests/unit" ]]; then
             pixi run pip install -e .
-            pixi run pytest "$TEST_PATH" -v --cov=scylla --cov-report=term-missing --cov-report=xml
+            pixi run pytest "$TEST_PATH" -v --cov=scylla --cov-report=term-missing --cov-report=xml --cov-fail-under=70
           else
-            pixi run pytest "$TEST_PATH" -v --cov=scylla --cov-report=term-missing --cov-report=xml
+            pixi run pytest "$TEST_PATH" -v --cov=scylla --cov-report=term-missing --cov-report=xml --cov-fail-under=70
           fi
 
       - name: Upload coverage

--- a/pixi.lock
+++ b/pixi.lock
@@ -2709,7 +2709,7 @@ packages:
 - pypi: ./
   name: scylla
   version: 0.1.0
-  sha256: 03c7bbd718bfb63f077a31c3fe70f80d862d39f9717931cf11f97f84aea943b6
+  sha256: 492b9c925af087094be622f801d9df6b4c860a96d0f7a3b2cfe88c1dd27a8309
   requires_dist:
   - click>=8.0
   - pydantic>=2.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,3 +79,25 @@ ignore = [
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 pythonpath = ["."]
+
+[tool.coverage.run]
+branch = true
+source = ["scylla"]
+omit = [
+    "*/tests/*",
+    "*/__init__.py",
+]
+
+[tool.coverage.report]
+fail_under = 70
+precision = 2
+show_missing = true
+skip_covered = false
+exclude_lines = [
+    "pragma: no cover",
+    "def __repr__",
+    "raise AssertionError",
+    "raise NotImplementedError",
+    "if __name__ == .__main__.:",
+    "if TYPE_CHECKING:",
+]


### PR DESCRIPTION
## Summary

Configures pytest-cov with 70% minimum coverage threshold to prevent silent quality regression. This PR adds coverage configuration to `pyproject.toml` and updates the CI workflow to fail when coverage drops below the threshold.

## Changes

- **pyproject.toml**: Added `[tool.coverage.run]` and `[tool.coverage.report]` sections
  - Enabled branch coverage (`branch = true`)
  - Set 70% minimum coverage threshold (`fail_under = 70`)
  - Excluded test files and `__init__.py` from coverage calculation
  - Added standard exclusion patterns (pragma: no cover, etc.)
  
- **.github/workflows/test.yml**: Added `--cov-fail-under=70` flag to pytest commands
  - CI will now fail if coverage drops below 70%
  - Coverage reports show missing lines for easier identification

- **pixi.lock**: Updated to reflect pyproject.toml changes

## Testing

✅ Current baseline: **72.89% coverage** (passes the 70% threshold)

Local testing confirms:
- Coverage enforcement works correctly (pytest exits with failure when below threshold)
- Coverage reports display missing lines as expected
- Branch coverage is enabled and working

## Context

Addresses Issue #480 which identified `scylla/core/` and `scylla/discovery/` with 0% coverage. Setting a 70% threshold prevents further regression while allowing current state to pass.

## Success Criteria

- [x] Coverage thresholds configured in pyproject.toml
- [x] CI fails when coverage drops below threshold (tested locally)
- [x] Current coverage baseline documented (72.89%)
- [x] Coverage report shows missing lines
- [x] Tests pass with current coverage level

Closes #596

🤖 Generated with [Claude Code](https://claude.com/claude-code)