### PR TITLE
feat(core): add runtime DeprecationWarning to BaseExecutionInfo

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,6 +24,24 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Track deprecated BaseExecutionInfo usage
+        run: |
+          count=$(grep -rn "BaseExecutionInfo" . \
+            --include="*.py" \
+            --exclude-dir=".pixi" \
+            | grep -v "scylla/core/results.py" \
+            | grep -v "# deprecated" \
+            | grep -v "test_results.py" \
+            | wc -l)
+          echo "BaseExecutionInfo usage count (excluding definition and tests): $count"
+          if [ "$count" -gt "0" ]; then
+            echo "::warning::Found $count usages of deprecated BaseExecutionInfo"
+            grep -rn "BaseExecutionInfo" . --include="*.py" --exclude-dir=".pixi" \
+              | grep -v "scylla/core/results.py" \
+              | grep -v "# deprecated" \
+              | grep -v "test_results.py"
+          fi
+
       - name: Install pixi
         uses: prefix-dev/setup-pixi@v0.8.1
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,22 @@
+# Changelog
+
+All notable changes to ProjectScylla are documented here.
+Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
+
+## [Unreleased]
+
+### Deprecated
+
+- `BaseExecutionInfo` dataclass in `scylla/core/results.py` is deprecated
+  as of v1.5.0. It will be removed in v2.0.0.
+  **Migration**: Replace all usages with `ExecutionInfoBase` (Pydantic model)
+  or its domain-specific subtypes (`ExecutorExecutionInfo`,
+  `ReportingExecutionInfo`). A runtime `DeprecationWarning` is now emitted
+  on each instantiation. Related: #728, follow-up from #658.
+
+## Migration Timeline
+
+| Version | Action |
+|---------|--------|
+| v1.5.0  | `BaseExecutionInfo` deprecated; `DeprecationWarning` added at runtime |
+| v2.0.0  | `BaseExecutionInfo` removed; only `ExecutionInfoBase` hierarchy remains |

--- a/scylla/core/results.py
+++ b/scylla/core/results.py
@@ -31,6 +31,7 @@ Architecture Notes:
 
 from __future__ import annotations
 
+import warnings
 from dataclasses import dataclass
 
 from pydantic import BaseModel, ConfigDict, Field
@@ -110,6 +111,15 @@ class BaseExecutionInfo:
     exit_code: int
     duration_seconds: float
     timed_out: bool = False
