### PR TITLE
fix(types): Add return type hint to _setup_workspace_and_semaphore

### DIFF
--- a/scylla/e2e/runner.py
+++ b/scylla/e2e/runner.py
@@ -14,7 +14,7 @@ from concurrent.futures import ThreadPoolExecutor, as_completed
 from concurrent.futures.process import BrokenProcessPool
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from scylla.e2e.checkpoint import (
     E2ECheckpoint,
@@ -260,11 +260,13 @@ class E2ERunner:
 
         return self.experiment_dir / "checkpoint.json"
 
-    def _setup_workspace_and_semaphore(self):
+    def _setup_workspace_and_semaphore(self) -> Any:
         """Set up workspace manager and global semaphore for parallel execution.
 
         Returns:
-            Global semaphore for limiting concurrent agents
+            Manager-created Semaphore for limiting concurrent agents across
+            all tiers. Type annotation is Any due to complexity of Manager
+            proxy types (returns multiprocessing.Manager().Semaphore()).
 
         """
         # Create/resume workspace manager


### PR DESCRIPTION
## Summary

Adds explicit `Any` return type annotation to `_setup_workspace_and_semaphore()` method in `scylla/e2e/runner.py`. The method returns a multiprocessing Manager Semaphore, which has complex proxy types that are difficult to annotate precisely.

## Changes

- Add `Any` import from `typing` module
- Add `-> Any` return type annotation to method signature  
- Enhance docstring to document actual return type and explain use of `Any`

## Testing

✅ All pre-commit hooks pass (including Mypy type checker)
✅ E2E checkpoint tests pass (23/23 tests)
✅ Return annotation correctly reflects as `Any` when inspected
✅ No behavior changes - purely type safety improvement

## Context

This follows the existing pattern in `scylla/e2e/parallel_executor.py` for handling Manager proxy objects. Using `Any` with clear documentation is the pragmatic approach for these complex types.

Closes #641