### PR TITLE
feat(vcs): add .gitattributes for line-ending normalization and diff drivers

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,25 @@
+# Normalize line endings for all text files
+* text=auto
+
+# Python source files — explicit LF
+*.py text diff=python eol=lf
+
+# YAML, TOML, Markdown — explicit LF
+*.yaml text eol=lf
+*.yml text eol=lf
+*.toml text eol=lf
+*.md text eol=lf
+
+# Shell scripts — LF (required for execution)
+*.sh text eol=lf
+
+# Windows batch — CRLF
+*.bat text eol=crlf
+*.cmd text eol=crlf
+
+# Binary files — no text processing
+*.png binary
+*.jpg binary
+*.pdf binary
+*.gz binary
+*.zip binary


### PR DESCRIPTION
## Summary

- Add `.gitattributes` at repo root to enforce consistent line endings across all four supported platforms (`linux-64`, `osx-arm64`, `osx-64`, `win-64`)
- `* text=auto` as catch-all baseline for all text files
- Explicit `eol=lf` for Python, YAML, TOML, Markdown, and shell scripts
- `diff=python` driver for `.py` files for improved diff hunk headers
- `eol=crlf` for Windows batch files (`.bat`, `.cmd`)
- Binary marking for `.png`, `.jpg`, `.pdf`, `.gz`, `.zip`

## Test plan

- [x] `git add --renormalize .` produced no changes — existing files already have consistent LF line endings
- [x] `git check-attr text -- scylla/cli/main.py` returns `text: set`
- [x] `git check-attr eol -- scylla/cli/main.py` returns `eol: lf`
- [x] `git check-attr diff -- scylla/cli/main.py` returns `diff: python`
- [x] Pre-commit hooks pass (`trim trailing whitespace`, `fix end of files`, `fix mixed line endings`)

Closes #852

🤖 Generated with [Claude Code](https://claude.com/claude-code)