### PR TITLE
feat(scripts): Add doc audit script for policy violation detection

### DIFF
--- a/scripts/audit_doc_examples.py
+++ b/scripts/audit_doc_examples.py
@@ -1,0 +1,266 @@
+#!/usr/bin/env python3
+"""Audit documentation command examples for policy violations.
+
+Scans all markdown files in the repository for command examples that contradict
+policies defined in CLAUDE.md and reports (or counts) violations with file:line
+references.
+
+Authoritative policy source: CLAUDE.md
+
+Policies enforced:
+  - ``gh pr create`` must NOT include ``--label``
+  - ``git commit`` must NOT use ``--no-verify``
+  - ``gh pr merge`` must use ``--auto --rebase`` (not ``--merge`` or ``--squash``)
+  - ``git push`` must NOT push directly to ``main``/``master``
+
+Excluded paths (archived / test-fixture content that is not authoritative):
+  - ``docs/arxiv/``
+  - ``tests/claude-code/``
+  - ``.pixi/``
+  - ``build/``
+  - ``node_modules/``
+
+Usage::
+
+    python scripts/audit_doc_examples.py
+    python scripts/audit_doc_examples.py --verbose
+    python scripts/audit_doc_examples.py --json
+
+Exit codes:
+    0: No violations found
+    1: One or more violations found
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import sys
+from dataclasses import dataclass
+from enum import Enum
+from pathlib import Path
+
+from scylla.automation.git_utils import get_repo_root
+
+# ---------------------------------------------------------------------------
+# Data model
+# ---------------------------------------------------------------------------
+
+
+class Severity(str, Enum):
+    """Violation severity levels."""
+
+    CRITICAL = "CRITICAL"
+    WARNING = "WARNING"
+
+
+@dataclass
+class Finding:
+    """A single policy violation found in a documentation file."""
+
+    file: str
+    line: int
+    content: str
+    rule: str
+    severity: Severity
+    description: str
+
+    def as_dict(self) -> dict[str, str | int]:
+        """Return finding as a plain dictionary (JSON-serialisable)."""
+        return {
+            "file": self.file,
+            "line": self.line,
+            "content": self.content.strip(),
+            "rule": self.rule,
+            "severity": self.severity.value,
+            "description": self.description,
+        }
+
+
+# ---------------------------------------------------------------------------
+# Policy rules
+# ---------------------------------------------------------------------------
+
+# Each rule is (rule_id, severity, description, compiled_pattern).
+# Patterns are checked against individual lines of text; a match == violation.
+#
+# NOTE: We specifically look for patterns *inside code blocks* only.  A naive
+# per-line grep would flag prohibition text such as "Never use --no-verify".
+# We therefore work at the code-block level: extract fenced bash/shell blocks,
+# then apply patterns to those lines only.
+_RAW_RULES: list[tuple[str, Severity, str, str]] = [
+    (
+        "no-label-in-pr-create",
+        Severity.CRITICAL,
+        "gh pr create must not use --label (labels are prohibited by CLAUDE.md)",
+        # Match lines where gh pr create is followed by --label as a flag
+        # (requires gh pr create to appear first, --label after — as a real flag,
+        # not prose describing the flag name).  We anchor to the command by
+        # requiring ``gh`` at the start of non-whitespace content on the line.
+        r"^\s*(?:gh|\$\s*gh|\\)\s*(?:pr\s+create\b.*--label\b|.*--label\b.*gh\s+pr\s+create\b)",
+    ),
+    (
+        "no-verify-in-commit",
+        Severity.CRITICAL,
+        "git commit must not use --no-verify (absolutely prohibited by CLAUDE.md)",
+        r"git\s+commit\b.*--no-verify\b",
+    ),
+    (
+        "wrong-merge-strategy",
+        Severity.CRITICAL,
+        "gh pr merge must use --auto --rebase, not --merge or --squash",
+        r"gh\s+pr\s+merge\b(?!.*--auto\s+--rebase\b)(?!.*--rebase\s+--auto\b).*(?:--merge\b|--squash\b)",
+    ),
+    (
+        "push-direct-to-main",
+        Severity.CRITICAL,
+        "git push must not push directly to main or master (use PRs)",
+        # Exclude lines with a # comment (often used to annotate prohibited examples
+        # e.g. ``git push origin main  # BLOCKED``) and --delete (branch cleanup).
+        r"git\s+push\b(?!.*--delete\b)(?![^#]*#).*\b(?:origin\s+main|origin\s+master|origin\s+HEAD:main|origin\s+HEAD:master)\b",
+    ),
+]
+
+RULES = [
+    (rule_id, severity, description, re.compile(pattern))
+    for rule_id, severity, description, pattern in _RAW_RULES
+]
+
+# ---------------------------------------------------------------------------
+# Paths to exclude from scanning
+# ---------------------------------------------------------------------------
+
+EXCLUDED_PREFIXES = (
+    "docs/arxiv/",
+    "tests/claude-code/",
+    ".pixi/",
+    "build/",
+    "node_modules/",
+)
+
+# ---------------------------------------------------------------------------
+# Core scanning logic
+# ---------------------------------------------------------------------------
+
+# Regex to extract fenced code blocks that look like shell/bash.
+# Captures language tag (optional) and the block body.
+_CODE_BLOCK_RE = re.compile(
+    r"^```(?P<lang>[a-zA-Z0-9_\-]*)\n(?P<body>.*?)^```",
+    re.MULTILINE | re.DOTALL,
+)
+
+_SHELL_LANGS = {"bash", "sh", "shell", "zsh", "console", ""}
+
+
+def _extract_code_blocks(content: str) -> list[tuple[int, str]]:
+    """Return list of (start_line_1indexed, block_text) for shell code blocks.
+
+    Only fenced blocks with a shell-like language tag (or no tag) are returned.
+    """
+    blocks: list[tuple[int, str]] = []
+    for match in _CODE_BLOCK_RE.finditer(content):
+        lang = match.group("lang").lower()
+        if lang not in _SHELL_LANGS:
+            continue
+        # Compute the line number of the opening ``` fence.
+        start_line = content[: match.start()].count("\n") + 1
+        blocks.append((start_line, match.group("body")))
+    return blocks
+
+
+def scan_file(file_path: Path, repo_root: Path) -> list[Finding]:
+    """Scan a single markdown file and return all findings."""
+    findings: list[Finding] = []
+    try:
+        content = file_path.read_text(encoding="utf-8", errors="replace")
+    except OSError:
+        return findings
+
+    relative_path = str(file_path.relative_to(repo_root))
+
+    blocks = _extract_code_blocks(content)
+    for block_start_line, block_body in blocks:
+        for block_line_offset, line in enumerate(block_body.splitlines(), start=1):
+            absolute_line = block_start_line + block_line_offset
+            for rule_id, severity, description, pattern in RULES:
+                if pattern.search(line):
+                    findings.append(
+                        Finding(
+                            file=relative_path,
+                            line=absolute_line,
+                            content=line,
+                            rule=rule_id,
+                            severity=severity,
+                            description=description,
+                        )
+                    )
+    return findings
+
+
+def scan_repository(repo_root: Path) -> list[Finding]:
+    """Scan all non-excluded markdown files in the repository."""
+    all_findings: list[Finding] = []
+
+    for md_file in sorted(repo_root.rglob("*.md")):
+        relative = md_file.relative_to(repo_root)
+        relative_str = str(relative).replace("\\", "/")
+        if any(relative_str.startswith(prefix) for prefix in EXCLUDED_PREFIXES):
+            continue
+        all_findings.extend(scan_file(md_file, repo_root))
+
+    return all_findings
+
+
+# ---------------------------------------------------------------------------
+# Reporting
+# ---------------------------------------------------------------------------
+
+
+def format_text_report(findings: list[Finding], verbose: bool = False) -> str:
+    """Format findings as a human-readable text report."""
+    if not findings:
+        return "No policy violations found.\n"
+
+    lines: list[str] = [
+        f"Found {len(findings)} policy violation(s):",
+        "",
+    ]
+    for f in findings:
+        lines.append(f"  [{f.severity.value}] {f.file}:{f.line}")
+        lines.append(f"    Rule: {f.rule}")
+        lines.append(f"    Reason: {f.description}")
+        if verbose:
+            lines.append(f"    Content: {f.content.strip()}")
+        lines.append("")
+
+    return "\n".join(lines)
+
+
+def format_json_report(findings: list[Finding]) -> str:
+    """Format findings as a JSON string."""
+    return json.dumps([f.as_dict() for f in findings], indent=2)
+
+
+# ---------------------------------------------------------------------------
+# Entry point
+# ---------------------------------------------------------------------------
+
+
+def main() -> int:
+    """Run the documentation audit."""
+    verbose = "--verbose" in sys.argv or "-v" in sys.argv
+    as_json = "--json" in sys.argv
+
+    repo_root = get_repo_root()
+    findings = scan_repository(repo_root)
+
+    if as_json:
+        print(format_json_report(findings))
+    else:
+        print(format_text_report(findings, verbose=verbose))
+
+    return 0 if not findings else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/unit/scripts/test_audit_doc_examples.py
+++ b/tests/unit/scripts/test_audit_doc_examples.py
@@ -1,0 +1,495 @@
+"""Tests for scripts/audit_doc_examples.py."""
+
+from __future__ import annotations
+
+import json
+import textwrap
+from pathlib import Path
+
+import pytest
+
+from scripts.audit_doc_examples import (
+    Finding,
+    Severity,
+    _extract_code_blocks,
+    format_json_report,
+    format_text_report,
+    scan_file,
+    scan_repository,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def make_md(tmp_path: Path, name: str, content: str) -> Path:
+    """Write a markdown file and return its path."""
+    path = tmp_path / name
+    path.write_text(textwrap.dedent(content))
+    return path
+
+
+# ---------------------------------------------------------------------------
+# _extract_code_blocks
+# ---------------------------------------------------------------------------
+
+
+class TestExtractCodeBlocks:
+    """Tests for _extract_code_blocks."""
+
+    def test_extracts_bash_block(self) -> None:
+        """Should extract body from a bash fenced code block."""
+        content = "before\n```bash\necho hello\n```\nafter\n"
+        blocks = _extract_code_blocks(content)
+        assert len(blocks) == 1
+        _, body = blocks[0]
+        assert "echo hello" in body
+
+    def test_extracts_no_lang_block(self) -> None:
+        """Should extract body from a fenced block with no language tag."""
+        content = "before\n```\necho hello\n```\nafter\n"
+        blocks = _extract_code_blocks(content)
+        assert len(blocks) == 1
+
+    def test_ignores_python_block(self) -> None:
+        """Should not extract python blocks (not shell)."""
+        content = "```python\nprint('hi')\n```\n"
+        blocks = _extract_code_blocks(content)
+        assert blocks == []
+
+    def test_ignores_yaml_block(self) -> None:
+        """Should not extract yaml blocks (not shell)."""
+        content = "```yaml\nkey: value\n```\n"
+        blocks = _extract_code_blocks(content)
+        assert blocks == []
+
+    def test_extracts_shell_block(self) -> None:
+        """Should extract body from a shell fenced code block."""
+        content = "```shell\ncmd\n```\n"
+        blocks = _extract_code_blocks(content)
+        assert len(blocks) == 1
+
+    def test_multiple_blocks_returned(self) -> None:
+        """Should return all shell blocks when multiple are present."""
+        content = "```bash\ncmd1\n```\ntext\n```bash\ncmd2\n```\n"
+        blocks = _extract_code_blocks(content)
+        assert len(blocks) == 2
+
+    def test_start_line_computed_correctly(self) -> None:
+        """Block start_line should be the line number of the opening fence."""
+        # The opening ``` is on line 3 (1-indexed), block body starts on line 4.
+        content = "line1\nline2\n```bash\ncmd\n```\n"
+        blocks = _extract_code_blocks(content)
+        assert len(blocks) == 1
+        start_line, _ = blocks[0]
+        # start_line is the line of the ``` opener; first body line is start_line+1
+        assert start_line == 3
+
+
+# ---------------------------------------------------------------------------
+# scan_file — detecting violations
+# ---------------------------------------------------------------------------
+
+
+class TestScanFileDetectsViolations:
+    """scan_file correctly detects known policy violations."""
+
+    def test_detects_label_flag_in_pr_create(self, tmp_path: Path) -> None:
+        """Should flag gh pr create that includes --label."""
+        md = make_md(
+            tmp_path,
+            "bad.md",
+            """\
+            # Doc
+
+            ```bash
+            gh pr create --title "fix" --body "Closes #1" --label "bug"
+            ```
+            """,
+        )
+        findings = scan_file(md, tmp_path)
+        assert any(f.rule == "no-label-in-pr-create" for f in findings)
+
+    def test_detects_no_verify_in_commit(self, tmp_path: Path) -> None:
+        """Should flag git commit that uses --no-verify."""
+        md = make_md(
+            tmp_path,
+            "bad.md",
+            """\
+            # Doc
+
+            ```bash
+            git commit --no-verify -m "skip hooks"
+            ```
+            """,
+        )
+        findings = scan_file(md, tmp_path)
+        assert any(f.rule == "no-verify-in-commit" for f in findings)
+
+    def test_detects_squash_merge_strategy(self, tmp_path: Path) -> None:
+        """Should flag gh pr merge that uses --squash."""
+        md = make_md(
+            tmp_path,
+            "bad.md",
+            """\
+            # Doc
+
+            ```bash
+            gh pr merge --squash
+            ```
+            """,
+        )
+        findings = scan_file(md, tmp_path)
+        assert any(f.rule == "wrong-merge-strategy" for f in findings)
+
+    def test_detects_merge_flag_strategy(self, tmp_path: Path) -> None:
+        """Should flag gh pr merge that uses --merge."""
+        md = make_md(
+            tmp_path,
+            "bad.md",
+            """\
+            # Doc
+
+            ```bash
+            gh pr merge --merge
+            ```
+            """,
+        )
+        findings = scan_file(md, tmp_path)
+        assert any(f.rule == "wrong-merge-strategy" for f in findings)
+
+    def test_detects_push_to_main(self, tmp_path: Path) -> None:
+        """Should flag git push directly to origin main."""
+        md = make_md(
+            tmp_path,
+            "bad.md",
+            """\
+            # Doc
+
+            ```bash
+            git push origin main
+            ```
+            """,
+        )
+        findings = scan_file(md, tmp_path)
+        assert any(f.rule == "push-direct-to-main" for f in findings)
+
+    def test_detects_push_to_master(self, tmp_path: Path) -> None:
+        """Should flag git push directly to origin master."""
+        md = make_md(
+            tmp_path,
+            "bad.md",
+            """\
+            # Doc
+
+            ```bash
+            git push origin master
+            ```
+            """,
+        )
+        findings = scan_file(md, tmp_path)
+        assert any(f.rule == "push-direct-to-main" for f in findings)
+
+
+# ---------------------------------------------------------------------------
+# scan_file — clean examples pass
+# ---------------------------------------------------------------------------
+
+
+class TestScanFilePassesCleanExamples:
+    """scan_file does not flag correct policy-compliant examples."""
+
+    def test_passes_clean_pr_create(self, tmp_path: Path) -> None:
+        """Clean gh pr create without --label should produce no findings."""
+        md = make_md(
+            tmp_path,
+            "good.md",
+            """\
+            # Doc
+
+            ```bash
+            gh pr create --title "fix: something" --body "Closes #1"
+            ```
+            """,
+        )
+        assert scan_file(md, tmp_path) == []
+
+    def test_passes_rebase_merge_strategy(self, tmp_path: Path) -> None:
+        """Gh pr merge --auto --rebase should produce no findings."""
+        md = make_md(
+            tmp_path,
+            "good.md",
+            """\
+            # Doc
+
+            ```bash
+            gh pr merge --auto --rebase
+            ```
+            """,
+        )
+        assert scan_file(md, tmp_path) == []
+
+    def test_passes_rebase_merge_strategy_with_pr_number(self, tmp_path: Path) -> None:
+        """Gh pr merge with PR number and --auto --rebase should produce no findings."""
+        md = make_md(
+            tmp_path,
+            "good.md",
+            """\
+            # Doc
+
+            ```bash
+            gh pr merge 42 --auto --rebase
+            ```
+            """,
+        )
+        assert scan_file(md, tmp_path) == []
+
+    def test_passes_push_to_feature_branch(self, tmp_path: Path) -> None:
+        """Git push to a feature branch should produce no findings."""
+        md = make_md(
+            tmp_path,
+            "good.md",
+            """\
+            # Doc
+
+            ```bash
+            git push -u origin 42-my-feature
+            ```
+            """,
+        )
+        assert scan_file(md, tmp_path) == []
+
+    def test_passes_prohibition_text_outside_code_block(self, tmp_path: Path) -> None:
+        """Prohibition text in prose should NOT be flagged."""
+        md = make_md(
+            tmp_path,
+            "good.md",
+            """\
+            # Policy
+
+            Never use --no-verify. git commit --no-verify is PROHIBITED.
+            Do not use --label in gh pr create.
+            git push origin main is blocked.
+            """,
+        )
+        assert scan_file(md, tmp_path) == []
+
+    def test_passes_delete_branch_push(self, tmp_path: Path) -> None:
+        """Git push --delete origin main (for cleanup) should not be flagged."""
+        md = make_md(
+            tmp_path,
+            "good.md",
+            """\
+            # Cleanup
+
+            ```bash
+            git push origin --delete main
+            ```
+            """,
+        )
+        assert scan_file(md, tmp_path) == []
+
+    def test_passes_gh_issue_list_with_label(self, tmp_path: Path) -> None:
+        """Gh issue list --label is legitimate (only gh pr create is restricted)."""
+        md = make_md(
+            tmp_path,
+            "good.md",
+            """\
+            # Issue query
+
+            ```bash
+            gh issue list --label "bug"
+            ```
+            """,
+        )
+        assert scan_file(md, tmp_path) == []
+
+
+# ---------------------------------------------------------------------------
+# scan_file — finding metadata
+# ---------------------------------------------------------------------------
+
+
+class TestFindingMetadata:
+    """Findings contain correct metadata."""
+
+    def test_finding_has_correct_severity(self, tmp_path: Path) -> None:
+        """Violation finding should have CRITICAL severity."""
+        md = make_md(
+            tmp_path,
+            "bad.md",
+            """\
+            ```bash
+            gh pr create --title "x" --label "bug"
+            ```
+            """,
+        )
+        findings = scan_file(md, tmp_path)
+        assert findings[0].severity == Severity.CRITICAL
+
+    def test_finding_has_relative_file_path(self, tmp_path: Path) -> None:
+        """Finding file path should be relative to repo root."""
+        sub = tmp_path / "docs"
+        sub.mkdir()
+        md = make_md(
+            sub,
+            "bad.md",
+            """\
+            ```bash
+            gh pr create --title "x" --label "bug"
+            ```
+            """,
+        )
+        findings = scan_file(md, tmp_path)
+        assert findings[0].file == "docs/bad.md"
+
+    def test_finding_has_positive_line_number(self, tmp_path: Path) -> None:
+        """Finding line number should be a positive integer."""
+        md = make_md(
+            tmp_path,
+            "bad.md",
+            """\
+            ```bash
+            gh pr create --title "x" --label "bug"
+            ```
+            """,
+        )
+        findings = scan_file(md, tmp_path)
+        assert findings[0].line > 0
+
+    def test_finding_content_contains_violating_text(self, tmp_path: Path) -> None:
+        """Finding content should contain the violating command text."""
+        md = make_md(
+            tmp_path,
+            "bad.md",
+            """\
+            ```bash
+            gh pr create --title "x" --label "bug"
+            ```
+            """,
+        )
+        findings = scan_file(md, tmp_path)
+        assert "--label" in findings[0].content
+
+
+# ---------------------------------------------------------------------------
+# scan_repository — exclusion paths
+# ---------------------------------------------------------------------------
+
+
+class TestScanRepositoryExclusions:
+    """scan_repository skips excluded directory prefixes."""
+
+    @pytest.mark.parametrize(
+        "excluded_dir",
+        [
+            "docs/arxiv",
+            "tests/claude-code",
+            ".pixi",
+            "build",
+            "node_modules",
+        ],
+    )
+    def test_excludes_path(self, tmp_path: Path, excluded_dir: str) -> None:
+        """Files under excluded paths should not be scanned."""
+        excluded_path = tmp_path / excluded_dir
+        excluded_path.mkdir(parents=True)
+        bad_md = excluded_path / "bad.md"
+        bad_md.write_text("```bash\ngh pr create --title 'x' --label 'bug'\n```\n")
+        findings = scan_repository(tmp_path)
+        assert findings == []
+
+    def test_scans_non_excluded_path(self, tmp_path: Path) -> None:
+        """Files outside excluded paths should be scanned and violations reported."""
+        make_md(
+            tmp_path,
+            "bad.md",
+            """\
+            ```bash
+            gh pr create --title "x" --label "bug"
+            ```
+            """,
+        )
+        findings = scan_repository(tmp_path)
+        assert len(findings) == 1
+
+
+# ---------------------------------------------------------------------------
+# Reporting
+# ---------------------------------------------------------------------------
+
+
+class TestFormatTextReport:
+    """format_text_report produces readable output."""
+
+    def test_no_findings_message(self) -> None:
+        """Should report no violations when findings list is empty."""
+        report = format_text_report([])
+        assert "No policy violations found" in report
+
+    def test_lists_each_finding(self, tmp_path: Path) -> None:
+        """Should include file:line and rule name in report."""
+        finding = Finding(
+            file="foo/bar.md",
+            line=10,
+            content="  gh pr create --label bug  ",
+            rule="no-label-in-pr-create",
+            severity=Severity.CRITICAL,
+            description="labels prohibited",
+        )
+        report = format_text_report([finding])
+        assert "foo/bar.md:10" in report
+        assert "no-label-in-pr-create" in report
+
+    def test_verbose_includes_content(self, tmp_path: Path) -> None:
+        """Verbose mode should include the violating line content."""
+        finding = Finding(
+            file="foo/bar.md",
+            line=10,
+            content="gh pr create --label bug",
+            rule="no-label-in-pr-create",
+            severity=Severity.CRITICAL,
+            description="labels prohibited",
+        )
+        report = format_text_report([finding], verbose=True)
+        assert "--label" in report
+
+    def test_non_verbose_omits_content(self, tmp_path: Path) -> None:
+        """Non-verbose mode should omit the raw violating line content."""
+        finding = Finding(
+            file="foo/bar.md",
+            line=10,
+            content="gh pr create --label bug",
+            rule="no-label-in-pr-create",
+            severity=Severity.CRITICAL,
+            description="labels prohibited",
+        )
+        report = format_text_report([finding], verbose=False)
+        # content line with "--label bug" should not appear (description will appear)
+        assert "gh pr create --label bug" not in report
+
+
+class TestFormatJsonReport:
+    """format_json_report produces valid JSON."""
+
+    def test_empty_findings_is_empty_list(self) -> None:
+        """Empty findings should produce a JSON empty list."""
+        result = json.loads(format_json_report([]))
+        assert result == []
+
+    def test_finding_serialised_correctly(self) -> None:
+        """Finding fields should be serialised correctly to JSON."""
+        finding = Finding(
+            file="docs/foo.md",
+            line=5,
+            content="git commit --no-verify",
+            rule="no-verify-in-commit",
+            severity=Severity.CRITICAL,
+            description="no-verify prohibited",
+        )
+        result = json.loads(format_json_report([finding]))
+        assert result[0]["file"] == "docs/foo.md"
+        assert result[0]["line"] == 5
+        assert result[0]["severity"] == "CRITICAL"
+        assert result[0]["rule"] == "no-verify-in-commit"


### PR DESCRIPTION
## Summary

- Adds `scripts/audit_doc_examples.py`: a reusable audit script that scans markdown documentation files for command examples that contradict CLAUDE.md policies
- Adds `tests/unit/scripts/test_audit_doc_examples.py`: 36 tests covering all audit functionality

## What the audit checks

| Rule | Violation | Policy |
|------|-----------|--------|
| `no-label-in-pr-create` | `gh pr create --label` | Labels prohibited |
| `no-verify-in-commit` | `git commit --no-verify` | Absolutely prohibited |
| `wrong-merge-strategy` | `gh pr merge --merge/--squash` | Must use `--auto --rebase` |
| `push-direct-to-main` | `git push origin main` | Must use PRs |

## Audit result

**No violations found** in primary docs. The previous `--label` violation in `CONTRIBUTING.md` was already fixed by #758.

## Test plan

- [x] 36 new tests pass (`test_audit_doc_examples.py`)
- [x] Full test suite: 2428 passed, 74.15% coverage
- [x] Pre-commit hooks pass (ruff, mypy, security checks)
- [x] Script runs cleanly on the repo: `No policy violations found.`

Closes #878