### PR TITLE
fix(skills): Fix preflight_check.sh path resolution in gh-implement-issue skill

### DIFF
--- a/tests/claude-code/shared/skills/github/gh-implement-issue/SKILL.md
+++ b/tests/claude-code/shared/skills/github/gh-implement-issue/SKILL.md
@@ -17,9 +17,15 @@ Complete workflow for implementing a GitHub issue from start to finish.
 
 ## Quick Reference
 
+> **Note:** `<skill-dir>` is the absolute path to this skill's directory.
+> Resolve it with: `SKILL_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"`
+> or use the skill's installed path directly, e.g.:
+> `tests/claude-code/shared/skills/github/gh-implement-issue` (ProjectScylla)
+
 ```bash
 # 0. Pre-flight check (REQUIRED - runs all 6 checks automatically)
-bash scripts/preflight_check.sh <issue>
+# Replace <skill-dir> with the absolute path to this skill directory
+bash <skill-dir>/scripts/preflight_check.sh <issue>
 
 # 1. Fetch issue and create branch (only after pre-flight passes)
 gh issue view <issue>
@@ -43,7 +49,7 @@ gh pr create --issue <issue>
 
 ## Workflow
 
-1. **Run pre-flight check**: `bash scripts/preflight_check.sh <issue>` — automatically runs all 6 checks; stops on critical failures
+1. **Run pre-flight check**: `bash <skill-dir>/scripts/preflight_check.sh <issue>` — automatically runs all 6 checks; stops on critical failures
 2. **Read issue context**: `gh issue view <issue> --comments` - understand requirements, prior context
 3. **Create branch**: `git checkout -b <issue>-<description>`
 4. **Post start comment**: Document approach on the issue

--- a/tests/claude-code/shared/skills/github/gh-implement-issue/scripts/preflight_check.sh
+++ b/tests/claude-code/shared/skills/github/gh-implement-issue/scripts/preflight_check.sh
@@ -7,11 +7,16 @@
 # Warnings (exit 0): existing commits, open PRs, existing branches
 #
 # Usage:
-#   ./preflight_check.sh <issue-number>
+#   bash /path/to/scripts/preflight_check.sh <issue-number>
+#   bash "$(dirname "${BASH_SOURCE[0]}")/preflight_check.sh" <issue-number>
 #
 # Exit codes:
 #   0 = all checks passed (or only warnings)
 #   1 = critical failure - do not proceed
+
+# Self-locating: works regardless of caller's CWD
+# shellcheck disable=SC2034
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 set -uo pipefail
 


### PR DESCRIPTION
## Summary

- Add `BASH_SOURCE[0]` self-location pattern to `preflight_check.sh` so the script documents the idiom and is robust to future internal path additions
- Replace relative `bash scripts/preflight_check.sh` invocation in `SKILL.md` Quick Reference with `bash <skill-dir>/scripts/preflight_check.sh` — works from any working directory
- Add `Note` callout block explaining how to resolve `<skill-dir>`
- Sync the same preflight sections into `build/ProjectMnemosyne` SKILL.md and `references/notes.md`

## Test plan

- [x] Ran `bash tests/claude-code/shared/skills/github/gh-implement-issue/scripts/preflight_check.sh 801` from repo root (different CWD than skill dir) — script executes without path errors
- [x] Ran with absolute path — same behavior
- [x] `grep "bash scripts/"` on both SKILL.md files returns zero matches — anti-pattern is gone
- [x] All pre-commit hooks pass (ShellCheck, Markdown Lint, etc.)

Closes #801

🤖 Generated with [Claude Code](https://claude.com/claude-code)