### PR TITLE
fix(gitignore): Add pattern to ignore root-level log files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -85,3 +85,6 @@ worktrees
 # Automation runtime directories
 .worktrees/
 .issue_implementer/
+
+# Root-level log files (automation scripts, debugging)
+/*.log


### PR DESCRIPTION
## Summary

Adds a `.gitignore` pattern to prevent root-level log files (like `output.log`) from being tracked in git.

## Problem

Temporary automation script log files in the repository root were showing as untracked files. The existing `.gitignore` had patterns for log files in specific subdirectories (`docs/*.log`, `docs/arxiv/dryrun/*.log`) but not for root-level logs.

## Change

Added pattern to `.gitignore`:
```
# Root-level log files (automation scripts, debugging)
/*.log
```

The `/` prefix ensures this pattern only matches log files in the repository root, not in subdirectories (which are already covered by existing patterns).

## Verification

✅ `output.log` is no longer shown as untracked
✅ Pattern is scoped to root directory only
✅ Existing subdirectory log patterns remain unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)