### PR TITLE
feat(security): configure pip-audit to fail only on HIGH/CRITICAL severity

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -7,6 +7,7 @@ on:
       - "pixi.lock"
       - "pyproject.toml"
       - "**/*.py"
+      - ".github/workflows/security.yml"
   schedule:
     - cron: "0 8 * * 1"
   workflow_dispatch:

--- a/pixi.toml
+++ b/pixi.toml
@@ -50,7 +50,10 @@ yamllint = ">=1.35.0"
 pre-commit = ">=3.0"
 
 [feature.lint.pypi-dependencies]
-pip-audit = ">=2.7"
+pip-audit = ">=2.8"
+
+[feature.lint.tasks]
+pip-audit = "pip-audit --min-severity high"
 
 [environments]
 default = { features = ["dev"], solve-group = "default" }


### PR DESCRIPTION
## Summary

- Bumps `pip-audit` dependency from `>=2.7` to `>=2.8` to guarantee `--min-severity` flag availability
- Adds `[feature.lint.tasks]` section to `pixi.toml` with `pip-audit = "pip-audit --min-severity high"` — the flags are baked into the task, so `pixi run --environment lint pip-audit` automatically filters to HIGH/CRITICAL only
- Adds `.github/workflows/security.yml` to the workflow path triggers so it self-triggers on changes

## How it works

The key insight: by defining a named task in `[feature.lint.tasks]`, the existing `security.yml` workflow call `pixi run --environment lint pip-audit` resolves through the task definition and automatically applies `--min-severity high` — no changes needed to the workflow YAML.

## Test plan

- [x] `pixi run --environment lint pip-audit --version` resolves to `pip-audit --min-severity high --version` (verified: pip-audit 2.10.0)
- [x] Pre-commit hooks pass (YAML lint, trailing whitespace, etc.)
- [ ] CI: Security workflow passes on this PR

Closes #874