### PR TITLE
docs: Add CODEOWNERS file for automated review routing

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,82 @@
+# ProjectScylla Code Owners
+#
+# This file defines code ownership for automatic review assignment.
+# Each line is a file pattern followed by one or more owners.
+#
+# More info: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+
+# Default owners for everything in the repo
+# This is a fallback and will be overridden by more specific rules below
+* @HomericIntelligence/projectscylla-maintainers
+
+# Core configuration and documentation
+/CLAUDE.md @HomericIntelligence/projectscylla-maintainers
+/CONTRIBUTING.md @HomericIntelligence/projectscylla-maintainers
+/README.md @HomericIntelligence/projectscylla-maintainers
+/LICENSE @HomericIntelligence/projectscylla-maintainers
+/.gitignore @HomericIntelligence/projectscylla-maintainers
+
+# Project configuration files
+/pyproject.toml @HomericIntelligence/projectscylla-maintainers
+/pixi.toml @HomericIntelligence/projectscylla-maintainers
+/.pre-commit-config.yaml @HomericIntelligence/projectscylla-maintainers
+
+# GitHub workflows and templates
+/.github/ @HomericIntelligence/projectscylla-maintainers
+
+# Docker configuration
+/docker/ @HomericIntelligence/projectscylla-maintainers
+/Dockerfile @HomericIntelligence/projectscylla-maintainers
+/docker-compose.yml @HomericIntelligence/projectscylla-maintainers
+
+# Agent configurations and hierarchy
+/.claude/ @HomericIntelligence/projectscylla-maintainers
+/agents/ @HomericIntelligence/projectscylla-maintainers
+
+# Model configurations
+/config/models/ @HomericIntelligence/projectscylla-maintainers
+
+# JSON schemas
+/schemas/ @HomericIntelligence/projectscylla-maintainers
+
+# Documentation
+/docs/ @HomericIntelligence/projectscylla-maintainers
+
+# Core Python modules - require maintainer review
+/scylla/core/ @HomericIntelligence/projectscylla-maintainers
+/scylla/config/ @HomericIntelligence/projectscylla-maintainers
+
+# Adapters - LLM integration layer
+/scylla/adapters/ @HomericIntelligence/projectscylla-maintainers
+
+# Execution engine
+/scylla/executor/ @HomericIntelligence/projectscylla-maintainers
+
+# E2E evaluation framework
+/scylla/e2e/ @HomericIntelligence/projectscylla-maintainers
+
+# LLM Judge system
+/scylla/judge/ @HomericIntelligence/projectscylla-maintainers
+
+# Metrics calculation
+/scylla/metrics/ @HomericIntelligence/projectscylla-maintainers
+
+# Statistical analysis and reporting
+/scylla/analysis/ @HomericIntelligence/projectscylla-maintainers
+/scylla/reporting/ @HomericIntelligence/projectscylla-maintainers
+
+# CLI interface
+/scylla/cli/ @HomericIntelligence/projectscylla-maintainers
+
+# Discovery and automation
+/scylla/discovery/ @HomericIntelligence/projectscylla-maintainers
+/scylla/automation/ @HomericIntelligence/projectscylla-maintainers
+
+# Tests - require review from code owner + test coverage verification
+/tests/ @HomericIntelligence/projectscylla-maintainers
+
+# Scripts and utilities
+/scripts/ @HomericIntelligence/projectscylla-maintainers
+
+# Environment configuration (review required for security)
+/.env.example @HomericIntelligence/projectscylla-maintainers


### PR DESCRIPTION
## Summary

Adds a CODEOWNERS file to automatically assign code reviewers based on component ownership, ensuring critical components receive proper review.

## Changes

**New File**: `.github/CODEOWNERS`

Ownership rules established for:
- **Core configuration**: `CLAUDE.md`, `CONTRIBUTING.md`, `README.md`, `LICENSE`, `.gitignore`
- **Project configuration**: `pyproject.toml`, `pixi.toml`, `.pre-commit-config.yaml`
- **GitHub workflows**: `.github/` directory
- **Docker**: `docker/`, `Dockerfile`, `docker-compose.yml`
- **Agent configs**: `.claude/`, `agents/`
- **Model configs**: `config/models/`
- **Schemas**: `schemas/`
- **Documentation**: `docs/`
- **Python modules**: All modules under `scylla/` (core, adapters, executor, e2e, judge, metrics, etc.)
- **Tests**: `tests/` (with coverage verification requirement)
- **Scripts**: `scripts/`
- **Security-sensitive**: `.env.example`

Default owner: `@HomericIntelligence/projectscylla-maintainers`

## Related Issues

Closes #655

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactoring
- [ ] Breaking change
- [x] Documentation update
- [ ] CI/CD or infrastructure change
- [ ] Test coverage improvement

## Testing

- [x] CODEOWNERS syntax validated (follows GitHub specification)
- [x] All critical paths covered with ownership rules
- [x] Default fallback rule provided

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review of code completed
- [x] Documentation is the deliverable
- [x] No new warnings introduced
- [x] Conventional commit message format used
- [x] Branch named following convention: `655-add-codeowners`

## Additional Notes

Once this PR is merged and the `@HomericIntelligence/projectscylla-maintainers` GitHub team is created, PRs will automatically request reviews from team members based on the files changed.

For now, the CODEOWNERS file will be in place and ready to use once the team is configured in the GitHub organization settings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)