### PR TITLE
fix(docs): Update CLAUDE.md 'Current Status' to reflect operational state

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,8 +8,8 @@ ProjectScylla is an AI agent testing and optimization framework designed to meas
 the performance and cost-efficiency of agentic AI workflows. Named after the mythic trial from Homer's Odyssey,
 Scylla represents the challenge of navigating trade-offs between capability gains and operational costs.
 
-**Current Status**: Research and planning phase - establishing benchmarking methodology, metrics definitions,
-and evaluation protocols before implementation begins.
+**Current Status**: Operational - active research with full evaluation infrastructure, running T0–T6 ablation
+studies across 120+ YAML subtests with published results and 73%+ test coverage enforced in CI.
 
 **Ecosystem Context**: Part of a three-project ecosystem:
 


### PR DESCRIPTION
## Summary

- Updated `CLAUDE.md` line 11 to replace the inaccurate "Research and planning phase" status with an accurate description of the project's operational state

## Changes

The old status falsely implied implementation hadn't begun:
> "Research and planning phase - establishing benchmarking methodology, metrics definitions, and evaluation protocols before implementation begins."

The new status reflects reality:
> "Operational - active research with full evaluation infrastructure, running T0–T6 ablation studies across 120+ YAML subtests with published results and 73%+ test coverage enforced in CI."

## Test plan

- [ ] No functional code changed — documentation-only fix
- [ ] Markdown lint passes (verified via pre-commit hooks)

Closes #753