### PR TITLE
chore(pre-commit): consolidate shellcheck exclude patterns into single regex

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -92,6 +92,7 @@ repos:
       - id: shellcheck
         name: ShellCheck
         description: Lint shell scripts and templates for best practices
+        exclude: ^(build/|docs/arxiv/)
         files: \.(sh|bash|sh\.template)$
         types: [text]
         args: ['--exclude=SC1091']


### PR DESCRIPTION
## Summary

- Adds `exclude: ^(build/|docs/arxiv/)` to the `shellcheck` hook in `.pre-commit-config.yaml`
- Matches the combined regex convention already used by `markdownlint-cli2` and `yamllint`
- Excludes `build/` (consistent with other hooks) and `docs/arxiv/` (generated content)

## Test plan

- [x] `pixi run pre-commit run shellcheck --all-files` — Passed
- [x] All pre-commit hooks pass on commit

Closes #782

🤖 Generated with [Claude Code](https://claude.com/claude-code)