### PR TITLE
fix(config): Validate tier IDs in load_all_tiers() match filenames

### DIFF
--- a/scylla/config/loader.py
+++ b/scylla/config/loader.py
@@ -242,7 +242,21 @@ class ConfigLoader:
 
         for tier_file in sorted(tiers_dir.glob("t*.yaml")):
             tier_name = tier_file.stem  # e.g., "t0" from "t0.yaml"
-            result[tier_name] = self.load_tier(tier_name)
+            tier_config = self.load_tier(tier_name)
+
+            # Validate that config.tier matches the filename stem.
+            # Apply the same normalization as load_tier() to avoid false positives.
+            expected = tier_name.lower().strip()
+            if not expected.startswith("t"):
+                expected = f"t{expected}"
+
+            if tier_config.tier != expected:
+                raise ConfigurationError(
+                    f"Tier ID mismatch in {tier_file}: "
+                    f"filename implies '{expected}' but config declares tier='{tier_config.tier}'"
+                )
+
+            result[tier_name] = tier_config
 
         return result
 


### PR DESCRIPTION
## Summary

- Added a consistency check in `load_all_tiers()` that raises `ConfigurationError` when a tier file's stem (e.g., `t0` from `t0.yaml`) does not match the `tier` field declared inside the config (e.g., `tier: t1`).
- Applied the same normalization used in `load_tier()` when computing the expected key, so uppercase, whitespace, and missing-prefix variants never produce false positives.
- Added two new tests in `TestConfigLoaderTier`:
  - `test_load_all_tiers_mismatched_id_raises` — verifies `ConfigurationError` is raised with both the filename stem and the conflicting `tier` value in the message.
  - `test_load_all_tiers_consistent_ids` — documents the invariant: every key in the returned dict equals `config.tier`.

## Test plan

- [x] `test_load_all_tiers_mismatched_id_raises` — PASS
- [x] `test_load_all_tiers_consistent_ids` — PASS
- [x] `test_load_all_tiers` (existing) — PASS (still finds exactly 2 tiers)
- [x] Full test suite: 2398 passed, coverage 74.16% (≥73% threshold)
- [x] Pre-commit hooks: all passed (ruff, mypy, black)

Closes #807

🤖 Generated with [Claude Code](https://claude.com/claude-code)