### PR TITLE
feat(skills): Add pre-commit-maintenance skill

### DIFF
--- a/.claude-plugin/skills/pre-commit-maintenance/SKILL.md
+++ b/.claude-plugin/skills/pre-commit-maintenance/SKILL.md
@@ -12,6 +12,7 @@
 ## When to Use
 
 Use this skill when:
+
 - Enabling or verifying linting hooks in pre-commit configuration
 - Updating pre-commit hook versions to latest releases
 - Troubleshooting why linting hooks appear to be disabled
@@ -43,6 +44,7 @@ pre-commit autoupdate
 ```
 
 **Expected Output**:
+
 ```
 [https://github.com/adrienverge/yamllint] updating v1.35.1 -> v1.38.0
 [https://github.com/pre-commit/pre-commit-hooks] updating v4.5.0 -> v6.0.0
@@ -107,7 +109,7 @@ git push -u origin <branch-name>
 - repo: https://github.com/adrienverge/yamllint
   rev: v1.38.0  # Updated from v1.35.1
 
-# pre-commit-hooks  
+# pre-commit-hooks
 - repo: https://github.com/pre-commit/pre-commit-hooks
   rev: v6.0.0  # Updated from v4.5.0
 ```

--- a/.claude-plugin/skills/pre-commit-maintenance/references/notes.md
+++ b/.claude-plugin/skills/pre-commit-maintenance/references/notes.md
@@ -10,6 +10,7 @@
 ## Initial Understanding
 
 Issue description stated:
+
 - Uncomment check-yaml hook (lines 67-68)
 - Uncomment markdownlint hook (lines 38-45)
 - Fix any linting errors that surface
@@ -20,6 +21,7 @@ Issue description stated:
 ### Current State Discovery
 
 Upon reading `.pre-commit-config.yaml`:
+
 - **Markdown linting** (lines 46-53): Already enabled with `markdownlint-cli2`
 - **YAML linting** (lines 56-63): Already enabled with `yamllint`
 - Line numbers from issue description didn't match current file
@@ -35,11 +37,13 @@ Upon reading `.pre-commit-config.yaml`:
 ### Configuration Files Verified
 
 #### .markdownlint.json
+
 - Configured with project-specific rules
 - Disables MD013 (line length), MD024 (duplicate headings), etc.
 - Allows specific HTML elements (details, summary, br, img, etc.)
 
 #### .yamllint.yaml
+
 - Line length max: 120 (warning level)
 - Indentation: 2 spaces
 - Ignores: .pixi/, build/, .git/, node_modules/, tests/fixtures/invalid/
@@ -47,6 +51,7 @@ Upon reading `.pre-commit-config.yaml`:
 ### Version Updates
 
 Ran `pre-commit autoupdate`:
+
 - `markdownlint-cli2`: Already up to date (v0.20.0)
 - `yamllint`: v1.35.1 → v1.38.0
 - `pre-commit-hooks`: v4.5.0 → v6.0.0
@@ -54,6 +59,7 @@ Ran `pre-commit autoupdate`:
 ### Post-Update Verification
 
 Ran `pre-commit run --all-files` after updates:
+
 - Initialized new environments for updated hooks
 - All 10 hooks passed successfully
 


### PR DESCRIPTION
## Summary

Captures learnings from implementing issue #678 (Enable YAML and markdown linting in pre-commit) as a reusable skill plugin.

## Skill Details

- **Category**: ci-cd
- **Name**: pre-commit-maintenance
- **Use Case**: Maintaining and updating pre-commit hooks for linting

## Key Learnings Documented

1. **Verify before assuming** - Check current state instead of trusting issue descriptions
2. **Use autoupdate** - `pre-commit autoupdate` is the standard way to update hook versions
3. **Test after updates** - Always run all hooks after version updates
4. **Line numbers drift** - Issue descriptions referencing specific line numbers may become outdated
5. **Don't ask mode** - Skills requiring user permission won't work in don't ask mode

## Contents

- `.claude-plugin/plugin.json` - Updated with new skill metadata
- `skills/pre-commit-maintenance/SKILL.md` - Comprehensive skill documentation
- `skills/pre-commit-maintenance/references/notes.md` - Detailed session notes

## Related

- Issue #678: Enable YAML and markdown linting in pre-commit
- PR #696: The implementation PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)