### PR TITLE
feat(validate-agent): implement per-tool content validation

### DIFF
--- a/tests/claude-code/shared/skills/agent/agent-validate-config/SKILL.md
+++ b/tests/claude-code/shared/skills/agent/agent-validate-config/SKILL.md
@@ -56,6 +56,7 @@ Validation includes:
 |-------|-----|
 | No YAML frontmatter | Ensure file starts/ends with `---` |
 | Invalid phase value | Use: Plan, Test, Implementation, Package, Cleanup |
+| Unknown tool name | Use: Read, Write, Edit, Bash, Grep, Glob, Task, WebFetch, WebSearch, TodoWrite, SlashCommand, AskUserQuestion, NotebookEdit, BashOutput, KillShell |
 | Delegation target not found | Verify agent name or create referenced agent |
 | Duplicate keys | Remove duplicate entries in frontmatter |
 | Wrong level type | Must be integer 0-5, not string |

--- a/tests/claude-code/shared/skills/agent/agent-validate-config/scripts/validate_agent.sh
+++ b/tests/claude-code/shared/skills/agent/agent-validate-config/scripts/validate_agent.sh
@@ -76,12 +76,34 @@ fi
 
 # Validate tools (if present)
 if echo "$FRONTMATTER" | grep -q "^tools:"; then
-    VALID_TOOLS=("Read" "Write" "Bash" "Grep" "Glob")
+    VALID_TOOLS=("Read" "Write" "Edit" "Bash" "Grep" "Glob" "Task" "WebFetch" "WebSearch" "TodoWrite" "SlashCommand" "AskUserQuestion" "NotebookEdit" "BashOutput" "KillShell")
     TOOLS_LINE=$(echo "$FRONTMATTER" | grep "^tools:" | cut -d':' -f2-)
 
-    # Simple validation (just check format)
+    # Check format: must be [tool1,tool2,...] bracketed list
     if [[ "$TOOLS_LINE" =~ \[.*\] ]]; then
         echo "✅ Tools field properly formatted"
+        # Strip brackets and split on commas
+        TOOLS_CONTENT="${TOOLS_LINE//[/}"
+        TOOLS_CONTENT="${TOOLS_CONTENT//]/}"
+        IFS=',' read -ra TOOL_LIST <<< "$TOOLS_CONTENT"
+        for tool_entry in "${TOOL_LIST[@]}"; do
+            tool_name=$(echo "$tool_entry" | tr -d ' ')
+            [[ -z "$tool_name" ]] && continue
+            TOOL_VALID=false
+            for valid_tool in "${VALID_TOOLS[@]}"; do
+                if [[ "$tool_name" == "$valid_tool" ]]; then
+                    TOOL_VALID=true
+                    break
+                fi
+            done
+            if [[ "$TOOL_VALID" == "true" ]]; then
+                echo "✅ Valid tool: $tool_name"
+            else
+                echo "❌ Invalid tool: $tool_name"
+                echo "   Valid tools: ${VALID_TOOLS[*]}"
+                ((ERRORS++))
+            fi
+        done
     else
         echo "⚠️  Tools field may be improperly formatted"
     fi


### PR DESCRIPTION
## Summary

- Replaces format-only tools validation with per-tool content validation in `validate_agent.sh`
- Expands `VALID_TOOLS` array to the full known set (matching `scripts/agents/validate_agents.py`)
- Parses tool names from the bracketed YAML list, validates each against the known valid set
- Hard `❌` failure for unknown tools with a hint showing valid tools
- `⚠️` warning preserved for malformed format (no brackets) — no `ERRORS` increment
- Updates `SKILL.md` error handling table with the new unknown tool name row

## Changes

### `tests/claude-code/shared/skills/agent/agent-validate-config/scripts/validate_agent.sh`
- `VALID_TOOLS` array expanded: `Read Write Edit Bash Grep Glob Task WebFetch WebSearch TodoWrite SlashCommand AskUserQuestion NotebookEdit BashOutput KillShell`
- Adds bracket-stripping, comma-split, whitespace-trim logic after format check
- Per-tool validation loop (same pattern as phase validation)
- `❌ Invalid tool: <name>` + `Valid tools: ...` hint on failure; `✅ Valid tool: <name>` on success

### `tests/claude-code/shared/skills/agent/agent-validate-config/SKILL.md`
- Added `| Unknown tool name | Use: Read, Write, Edit, Bash, ...` row to Error Handling table

## Test plan

- [x] Valid tools (`[Read, Write, Bash]`) → exits 0, `✅ Valid tool:` for each
- [x] Invalid tool (`[Read, FakeTool, Bash]`) → exits 1, `❌ Invalid tool: FakeTool`
- [x] No `tools:` field → exits 0 (tools is optional)
- [x] Malformed format (no brackets) → exits 0, `⚠️` warning only
- [x] All 2209 pytest tests pass

Closes #780

🤖 Generated with [Claude Code](https://claude.com/claude-code)