### PR TITLE
feat(automation): Improve error handling and UI status granularity

### DIFF
--- a/scylla/automation/github_api.py
+++ b/scylla/automation/github_api.py
@@ -54,6 +54,7 @@ def _gh_call(
                 ["gh"] + args,
                 check=check,
                 capture_output=True,
+                timeout=120,  # 2 minute timeout for gh CLI calls
             )
             return result
         except subprocess.CalledProcessError as e:
@@ -251,7 +252,7 @@ def gh_pr_create(
             try:
                 _gh_call(["pr", "merge", str(pr_number), "--auto", "--rebase"])
                 logger.info(f"Enabled auto-merge for PR #{pr_number}")
-            except subprocess.CalledProcessError as e:
+            except Exception as e:
                 logger.warning(f"Failed to enable auto-merge for PR #{pr_number}: {e}")
 
         return pr_number

--- a/tests/unit/automation/test_github_api_errors.py
+++ b/tests/unit/automation/test_github_api_errors.py
@@ -1,0 +1,91 @@
+"""Tests for GitHub API error handling."""
+
+import subprocess
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from scylla.automation.github_api import _gh_call, gh_pr_create
+
+
+class TestAutoMergeErrorHandling:
+    """Tests for auto-merge error handling."""
+
+    def test_auto_merge_runtime_error_caught(self):
+        """Test that RuntimeError from rate limit doesn't escape gh_pr_create."""
+        with (
+            patch("scylla.automation.github_api._gh_call") as mock_gh_call,
+            patch("scylla.automation.github_api.logger") as mock_logger,
+        ):
+            # First call succeeds (PR creation), second call raises RuntimeError
+            pr_output = "https://github.com/owner/repo/pull/123"
+            mock_gh_call.side_effect = [
+                MagicMock(stdout=pr_output),
+                RuntimeError("GitHub API usage limit reached"),
+            ]
+
+            # Should not raise - error is caught and logged
+            pr_number = gh_pr_create(
+                branch="test-branch",
+                title="Test PR",
+                body="Test body",
+                auto_merge=True,
+            )
+
+            # PR should still be created successfully
+            assert pr_number == 123
+
+            # Warning should be logged about auto-merge failure
+            assert mock_logger.warning.called
+            warning_msg = str(mock_logger.warning.call_args)
+            assert "auto-merge" in warning_msg.lower()
+
+    def test_auto_merge_called_process_error_caught(self):
+        """Test that CalledProcessError is also caught."""
+        with (
+            patch("scylla.automation.github_api._gh_call") as mock_gh_call,
+            patch("scylla.automation.github_api.logger") as mock_logger,
+        ):
+            # First call succeeds, second call raises CalledProcessError
+            pr_output = "https://github.com/owner/repo/pull/456"
+            mock_gh_call.side_effect = [
+                MagicMock(stdout=pr_output),
+                subprocess.CalledProcessError(1, ["gh", "pr", "merge"], stderr="Error"),
+            ]
+
+            # Should not raise
+            pr_number = gh_pr_create(
+                branch="test-branch",
+                title="Test PR",
+                body="Test body",
+                auto_merge=True,
+            )
+
+            assert pr_number == 456
+            assert mock_logger.warning.called
+
+
+class TestGhCallTimeout:
+    """Tests for gh CLI timeout."""
+
+    def test_gh_call_timeout(self):
+        """Test that timeout is passed to subprocess."""
+        with patch("scylla.automation.github_api.run") as mock_run:
+            mock_run.return_value = MagicMock(stdout="output")
+
+            _gh_call(["issue", "view", "123"])
+
+            # Verify timeout was passed
+            mock_run.assert_called_once()
+            call_kwargs = mock_run.call_args[1]
+            assert "timeout" in call_kwargs
+            assert call_kwargs["timeout"] == 120
+
+    def test_gh_call_timeout_expired(self):
+        """Test that TimeoutExpired is propagated."""
+        with patch("scylla.automation.github_api.run") as mock_run:
+            mock_run.side_effect = subprocess.TimeoutExpired(["gh", "issue", "view"], 120)
+
+            # Should raise after all retries
+            with pytest.raises(subprocess.TimeoutExpired):
+                _gh_call(["issue", "view", "123"])


### PR DESCRIPTION
## Summary

Improves error handling and UI status granularity in `implement_issues.py` to make errors visible in the curses UI and provide more detailed progress feedback.

## Changes

### Error Visibility
- **Added `_log()` helper** that routes all messages to both standard logger and UI `log_manager`
- **Classified exception handling** into 4 types: `TimeoutExpired`, `CalledProcessError`, `RuntimeError`, and generic `Exception`
- **Show failure in UI slot** with "FAILED - {error}" message before releasing slot
- All `logger.error()` and `logger.warning()` calls now also appear in UI "Recent Activity"

### Status Granularity
- **Increased from 5 to 12+ status updates** showing granular sub-steps:
  - Creating worktree
  - Checking plan / Generating plan
  - Fetching issue
  - Running Claude Code
  - Checking commit / Pushing branch / Creating PR
  - Running retrospective
  - Identifying follow-ups / Creating follow-up X/N
- **Pass `slot_id` to all sub-methods** (`_run_claude_code`, `_ensure_pr_created`, `_run_retrospective`, `_run_follow_up_issues`)

### Bug Fixes
- **Fix auto-merge exception handling** - catch all `Exception` instead of only `CalledProcessError` (prevents `RuntimeError` from rate limit escaping)
- **Add 120s timeout to gh CLI calls** - prevents hanging on stuck commands

## Test Coverage

- Added 4 tests for `_log()` helper (all log levels + custom thread_id)
- Added 3 tests for error visibility (failure status, timeout/error classification)
- Added 1 test for granular status updates
- Added 4 tests for GitHub API error handling (auto-merge errors, timeout)
- Updated existing tests for new method signatures

**All 211 automation tests pass ✅**

## Verification

- ✅ Unit tests pass (`pixi run python -m pytest tests/unit/automation/ -v`)
- ✅ Pre-commit hooks pass (`pre-commit run --all-files`)
- ✅ Error messages now visible in curses UI
- ✅ Failed workers show "FAILED - ..." before going idle
- ✅ Status updates are granular (12+ vs previous 5)

Closes #632

🤖 Generated with [Claude Code](https://claude.com/claude-code)