### PR TITLE
fix(automation): Create missing GitHub labels and fix prompt label names

### DIFF
--- a/scylla/automation/prompts.py
+++ b/scylla/automation/prompts.py
@@ -143,7 +143,7 @@ Return a JSON array of follow-up items (max 5). Each item must have:
 - `title`: Brief, specific title (under 70 characters)
 - `body`: Detailed description of the follow-up work
 - `labels`: Array of relevant labels from:
-  ["enhancement", "bug", "test", "docs", "refactor", "research"]
+  ["enhancement", "bug", "testing", "documentation", "refactor", "research"]
 
 If there are no follow-up items, return an empty array: `[]`
 
@@ -160,7 +160,7 @@ misleading error. Should add validation and specific error message.",
     "title": "Add integration tests for new feature",
     "body": "Current tests only cover unit level. Need integration tests
 to verify end-to-end behavior with real GitHub API.",
-    "labels": ["test"]
+    "labels": ["testing"]
   }}
 ]
 ```

--- a/tests/unit/automation/test_prompts.py
+++ b/tests/unit/automation/test_prompts.py
@@ -76,7 +76,7 @@ def test_get_follow_up_prompt():
     assert "labels" in prompt
     assert "enhancement" in prompt
     assert "bug" in prompt
-    assert "test" in prompt
+    assert "testing" in prompt
 
 
 def test_get_pr_description():


### PR DESCRIPTION
## Summary

Fixes the `implement_issues.py` automation by creating missing GitHub labels and updating the `FOLLOW_UP_PROMPT` to use correct label names that match the repository.

## Problem

The automation was failing when creating follow-up issues because:
- The prompt referenced `"test"` but the repo has `"testing"`
- The prompt referenced `"docs"` but the repo has `"documentation"`
- Several commonly referenced labels didn't exist in the repo

This caused `gh issue create` to fail with errors like `"could not add label: 'test' not found"`.

## Changes

### 1. Created 10 Missing GitHub Labels

| Label | Color | Description |
|-------|-------|-------------|
| `research` | `#d4c5f9` | Research and methodology |
| `ci` | `#0052cc` | CI/CD pipeline |
| `quality` | `#fbca04` | Code quality improvements |
| `implementation` | `#1d76db` | Implementation work |
| `tooling` | `#c5def5` | Developer tools and automation |
| `ready-to-merge` | `#0e8a16` | PR ready for merge |
| `automation` | `#5319e7` | Automation scripts and workflows |
| `performance` | `#f9d0c4` | Performance improvements |
| `security` | `#d73a4a` | Security related |
| `blocked` | `#e4e669` | Blocked by dependency |

### 2. Fixed FOLLOW_UP_PROMPT Label Names

**File:** `scylla/automation/prompts.py:145-146`

Changed allowed labels from:
```python
["enhancement", "bug", "test", "docs", "refactor", "research"]
```

to:
```python
["enhancement", "bug", "testing", "documentation", "refactor", "research"]
```

Also updated the example on line 163 to use `"testing"` instead of `"test"`.

### 3. Updated Tests

**File:** `tests/unit/automation/test_prompts.py:79`

Updated assertion to check for `"testing"` instead of `"test"`.

## Testing

- ✅ All 6 tests pass in `tests/unit/automation/test_prompts.py`
- ✅ Pre-commit hooks pass (ruff, mypy, formatting)
- ✅ All 10 new labels verified in GitHub repo via `gh label list`

## Impact

The `implement_issues.py` automation will now correctly create follow-up issues with valid labels that exist in the repository, preventing the label creation failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)