### PR TITLE
fix(ci): Align coverage threshold between CI and pyproject.toml

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -82,9 +82,9 @@ jobs:
           # Install package in dev mode for unit tests
           if [[ "$TEST_PATH" == "tests/unit" ]]; then
             pixi run pip install -e .
-            pixi run pytest "$TEST_PATH" -v --cov=scylla --cov-report=term-missing --cov-report=xml --cov-fail-under=72
+            pixi run pytest "$TEST_PATH" -v --cov=scylla --cov-report=term-missing --cov-report=xml
           else
-            pixi run pytest "$TEST_PATH" -v --cov=scylla --cov-report=term-missing --cov-report=xml --cov-fail-under=72
+            pixi run pytest "$TEST_PATH" -v --cov=scylla --cov-report=term-missing --cov-report=xml
           fi
 
       - name: Upload coverage


### PR DESCRIPTION
## Summary

- Removes `--cov-fail-under=72` from `.github/workflows/test.yml`
- pytest-cov will now read `fail_under = 73` from `[tool.coverage.report]` in `pyproject.toml`
- `pyproject.toml` becomes the single source of truth for the coverage threshold

This eliminates the 1% mismatch where CI (72%) was less strict than local (73%), creating a false sense of confidence.

## Test plan
- [ ] CI passes with the threshold now enforced via `pyproject.toml`
- [ ] Local and CI both use 73% threshold

Closes #754

🤖 Generated with [Claude Code](https://claude.com/claude-code)