### PR TITLE
fix(config): Rename claude-opus-4.yaml to match model_id

### DIFF
--- a/config/models/claude-opus-4-1.yaml
+++ b/config/models/claude-opus-4-1.yaml
@@ -1,4 +1,11 @@
 # Claude Opus 4.1 (Legacy) Model Configuration
+#
+# File naming convention:
+#   - Filename: {model_id}.yaml (e.g., claude-opus-4-1.yaml)
+#   - model_id: API identifier from provider (e.g., "claude-opus-4-1")
+#   - name: Human-readable display name (e.g., "Claude Opus 4.1")
+#
+# The filename MUST match the model_id field for ConfigLoader resolution.
 model_id: "claude-opus-4-1"
 name: "Claude Opus 4.1"
 provider: "anthropic"


### PR DESCRIPTION
Closes #673

## Summary
Fixed naming inconsistency in model configuration where the filename `claude-opus-4.yaml` did not match the `model_id` field `"claude-opus-4-1"`.

## Changes
- **Renamed**: `config/models/claude-opus-4.yaml` → `config/models/claude-opus-4-1.yaml`
- **Added**: Naming convention documentation to file header
- **Verified**: ConfigLoader can successfully load the model by its correct model_id

## Naming Convention
Established and documented the following convention:
- **Filename**: `{model_id}.yaml` (e.g., `claude-opus-4-1.yaml`)
- **model_id**: API identifier from provider (e.g., `"claude-opus-4-1"`)
- **name**: Human-readable display name (e.g., `"Claude Opus 4.1"`)

The filename MUST match the model_id field for ConfigLoader resolution.

## Testing
```bash
# Verified ConfigLoader can load the model
python3 -c "
from scylla.config.loader import ConfigLoader
loader = ConfigLoader()
config = loader.load_model('claude-opus-4-1')
print(f'Name: {config.name}')
print(f'Model ID: {config.model_id}')
"

# Output:
# Name: Claude Opus 4.1
# Model ID: claude-opus-4-1
```

## Verification
- ✓ File renamed successfully
- ✓ Old file removed
- ✓ model_id field correct
- ✓ name field correct
- ✓ Naming convention documented
- ✓ ConfigLoader loads model successfully
- ✓ Old model_id no longer resolves

🤖 Generated with [Claude Code](https://claude.com/claude-code)