### PR TITLE
refactor(config): Centralize hardcoded model IDs into constants module

### DIFF
--- a/scylla/cli/main.py
+++ b/scylla/cli/main.py
@@ -8,7 +8,7 @@ from pathlib import Path
 
 import click
 
-from scylla.config import ConfigLoader
+from scylla.config import DEFAULT_JUDGE_MODEL, ConfigLoader
 from scylla.e2e.orchestrator import EvalOrchestrator, OrchestratorConfig
 from scylla.reporting import (
     MarkdownReportGenerator,
@@ -335,7 +335,7 @@ def report(
         test_name=test_id.replace("-", " ").title(),
         timestamp=timestamp,
         runs_per_tier=runs_per_tier,
-        judge_model="claude-opus-4-5-20251101",
+        judge_model=DEFAULT_JUDGE_MODEL,
         tiers=tier_metrics,
         sensitivity=sensitivity,
         transitions=transitions,

--- a/scylla/config/__init__.py
+++ b/scylla/config/__init__.py
@@ -13,6 +13,7 @@ Example:
 
 """
 
+from .constants import DEFAULT_AGENT_MODEL, DEFAULT_JUDGE_MODEL
 from .loader import ConfigLoader
 from .models import (
     AdaptersConfig,
@@ -43,6 +44,9 @@ from .pricing import (
 )
 
 __all__ = [
+    # Constants
+    "DEFAULT_AGENT_MODEL",
+    "DEFAULT_JUDGE_MODEL",
     # Loader
     "ConfigLoader",
     # Exceptions

--- a/scylla/config/constants.py
+++ b/scylla/config/constants.py
@@ -1,0 +1,8 @@
+"""Shared constants for ProjectScylla configuration.
+
+This module is the single source of truth for default model IDs.
+Import from here rather than hardcoding model strings at call sites.
+"""
+
+DEFAULT_AGENT_MODEL: str = "claude-sonnet-4-5-20250929"
+DEFAULT_JUDGE_MODEL: str = "claude-opus-4-5-20251101"

--- a/scylla/config/models.py
+++ b/scylla/config/models.py
@@ -9,6 +9,7 @@ from typing import Literal
 
 from pydantic import BaseModel, Field, field_validator
 
+from scylla.config.constants import DEFAULT_JUDGE_MODEL
 from scylla.metrics.grading import DEFAULT_PASS_THRESHOLD
 
 
@@ -208,7 +209,7 @@ class TierConfig(BaseModel):
 class JudgeConfig(BaseModel):
     """Judge model configuration."""
 
-    model: str = Field(default="claude-opus-4-5-20251101")
+    model: str = Field(default=DEFAULT_JUDGE_MODEL)
     adapter: str = Field(default="claude_code")
 
 
@@ -276,7 +277,7 @@ class DefaultsConfig(BaseModel):
     logging: LoggingConfig = Field(default_factory=LoggingConfig)
 
     default_model: str = Field(
-        default="claude-opus-4-5-20251101",
+        default=DEFAULT_JUDGE_MODEL,
         description="Default model ID when none is specified",
     )
 

--- a/scylla/e2e/llm_judge.py
+++ b/scylla/e2e/llm_judge.py
@@ -16,6 +16,7 @@ from typing import Any
 
 from pydantic import BaseModel
 
+from scylla.config.constants import DEFAULT_JUDGE_MODEL
 from scylla.e2e.filters import is_test_config_file
 from scylla.e2e.template_loader import write_script
 from scylla.judge import extract_json_from_llm_response
@@ -765,7 +766,7 @@ def run_llm_judge(
     workspace: Path,
     task_prompt: str,
     agent_output: str,
-    model: str = "claude-opus-4-5-20251101",  # REQUIRED: Must use Opus for accurate judging
+    model: str = DEFAULT_JUDGE_MODEL,  # REQUIRED: Must use Opus for accurate judging
     judge_dir: Path | None = None,
     reference_patch_path: Path | None = None,
     rubric_path: Path | None = None,

--- a/scylla/e2e/models.py
+++ b/scylla/e2e/models.py
@@ -15,6 +15,7 @@ from typing import TYPE_CHECKING, Any
 import yaml
 from pydantic import BaseModel, ConfigDict, Field, field_validator
 
+from scylla.config.constants import DEFAULT_AGENT_MODEL, DEFAULT_JUDGE_MODEL
 from scylla.core.results import RunResultBase
 
 if TYPE_CHECKING:
@@ -779,10 +780,10 @@ class ExperimentConfig(BaseModel):
     task_commit: str
     task_prompt_file: Path
     language: str  # REQUIRED: Programming language for build pipeline
-    models: list[str] = Field(default_factory=lambda: ["claude-sonnet-4-5-20250929"])
+    models: list[str] = Field(default_factory=lambda: [DEFAULT_AGENT_MODEL])
     runs_per_subtest: int = 10
     tiers_to_run: list[TierID] = Field(default_factory=lambda: list(TierID))
-    judge_models: list[str] = Field(default_factory=lambda: ["claude-opus-4-5-20251101"])
+    judge_models: list[str] = Field(default_factory=lambda: [DEFAULT_JUDGE_MODEL])
     parallel_subtests: int = 4
     timeout_seconds: int = 3600
     max_turns: int | None = None  # Max conversation turns for agent (None = unlimited)
@@ -832,7 +833,7 @@ class ExperimentConfig(BaseModel):
         if "judge_model" in data and "judge_models" not in data:
             judge_models = [data["judge_model"]]
         else:
-            judge_models = data.get("judge_models", ["claude-opus-4-5-20251101"])
+            judge_models = data.get("judge_models", [DEFAULT_JUDGE_MODEL])
 
         return cls(
             experiment_id=data["experiment_id"],
@@ -840,7 +841,7 @@ class ExperimentConfig(BaseModel):
             task_commit=data["task_commit"],
             task_prompt_file=Path(data["task_prompt_file"]),
             language=data["language"],
-            models=data.get("models", ["claude-sonnet-4-5-20250929"]),
+            models=data.get("models", [DEFAULT_AGENT_MODEL]),
             runs_per_subtest=data.get("runs_per_subtest", 10),
             tiers_to_run=[TierID.from_string(t) for t in data.get("tiers_to_run", [])],
             judge_models=judge_models,

--- a/scylla/e2e/regenerate.py
+++ b/scylla/e2e/regenerate.py
@@ -16,6 +16,7 @@ from pathlib import Path
 
 from pydantic import BaseModel
 
+from scylla.config.constants import DEFAULT_JUDGE_MODEL
 from scylla.e2e.judge_selection import select_best_subtest
 from scylla.e2e.llm_judge import run_llm_judge
 from scylla.e2e.models import (
@@ -89,7 +90,7 @@ def regenerate_experiment(
     if effective_judge_model is None:
         # Use first judge model from config (primary judge)
         effective_judge_model = (
-            config.judge_models[0] if config.judge_models else "claude-opus-4-5-20251101"
+            config.judge_models[0] if config.judge_models else DEFAULT_JUDGE_MODEL
         )
     logger.info(f"📊 Using judge model: {effective_judge_model}")
 

--- a/scylla/executor/agent_container.py
+++ b/scylla/executor/agent_container.py
@@ -20,6 +20,8 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING
 
+from scylla.config.constants import DEFAULT_AGENT_MODEL
+
 if TYPE_CHECKING:
     pass
 
@@ -50,7 +52,7 @@ class AgentContainerConfig:
     output_dir: Path
     task_prompt_path: Path
     claude_md_path: Path | None = None
-    model: str = "claude-sonnet-4-5-20250929"
+    model: str = DEFAULT_AGENT_MODEL
     timeout_seconds: int = 600
     image: str = "scylla-runner:latest"
     container_name: str | None = None

--- a/scylla/executor/judge_container.py
+++ b/scylla/executor/judge_container.py
@@ -19,6 +19,7 @@ import uuid
 from dataclasses import dataclass
 from pathlib import Path
 
+from scylla.config.constants import DEFAULT_JUDGE_MODEL
 from scylla.executor.docker import (
     ContainerConfig,
     ContainerError,
@@ -45,7 +46,7 @@ class JudgeContainerConfig:
 
     agent_workspace: Path
     output_dir: Path
-    judge_model: str = "claude-opus-4-5-20251101"
+    judge_model: str = DEFAULT_JUDGE_MODEL
     rubric_path: Path | None = None
     criteria_path: Path | None = None
     prompt_path: Path | None = None

--- a/scylla/judge/evaluator.py
+++ b/scylla/judge/evaluator.py
@@ -14,6 +14,7 @@ from typing import Any, Protocol
 
 from pydantic import BaseModel, Field
 
+from scylla.config.constants import DEFAULT_JUDGE_MODEL
 from scylla.judge.utils import extract_json_from_llm_response
 from scylla.metrics.grading import assign_letter_grade
 
@@ -153,7 +154,7 @@ class EvaluatorConfig(BaseModel):
 
     """
 
-    model: str = Field(default="claude-opus-4-5-20251101")
+    model: str = Field(default=DEFAULT_JUDGE_MODEL)
     num_runs: int = Field(default=3, ge=1)
     timeout: int = Field(default=300, ge=30)
     pass_threshold: float = Field(default=0.70, ge=0.0, le=1.0)

--- a/tests/unit/config/test_constants.py
+++ b/tests/unit/config/test_constants.py
@@ -1,0 +1,73 @@
+"""Tests for scylla.config.constants module."""
+
+import scylla.config.constants as constants_module
+from scylla.config import DEFAULT_AGENT_MODEL, DEFAULT_JUDGE_MODEL
+from scylla.config.constants import DEFAULT_AGENT_MODEL as AGENT_MODEL_DIRECT
+from scylla.config.constants import DEFAULT_JUDGE_MODEL as JUDGE_MODEL_DIRECT
+
+
+class TestConstantsImportable:
+    """Verify constants are importable from both the module and the package."""
+
+    def test_importable_from_package(self) -> None:
+        """Constants exported from scylla.config package are not None."""
+        assert DEFAULT_AGENT_MODEL is not None
+        assert DEFAULT_JUDGE_MODEL is not None
+
+    def test_importable_from_module(self) -> None:
+        """Constants importable directly from scylla.config.constants."""
+        assert AGENT_MODEL_DIRECT is not None
+        assert JUDGE_MODEL_DIRECT is not None
+
+    def test_package_and_module_values_match(self) -> None:
+        """Package re-export values match the module-level constants."""
+        assert DEFAULT_AGENT_MODEL == AGENT_MODEL_DIRECT
+        assert DEFAULT_JUDGE_MODEL == JUDGE_MODEL_DIRECT
+
+
+class TestConstantValues:
+    """Verify constant values are valid model ID strings."""
+
+    def test_default_agent_model_is_string(self) -> None:
+        """DEFAULT_AGENT_MODEL is a str instance."""
+        assert isinstance(DEFAULT_AGENT_MODEL, str)
+
+    def test_default_judge_model_is_string(self) -> None:
+        """DEFAULT_JUDGE_MODEL is a str instance."""
+        assert isinstance(DEFAULT_JUDGE_MODEL, str)
+
+    def test_default_agent_model_nonempty(self) -> None:
+        """DEFAULT_AGENT_MODEL is a non-empty string."""
+        assert len(DEFAULT_AGENT_MODEL) > 0
+
+    def test_default_judge_model_nonempty(self) -> None:
+        """DEFAULT_JUDGE_MODEL is a non-empty string."""
+        assert len(DEFAULT_JUDGE_MODEL) > 0
+
+    def test_default_agent_model_contains_sonnet(self) -> None:
+        """DEFAULT_AGENT_MODEL identifies a Sonnet-family model."""
+        assert "sonnet" in DEFAULT_AGENT_MODEL.lower()
+
+    def test_default_judge_model_contains_opus(self) -> None:
+        """DEFAULT_JUDGE_MODEL identifies an Opus-family model."""
+        assert "opus" in DEFAULT_JUDGE_MODEL.lower()
+
+
+class TestNoCircularImports:
+    """Verify constants.py has no scylla.* imports (prevents circular imports)."""
+
+    def test_constants_module_has_no_scylla_imports(self) -> None:
+        """constants.py must only use stdlib; no scylla.* imports allowed."""
+        import inspect
+
+        source = inspect.getsource(constants_module)
+        for line in source.splitlines():
+            stripped = line.strip()
+            if stripped.startswith("#"):
+                continue
+            assert not stripped.startswith("from scylla"), (
+                f"constants.py must not import from scylla.*: {line!r}"
+            )
+            assert not stripped.startswith("import scylla"), (
+                f"constants.py must not import scylla.*: {line!r}"
+            )


### PR DESCRIPTION
## Summary

- Create `scylla/config/constants.py` with `DEFAULT_AGENT_MODEL` and `DEFAULT_JUDGE_MODEL` as the single source of truth for default model ID strings
- Export both constants from `scylla/config/__init__.py`
- Replace all 9 functional hardcoded occurrences across the codebase to use the constants

## Files Changed

| File | Change |
|------|--------|
| `scylla/config/constants.py` | **New**: Single source of truth for model ID constants |
| `scylla/config/__init__.py` | Export `DEFAULT_AGENT_MODEL` and `DEFAULT_JUDGE_MODEL` |
| `scylla/config/models.py` | `JudgeConfig.model` and `DefaultsConfig.default_model` defaults |
| `scylla/executor/agent_container.py` | `AgentContainerConfig.model` default |
| `scylla/executor/judge_container.py` | `JudgeContainerConfig.judge_model` default |
| `scylla/e2e/models.py` | `ExperimentConfig.models`/`judge_models` Field defaults and `load()` fallbacks |
| `scylla/e2e/llm_judge.py` | `run_llm_judge()` model parameter default |
| `scylla/e2e/regenerate.py` | `effective_judge_model` fallback |
| `scylla/judge/evaluator.py` | `JudgeConfig.model` Field default |
| `scylla/cli/main.py` | `ReportData.judge_model` value |
| `tests/unit/config/test_constants.py` | **New**: 10 tests for importability, value validation, circular import prevention |

## Test Plan

- [x] 10 new tests in `tests/unit/config/test_constants.py` all pass
- [x] All 2442 existing tests pass (74.17% coverage, above 73% threshold)
- [x] All pre-commit hooks pass (ruff, mypy, black)
- [x] `scylla/config/constants.py` has no `scylla.*` imports (no circular imports)

Closes #851

🤖 Generated with [Claude Code](https://claude.com/claude-code)