### PR TITLE
feat(config): Apply filename validation to DefaultsConfig loader

### DIFF
--- a/scylla/config/loader.py
+++ b/scylla/config/loader.py
@@ -22,6 +22,7 @@ from .models import (
     TierConfig,
 )
 from .validation import (
+    validate_defaults_filename,
     validate_filename_model_id_consistency,
     validate_model_config_referenced,
 )
@@ -329,6 +330,11 @@ class ConfigLoader:
     def load_defaults(self) -> DefaultsConfig:
         """Load global defaults configuration.
 
+        Loads config/defaults.yaml. Note: DefaultsConfig has no model_id-style
+        field, so field-level filename consistency validation (as applied to
+        ModelConfig) is intentionally not performed. A stem-only check is
+        applied to catch gross misconfiguration (wrong file entirely).
+
         Returns:
             DefaultsConfig model
 
@@ -338,6 +344,11 @@ class ConfigLoader:
         """
         defaults_path = self.base_path / "config" / "defaults.yaml"
         data = self._load_yaml(defaults_path)
+
+        # Validate filename stem only — DefaultsConfig has no ID field,
+        # so model_id↔filename consistency checks are not applicable.
+        for warning in validate_defaults_filename(defaults_path):
+            logger.warning(warning)
 
         try:
             return DefaultsConfig(**data)

--- a/scylla/config/validation.py
+++ b/scylla/config/validation.py
@@ -133,6 +133,32 @@ def validate_filename_model_id_consistency(config_path: Path, model_id: str) -> 
     return warnings
 
 
+def validate_defaults_filename(config_path: Path) -> list[str]:
+    """Validate that the defaults config file is named 'defaults.yaml'.
+
+    DefaultsConfig has no single ID field (unlike ModelConfig which has
+    model_id), so field-level filename consistency is not applicable.
+    This function checks only that the file stem is 'defaults' — catching
+    accidental misconfiguration (e.g., loading the wrong file entirely).
+
+    Args:
+        config_path: Path to the defaults YAML file.
+
+    Returns:
+        List of warning strings; empty if validation passes.
+
+    """
+    warnings: list[str] = []
+    if config_path.stem != "defaults":
+        warnings.append(
+            f"Defaults config loaded from unexpected filename "
+            f"'{config_path.name}' (expected 'defaults.yaml'). "
+            f"Note: DefaultsConfig has no ID field — filename consistency "
+            f"validation is intentionally limited to stem check only."
+        )
+    return warnings
+
+
 def validate_model_config_referenced(config_path: Path, search_roots: list[Path]) -> list[str]:
     """Warn if model config file is not referenced by any file under search_roots.
 


### PR DESCRIPTION
## Summary

- Add `validate_defaults_filename(config_path: Path) -> list[str]` to `scylla/config/validation.py`, following the same contract as `validate_filename_model_id_consistency`
- Call it inside `ConfigLoader.load_defaults()` to warn if the loaded file has an unexpected filename stem, with an explicit comment documenting that field-level ID validation is intentionally skipped for `DefaultsConfig` (no `model_id`-equivalent field)
- Add parametrized unit tests in `tests/unit/config/test_validation.py` and integration tests in `tests/unit/test_config_loader.py`

## Test plan

- [x] `TestValidateDefaultsFilename` — 8 parametrized cases: `defaults.yaml`/`.yml` → no warnings; 5 non-standard names → 1 warning each; warning message content check
- [x] `TestDefaultsFilenameValidation` — standard path produces no warnings; non-standard path produces expected warning
- [x] All 78 existing + new tests pass (`pixi run python -m pytest tests/unit/test_config_loader.py tests/unit/config/test_validation.py -v --no-cov`)
- [x] Pre-commit hooks pass (ruff, mypy, black)

Closes #806

🤖 Generated with [Claude Code](https://claude.com/claude-code)