### PR TITLE
docs: Add GitHub issue and PR templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,79 @@
+name: Bug Report
+description: Report a bug or unexpected behavior
+title: "[Bug] "
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to fill out this bug report! Please provide as much detail as possible.
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: A clear and concise description of what the bug is
+      placeholder: Tell us what you see!
+    validations:
+      required: true
+
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Steps to Reproduce
+      description: Steps to reproduce the behavior
+      placeholder: |
+        1. Run command '...'
+        2. Execute test '...'
+        3. See error
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected Behavior
+      description: What you expected to happen
+      placeholder: It should...
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual Behavior
+      description: What actually happened
+      placeholder: Instead it...
+    validations:
+      required: true
+
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: Your environment details
+      placeholder: |
+        - OS: [e.g., Ubuntu 22.04]
+        - Python version: [e.g., 3.10.12]
+        - ProjectScylla version/commit: [e.g., v0.1.0 or commit abc123]
+      render: markdown
+    validations:
+      required: false
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant Logs
+      description: Any relevant log output or error messages
+      render: shell
+    validations:
+      required: false
+
+  - type: textarea
+    id: additional
+    attributes:
+      label: Additional Context
+      description: Any other context about the problem
+      placeholder: Screenshots, related issues, etc.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Documentation
+    url: https://github.com/HomericIntelligence/ProjectScylla/blob/main/README.md
+    about: Check the project documentation
+  - name: Discussions
+    url: https://github.com/HomericIntelligence/ProjectScylla/discussions
+    about: Ask questions and discuss ideas

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,69 @@
+name: Feature Request
+description: Suggest a new feature or enhancement
+title: "[Feature] "
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for suggesting a feature! Please provide as much detail as possible.
+
+  - type: textarea
+    id: objective
+    attributes:
+      label: Objective
+      description: Brief description of what you want to achieve (2-3 sentences)
+      placeholder: I would like to...
+    validations:
+      required: true
+
+  - type: textarea
+    id: motivation
+    attributes:
+      label: Motivation
+      description: Why is this feature needed? What problem does it solve?
+      placeholder: This would help by...
+    validations:
+      required: true
+
+  - type: textarea
+    id: deliverables
+    attributes:
+      label: Proposed Deliverables
+      description: What should be delivered? (Use checkboxes if multiple)
+      placeholder: |
+        - [ ] Deliverable 1
+        - [ ] Deliverable 2
+      render: markdown
+    validations:
+      required: false
+
+  - type: textarea
+    id: success-criteria
+    attributes:
+      label: Success Criteria
+      description: How will we know this feature is complete and working?
+      placeholder: |
+        - [ ] Criterion 1
+        - [ ] Criterion 2
+      render: markdown
+    validations:
+      required: false
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives Considered
+      description: What alternative solutions or features have you considered?
+      placeholder: I also considered...
+    validations:
+      required: false
+
+  - type: textarea
+    id: additional
+    attributes:
+      label: Additional Context
+      description: Any other context, mockups, or examples
+      placeholder: Screenshots, related issues, etc.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/refactoring.yml
+++ b/.github/ISSUE_TEMPLATE/refactoring.yml
@@ -1,0 +1,94 @@
+name: Refactoring
+description: Propose a code refactoring or quality improvement
+title: "[Refactor] "
+labels: ["refactoring"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for suggesting a refactoring! Code quality improvements are always welcome.
+
+  - type: textarea
+    id: objective
+    attributes:
+      label: Objective
+      description: What needs to be refactored and why?
+      placeholder: Refactor X to improve Y...
+    validations:
+      required: true
+
+  - type: dropdown
+    id: category
+    attributes:
+      label: Category
+      description: What type of refactoring is this?
+      options:
+        - Code organization/structure
+        - Naming/clarity
+        - Performance optimization
+        - Reduce complexity
+        - DRY violation
+        - Type safety
+        - Error handling
+        - Testing improvements
+        - Other
+    validations:
+      required: true
+
+  - type: textarea
+    id: current-state
+    attributes:
+      label: Current State
+      description: Describe the current code/structure
+      placeholder: Currently the code...
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposed-state
+    attributes:
+      label: Proposed State
+      description: Describe the desired end state
+      placeholder: After refactoring, the code should...
+    validations:
+      required: true
+
+  - type: textarea
+    id: benefits
+    attributes:
+      label: Benefits
+      description: What improvements will this bring?
+      placeholder: |
+        - Improved readability
+        - Better performance
+        - Easier maintenance
+    validations:
+      required: true
+
+  - type: textarea
+    id: files-affected
+    attributes:
+      label: Files/Modules Affected
+      description: Which files or modules will be changed?
+      placeholder: |
+        - scylla/e2e/llm_judge.py
+        - tests/unit/e2e/test_llm_judge.py
+    validations:
+      required: false
+
+  - type: checkboxes
+    id: breaking-changes
+    attributes:
+      label: Breaking Changes
+      description: Will this refactoring introduce breaking changes?
+      options:
+        - label: This refactoring may introduce breaking changes
+          required: false
+
+  - type: textarea
+    id: additional
+    attributes:
+      label: Additional Context
+      description: Any other context or considerations
+    validations:
+      required: false

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,56 @@
+## Summary
+
+<!-- Brief description of what this PR accomplishes -->
+
+## Changes
+
+<!-- List of key changes made -->
+
+- Change 1
+- Change 2
+
+## Related Issues
+
+<!-- Link related issues using keywords: Closes #123, Fixes #456, Related to #789 -->
+
+Closes #
+
+## Type of Change
+
+<!-- Mark with an 'x' all that apply -->
+
+- [ ] Bug fix (non-breaking change which fixes an issue)
+- [ ] New feature (non-breaking change which adds functionality)
+- [ ] Refactoring (code improvement without changing functionality)
+- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
+- [ ] Documentation update
+- [ ] CI/CD or infrastructure change
+- [ ] Test coverage improvement
+
+## Testing
+
+<!-- Describe the testing you've done -->
+
+- [ ] All existing tests pass
+- [ ] New tests added to cover changes
+- [ ] Manual testing performed
+
+## Checklist
+
+<!-- Mark with an 'x' all that have been completed -->
+
+- [ ] Code follows project style guidelines (ruff, mypy)
+- [ ] Self-review of code completed
+- [ ] Comments added in hard-to-understand areas
+- [ ] Documentation updated (if needed)
+- [ ] No new warnings introduced
+- [ ] Conventional commit message format used
+- [ ] Branch named following convention: `<issue-number>-<description>`
+
+## Additional Notes
+
+<!-- Any additional context, screenshots, or information -->
+
+---
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)


