### PR TITLE
feat(scripts): add log_debug() using BLUE color to docker_common.sh

### DIFF
--- a/scripts/docker_common.sh
+++ b/scripts/docker_common.sh
@@ -15,7 +15,7 @@
 
 set -euo pipefail
 
-# Colors for output
+# Colors for output: RED=error, GREEN=info, YELLOW=warn, BLUE=debug
 RED='\033[0;31m'
 GREEN='\033[0;32m'
 YELLOW='\033[1;33m'
@@ -23,15 +23,19 @@ BLUE='\033[0;34m'
 NC='\033[0m' # No Color
 
 log_info() {
-    echo -e "${GREEN}[INFO]${NC} $1"
+    echo -e "${GREEN}[INFO]${NC} $*"
 }
 
 log_warn() {
-    echo -e "${YELLOW}[WARN]${NC} $1"
+    echo -e "${YELLOW}[WARN]${NC} $*"
 }
 
 log_error() {
-    echo -e "${RED}[ERROR]${NC} $1" >&2
+    echo -e "${RED}[ERROR]${NC} $*" >&2
+}
+
+log_debug() {
+    echo -e "${BLUE}[DEBUG]${NC} $*"
 }
 
 # Configuration (can be overridden before sourcing)


### PR DESCRIPTION
## Summary

- Added `log_debug()` function to `scripts/docker_common.sh` that uses the already-defined `BLUE` color variable, completing the four-level color palette
- Updated comment from `# Colors for output` to `# Colors for output: RED=error, GREEN=info, YELLOW=warn, BLUE=debug`
- Changed `$1` to `$*` in all three existing log functions for consistent variadic style

## Test plan

- [x] `bash -n scripts/docker_common.sh` — syntax check passes
- [x] `bash -n scripts/run_experiment_in_container.sh` — dependent script syntax check passes
- [x] `bash -n scripts/launch_container_shell.sh` — dependent script syntax check passes
- [x] `pre-commit run --files scripts/docker_common.sh` — ShellCheck and all other hooks pass

Closes #781

🤖 Generated with [Claude Code](https://claude.com/claude-code)