### PR TITLE
Add ConfigLoader validation for filename/model_id consistency

### DIFF
--- a/scylla/config/validation.py
+++ b/scylla/config/validation.py
@@ -1,0 +1,61 @@
+"""Configuration validation utilities."""
+
+import logging
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+
+def get_expected_filename(model_id: str) -> str:
+    """Get expected filename for a model_id.
+
+    Converts model_id to valid filename format by replacing ':' with '-'.
+
+    Args:
+        model_id: Model identifier (e.g., 'claude-sonnet-4-5')
+
+    Returns:
+        Expected filename stem (without .yaml extension)
+
+    """
+    return model_id.replace(":", "-")
+
+
+def validate_filename_model_id_consistency(config_path: Path, model_id: str) -> list[str]:
+    """Validate config filename matches model_id.
+
+    Checks two patterns:
+    1. Exact match: filename.stem == model_id
+    2. Simplified match: normalized versions match (: → -)
+
+    Args:
+        config_path: Path to config file
+        model_id: model_id field from config
+
+    Returns:
+        List of warning messages (empty if valid)
+
+    """
+    warnings = []
+    filename_stem = config_path.stem
+
+    # Skip validation for test fixtures (prefixed with _)
+    if filename_stem.startswith("_"):
+        return warnings
+
+    # Check exact match
+    if filename_stem == model_id:
+        return warnings
+
+    # Check simplified match
+    expected = get_expected_filename(model_id)
+    if filename_stem == expected:
+        return warnings
+
+    # Mismatch detected
+    warnings.append(
+        f"Config filename '{filename_stem}.yaml' does not match model_id "
+        f"'{model_id}'. Expected '{expected}.yaml'"
+    )
+
+    return warnings

--- a/tests/config/test_validation.py
+++ b/tests/config/test_validation.py
@@ -1,0 +1,56 @@
+"""Tests for configuration validation utilities."""
+
+from pathlib import Path
+
+from scylla.config.validation import (
+    get_expected_filename,
+    validate_filename_model_id_consistency,
+)
+
+
+class TestGetExpectedFilename:
+    """Test get_expected_filename helper."""
+
+    def test_simple_model_id(self) -> None:
+        """Test simple model_id without special characters."""
+        assert get_expected_filename("gpt-4") == "gpt-4"
+
+    def test_model_id_with_colons(self) -> None:
+        """Test model_id with colons converts to hyphens."""
+        assert get_expected_filename("claude:opus:4") == "claude-opus-4"
+
+    def test_already_hyphenated(self) -> None:
+        """Test model_id that already uses hyphens."""
+        assert get_expected_filename("claude-sonnet-4-5") == "claude-sonnet-4-5"
+
+
+class TestValidateFilenameModelIdConsistency:
+    """Test filename/model_id validation."""
+
+    def test_exact_match_no_warnings(self) -> None:
+        """Test exact match returns no warnings."""
+        path = Path("/config/models/test-model.yaml")
+        warnings = validate_filename_model_id_consistency(path, "test-model")
+        assert warnings == []
+
+    def test_simplified_match_no_warnings(self) -> None:
+        """Test simplified match (colon to hyphen) returns no warnings."""
+        path = Path("/config/models/claude-opus-4.yaml")
+        warnings = validate_filename_model_id_consistency(path, "claude:opus:4")
+        assert warnings == []
+
+    def test_mismatch_returns_warning(self) -> None:
+        """Test mismatch returns warning message."""
+        path = Path("/config/models/claude-opus-4.yaml")
+        warnings = validate_filename_model_id_consistency(path, "claude-sonnet-4-5")
+
+        assert len(warnings) == 1
+        assert "claude-opus-4.yaml" in warnings[0]
+        assert "claude-sonnet-4-5" in warnings[0]
+        assert "claude-sonnet-4-5.yaml" in warnings[0]
+
+    def test_test_fixture_skips_validation(self) -> None:
+        """Test files prefixed with _ skip validation."""
+        path = Path("/config/models/_test-fixture.yaml")
+        warnings = validate_filename_model_id_consistency(path, "different-id")
+        assert warnings == []


### PR DESCRIPTION
## Summary

Implements ConfigLoader validation to detect and warn when a configuration file's name doesn't match its `model_id` field, preventing mismatches like the `claude-opus-4.yaml` issue discovered in #673.

## Changes

### New Files
- **scylla/config/validation.py** - Validation utilities for filename/model_id consistency
  - `get_expected_filename()` - Helper to calculate expected filename from model_id
  - `validate_filename_model_id_consistency()` - Core validation function

### Modified Files
- **scylla/config/loader.py** - Integrated validation into `load_model()` method
  - Added import for validation function
  - Added validation call after YAML parsing
  - Logs warnings for mismatches

### Tests
- **tests/config/test_validation.py** - Unit tests for validation logic (7 tests)
  - Test exact match, simplified match, mismatches, and test fixture handling
- **tests/unit/test_config_loader.py** - Integration tests for ConfigLoader (4 tests)
  - Test validation behavior in full ConfigLoader context

## Validation Rules

✅ **Exact match**: `filename.stem == model_id` → No warning  
✅ **Simplified match**: `claude-opus-4.yaml` with `model_id: claude:opus:4` → No warning (`:` → `-`)  
✅ **Test fixtures**: Files prefixed with `_` skip validation  
⚠️ **Mismatch**: `claude-opus-4.yaml` with `model_id: claude-sonnet-4-5` → Warning logged  

## Testing

All tests pass:
```bash
pytest tests/config/test_validation.py -v  # 7 passed
pytest tests/unit/test_config_loader.py::TestFilenameModelIdValidation -v  # 4 passed
```

## Impact

- **Backward compatible** - Uses warnings instead of errors
- **No breaking changes** - Existing configurations continue to work
- **Early detection** - Catches mismatches at load time

Closes #692

🤖 Generated with [Claude Code](https://claude.com/claude-code)