### PR DESCRIPTION
## Summary

Adds structured GitHub issue templates and a PR template to improve collaboration quality and standardize the contribution workflow.

## Changes

**Issue Templates** (`.github/ISSUE_TEMPLATE/`):
- `bug_report.yml` - Structured bug reporting with reproduction steps and environment details
- `feature_request.yml` - Feature proposals with objectives and success criteria
- `refactoring.yml` - Code quality improvements with categorization (DRY, complexity, etc.)
- `config.yml` - Template configuration with links to docs and discussions

**PR Template** (`.github/pull_request_template.md`):
- Standardized PR format with summary, changes, testing, and checklist
- Aligns with conventional commit format
- Includes type of change categorization

## Related Issues

Closes #654

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactoring
- [ ] Breaking change
- [x] Documentation update
- [ ] CI/CD or infrastructure change
- [ ] Test coverage improvement

## Testing

- [x] Templates follow GitHub's YAML schema for issue forms
- [x] All required fields marked appropriately
- [x] PR template provides clear structure

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review of code completed
- [x] Documentation updated (templates are documentation)
- [x] No new warnings introduced
- [x] Conventional commit message format used
- [x] Branch named following convention: `654-add-github-templates`

## Additional Notes

These templates will appear when users create new issues or PRs, guiding them to provide the right information upfront. This should reduce back-and-forth and improve issue quality.

The issue templates align with the project's existing issue structure documented in `CLAUDE.md` (Objective, Deliverables, Success Criteria).

🤖 Generated with [Claude Code](https://claude.com/claude-code)