### PR TITLE
feat(automation): Persist execution logs for post-mortem analysis

### DIFF
--- a/scylla/automation/implementer.py
+++ b/scylla/automation/implementer.py
@@ -533,6 +533,8 @@ class IssueImplementer:
             issue_number: Parent issue number
 
         """
+        self.state_dir.mkdir(parents=True, exist_ok=True)
+
         # Write follow-up prompt to temp file in worktree
         prompt_file = worktree_path / f".claude-followup-{issue_number}.md"
         prompt_file.write_text(get_follow_up_prompt(issue_number))
@@ -551,6 +553,10 @@ class IssueImplementer:
                 cwd=worktree_path,
                 timeout=600,  # 10 minutes
             )
+
+            # Save successful output to log file
+            follow_up_log = self.state_dir / f"follow-up-{issue_number}.log"
+            follow_up_log.write_text(result.stdout or "")
 
             # Parse JSON output
             try:
@@ -606,6 +612,16 @@ class IssueImplementer:
 
         except Exception as e:
             logger.warning(f"Follow-up issues failed for issue #{issue_number}: {e}")
+
+            # Save failure output to log file
+            follow_up_log = self.state_dir / f"follow-up-{issue_number}.log"
+            error_output = f"FAILED: {e}\n"
+            if hasattr(e, "stdout"):
+                error_output += f"\nSTDOUT:\n{e.stdout or ''}"
+            if hasattr(e, "stderr"):
+                error_output += f"\nSTDERR:\n{e.stderr or ''}"
+            follow_up_log.write_text(error_output)
+
             # Non-blocking: never re-raise
         finally:
             # Clean up temp file
@@ -620,6 +636,7 @@ class IssueImplementer:
         Runs from repo root so ProjectMnemosyne clone persists in build/.
         Output is logged to .issue_implementer/retrospective-{issue_number}.log.
         """
