### PR TITLE
feat(core): remove BaseExecutionInfo dataclass (v2.0.0 cleanup)

### DIFF
--- a/scylla/core/__init__.py
+++ b/scylla/core/__init__.py
@@ -4,13 +4,11 @@ This module provides foundational types used across the codebase.
 """
 
 from scylla.core.results import (
-    BaseExecutionInfo,
     BaseRunMetrics,
     ExecutionInfoBase,
 )
 
 __all__ = [
-    "BaseExecutionInfo",
     "BaseRunMetrics",
     "ExecutionInfoBase",
 ]

--- a/scylla/core/results.py
+++ b/scylla/core/results.py
@@ -19,9 +19,6 @@ Architecture Notes:
       ├── ExecutorExecutionInfo (executor/runner.py) - Container execution (detailed)
       └── ReportingExecutionInfo (reporting/result.py) - Result persistence (minimal)
 
-    Legacy dataclass (deprecated):
-    - BaseExecutionInfo - Kept for backward compatibility, use ExecutionInfoBase instead
-
     Migration from dataclasses to Pydantic (Issues #604, #658):
     - Leverages recent Pydantic migration (commit 38a3df1)
     - Enables shared validation logic via Pydantic
@@ -31,7 +28,6 @@ Architecture Notes:
 
 from __future__ import annotations
 
-import warnings
 from dataclasses import dataclass
 
 from pydantic import BaseModel, ConfigDict, Field
@@ -85,41 +81,6 @@ class ExecutionInfoBase(BaseModel):
     exit_code: int = Field(..., description="Process/container exit code (0 = success)")
     duration_seconds: float = Field(default=0.0, description="Total execution duration in seconds")
     timed_out: bool = Field(default=False, description="Whether execution timed out")
-
-
-@dataclass
-class BaseExecutionInfo:
-    """Base execution information shared across all result types.
-
-    .. deprecated::
-        Use ExecutionInfoBase (Pydantic model) instead. This dataclass is kept
-        for backward compatibility only. New code should use ExecutionInfoBase
-        and its domain-specific subtypes (ExecutorExecutionInfo, ReportingExecutionInfo).
-
-    For the new Pydantic-based hierarchy, see:
-    - ExecutionInfoBase (this module) - Base Pydantic model
-    - ExecutorExecutionInfo (executor/runner.py) - Container execution
-    - ReportingExecutionInfo (reporting/result.py) - Result persistence
-
-    Attributes:
-        exit_code: Process/container exit code (0 = success).
-        duration_seconds: Total execution duration.
-        timed_out: Whether execution timed out.
-
-    """
-
-    exit_code: int
-    duration_seconds: float
-    timed_out: bool = False
-
-    def __post_init__(self) -> None:
-        """Emit a DeprecationWarning on instantiation."""
-        warnings.warn(
-            "BaseExecutionInfo is deprecated and will be removed in v2.0.0. "
-            "Use ExecutionInfoBase instead.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
 
 
 @dataclass

--- a/scylla/executor/runner.py
+++ b/scylla/executor/runner.py
@@ -67,7 +67,6 @@ class ExecutorExecutionInfo(ExecutionInfoBase):
     For other ExecutorExecutionInfo types in the hierarchy, see:
     - ExecutionInfoBase (core/results.py) - Base Pydantic model
     - ReportingExecutionInfo (reporting/result.py) - Minimal, for persistence
-    - BaseExecutionInfo (core/results.py) - Legacy dataclass (deprecated)
 
     Attributes:
         container_id: Docker container ID.

--- a/scylla/reporting/result.py
+++ b/scylla/reporting/result.py
@@ -18,7 +18,6 @@ class ReportingExecutionInfo(ExecutionInfoBase):
     For other ExecutionInfo types in the hierarchy, see:
     - ExecutionInfoBase (core/results.py) - Base Pydantic model
     - ExecutorExecutionInfo (executor/runner.py) - Detailed with container info
-    - BaseExecutionInfo (core/results.py) - Legacy dataclass (deprecated)
 
     Attributes:
         status: Execution status (e.g., "completed", "failed", "timeout").

--- a/tests/unit/core/test_results.py
+++ b/tests/unit/core/test_results.py
@@ -3,91 +3,7 @@
 import pytest
 from pydantic import ValidationError
 
-from scylla.core.results import BaseExecutionInfo, BaseRunMetrics, ExecutionInfoBase
-
-
-class TestBaseExecutionInfo:
-    """Tests for BaseExecutionInfo dataclass."""
-
-    def test_construction_success(self) -> None:
-        """Basic construction with valid parameters."""
-        with pytest.warns(DeprecationWarning, match="BaseExecutionInfo is deprecated"):
-            info = BaseExecutionInfo(
-                exit_code=0,
-                duration_seconds=10.5,
-                timed_out=False,
-            )
-        assert info.exit_code == 0
-        assert info.duration_seconds == 10.5
-        assert info.timed_out is False
-
-    def test_construction_failure(self) -> None:
-        """Construction with failure exit code."""
-        with pytest.warns(DeprecationWarning, match="BaseExecutionInfo is deprecated"):
-            info = BaseExecutionInfo(
-                exit_code=1,
-                duration_seconds=5.0,
-                timed_out=False,
-            )
-        assert info.exit_code == 1
-        assert info.duration_seconds == 5.0
-
-    def test_construction_timeout(self) -> None:
-        """Construction with timeout flag."""
-        with pytest.warns(DeprecationWarning, match="BaseExecutionInfo is deprecated"):
-            info = BaseExecutionInfo(
-                exit_code=124,
-                duration_seconds=30.0,
-                timed_out=True,
-            )
-        assert info.exit_code == 124
-        assert info.duration_seconds == 30.0
-        assert info.timed_out is True
-
-    def test_timed_out_default_false(self) -> None:
-        """timed_out should default to False if not specified."""
-        with pytest.warns(DeprecationWarning, match="BaseExecutionInfo is deprecated"):
-            info = BaseExecutionInfo(exit_code=0, duration_seconds=1.0)
-        assert info.timed_out is False
-
-    def test_negative_exit_code(self) -> None:
-        """Support negative exit codes (e.g., killed by signal)."""
-        with pytest.warns(DeprecationWarning, match="BaseExecutionInfo is deprecated"):
-            info = BaseExecutionInfo(
-                exit_code=-9,
-                duration_seconds=2.5,
-            )
-        assert info.exit_code == -9
-
-    def test_zero_duration(self) -> None:
-        """Support zero duration (very fast execution)."""
-        with pytest.warns(DeprecationWarning, match="BaseExecutionInfo is deprecated"):
-            info = BaseExecutionInfo(
-                exit_code=0,
-                duration_seconds=0.0,
-            )
-        assert info.duration_seconds == 0.0
-
-    def test_equality(self) -> None:
-        """Test dataclass equality."""
-        with pytest.warns(DeprecationWarning):
-            info1 = BaseExecutionInfo(exit_code=0, duration_seconds=10.0, timed_out=False)
-        with pytest.warns(DeprecationWarning):
-            info2 = BaseExecutionInfo(exit_code=0, duration_seconds=10.0, timed_out=False)
-        with pytest.warns(DeprecationWarning):
-            info3 = BaseExecutionInfo(exit_code=1, duration_seconds=10.0, timed_out=False)
-
-        assert info1 == info2
-        assert info1 != info3
-
-    def test_repr(self) -> None:
-        """Test string representation."""
-        with pytest.warns(DeprecationWarning, match="BaseExecutionInfo is deprecated"):
-            info = BaseExecutionInfo(exit_code=0, duration_seconds=10.5, timed_out=False)
-        repr_str = repr(info)
-        assert "BaseExecutionInfo" in repr_str
-        assert "exit_code=0" in repr_str
-        assert "duration_seconds=10.5" in repr_str
+from scylla.core.results import BaseRunMetrics, ExecutionInfoBase
 
 
 class TestBaseRunMetrics:
@@ -157,21 +73,6 @@ class TestBaseRunMetrics:
 class TestComposedTypes:
     """Tests for composed usage of base types."""
 
-    def test_execution_info_composition(self) -> None:
-        """Test composing execution info."""
-        # This tests the pattern used in domain-specific types
-        duration = 10.5
-
-        with pytest.warns(DeprecationWarning, match="BaseExecutionInfo is deprecated"):
-            execution = BaseExecutionInfo(
-                exit_code=0,
-                duration_seconds=duration,
-                timed_out=False,
-            )
-
-        # Verify duration is captured
-        assert execution.duration_seconds == duration
-
     def test_metrics_composition(self) -> None:
         """Test composing metrics."""
         cost = 0.05
@@ -184,29 +85,6 @@ class TestComposedTypes:
 
         # Verify cost is captured
         assert metrics.cost_usd == cost
-
-    def test_full_composition_pattern(self) -> None:
-        """Test full composition of execution info and metrics."""
-        # Simulates the pattern used in reporting.result.py
-        cost = 0.05
-        duration = 10.5
-
-        with pytest.warns(DeprecationWarning, match="BaseExecutionInfo is deprecated"):
-            execution = BaseExecutionInfo(
-                exit_code=0,
-                duration_seconds=duration,
-                timed_out=False,
-            )
-
-        metrics = BaseRunMetrics(
-            tokens_input=1000,
-            tokens_output=500,
-            cost_usd=cost,
-        )
-
-        # Verify consistency across composed types
-        assert metrics.cost_usd == cost
-        assert execution.duration_seconds == duration
 
 
 class TestExecutionInfoBase:
@@ -277,46 +155,3 @@ class TestExecutionInfoBase:
 
         assert info1 == info2
         assert info1 != info3
-
-
-class TestBaseExecutionInfoBackwardCompatibility:
-    """Tests for BaseExecutionInfo dataclass (deprecated, backward compatibility)."""
-
-    def test_dataclass_still_works(self) -> None:
-        """Test that legacy BaseExecutionInfo dataclass still works."""
-        with pytest.warns(DeprecationWarning, match="BaseExecutionInfo is deprecated"):
-            info = BaseExecutionInfo(
-                exit_code=0,
-                duration_seconds=10.5,
-                timed_out=False,
-            )
-        assert info.exit_code == 0
-        assert info.duration_seconds == 10.5
-        assert info.timed_out is False
-
-    def test_dataclass_and_pydantic_have_same_fields(self) -> None:
-        """Test that dataclass and Pydantic model have the same core fields."""
-        with pytest.warns(DeprecationWarning, match="BaseExecutionInfo is deprecated"):
-            dataclass_info = BaseExecutionInfo(
-                exit_code=0,
-                duration_seconds=10.5,
-                timed_out=False,
-            )
-        pydantic_info = ExecutionInfoBase(
-            exit_code=0,
-            duration_seconds=10.5,
-            timed_out=False,
-        )
-
-        # Same values in same fields
-        assert dataclass_info.exit_code == pydantic_info.exit_code
-        assert dataclass_info.duration_seconds == pydantic_info.duration_seconds
-        assert dataclass_info.timed_out == pydantic_info.timed_out
-
-    def test_deprecation_warning_emitted(self) -> None:
-        """Test that a DeprecationWarning is emitted on instantiation."""
-        with pytest.warns(
-            DeprecationWarning,
-            match="BaseExecutionInfo is deprecated and will be removed in v2.0.0",
-        ):
-            BaseExecutionInfo(exit_code=0, duration_seconds=1.0)


### PR DESCRIPTION
## Summary

- Delete `BaseExecutionInfo` dataclass from `scylla/core/results.py` (deprecated since #779)
- Remove from `scylla/core/__init__.py` imports and `__all__`
- Remove deprecated reference from `executor/runner.py` and `reporting/result.py` docstrings
- Delete `TestBaseExecutionInfo` and `TestBaseExecutionInfoBackwardCompatibility` test classes entirely
- Remove `TestComposedTypes` methods that depended on `BaseExecutionInfo`

## Test plan

- [x] Ran `pixi run python -m pytest tests/unit/core/test_results.py -v` — 14 tests pass
- [x] Ran `pixi run python -m pytest tests/ -v` — 2266 tests pass, coverage 73.57%
- [x] All pre-commit hooks pass (ruff, mypy, etc.)
- [x] Verified zero remaining `BaseExecutionInfo` references in `scylla/` and `tests/`

Closes #784

🤖 Generated with [Claude Code](https://claude.com/claude-code)