### PR TITLE
fix(docker): Pin Python base image to SHA256 digest for reproducibility

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -10,7 +10,8 @@
 # ============================================================================
 # Stage 1: Builder - Install Python packages with build dependencies
 # ============================================================================
-FROM python:3.14.2-slim AS builder
+# Pinned to SHA256 digest for reproducibility - prevents drift from upstream updates
+FROM python:3.14.2-slim@sha256:1a3c6dbfd2173971abba880c3cc2ec4643690901f6ad6742d0827bae6cefc925 AS builder
 
 # Set build environment variables
 ENV DEBIAN_FRONTEND=noninteractive \
@@ -38,7 +39,8 @@ RUN pip install --user --no-cache-dir /opt/scylla/
 # ============================================================================
 # Stage 2: Runtime - Minimal production image
 # ============================================================================
-FROM python:3.14.2-slim
+# Pinned to SHA256 digest for reproducibility - prevents drift from upstream updates
+FROM python:3.14.2-slim@sha256:1a3c6dbfd2173971abba880c3cc2ec4643690901f6ad6742d0827bae6cefc925
 
 # Set labels for image metadata
 LABEL org.opencontainers.image.title="scylla-runner"


### PR DESCRIPTION
## Summary

Pin both builder and runtime stages in the Dockerfile to `python:3.14.2-slim@sha256:1a3c6dbfd2173971abba880c3cc2ec4643690901f6ad6742d0827bae6cefc925` to prevent drift from upstream image updates.

## Changes

- **docker/Dockerfile**
  - Line 13 (builder stage): Added SHA256 digest with explanatory comment
  - Line 41 (runtime stage): Added SHA256 digest with explanatory comment

- **tests/docker/test_docker_build.py**
  - Added `TestDockerfileDigestPinning` class with two validation tests:
    - `test_base_image_uses_sha256_digest`: Verifies all FROM instructions use SHA256 digest
    - `test_both_stages_use_same_digest`: Ensures builder and runtime use identical digest

## Testing

- ✅ `docker build --check docker/` passes with pinned digest
- ✅ All 21 Docker tests pass including new digest pinning tests
- ✅ All pre-commit hooks pass (ruff, mypy, markdown, yaml)
- ✅ No changes to container runtime behavior

## Verification

```bash
# Verify Docker build syntax
docker build --check docker/

# Run Docker tests
pixi run pytest tests/docker/test_docker_build.py -v
```

Closes #651

🤖 Generated with [Claude Code](https://claude.com/claude-code)