### PR TITLE
feat(skills): add test-internal-method-with-mocks skill

### DIFF
--- a/tests/unit/e2e/test_runner.py
+++ b/tests/unit/e2e/test_runner.py
@@ -260,6 +260,7 @@ class TestLogCheckpointResume:
 
         mock_log.assert_called_once_with(checkpoint_path)
 
+
 @pytest.fixture
 def mock_config_with_t5() -> ExperimentConfig:
     """Create a mock ExperimentConfig that includes TierID.T5."""


### PR DESCRIPTION
## Summary
- New skill: `test-internal-method-with-mocks` (category: testing)
- Captures learnings from issue #773 on how to unit-test `E2ERunner` internal methods
- Documents 3 pitfalls: wrong constructor arg order, missing `tiers_to_run`, unset `experiment_dir`

## Skill triggers
- "no unit tests for internal runner method"
- "add coverage for E2ERunner internal method"
- "test method that delegates to tier_manager"
- "test method using self.experiment_dir"

## Files
- `.claude-plugin/skills/test-internal-method-with-mocks/SKILL.md` — verified workflow + failed attempts
- `.claude-plugin/plugin.json` — updated with new skill entry