### PR TITLE
fix(e2e): fix criteria_scores=None propagation across 8 vulnerable sites

### DIFF
--- a/scylla/e2e/judge_runner.py
+++ b/scylla/e2e/judge_runner.py
@@ -243,10 +243,10 @@ def _run_judge(
             key=lambda j: abs(j.score - consensus_score),
         )
         primary_reasoning = closest_judge.reasoning
-        primary_criteria_scores = closest_judge.criteria_scores
+        primary_criteria_scores = closest_judge.criteria_scores or {}
     else:
         primary_reasoning = judges[0].reasoning if judges else ""
-        primary_criteria_scores = judges[0].criteria_scores if judges else None
+        primary_criteria_scores = (judges[0].criteria_scores if judges else None) or {}
     # All judges must be valid for consensus to be valid
     consensus_is_valid = all(j.is_valid for j in judges)
     consensus_dict = {

--- a/scylla/e2e/models.py
+++ b/scylla/e2e/models.py
@@ -13,7 +13,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 import yaml
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, field_validator
 
 from scylla.core.results import RunResultBase
 
@@ -306,6 +306,12 @@ class E2ERunResult(RunResultBase):
     command_log_path: Path | None = None
     criteria_scores: dict[str, dict[str, Any]] = Field(default_factory=dict)
     baseline_pipeline_summary: dict[str, Any] | None = None
+
+    @field_validator("criteria_scores", mode="before")
+    @classmethod
+    def coerce_none_criteria_scores(cls, v: Any) -> dict:
+        """Coerce None to empty dict — judges may return None for criteria_scores."""
+        return v if v is not None else {}
 
     # Legacy properties for backwards compatibility
     @property

--- a/scylla/e2e/regenerate.py
+++ b/scylla/e2e/regenerate.py
@@ -207,7 +207,7 @@ def scan_run_results(
                     command_log_path=(
                         Path(data["command_log_path"]) if data.get("command_log_path") else None
                     ),
-                    criteria_scores=data.get("criteria_scores", {}),
+                    criteria_scores=data.get("criteria_scores") or {},
                 )
 
                 # Add to results
@@ -397,7 +397,7 @@ def rejudge_missing_runs(
                         run.judge_passed = judge_result.passed
                         run.judge_grade = judge_result.grade
                         run.judge_reasoning = judge_result.reasoning
-                        run.criteria_scores = judge_result.criteria_scores
+                        run.criteria_scores = judge_result.criteria_scores or {}
 
                         # Save updated run_result.json
                         with open(run_result_file, "w") as f:

--- a/scylla/e2e/rerun.py
+++ b/scylla/e2e/rerun.py
@@ -737,7 +737,7 @@ def rerun_experiment(
                         "workspace_path": str(run_info.run_dir / "workspace"),
                         "logs_path": str(run_info.run_dir / "agent"),
                         "command_log_path": str(run_info.run_dir / "agent" / "command_log.json"),
-                        "criteria_scores": judge_result.get("criteria_scores", {}),
+                        "criteria_scores": judge_result.get("criteria_scores") or {},
                     }
 
                     # Save run_result.json

--- a/scylla/e2e/rerun_judges.py
+++ b/scylla/e2e/rerun_judges.py
@@ -604,6 +604,7 @@ def _regenerate_consensus(run_dir: Path, judge_models: list[str]) -> bool:
             run_data["judge_passed"] = passed
             run_data["judge_grade"] = grade
             run_data["judge_reasoning"] = representative_reasoning
+            run_data["criteria_scores"] = representative_criteria or {}
             with open(run_result_file, "w") as f:
                 json.dump(run_data, f, indent=2)
         except Exception as e:

--- a/scylla/e2e/subtest_executor.py
+++ b/scylla/e2e/subtest_executor.py
@@ -357,7 +357,7 @@ class SubTestExecutor:
                                 if report_data.get("command_log_path")
                                 else None
                             ),
-                            criteria_scores=report_data.get("criteria_scores", {}),
+                            criteria_scores=report_data.get("criteria_scores") or {},
                             baseline_pipeline_summary=report_data.get("baseline_pipeline_summary"),
                         )
                         runs.append(run_result)
@@ -855,7 +855,7 @@ class SubTestExecutor:
             workspace_path=workspace,
             logs_path=agent_dir,  # Points to agent/ subdirectory
             command_log_path=agent_dir / "command_log.json",
-            criteria_scores=judgment.get("criteria_scores", {}),
+            criteria_scores=judgment.get("criteria_scores") or {},
             baseline_pipeline_summary=baseline_summary,
         )
 

--- a/tests/unit/e2e/test_models.py
+++ b/tests/unit/e2e/test_models.py
@@ -218,6 +218,76 @@ class TestE2ERunResult:
         assert result.tokens_input == 1000
         assert result.tokens_output == 200
 
