### PR TITLE
fix(metrics): Replace production assert with ValueError in grading.py; fix hardcoded /tmp path in llm_judge.py

### DIFF
--- a/scylla/e2e/llm_judge.py
+++ b/scylla/e2e/llm_judge.py
@@ -367,7 +367,7 @@ def _get_pipeline_env() -> dict[str, str]:
 
     """
     env = os.environ.copy()
-    env["PYTHONPYCACHEPREFIX"] = "/tmp/scylla_pycache"
+    env["PYTHONPYCACHEPREFIX"] = str(Path(tempfile.gettempdir()) / "scylla_pycache")
     return env
 
 

--- a/scylla/metrics/grading.py
+++ b/scylla/metrics/grading.py
@@ -128,8 +128,8 @@ def assign_letter_grade(score: float) -> str:
         Letter grade (S/A/B/C/D/F).
 
     """
-    # Scores outside [0.0, 1.0] are errors - should never occur
-    assert 0.0 <= score <= 1.0, f"Score {score} is outside valid range [0.0, 1.0]"
+    if not (0.0 <= score <= 1.0):
+        raise ValueError(f"score must be in [0.0, 1.0], got {score}")
 
     if score == 1.0:
         return "S"

--- a/tests/unit/metrics/test_grading.py
+++ b/tests/unit/metrics/test_grading.py
@@ -142,6 +142,12 @@ class TestAssignLetterGrade:
         assert assign_letter_grade(0.19) == "F"
         assert assign_letter_grade(0.0) == "F"
 
+    @pytest.mark.parametrize("score", [-0.1, 1.1, -1.0, 2.0])
+    def test_invalid_score_raises_value_error(self, score: float) -> None:
+        """Scores outside [0.0, 1.0] raise ValueError (not silently ignored)."""
+        with pytest.raises(ValueError, match="score must be in"):
+            assign_letter_grade(score)
+
 
 class TestCalculateTierUplift:
     """Tests for tier uplift calculation."""

--- a/tests/unit/test_grading_consistency.py
+++ b/tests/unit/test_grading_consistency.py
@@ -63,19 +63,19 @@ class TestGradingConsistency:
             )
 
     def test_metrics_grading_validates_range(self):
-        """Test that assign_letter_grade asserts on invalid scores."""
-        # Scores > 1.0 should raise assertion
-        with pytest.raises(AssertionError, match="outside valid range"):
+        """Test that assign_letter_grade raises ValueError on invalid scores."""
+        # Scores > 1.0 should raise ValueError
+        with pytest.raises(ValueError, match="score must be in"):
             assign_letter_grade(1.1)
 
-        with pytest.raises(AssertionError, match="outside valid range"):
+        with pytest.raises(ValueError, match="score must be in"):
             assign_letter_grade(1.01)
 
-        # Scores < 0.0 should raise assertion
-        with pytest.raises(AssertionError, match="outside valid range"):
+        # Scores < 0.0 should raise ValueError
+        with pytest.raises(ValueError, match="score must be in"):
             assign_letter_grade(-0.1)
 
-        with pytest.raises(AssertionError, match="outside valid range"):
+        with pytest.raises(ValueError, match="score must be in"):
             assign_letter_grade(-1.0)
 
     def test_grade_assignment_exhaustive(self):


### PR DESCRIPTION
## Summary

- Replace `assert 0.0 <= score <= 1.0` with explicit `ValueError` in `scylla/metrics/grading.py:132` — production asserts are stripped by Python `-O` optimization
- Replace hardcoded `/tmp/scylla_pycache` with `tempfile.gettempdir()`-based path in `scylla/e2e/llm_judge.py:370` for cross-platform portability
- Update `tests/unit/test_grading_consistency.py` to expect `ValueError` (not `AssertionError`)
- Add parametrized `ValueError` test cases to `tests/unit/metrics/test_grading.py`

## Test plan

- [x] All 241 unit tests pass (`pixi run python -m pytest tests/unit/metrics/ tests/unit/test_grading_consistency.py --no-cov`)
- [x] Pre-commit hooks pass (ruff, mypy, black, shellcheck)
- [x] New parametrized tests cover invalid scores: -0.1, 1.1, -1.0, 2.0

Closes #757

🤖 Generated with [Claude Code](https://claude.com/claude-code)