### PR TITLE
feat(dev): add pip-audit audit task alias for local CVE scanning

### DIFF
--- a/pixi.toml
+++ b/pixi.toml
@@ -11,6 +11,7 @@ lint = "ruff check scylla scripts tests"
 format = "ruff format scylla scripts tests"
 plan-issues = "python scripts/plan_issues.py"
 mypy-regression = "python scripts/check_mypy_counts.py"
+audit = "pixi run --environment lint pip-audit"
 
 [dependencies]
 python = ">=3.10"


### PR DESCRIPTION
Closes #872

## Summary
- Adds `audit = "pixi run --environment lint pip-audit"` to `[tasks]` in `pixi.toml`
- `pip-audit` was already declared in `[feature.lint.pypi-dependencies]`; no dependency changes needed
- Developers can now run `pixi run audit` from any environment without the `--environment lint` flag

## Test plan
- [x] `pixi install --environment lint` resolves without error
- [x] `pixi task list` shows `audit` in the task list
- [x] All 2436 existing tests pass with 74.16% coverage (above 73% threshold)

🤖 Generated with [Claude Code](https://claude.com/claude-code)