+    def test_criteria_scores_coerces_none_to_empty_dict(self) -> None:
+        """Test that criteria_scores=None is coerced to {} by the Pydantic validator."""
+        from scylla.e2e.models import TokenStats
+
+        result = E2ERunResult(
+            run_number=1,
+            exit_code=0,
+            token_stats=TokenStats(input_tokens=0, output_tokens=0),
+            cost_usd=0.0,
+            duration_seconds=0.0,
+            agent_duration_seconds=0.0,
+            judge_duration_seconds=0.0,
+            judge_score=0.0,
+            judge_passed=False,
+            judge_grade="F",
+            judge_reasoning="",
+            workspace_path=Path("/workspace"),
+            logs_path=Path("/logs"),
+            criteria_scores=None,  # type: ignore[arg-type]
+        )
+
+        assert result.criteria_scores == {}
+
+    def test_criteria_scores_accepts_empty_dict(self) -> None:
+        """Test that criteria_scores={} is accepted without modification."""
+        from scylla.e2e.models import TokenStats
+
+        result = E2ERunResult(
+            run_number=1,
+            exit_code=0,
+            token_stats=TokenStats(input_tokens=0, output_tokens=0),
+            cost_usd=0.0,
+            duration_seconds=0.0,
+            agent_duration_seconds=0.0,
+            judge_duration_seconds=0.0,
+            judge_score=0.0,
+            judge_passed=False,
+            judge_grade="F",
+            judge_reasoning="",
+            workspace_path=Path("/workspace"),
+            logs_path=Path("/logs"),
+            criteria_scores={},
+        )
+
+        assert result.criteria_scores == {}
+
+    def test_criteria_scores_accepts_populated_dict(self) -> None:
+        """Test that a populated criteria_scores dict is preserved."""
+        from scylla.e2e.models import TokenStats
+
+        scores = {"accuracy": {"score": 0.9, "explanation": "Good"}}
+        result = E2ERunResult(
+            run_number=1,
+            exit_code=0,
+            token_stats=TokenStats(input_tokens=0, output_tokens=0),
+            cost_usd=0.0,
+            duration_seconds=0.0,
+            agent_duration_seconds=0.0,
+            judge_duration_seconds=0.0,
+            judge_score=0.9,
+            judge_passed=True,
+            judge_grade="A",
+            judge_reasoning="Good work",
+            workspace_path=Path("/workspace"),
+            logs_path=Path("/logs"),
+            criteria_scores=scores,
+        )
+
+        assert result.criteria_scores == scores
+
 
 class TestSubTestResult:
     """Tests for SubTestResult."""


### PR DESCRIPTION
## Summary

Fixes a type mismatch where `JudgeResult`/`JudgeResultSummary` type `criteria_scores` as `Optional[dict]` (can be `None`), but `E2ERunResult` types it as `dict` (non-Optional). When `None` flows into `E2ERunResult` construction, Pydantic raises a `ValidationError` that causes silent test failures ($0 cost, 8-22s duration, zero tokens).

Root cause: `dict.get("criteria_scores", {})` returns the default `{}` only when the **key is absent**, but returns `None` when the key exists with value `None` — exactly the case in checkpoint/resume and consensus data.

## Changes

| File | Fix |
|------|-----|
| `scylla/e2e/models.py` | Add `field_validator` to coerce `None → {}` on `E2ERunResult` (defense-in-depth) |
| `scylla/e2e/subtest_executor.py:360` | `.get("criteria_scores", {})` → `or {}` (checkpoint resume) |
| `scylla/e2e/subtest_executor.py:858` | `.get("criteria_scores", {})` → `or {}` (consensus dict) |
| `scylla/e2e/regenerate.py:210` | `.get("criteria_scores", {})` → `or {}` (stored data) |
| `scylla/e2e/regenerate.py:400` | Direct `None` assignment guarded with `or {}` |
| `scylla/e2e/rerun.py:740` | `.get("criteria_scores", {})` → `or {}` |
| `scylla/e2e/judge_runner.py:246,249` | `primary_criteria_scores` can be `None` → guarded with `or {}` |
| `scylla/e2e/rerun_judges.py:606` | Add missing `criteria_scores` write to `run_result.json` |
| `tests/unit/e2e/test_models.py` | 3 new tests: coerce None, accept {}, accept populated dict |
| `tests/unit/e2e/test_subtest_executor.py` | 2 new tests: null in checkpoint data, missing key |
| `tests/unit/e2e/test_rerun_judges.py` | 2 new tests: criteria_scores written, None → {} |

## Test plan

- [x] `pixi run python -m pytest tests/unit/e2e/test_models.py tests/unit/e2e/test_subtest_executor.py tests/unit/e2e/test_rerun_judges.py -v` — 71 tests pass
- [x] `pre-commit run --all-files` — all hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)