### PR TITLE
feat(e2e): Forbid remote operations in tests and optimize worktree creation

### DIFF
--- a/scylla/e2e/tier_manager.py
+++ b/scylla/e2e/tier_manager.py
@@ -606,6 +606,19 @@ class TierManager:
         else:
             base_message = "\n\n".join(suffixes)
 
+        # Test environment constraints (always applied)
+        test_constraints = (
+            "\n\n## Test Environment Constraints\n\n"
+            "**CRITICAL: This is a test environment. "
+            "The following WRITE operations are FORBIDDEN:**\n\n"
+            "- DO NOT run `git push` or push to any remote repository\n"
+            "- DO NOT create pull requests (`gh pr create` or similar)\n"
+            "- DO NOT comment on or modify GitHub issues or PRs\n"
+            "- DO NOT delete remote branches (`git push origin --delete`)\n"
+            "- All changes must remain LOCAL to this workspace - no remote writes\n"
+            "- Read-only remote operations (`git fetch`, `git pull`) are permitted\n"
+        )
+
         # Always add cleanup instructions (temporary files only)
         cleanup_instructions = (
             "\n\n## Cleanup Requirements\n\n"
@@ -614,7 +627,7 @@ class TierManager:
             "- Clean up after yourself - the workspace should contain only final deliverables\n"
         )
 
-        return base_message + cleanup_instructions
+        return base_message + test_constraints + cleanup_instructions
 
     def get_baseline_for_subtest(
         self,

--- a/tests/unit/e2e/test_tier_manager.py
+++ b/tests/unit/e2e/test_tier_manager.py
@@ -9,13 +9,29 @@ import yaml
 from scylla.e2e.models import SubTestConfig, TierID
 from scylla.e2e.tier_manager import TierManager
 
+# Test constraints that are appended to all prompts
+TEST_CONSTRAINTS = (
+    "\n\n## Test Environment Constraints\n\n"
+    "**CRITICAL: This is a test environment. "
+    "The following WRITE operations are FORBIDDEN:**\n\n"
+    "- DO NOT run `git push` or push to any remote repository\n"
+    "- DO NOT create pull requests (`gh pr create` or similar)\n"
+    "- DO NOT comment on or modify GitHub issues or PRs\n"
+    "- DO NOT delete remote branches (`git push origin --delete`)\n"
+    "- All changes must remain LOCAL to this workspace - no remote writes\n"
+    "- Read-only remote operations (`git fetch`, `git pull`) are permitted\n"
+)
+
 # Cleanup instructions that are appended to all prompts
-CLEANUP_INSTRUCTIONS = (
+SUFFIX_TAIL = (
     "\n\n## Cleanup Requirements\n\n"
     "- Remove any temporary files created during task completion "
     "(build artifacts, cache files, etc.)\n"
     "- Clean up after yourself - the workspace should contain only final deliverables\n"
 )
+
+# Combined suffix tail (test constraints + cleanup instructions)
+SUFFIX_TAIL = TEST_CONSTRAINTS + SUFFIX_TAIL
 
 
 class TestBuildResourceSuffix:
@@ -31,9 +47,7 @@ class TestBuildResourceSuffix:
         )
         manager = TierManager(Path("/tmp/tiers"))
         result = manager.build_resource_suffix(subtest)
-        expected = (
-            "Maximize usage of all available tools to complete this task." + CLEANUP_INSTRUCTIONS
-        )
+        expected = "Maximize usage of all available tools to complete this task." + SUFFIX_TAIL
         assert result == expected
 
     def test_tools_with_names(self) -> None:
@@ -48,7 +62,7 @@ class TestBuildResourceSuffix:
         result = manager.build_resource_suffix(subtest)
         expected = (
             "Maximize usage of the following tools to complete this task:\n\n"
-            "- Bash\n- Read\n- Write" + CLEANUP_INSTRUCTIONS
+            "- Bash\n- Read\n- Write" + SUFFIX_TAIL
         )
         assert result == expected
 
@@ -64,7 +78,7 @@ class TestBuildResourceSuffix:
         result = manager.build_resource_suffix(subtest)
         expected = (
             "Maximize usage of the following MCP servers to complete this task:\n\n"
-            "- filesystem\n- git\n- memory" + CLEANUP_INSTRUCTIONS
+            "- filesystem\n- git\n- memory" + SUFFIX_TAIL
         )
         assert result == expected
 
@@ -78,10 +92,7 @@ class TestBuildResourceSuffix:
         )
         manager = TierManager(Path("/tmp/tiers"))
         result = manager.build_resource_suffix(subtest)