+
+    def __post_init__(self) -> None:
+        """Emit a DeprecationWarning on instantiation."""
+        warnings.warn(
+            "BaseExecutionInfo is deprecated and will be removed in v2.0.0. "
+            "Use ExecutionInfoBase instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
 
 
 @dataclass

--- a/tests/unit/core/test_results.py
+++ b/tests/unit/core/test_results.py
@@ -11,69 +11,79 @@ class TestBaseExecutionInfo:
 
     def test_construction_success(self) -> None:
         """Basic construction with valid parameters."""
-        info = BaseExecutionInfo(
-            exit_code=0,
-            duration_seconds=10.5,
-            timed_out=False,
-        )
+        with pytest.warns(DeprecationWarning, match="BaseExecutionInfo is deprecated"):
+            info = BaseExecutionInfo(
+                exit_code=0,
+                duration_seconds=10.5,
+                timed_out=False,
+            )
         assert info.exit_code == 0
         assert info.duration_seconds == 10.5
         assert info.timed_out is False
 
     def test_construction_failure(self) -> None:
         """Construction with failure exit code."""
-        info = BaseExecutionInfo(
-            exit_code=1,
-            duration_seconds=5.0,
-            timed_out=False,
-        )
+        with pytest.warns(DeprecationWarning, match="BaseExecutionInfo is deprecated"):
+            info = BaseExecutionInfo(
+                exit_code=1,
+                duration_seconds=5.0,
+                timed_out=False,
+            )
         assert info.exit_code == 1
         assert info.duration_seconds == 5.0
 
     def test_construction_timeout(self) -> None:
         """Construction with timeout flag."""
-        info = BaseExecutionInfo(
-            exit_code=124,
-            duration_seconds=30.0,
-            timed_out=True,
-        )
+        with pytest.warns(DeprecationWarning, match="BaseExecutionInfo is deprecated"):
+            info = BaseExecutionInfo(
+                exit_code=124,
+                duration_seconds=30.0,
+                timed_out=True,
+            )
         assert info.exit_code == 124
         assert info.duration_seconds == 30.0
         assert info.timed_out is True
 
     def test_timed_out_default_false(self) -> None:
         """timed_out should default to False if not specified."""
-        info = BaseExecutionInfo(exit_code=0, duration_seconds=1.0)
+        with pytest.warns(DeprecationWarning, match="BaseExecutionInfo is deprecated"):
+            info = BaseExecutionInfo(exit_code=0, duration_seconds=1.0)
         assert info.timed_out is False
 
     def test_negative_exit_code(self) -> None:
         """Support negative exit codes (e.g., killed by signal)."""
-        info = BaseExecutionInfo(
-            exit_code=-9,
-            duration_seconds=2.5,
-        )
+        with pytest.warns(DeprecationWarning, match="BaseExecutionInfo is deprecated"):
+            info = BaseExecutionInfo(
+                exit_code=-9,
+                duration_seconds=2.5,
+            )
         assert info.exit_code == -9
 
     def test_zero_duration(self) -> None:
         """Support zero duration (very fast execution)."""
-        info = BaseExecutionInfo(
-            exit_code=0,
-            duration_seconds=0.0,
-        )
+        with pytest.warns(DeprecationWarning, match="BaseExecutionInfo is deprecated"):
+            info = BaseExecutionInfo(
+                exit_code=0,
+                duration_seconds=0.0,
+            )
         assert info.duration_seconds == 0.0
 
     def test_equality(self) -> None:
         """Test dataclass equality."""
-        info1 = BaseExecutionInfo(exit_code=0, duration_seconds=10.0, timed_out=False)
-        info2 = BaseExecutionInfo(exit_code=0, duration_seconds=10.0, timed_out=False)
-        info3 = BaseExecutionInfo(exit_code=1, duration_seconds=10.0, timed_out=False)
+        with pytest.warns(DeprecationWarning):
+            info1 = BaseExecutionInfo(exit_code=0, duration_seconds=10.0, timed_out=False)
+        with pytest.warns(DeprecationWarning):
+            info2 = BaseExecutionInfo(exit_code=0, duration_seconds=10.0, timed_out=False)
+        with pytest.warns(DeprecationWarning):
+            info3 = BaseExecutionInfo(exit_code=1, duration_seconds=10.0, timed_out=False)
 
         assert info1 == info2
         assert info1 != info3
 
     def test_repr(self) -> None:
         """Test string representation."""
-        info = BaseExecutionInfo(exit_code=0, duration_seconds=10.5, timed_out=False)
+        with pytest.warns(DeprecationWarning, match="BaseExecutionInfo is deprecated"):
+            info = BaseExecutionInfo(exit_code=0, duration_seconds=10.5, timed_out=False)
         repr_str = repr(info)
         assert "BaseExecutionInfo" in repr_str
         assert "exit_code=0" in repr_str
@@ -152,11 +162,12 @@ class TestComposedTypes:
         # This tests the pattern used in domain-specific types
         duration = 10.5
 
-        execution = BaseExecutionInfo(
-            exit_code=0,
-            duration_seconds=duration,
-            timed_out=False,
-        )
+        with pytest.warns(DeprecationWarning, match="BaseExecutionInfo is deprecated"):
+            execution = BaseExecutionInfo(
+                exit_code=0,
+                duration_seconds=duration,
+                timed_out=False,
+            )
 
         # Verify duration is captured
         assert execution.duration_seconds == duration
@@ -180,11 +191,12 @@ class TestComposedTypes:
         cost = 0.05
         duration = 10.5
 
-        execution = BaseExecutionInfo(
-            exit_code=0,
-            duration_seconds=duration,
-            timed_out=False,
-        )
+        with pytest.warns(DeprecationWarning, match="BaseExecutionInfo is deprecated"):
+            execution = BaseExecutionInfo(
+                exit_code=0,
+                duration_seconds=duration,
+                timed_out=False,
+            )
 
         metrics = BaseRunMetrics(
             tokens_input=1000,
@@ -272,22 +284,24 @@ class TestBaseExecutionInfoBackwardCompatibility:
 
     def test_dataclass_still_works(self) -> None:
         """Test that legacy BaseExecutionInfo dataclass still works."""
-        info = BaseExecutionInfo(
-            exit_code=0,
-            duration_seconds=10.5,
-            timed_out=False,
-        )
+        with pytest.warns(DeprecationWarning, match="BaseExecutionInfo is deprecated"):
+            info = BaseExecutionInfo(
+                exit_code=0,
+                duration_seconds=10.5,
+                timed_out=False,
+            )
         assert info.exit_code == 0
         assert info.duration_seconds == 10.5
         assert info.timed_out is False
 
     def test_dataclass_and_pydantic_have_same_fields(self) -> None:
         """Test that dataclass and Pydantic model have the same core fields."""
-        dataclass_info = BaseExecutionInfo(
-            exit_code=0,
-            duration_seconds=10.5,
-            timed_out=False,
-        )
+        with pytest.warns(DeprecationWarning, match="BaseExecutionInfo is deprecated"):
+            dataclass_info = BaseExecutionInfo(
+                exit_code=0,
+                duration_seconds=10.5,
+                timed_out=False,
+            )
         pydantic_info = ExecutionInfoBase(
             exit_code=0,
             duration_seconds=10.5,
@@ -298,3 +312,11 @@ class TestBaseExecutionInfoBackwardCompatibility:
         assert dataclass_info.exit_code == pydantic_info.exit_code
         assert dataclass_info.duration_seconds == pydantic_info.duration_seconds
         assert dataclass_info.timed_out == pydantic_info.timed_out
+
+    def test_deprecation_warning_emitted(self) -> None:
+        """Test that a DeprecationWarning is emitted on instantiation."""
+        with pytest.warns(
+            DeprecationWarning,
+            match="BaseExecutionInfo is deprecated and will be removed in v2.0.0",
+        ):
+            BaseExecutionInfo(exit_code=0, duration_seconds=1.0)


### PR DESCRIPTION
## Summary

- Add `warnings.warn(DeprecationWarning, stacklevel=2)` in `BaseExecutionInfo.__post_init__` so every instantiation emits a runtime deprecation notice
- Update all `BaseExecutionInfo` test instantiations to use `pytest.warns(DeprecationWarning)`, including a new explicit `test_deprecation_warning_emitted` test
- Add CI step in `.github/workflows/test.yml` to grep and report deprecated class usage (non-blocking `::warning::` annotation)
- Create `CHANGELOG.md` with `### Deprecated` section and v1.5 → v2.0 migration timeline

## Test plan

- [x] `pixi run python -m pytest tests/unit/core/test_results.py -v` — 27 passed
- [x] `pixi run python -m pytest tests/unit/ -v` — 2206 passed
- [x] `pre-commit run --all-files` — all hooks passed

Closes #728