### PR TITLE
feat(skills): Add config-filename-validation skill

### DIFF
--- a/.claude-plugin/skills/config-filename-validation/SKILL.md
+++ b/.claude-plugin/skills/config-filename-validation/SKILL.md
@@ -1,0 +1,156 @@
+# Skill: Config Filename/ID Validation Pattern
+
+## Overview
+
+| Field | Value |
+|-------|-------|
+| Date | 2026-02-19 |
+| Issue | #733 (follow-up to #692) |
+| PR | #795 |
+| Objective | Add validation that tier config filenames match their `tier` field |
+| Outcome | Success — 2213 tests pass, 73.38% coverage |
+| Category | testing |
+
+## When to Use
+
+Apply this pattern when:
+
+- A config dataclass has an ID/key field that should match its filename
+- You want to catch silent mismatches between filename and config content
+- You're adding a new config type that follows the same load/validate pattern
+- A follow-up issue asks to mirror an existing validation pattern to a new config type
+
+Trigger conditions:
+
+- "filename should match the X field"
+- "prevent filename/ID mismatch"
+- "consistent validation across all config types"
+- "mirror the model config pattern"
+
+## Verified Workflow
+
+### 1. Add validation function to `scylla/config/validation.py`
+
+For simple exact-match validation (no normalization needed):
+
+```python
+def validate_filename_tier_consistency(config_path: Path, tier: str) -> list[str]:
+    """Validate that config filename matches the tier field."""
+    warnings = []
+    filename_stem = config_path.stem
+
+    # Skip validation for test fixtures (prefixed with _)
+    if filename_stem.startswith("_"):
+        return warnings
+
+    # Check exact match
+    if filename_stem == tier:
+        return warnings
+
+    # Mismatch detected
+    warnings.append(
+        f"Config filename '{filename_stem}.yaml' does not match tier "
+        f"'{tier}'. Expected '{tier}.yaml'"
+    )
+    return warnings
+```
+
+For IDs requiring normalization (e.g., `:` → `-` for model IDs), see
+`validate_filename_model_id_consistency` — adds a `get_expected_filename()` helper
+and checks both exact and normalized match.
+
+### 2. Call validation in the loader after constructing the dataclass
+
+In `scylla/config/loader.py`, update the relevant `load_X()` method:
+
+```python
+from .validation import validate_filename_model_id_consistency, validate_filename_tier_consistency
+
+# After constructing the config object:
+try:
+    config = TierConfig(**data)
+except Exception as e:
+    raise ConfigurationError(f"Invalid tier configuration in {tier_path}: {e}")
+
+# Validate filename/tier consistency
+warnings = validate_filename_tier_consistency(tier_path, config.tier)
+for warning in warnings:
+    logger.warning(warning)
+
+return config
+```
+
+Key decisions:
+
+- **Warning, not error** — load succeeds even with mismatch (matches existing model config behavior)
+- **After dataclass construction** — validate the actual field value, not raw YAML data
+- **Use `config.tier` not `data["tier"]`** — field may have been normalized by validators
+
+### 3. Write 4 test cases in `TestFilenameTierConsistency`
+
+```python
+class TestFilenameTierConsistency:
+    def test_filename_matches_tier_exact(self, tmp_path, caplog):
+        # exact match → no warnings
+
+    def test_filename_mismatch_warns(self, tmp_path, caplog):
+        # mismatch → 1 warning containing filename, tier field, expected filename
+
+    def test_test_fixtures_skip_validation(self, tmp_path):
+        # _-prefixed filename → import validation fn directly, no loader call needed
+        from scylla.config.validation import validate_filename_tier_consistency
+        config_path = tmp_path / "_test-fixture.yaml"
+        warnings = validate_filename_tier_consistency(config_path, "t0")
+        assert not warnings
+
+    def test_warning_message_format(self, tmp_path, caplog):
+        # assert exact message text contains filename and tier field
+```
+
+## Failed Attempts
+
+### Fixture test via loader with `_`-prefixed tier name
+
+**Attempted:** `loader.load_tier("_test-fixture")` — mirroring how model fixture test uses `load_model("_test-fixture")`
+
+**Why it failed:** `load_tier()` normalizes the tier name:
+
+```python
+tier = tier.lower().strip()
+if not tier.startswith("t"):
+    tier = f"t{tier}"  # "_test-fixture" → "t_test-fixture"
+```
+
+So it would look for `t_test-fixture.yaml` (not found) rather than `_test-fixture.yaml`.
+
+**Fix:** Test the validation function directly instead of going through the loader. Import `validate_filename_tier_consistency` and call it with a manually constructed path.
+
+### Pre-commit hook formatting failure
+
+Ruff reformatted `tests/unit/test_config_loader.py` on first commit attempt. The pre-commit hook modifies files in place but the commit still fails. Re-stage and commit again — the second commit succeeds.
+
+## Results & Parameters
+
+### Files modified
+
+| File | Change |
+|------|--------|
+| `scylla/config/validation.py` | Added `validate_filename_tier_consistency()` (+31 lines) |
+| `scylla/config/loader.py` | Import + 7 lines in `load_tier()` |
+| `tests/unit/test_config_loader.py` | Added `TestFilenameTierConsistency` class (+84 lines) |
+
+### Test results
+
+```
+2213 passed, 8 warnings
+Coverage: 73.38% (threshold: 73%)
+```
+
+### Pattern applicability
+
+This exact pattern (validation function + loader call + 4 tests) can be applied to any
+new config type with a filename-matching field. The only variation needed:
+
+- If the ID has special characters (like `:`), add a normalization helper
+- If the loader normalizes the ID before building the path, test the validation function
+  directly for the `_`-prefix fixture case