+        self.state_dir.mkdir(parents=True, exist_ok=True)
         log_file = self.state_dir / f"retrospective-{issue_number}.log"
         try:
             result = run(
@@ -643,6 +660,15 @@ class IssueImplementer:
             logger.info(f"Retrospective log: {log_file}")
         except Exception as e:
             logger.warning(f"Retrospective failed for issue #{issue_number}: {e}")
+
+            # Save failure output to log file
+            error_output = f"FAILED: {e}\n"
+            if hasattr(e, "stdout"):
+                error_output += f"\nSTDOUT:\n{e.stdout or ''}"
+            if hasattr(e, "stderr"):
+                error_output += f"\nSTDERR:\n{e.stderr or ''}"
+            log_file.write_text(error_output)
+
             # Non-blocking: never re-raise
 
     def _run_claude_code(self, issue_number: int, worktree_path: Path, prompt: str) -> str | None:
@@ -655,6 +681,8 @@ class IssueImplementer:
         if self.options.dry_run:
             logger.info(f"[DRY RUN] Would run Claude Code for issue #{issue_number}")
             return None
+
+        self.state_dir.mkdir(parents=True, exist_ok=True)
 
         # Write prompt to temp file in worktree
         prompt_file = worktree_path / f".claude-prompt-{issue_number}.md"
@@ -678,10 +706,21 @@ class IssueImplementer:
             # Parse session_id from JSON output
             try:
                 data = json.loads(result.stdout)
-                return data.get("session_id")
+                session_id = data.get("session_id")
+
+                # Save successful output to log file
+                log_file = self.state_dir / f"claude-{issue_number}.log"
+                log_file.write_text(result.stdout or "")
+
+                return session_id
             except (json.JSONDecodeError, AttributeError):
                 logger.warning(f"Could not parse session_id for issue #{issue_number}")
                 logger.debug(f"Claude stdout: {result.stdout[:500]}")
+
+                # Save output even if JSON parsing failed
+                log_file = self.state_dir / f"claude-{issue_number}.log"
+                log_file.write_text(result.stdout or "")
+
                 return None
         except subprocess.CalledProcessError as e:
             logger.error(f"Claude Code failed for issue #{issue_number}")
@@ -690,8 +729,20 @@ class IssueImplementer:
                 logger.error(f"Stdout: {e.stdout[:1000]}")
             if e.stderr:
                 logger.error(f"Stderr: {e.stderr[:1000]}")
+
+            # Save failure output to log file
+            log_file = self.state_dir / f"claude-{issue_number}.log"
+            stdout = e.stdout or ""
+            stderr = e.stderr or ""
+            output = f"EXIT CODE: {e.returncode}\n\nSTDOUT:\n{stdout}\n\nSTDERR:\n{stderr}"
+            log_file.write_text(output)
+
             raise RuntimeError(f"Claude Code failed: {e.stderr or e.stdout}") from e
         except subprocess.TimeoutExpired as e:
+            # Save timeout info to log file
+            log_file = self.state_dir / f"claude-{issue_number}.log"
+            log_file.write_text(f"TIMEOUT after {e.timeout}s\n\nOutput:\n{e.output or ''}")
+
             raise RuntimeError("Claude Code timed out") from e
         finally:
             # Clean up temp file


### PR DESCRIPTION
## Summary

Persist execution logs (Claude Code output, retrospective, follow-up) to `.issue_implementer/` directory so failures can be analyzed even after worktrees are cleaned up.

## Problem

When `implement_issues.py` runs with curses UI:
1. Claude Code stdout/stderr is invisible until completion
2. Retrospective/follow-up failures only log to stderr (invisible in curses)
3. After `worktree_manager.cleanup_all()`, all evidence is destroyed
4. No way to debug what happened after the script exits

**Trigger**: User ran script for issue #602, retrospective failed silently, worktree cleaned up → impossible to debug.

## Solution

### 1. File Logging in Main Script
Added `FileHandler` to capture all Python logger output to `.issue_implementer/run.log`:

```python
def setup_logging(verbose: bool = False, log_dir: Path | None = None):
    # ... basic config ...
    if log_dir:
        log_dir.mkdir(parents=True, exist_ok=True)
        fh = logging.FileHandler(log_dir / "run.log", mode="a")
        logging.getLogger().addHandler(fh)
```

### 2. Save Subprocess Output on All Exit Paths
For `_run_claude_code()`, `_run_retrospective()`, `_run_follow_up_issues()`:

**On success**: Save stdout to log file
**On CalledProcessError**: Save exit code, stdout, stderr to log file
**On TimeoutExpired**: Save timeout info to log file

### 3. Ensure Directory Exists
Added `self.state_dir.mkdir(parents=True, exist_ok=True)` at start of each method to prevent `FileNotFoundError`.

## Files Created After Run

```
.issue_implementer/
├── run.log                      # Full Python logger output (all phases)
├── claude-{N}.log               # Claude Code output per issue
├── retrospective-{N}.log        # Retrospective output per issue  
├── follow-up-{N}.log            # Follow-up issues output per issue
└── issue-{N}.json               # State files (already existed)
```

## Changes

| File | Changes |
|------|---------|
| `scripts/implement_issues.py` | Add `FileHandler` for `.issue_implementer/run.log` |
| `scylla/automation/implementer.py` | Save Claude/retrospective/follow-up output on success AND failure |
| `tests/unit/automation/test_implementer.py` | Add 5 new log persistence tests, update 10 existing tests |

## Test Coverage

- **Before**: 24 tests passing
- **After**: 30 tests passing
- **New tests**:
  - `test_claude_code_output_saved_to_log` - Verify stdout saved on success
  - `test_claude_code_failure_saved_to_log` - Verify failure output with exit code, stdout, stderr
  - `test_retrospective_failure_saved_to_log` - Verify retrospective failures logged
  - `test_follow_up_output_saved_to_log` - Verify follow-up output saved
  - `test_follow_up_failure_saved_to_log` - Verify follow-up failures logged

## Verification

```bash
# Run tests
pixi run python -m pytest tests/unit/automation/test_implementer.py -v
# Result: 30/30 passing

# Run pre-commit hooks
pre-commit run --all-files
# Result: All hooks passing
```

## Related

- Complements #632 (improve-automation-error-visibility)
  - #632: Make errors visible **during** execution (curses UI)
  - #602: Make errors analyzable **after** execution (log files)

Closes #602

🤖 Generated with [Claude Code](https://claude.com/claude-code)