-        expected = (
-            "Complete this task using available tools and your best judgment."
-            + CLEANUP_INSTRUCTIONS
-        )
+        expected = "Complete this task using available tools and your best judgment." + SUFFIX_TAIL
         assert result == expected
 
     def test_single_tool(self) -> None:
@@ -94,7 +105,7 @@ class TestBuildResourceSuffix:
         )
         manager = TierManager(Path("/tmp/tiers"))
         result = manager.build_resource_suffix(subtest)
-        expected = "Use the following tool to complete this task:\n\n- Read" + CLEANUP_INSTRUCTIONS
+        expected = "Use the following tool to complete this task:\n\n- Read" + SUFFIX_TAIL
         assert result == expected
 
     def test_single_mcp_server(self) -> None:
@@ -108,8 +119,7 @@ class TestBuildResourceSuffix:
         manager = TierManager(Path("/tmp/tiers"))
         result = manager.build_resource_suffix(subtest)
         expected = (
-            "Use the following MCP server to complete this task:\n\n- filesystem"
-            + CLEANUP_INSTRUCTIONS
+            "Use the following MCP server to complete this task:\n\n- filesystem" + SUFFIX_TAIL
         )
         assert result == expected
 


### PR DESCRIPTION
## Summary

This PR implements two critical improvements to the e2e testing infrastructure:

1. **Forbids remote Git operations during e2e tests** - Prevents agents from pushing to remote repos or creating real PRs during test runs
2. **Optimizes worktree creation** - Reduces subprocess calls by passing commit hash directly to `git worktree add`

## Changes

### Test Environment Constraints (`scylla/e2e/tier_manager.py`)
- Added "Test Environment Constraints" section to `build_resource_suffix()`
- Appended to all composed CLAUDE.md files in test workspaces
- Explicitly forbids:
  - `git push` operations
  - Creating pull requests (`gh pr create`)
  - Commenting on/modifying GitHub issues or PRs
  - Deleting remote branches
- Allows read-only operations (`git fetch`, `git pull`)

### Worktree Creation Optimization
- **`scylla/e2e/workspace_setup.py`**: Pass commit directly to `git worktree add` command
- **`scylla/e2e/workspace_manager.py`**: Same optimization in `create_worktree()`
- Eliminates separate `git checkout` subprocess call
- Reduces worktree creation from 2 steps to 1

### Test Updates
- **`tests/unit/e2e/test_tier_manager.py`**: 
  - Added `TEST_CONSTRAINTS` constant
  - Created `SUFFIX_TAIL` combining constraints + cleanup instructions
  - Updated all assertions to verify new section
- **`tests/unit/e2e/test_workspace_manager.py`**: 
  - Renamed `test_worktree_separate_checkout` → `test_worktree_includes_commit`
  - Verifies single subprocess call with commit

## Verification

✅ All unit tests pass (56/56)
✅ Pre-commit hooks pass (formatting, linting)
✅ Manual verification confirms test constraints in generated CLAUDE.md
✅ Worktree commands include commit hash as expected

## Test Plan

- [x] Run unit tests: `pixi run python -m pytest tests/unit/e2e/ -v`
- [x] Run pre-commit hooks: `pre-commit run --all-files`
- [x] Verify test constraints appear in composed CLAUDE.md
- [x] Verify worktree command structure includes commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)