--- a/.claude-plugin/skills/config-filename-validation/references/notes.md
+++ b/.claude-plugin/skills/config-filename-validation/references/notes.md
@@ -1,0 +1,52 @@
+# Raw Session Notes: config-filename-validation
+
+## Session Context
+
+- **Date**: 2026-02-19
+- **Issue**: #733 — Add validation for tier config filename/tier ID consistency
+- **Branch**: `733-auto-impl`
+- **PR**: #795
+
+## Problem Statement
+
+Issue #692 added validation that model config filenames match their `model_id` field.
+Issue #733 asked to mirror that same pattern for tier configs (`config/tiers/*.yaml`),
+where the `tier` field (e.g., `t0`) should match the filename stem (e.g., `t0.yaml`).
+
+## Key Architectural Observations
+
+1. **Validation is separate from loading** — `scylla/config/validation.py` holds pure
+   validation functions that return `list[str]` of warnings. The loader calls them after
+   constructing the dataclass.
+
+2. **Warning-based** — mismatches log a warning but don't fail the load. This avoids
+   breaking changes and matches the established model config pattern.
+
+3. **Tier validation is simpler than model validation** — model IDs can contain `:` which
+   must be normalized to `-` for filenames. Tier IDs (`t0`–`t6`) are simple strings with
+   no special character normalization needed.
+
+4. **`TierConfig` has a field validator** — `validate_tier_format` enforces `t0`–`t6`
+   format. This means the `tier` field in the config can't be arbitrary — it must match
+   the pattern. This is why the fixture test case (which would use a `_`-prefixed file)
+   can't pass an invalid tier like `t99` through the loader; we test the validation
+   function directly instead.
+
+## Loader Normalization Gotcha
+
+`load_tier()` normalizes input:
+
+```python
+tier = tier.lower().strip()
+if not tier.startswith("t"):
+    tier = f"t{tier}"
+```
+
+This means calling `load_tier("_test-fixture")` would look for `t_test-fixture.yaml`
+because `_` is not `t`. The model loader has no such normalization, which is why the
+model fixture test works with `load_model("_test-fixture")` directly.
+
+## Commit Workflow Note
+
+Pre-commit hook (ruff-format) modifies files in place on first run. This causes the
+commit to fail. Solution: re-stage modified files and commit again. Never use `--no-verify`.


### PR DESCRIPTION
## Summary

Captures session learnings from issue #733 as a reusable skill plugin.

- **Skill**: `config-filename-validation` (category: testing)
- **Files**:
  - `.claude-plugin/skills/config-filename-validation/SKILL.md` — verified workflow, failed attempts, pattern applicability
  - `.claude-plugin/skills/config-filename-validation/references/notes.md` — raw session notes
  - `.claude-plugin/plugin.json` — skill registered

## What's Captured

- Pattern for adding filename/ID consistency validation to config loaders
- 3-step verified workflow: validation function → loader call → 4 test cases
- Key failure: `load_tier("_test-fixture")` normalizes to `t_test-fixture` — must test validation function directly for `_`-prefixed fixture case
- Pre-commit ruff-format re-stage workflow

## Test plan

- [x] Skill files created and formatted (markdownlint passes)
- [x] plugin.json updated with triggers and metadata
- [x] Commit passes all pre-commit hooks

🤖 Generated with [Claude Code](https://claude.com/claude-code)