### PR TITLE
fix(docs): Resolve PR label contradiction between CLAUDE.md and CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -187,8 +187,7 @@ How you tested the changes
 ## Checklist
 - [x] Tests pass
 - [x] Code formatted
-- [x] Documentation updated" \
-  --label "appropriate-label"
+- [x] Documentation updated"
 ```
 
 ## Code Quality Standards


### PR DESCRIPTION
## Summary

Removes `--label "appropriate-label"` from the `gh pr create` example in `CONTRIBUTING.md` to align with CLAUDE.md's explicit policy: **"Never use labels"**.

## Changes

- `CONTRIBUTING.md`: Removed `--label "appropriate-label"` from the PR creation example (line ~191)

## Verification

- `grep --label CONTRIBUTING.md` returns no matches
- `.claude/shared/pr-workflow.md` already had no label references (confirmed, no change needed)
- CLAUDE.md unchanged (already correct)

Closes #758