### PR TITLE
feat(config): add validation for tier config filename/tier ID consistency

### DIFF
--- a/scylla/config/loader.py
+++ b/scylla/config/loader.py
@@ -21,7 +21,7 @@ from .models import (
     ScyllaConfig,
     TierConfig,
 )
-from .validation import validate_filename_model_id_consistency
+from .validation import validate_filename_model_id_consistency, validate_filename_tier_consistency
 
 logger = logging.getLogger(__name__)
 
@@ -217,9 +217,16 @@ class ConfigLoader:
             data["tier"] = tier
 
         try:
-            return TierConfig(**data)
+            config = TierConfig(**data)
         except Exception as e:
             raise ConfigurationError(f"Invalid tier configuration in {tier_path}: {e}")
+
+        # Validate filename/tier consistency
+        warnings = validate_filename_tier_consistency(tier_path, config.tier)
+        for warning in warnings:
+            logger.warning(warning)
+
+        return config
 
     def load_all_tiers(self) -> dict[str, TierConfig]:
         """Load all available tier configurations.

--- a/scylla/config/validation.py
+++ b/scylla/config/validation.py
@@ -59,3 +59,34 @@ def validate_filename_model_id_consistency(config_path: Path, model_id: str) -> 
     )
 
     return warnings
+
+
+def validate_filename_tier_consistency(config_path: Path, tier: str) -> list[str]:
+    """Validate that config filename matches the tier field.
+
+    Args:
+        config_path: Path to config file
+        tier: tier field from config (e.g., 't0')
+
+    Returns:
+        List of warning messages (empty if valid)
+
+    """
+    warnings = []
+    filename_stem = config_path.stem
+
+    # Skip validation for test fixtures (prefixed with _)
+    if filename_stem.startswith("_"):
+        return warnings
+
+    # Check exact match
+    if filename_stem == tier:
+        return warnings
+
+    # Mismatch detected
+    warnings.append(
+        f"Config filename '{filename_stem}.yaml' does not match tier "
+        f"'{tier}'. Expected '{tier}.yaml'"
+    )
+
+    return warnings


### PR DESCRIPTION
## Summary

- Add `validate_filename_tier_consistency()` to `scylla/config/validation.py` — mirrors the model config pattern from #692
- Call validation in `ConfigLoader.load_tier()` after constructing `TierConfig` — emits `logger.warning()` on mismatch, load still succeeds
- Add `TestFilenameTierConsistency` test class with 4 tests (exact match, mismatch warn, fixture skip, message format)

## Test plan

- [x] `test_filename_matches_tier_exact` — `t0.yaml` with `tier: t0` → no warnings
- [x] `test_filename_mismatch_warns` — `t0.yaml` with `tier: t1` → 1 warning containing both values
- [x] `test_test_fixtures_skip_validation` — `_test-fixture.yaml` → no warnings
- [x] `test_warning_message_format` — asserts exact message text contains filename and tier field
- [x] Full test suite: 2213 passed, coverage 73.38% ✓

Closes #733

🤖 Generated with [Claude Code](https://claude.com/claude-code)