### PR TITLE
feat(docker): Add HEALTHCHECK instruction to Dockerfile

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -108,6 +108,10 @@ RUN chmod +x /entrypoint.sh
 # Switch to non-root user
 USER scylla
 
+# Health check for container orchestration platforms
+HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \
+  CMD python -c 'import scylla; print("OK")' || exit 1
+
 # Default entry point
 ENTRYPOINT ["/entrypoint.sh"]
 

--- a/tests/docker/test_docker_build.py
+++ b/tests/docker/test_docker_build.py
@@ -152,6 +152,14 @@ class TestDockerfileContent:
         content = dockerfile_path.read_text()
         assert "ENV" in content, "Dockerfile should set environment variables"
 
+    def test_dockerfile_has_healthcheck(self, dockerfile_path):
+        """Dockerfile contains HEALTHCHECK instruction for container orchestration."""
+        content = dockerfile_path.read_text()
+        assert "HEALTHCHECK" in content, (
+            "Dockerfile should contain HEALTHCHECK instruction for "
+            "container health monitoring in orchestration platforms"
+        )
+
 
 class TestDockerComposeContent:
     """Tests for docker-compose.yml content and configuration."""


### PR DESCRIPTION
## Summary

Add HEALTHCHECK instruction to `/docker/Dockerfile` to enable container orchestration platforms (Kubernetes, Docker Swarm, ECS) to monitor container health.

## Changes

- **docker/Dockerfile**: Added HEALTHCHECK instruction after `USER scylla` statement
  - Verifies Python and scylla package are accessible
  - Uses standard parameters: interval=30s, timeout=10s, start-period=5s, retries=3
  
- **tests/docker/test_docker_build.py**: Added test case to verify HEALTHCHECK instruction exists

## Testing

All 20 Docker build tests pass:
```bash
pixi run python -m pytest tests/docker/test_docker_build.py -v
# 20 passed in 2.40s
```

Dockerfile syntax validated:
```bash
docker build --check docker/
# Check complete, no warnings found.
```

## Verification

The HEALTHCHECK runs as the non-root `scylla` user and validates critical runtime dependencies:
```dockerfile
HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \
  CMD python -c 'import scylla; print("OK")' || exit 1
```

Closes #652

🤖 Generated with [Claude Code](https://claude.com/claude-code)