### PR TITLE
fix(config): explicitly declare model_id in claude-opus-4-1.yaml and remove incorrect comment

### DIFF
--- a/config/models/claude-opus-4-1.yaml
+++ b/config/models/claude-opus-4-1.yaml
@@ -1,11 +1,4 @@
 # Claude Opus 4.1 (Legacy) Model Configuration
-#
-# File naming convention:
-#   - Filename: {model_id}.yaml (e.g., claude-opus-4-1.yaml)
-#   - model_id: API identifier from provider (e.g., "claude-opus-4-1")
-#   - name: Human-readable display name (e.g., "Claude Opus 4.1")
-#
-# The filename MUST match the model_id field for ConfigLoader resolution.
 model_id: "claude-opus-4-1"
 name: "Claude Opus 4.1"
 provider: "anthropic"


### PR DESCRIPTION
## Summary
- Removes a verbose and incorrect header comment block from `config/models/claude-opus-4-1.yaml` that falsely claimed "The filename MUST match the model_id field" — this is wrong per the established pattern where other models use versioned `model_id` values with simplified filenames
- The `model_id: "claude-opus-4-1"` field is already explicitly declared, satisfying the issue's first resolution option
- File now matches the minimal format used by all other model config files (single comment line + fields)

## Test plan
- [x] `tests/unit/config/test_loader.py::TestLoadAllModels::test_load_all_models_no_warnings` — passes (no validation warnings emitted)
- [x] `tests/unit/config/test_loader.py::TestLoadAllModels::test_load_model_by_versioned_id[claude-opus-4-1]` — passes
- [x] Full test suite: 2266 passed, 0 failed
- [x] Pre-commit hooks: all passed (YAML lint, validate-model-config-naming)

Closes #794

🤖 Generated with [Claude Code](https://claude.com/claude-code)