### PR TITLE
fix(docs): Remove phantom tests/integration/ references from README and CONTRIBUTING

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -115,7 +115,7 @@ git checkout -b 123-fix-judge-timeout
 ### 3. Write Tests
 
 ```bash
-# Create tests in tests/unit/ or tests/integration/
+# Create tests in tests/unit/
 # Follow existing test patterns
 
 # Run your tests
@@ -236,7 +236,7 @@ pixi run pytest tests/ --verbose
 
 # Specific categories
 pixi run pytest tests/unit/ -v          # Unit tests only
-pixi run pytest tests/integration/ -v   # Integration tests
+pixi run pytest tests/unit/analysis/ -v # Includes integration-style tests
 
 # Specific modules
 pixi run pytest tests/unit/analysis/ -v

--- a/README.md
+++ b/README.md
@@ -343,8 +343,7 @@ ProjectScylla has a comprehensive test suite with **85+ test files** covering al
 
 #### Test Categories
 
-- **Unit Tests** (67+ files): Analysis, adapters, config, executors, judges, metrics, reporting
-- **Integration Tests** (2 files): End-to-end workflow testing
+- **Unit Tests** (70+ files): Analysis (incl. integration-style tests), adapters, config, executors, judges, metrics, reporting
 - **E2E Tests** (1 file): Full pipeline validation
 - **Test Fixtures** (47+ scenarios): Complete test cases with expected outputs
 
@@ -361,9 +360,6 @@ pixi run pytest tests/unit/ -v
 pixi run pytest tests/unit/analysis/ -v
 pixi run pytest tests/unit/adapters/ -v
 pixi run pytest tests/unit/config/ -v
-
-# Integration tests
-pixi run pytest tests/integration/ -v
 
 # Coverage analysis
 pixi run pytest tests/ --cov=scylla/scylla --cov-report=html


### PR DESCRIPTION
## Summary

- Removed the "Integration Tests (2 files)" bullet from README.md and updated unit test count to 70+ (integration-style tests are in `tests/unit/analysis/`)
- Removed the non-existent `pixi run pytest tests/integration/ -v` command from README.md
- Fixed comment in CONTRIBUTING.md from `tests/unit/ or tests/integration/` to `tests/unit/`
- Replaced `tests/integration/ -v` with `tests/unit/analysis/ -v` in CONTRIBUTING.md Running Tests section

## Test plan

- [x] `grep -r "tests/integration" docs/ README.md CONTRIBUTING.md` returns no results (verified; only `docs/arxiv/` archived dryrun snapshots remain, which are out of scope)
- [x] All referenced directories (`tests/unit/`, `tests/unit/analysis/`) actually exist
- [x] Pre-commit hooks pass (markdown lint, trailing whitespace, etc.)

Closes #848

🤖 Generated with [Claude Code](https://claude.com/claude-code)