### PR TITLE
feat(adapters): Add GooseAdapter for Goose CLI integration

### DIFF
--- a/config/models/goose.yaml
+++ b/config/models/goose.yaml
@@ -1,0 +1,16 @@
+# Goose Agent Model Configuration
+model_id: "goose"
+name: "Goose"
+provider: "block"
+adapter: "goose"
+temperature: 0.0
+max_tokens: 8192
+
+# Pricing: Goose delegates to underlying LLM; use 0.0 as default
+# Override per-run via env vars or extra_args for actual model pricing
+cost_per_1k_input: 0.0
+cost_per_1k_output: 0.0
+
+# Optional overrides (null uses defaults)
+timeout_seconds: null
+max_cost_usd: null

--- a/scylla/adapters/__init__.py
+++ b/scylla/adapters/__init__.py
@@ -15,6 +15,7 @@ from scylla.adapters.base import (
 from scylla.adapters.base_cli import BaseCliAdapter
 from scylla.adapters.claude_code import ClaudeCodeAdapter
 from scylla.adapters.cline import ClineAdapter
+from scylla.adapters.goose import GooseAdapter
 from scylla.adapters.openai_codex import OpenAICodexAdapter
 from scylla.adapters.opencode import OpenCodeAdapter
 
@@ -28,6 +29,7 @@ __all__ = [
     "BaseCliAdapter",
     "ClaudeCodeAdapter",
     "ClineAdapter",
+    "GooseAdapter",
     "OpenAICodexAdapter",
     "OpenCodeAdapter",
 ]

--- a/scylla/adapters/goose.py
+++ b/scylla/adapters/goose.py
@@ -1,0 +1,133 @@
+"""Goose CLI adapter.
+
+This module provides an adapter for running the Goose CLI
+within the Scylla evaluation framework.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import TYPE_CHECKING
+
+from scylla.adapters.base import AdapterConfig
+from scylla.adapters.base_cli import BaseCliAdapter
+
+if TYPE_CHECKING:
+    from scylla.executor.tier_config import TierConfig
+
+
+class GooseAdapter(BaseCliAdapter):
+    """Adapter for Goose CLI.
+
+    Executes the Goose CLI with the specified configuration and
+    captures output, token counts, and metrics.
+
+    Example:
+        >>> adapter = GooseAdapter()
+        >>> config = AdapterConfig(
+        ...     model="claude-sonnet-4-5-20250929",
+        ...     prompt_file=Path("prompt.md"),
+        ...     workspace=Path("/workspace"),
+        ...     output_dir=Path("/output"),
+        ... )
+        >>> result = adapter.run(config)
+        >>> print(f"Exit code: {result.exit_code}")
+
+    """
+
+    # Goose CLI executable
+    CLI_EXECUTABLE = "goose"
+
+    # Fallback pattern for API call detection (Goose uses ◆ for tool calls)
+    _api_call_fallback_pattern = r"(?:calling tool|tool result|◆)"
+
+    def _build_command(
+        self,
+        config: AdapterConfig,
+        prompt: str,
+        tier_config: TierConfig | None,
+    ) -> list[str]:
+        """Build the Goose CLI command.
+
+        Args:
+            config: Adapter configuration.
+            prompt: The prompt to send (with tier injection if applicable).
+            tier_config: Tier configuration for tool/delegation settings.
+
+        Returns:
+            Command as list of strings.
+
+        """
+        cmd = [
+            self.CLI_EXECUTABLE,
+            "run",
+            "--text",
+            prompt,
+        ]
+
+        # Apply tier settings
+        tier_settings = self.get_tier_settings(tier_config)
+
+        # Disable toolkits if explicitly set to False
+        if tier_settings["tools_enabled"] is False:
+            cmd.append("--disable-toolkits")
+
+        # Add extra arguments from config
+        if config.extra_args:
+            cmd.extend(config.extra_args)
+
+        return cmd
+
+    def _parse_token_counts(self, stdout: str, stderr: str) -> tuple[int, int]:
+        """Parse token counts from Goose output.
+
+        Looks for patterns like:
+        - "Input tokens: N"
+        - "Output tokens: M"
+        - "Tokens used: N input, M output"
+        - "N input, M output"
+        - "(N input, M output)"
+
+        Args:
+            stdout: Standard output from CLI.
+            stderr: Standard error from CLI.
+
+        Returns:
+            Tuple of (input_tokens, output_tokens).
+
+        """
+        combined = stdout + "\n" + stderr
+        input_tokens = 0
+        output_tokens = 0
+
+        # Pattern: "Input tokens: N" or "input: N tokens"
+        input_match = re.search(r"input\s*(?:tokens?)?:?\s*(\d+)", combined, re.IGNORECASE)
+        if input_match:
+            input_tokens = int(input_match.group(1))
+
+        # Pattern: "Output tokens: N" or "output: N tokens"
+        output_match = re.search(r"output\s*(?:tokens?)?:?\s*(\d+)", combined, re.IGNORECASE)
+        if output_match:
+            output_tokens = int(output_match.group(1))
+
+        # Pattern: "N input, M output" or similar
+        combined_match = re.search(
+            r"(\d+)\s*(?:input|in)\s*[,/]\s*(\d+)\s*(?:output|out)",
+            combined,
+            re.IGNORECASE,
+        )
+        if combined_match:
+            input_tokens = int(combined_match.group(1))
+            output_tokens = int(combined_match.group(2))
+
+        # Pattern: "Total: N tokens (X input, Y output)"
+        total_match = re.search(
+            r"\((\d+)\s*input,\s*(\d+)\s*output\)",
+            combined,
+            re.IGNORECASE,
+        )
+        if total_match:
+            input_tokens = int(total_match.group(1))
+            output_tokens = int(total_match.group(2))
+
+        return input_tokens, output_tokens

--- a/tests/unit/adapters/test_goose.py
+++ b/tests/unit/adapters/test_goose.py
@@ -1,0 +1,425 @@
+"""Tests for Goose CLI adapter."""
+
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from scylla.adapters.base import AdapterConfig, AdapterError
+from scylla.adapters.goose import GooseAdapter
+
+
+class TestGooseAdapter:
+    """Tests for GooseAdapter class."""
+
+    def test_get_name(self) -> None:
+        """Test adapter name."""
+        adapter = GooseAdapter()
+        assert adapter.get_name() == "GooseAdapter"
+
+    def test_cli_executable(self) -> None:
+        """Test CLI executable constant."""
+        assert GooseAdapter.CLI_EXECUTABLE == "goose"
+
+
+class TestBuildCommand:
+    """Tests for command building."""
+
+    def test_basic_command(self) -> None:
+        """Test basic command structure."""
+        with TemporaryDirectory() as tmpdir:
+            tmppath = Path(tmpdir)
+            prompt_file = tmppath / "prompt.md"
+            prompt_file.write_text("Test prompt")
+
+            adapter = GooseAdapter()
+            config = AdapterConfig(
+                model="claude-sonnet-4-5-20250929",
+                prompt_file=prompt_file,
+                workspace=tmppath,
+                output_dir=tmppath,
+            )
+
+            cmd = adapter._build_command(config, "Test prompt", None)
+
+            assert cmd[0] == "goose"
+            assert "run" in cmd
+            assert "--text" in cmd
+            assert "Test prompt" in cmd
+
+    def test_command_with_tools_disabled(self) -> None:
+        """Test command with tools disabled."""
+        with TemporaryDirectory() as tmpdir:
+            tmppath = Path(tmpdir)
+            prompt_file = tmppath / "prompt.md"
+            prompt_file.write_text("Test prompt")
+
+            adapter = GooseAdapter()
+            config = AdapterConfig(
+                model="claude-sonnet-4-5-20250929",
+                prompt_file=prompt_file,
+                workspace=tmppath,
+                output_dir=tmppath,
+            )
+
+            tier_config = MagicMock()
+            tier_config.tools_enabled = False
+            tier_config.delegation_enabled = None
+
+            cmd = adapter._build_command(config, "Test prompt", tier_config)
+
+            assert "--disable-toolkits" in cmd
+
+    def test_command_with_extra_args(self) -> None:
+        """Test command with extra arguments."""
+        with TemporaryDirectory() as tmpdir:
+            tmppath = Path(tmpdir)
+            prompt_file = tmppath / "prompt.md"
+            prompt_file.write_text("Test prompt")
+
+            adapter = GooseAdapter()
+            config = AdapterConfig(
+                model="claude-sonnet-4-5-20250929",
+                prompt_file=prompt_file,
+                workspace=tmppath,
+                output_dir=tmppath,
+                extra_args=["--verbose", "--debug"],
+            )
+
+            cmd = adapter._build_command(config, "Test prompt", None)
+
+            assert "--verbose" in cmd
+            assert "--debug" in cmd
+
+
+class TestParseTokenCounts:
+    """Tests for token count parsing."""
+
+    def test_parse_input_tokens_pattern(self) -> None:
+        """Test parsing 'Input tokens: N' pattern."""
+        adapter = GooseAdapter()
+        stdout = "Input tokens: 1234\nOutput tokens: 567"
+        stderr = ""
+
+        tokens_in, tokens_out = adapter._parse_token_counts(stdout, stderr)
+
+        assert tokens_in == 1234
+        assert tokens_out == 567
+
+    def test_parse_combined_pattern(self) -> None:
+        """Test parsing 'N input, M output' pattern."""
+        adapter = GooseAdapter()
+        stdout = "Used 1000 input, 500 output tokens"
+        stderr = ""
+
+        tokens_in, tokens_out = adapter._parse_token_counts(stdout, stderr)
+
+        assert tokens_in == 1000
+        assert tokens_out == 500
+
+    def test_parse_parenthetical_pattern(self) -> None:
+        """Test parsing '(N input, M output)' pattern."""
+        adapter = GooseAdapter()
+        stdout = "Total: 1500 tokens (1000 input, 500 output)"
+        stderr = ""
+
+        tokens_in, tokens_out = adapter._parse_token_counts(stdout, stderr)
+
+        assert tokens_in == 1000
+        assert tokens_out == 500
+
+    def test_parse_from_stderr(self) -> None:
+        """Test parsing from stderr."""
+        adapter = GooseAdapter()
+        stdout = ""
+        stderr = "Input: 100\nOutput: 50"
+
+        tokens_in, tokens_out = adapter._parse_token_counts(stdout, stderr)
+
+        assert tokens_in == 100
+        assert tokens_out == 50
+
+    def test_parse_no_tokens(self) -> None:
+        """Test parsing with no token information."""
+        adapter = GooseAdapter()
+        stdout = "Just some output"
+        stderr = ""
+
+        tokens_in, tokens_out = adapter._parse_token_counts(stdout, stderr)
+
+        assert tokens_in == 0
+        assert tokens_out == 0
+
+
+class TestParseApiCalls:
+    """Tests for API call count parsing."""
+
+    def test_parse_api_calls_pattern(self) -> None:
+        """Test parsing 'API calls: N' pattern."""
+        adapter = GooseAdapter()
+        stdout = "API calls: 3"
+        stderr = ""
+
+        count = adapter._parse_api_calls(stdout, stderr)
+
+        assert count == 3
+
+    def test_parse_tool_markers(self) -> None:
+        """Test counting Goose tool call markers."""
+        adapter = GooseAdapter()
+        stdout = "calling tool foo\ntool result bar\ncalling tool baz"
+        stderr = ""
+
+        count = adapter._parse_api_calls(stdout, stderr)
+
+        assert count == 3
+
+    def test_parse_meaningful_output(self) -> None:
+        """Test default count for meaningful output."""
+        adapter = GooseAdapter()
+        stdout = "A" * 200
+        stderr = ""
+
+        count = adapter._parse_api_calls(stdout, stderr)
+
+        assert count == 1
+
+    def test_parse_empty_output(self) -> None:
+        """Test zero count for empty output."""
+        adapter = GooseAdapter()
+        stdout = ""
+        stderr = ""
+
+        count = adapter._parse_api_calls(stdout, stderr)
+
+        assert count == 0
+
+
+class TestPrepareEnv:
+    """Tests for environment preparation."""
+
+    def test_prepare_env_inherits_current(self) -> None:
+        """Test that env inherits current environment."""
+        with TemporaryDirectory() as tmpdir:
+            tmppath = Path(tmpdir)
+
+            adapter = GooseAdapter()
+            config = AdapterConfig(
+                model="test",
+                prompt_file=tmppath / "prompt.md",
+                workspace=tmppath,
+                output_dir=tmppath,
+                env_vars={},
+            )
+
+            env = adapter._prepare_env(config)
+
+            assert len(env) > 0
+
+    def test_prepare_env_adds_custom_vars(self) -> None:
+        """Test that custom env vars are added."""
+        with TemporaryDirectory() as tmpdir:
+            tmppath = Path(tmpdir)
+
+            adapter = GooseAdapter()
+            config = AdapterConfig(
+                model="test",
+                prompt_file=tmppath / "prompt.md",
+                workspace=tmppath,
+                output_dir=tmppath,
+                env_vars={"GOOSE_MODEL": "claude-sonnet-4-5"},
+            )
+
+            env = adapter._prepare_env(config)
+
+            assert env["GOOSE_MODEL"] == "claude-sonnet-4-5"
+
+
+class TestRun:
+    """Tests for run method."""
+
+    def test_run_success(self) -> None:
+        """Test successful execution."""
+        with TemporaryDirectory() as tmpdir:
+            tmppath = Path(tmpdir)
+            prompt_file = tmppath / "prompt.md"
+            prompt_file.write_text("Test prompt")
+
+            adapter = GooseAdapter()
+            config = AdapterConfig(
+                model="claude-sonnet-4-5-20250929",
+                prompt_file=prompt_file,
+                workspace=tmppath,
+                output_dir=tmppath,
+            )
+
+            mock_result = MagicMock()
+            mock_result.returncode = 0
+            mock_result.stdout = "Success\nInput tokens: 100\nOutput tokens: 50"
+            mock_result.stderr = ""
+
+            with patch("subprocess.run", return_value=mock_result):
+                result = adapter.run(config)
+
+            assert result.exit_code == 0
+            assert result.tokens_input == 100
+            assert result.tokens_output == 50
+            assert result.timed_out is False
+
+    def test_run_with_tier_config(self) -> None:
+        """Test execution with tier configuration."""
+        with TemporaryDirectory() as tmpdir:
+            tmppath = Path(tmpdir)
+            prompt_file = tmppath / "prompt.md"
+            prompt_file.write_text("Test prompt")
+
+            adapter = GooseAdapter()
+            config = AdapterConfig(
+                model="claude-sonnet-4-5-20250929",
+                prompt_file=prompt_file,
+                workspace=tmppath,
+                output_dir=tmppath,
+            )
+
+            tier_config = MagicMock()
+            tier_config.tier_id = "T1"
+            tier_config.tools_enabled = False
+            tier_config.delegation_enabled = None
+
+            mock_result = MagicMock()
+            mock_result.returncode = 0
+            mock_result.stdout = "Success"
+            mock_result.stderr = ""
+
+            with patch("subprocess.run", return_value=mock_result) as mock_run:
+                adapter.run(config, tier_config)
+
+            call_args = mock_run.call_args
+            cmd = call_args[0][0]
+            assert "--disable-toolkits" in cmd
+
+    def test_run_timeout(self) -> None:
+        """Test execution timeout."""
+        import subprocess
+
+        with TemporaryDirectory() as tmpdir:
+            tmppath = Path(tmpdir)
+            prompt_file = tmppath / "prompt.md"
+            prompt_file.write_text("Test prompt")
+
+            adapter = GooseAdapter()
+            config = AdapterConfig(
+                model="claude-sonnet-4-5-20250929",
+                prompt_file=prompt_file,
+                workspace=tmppath,
+                output_dir=tmppath,
+                timeout=30,
+            )
+
+            timeout_error = subprocess.TimeoutExpired(
+                cmd=["goose"],
+                timeout=30,
+                output=b"partial",
+                stderr=b"error",
+            )
+
+            with patch("subprocess.run", side_effect=timeout_error):
+                result = adapter.run(config)
+
+            assert result.exit_code == -1
+            assert result.timed_out is True
+            assert "timed out" in result.error_message.lower()
+
+    def test_run_cli_not_found(self) -> None:
+        """Test CLI not found error."""
+        with TemporaryDirectory() as tmpdir:
+            tmppath = Path(tmpdir)
+            prompt_file = tmppath / "prompt.md"
+            prompt_file.write_text("Test prompt")
+
+            adapter = GooseAdapter()
+            config = AdapterConfig(
+                model="claude-sonnet-4-5-20250929",
+                prompt_file=prompt_file,
+                workspace=tmppath,
+                output_dir=tmppath,
+            )
+
+            with patch("subprocess.run", side_effect=FileNotFoundError()):
+                with pytest.raises(AdapterError, match="CLI not found"):
+                    adapter.run(config)
+
+    def test_run_writes_logs(self) -> None:
+        """Test that logs are written on success."""
+        with TemporaryDirectory() as tmpdir:
+            tmppath = Path(tmpdir)
+            prompt_file = tmppath / "prompt.md"
+            prompt_file.write_text("Test prompt")
+
+            adapter = GooseAdapter()
+            config = AdapterConfig(
+                model="claude-sonnet-4-5-20250929",
+                prompt_file=prompt_file,
+                workspace=tmppath,
+                output_dir=tmppath,
+            )
+
+            mock_result = MagicMock()
+            mock_result.returncode = 0
+            mock_result.stdout = "stdout content"
+            mock_result.stderr = "stderr content"
+
+            with patch("subprocess.run", return_value=mock_result):
+                adapter.run(config)
+
+            # Logs are written directly to output_dir (no logs/ subdirectory)
+            assert (tmppath / "stdout.log").read_text() == "stdout content"
+            assert (tmppath / "stderr.log").read_text() == "stderr content"
+
+    def test_run_calculates_cost(self) -> None:
+        """Test cost calculation."""
+        with TemporaryDirectory() as tmpdir:
+            tmppath = Path(tmpdir)
+            prompt_file = tmppath / "prompt.md"
+            prompt_file.write_text("Test prompt")
+
+            adapter = GooseAdapter()
+            config = AdapterConfig(
+                model="claude-sonnet-4-5-20250929",
+                prompt_file=prompt_file,
+                workspace=tmppath,
+                output_dir=tmppath,
+            )
+
+            mock_result = MagicMock()
+            mock_result.returncode = 0
+            mock_result.stdout = "Input tokens: 1000\nOutput tokens: 500"
+            mock_result.stderr = ""
+
+            with patch("subprocess.run", return_value=mock_result):
+                result = adapter.run(config)
+
+            # Sonnet: 0.003 per 1K input, 0.015 per 1K output
+            expected_cost = (1000 / 1000 * 0.003) + (500 / 1000 * 0.015)
+            assert result.cost_usd == pytest.approx(expected_cost)
+
+
+class TestValidation:
+    """Tests for configuration validation."""
+
+    def test_validates_prompt_file(self) -> None:
+        """Test that missing prompt file raises error."""
+        with TemporaryDirectory() as tmpdir:
+            tmppath = Path(tmpdir)
+
+            adapter = GooseAdapter()
+            config = AdapterConfig(
+                model="test",
+                prompt_file=tmppath / "nonexistent.md",
+                workspace=tmppath,
+                output_dir=tmppath,
+            )
+
+            with pytest.raises(Exception, match="Prompt file not found"):
+                adapter.run(config)


### PR DESCRIPTION
## Summary
- Add `GooseAdapter` in `scylla/adapters/goose.py` extending `BaseCliAdapter`, following the established `cline.py` pattern
- Implements `_build_command()` (uses `goose run --text <prompt>`) and `_parse_token_counts()`
- Add `config/models/goose.yaml` with Goose model configuration (cost defaults to 0.0 since Goose delegates to underlying LLM)
- Register `GooseAdapter` in `scylla/adapters/__init__.py`
- Add 23 unit tests in `tests/unit/adapters/test_goose.py` (all passing, no regressions)

## Test plan
- [x] `pixi run python -m pytest tests/unit/adapters/test_goose.py -v --no-cov` — 23/23 pass
- [x] `pixi run python -m pytest tests/unit/adapters/ -v --no-cov` — 160/160 pass
- [x] `pre-commit run --all-files` — all hooks pass
- [x] Smoke test: `from scylla.adapters import GooseAdapter; GooseAdapter.CLI_EXECUTABLE == "goose"`

Closes #744

🤖 Generated with [Claude Code](https://claude.com/claude-code)