### PR TITLE
docs(design): audit and fix stale Future Improvements entries

### DIFF
--- a/docs/design/architecture.md
+++ b/docs/design/architecture.md
@@ -127,6 +127,7 @@ Each tier runs 9 times per test case for statistical validity:
     |  | - Codex       |     |  Container    |     | - CoP         |        |
     |  | - Cline       |     |               |     | - Latency     |        |
     |  | - OpenCode    |     |               |     | - R_Prog      |        |
+    |  | - Goose       |     |               |     |               |        |
     |  +---------------+     +---------------+     +---------------+        |
     |                                                                       |
     +----------------------------------------------------------------------+
@@ -226,10 +227,11 @@ class BaseAdapter:
 
 | Adapter | Agent Tool | Status |
 |---------|------------|--------|
-| `ClaudeCodeAdapter` | Claude Code CLI | Planned |
-| `CodexAdapter` | OpenAI Codex | Planned |
-| `ClineAdapter` | Cline | Planned |
-| `OpenCodeAdapter` | OpenCode | Planned |
+| `ClaudeCodeAdapter` | Claude Code CLI | Implemented |
+| `CodexAdapter` | OpenAI Codex CLI | Implemented |
+| `ClineAdapter` | Cline | Implemented |
+| `OpenCodeAdapter` | OpenCode | Implemented |
+| `GooseAdapter` | Goose CLI | Implemented |
 
 ### 4.4 Judge
 
@@ -496,9 +498,10 @@ ProjectScylla/
         adapters/                       # Agent CLI adapters
             base.py                     # Abstract base class
             claude_code.py              # Claude Code adapter
-            codex.py                    # OpenAI Codex adapter
+            openai_codex.py             # OpenAI Codex adapter
             cline.py                    # Cline adapter
             opencode.py                 # OpenCode adapter
+            goose.py                    # Goose adapter
         judge/                          # Claude + Opus evaluation
             rubric.py                   # Rubric parser
             prompts/                    # Judge prompt templates

--- a/docs/research.md
+++ b/docs/research.md
@@ -205,6 +205,12 @@ The following metrics are **fully implemented** in both the metrics calculation 
 * **Latency**: Time from query initiation to resolution
 * **Judge Agreement**: Inter-rater reliability using Krippendorff's alpha
 
+**Statistical Analysis:**
+
+* **Power Analysis**: Post-hoc statistical power for Mann-Whitney U and Kruskal-Wallis tests
+  * Implementation: `scylla/analysis/stats.py:mann_whitney_power()`, `kruskal_wallis_power()`
+  * Status: Calculation functions complete; not yet surfaced in comparison tables
+
 ### **6.2. Metrics Defined but Not Yet Integrated**
 
 The following metrics are **implemented** in `scylla/metrics/process.py` but **not yet integrated** into the analysis pipeline (`scylla/analysis/`):
@@ -256,8 +262,8 @@ The following metrics are **implemented** in `scylla/metrics/process.py` but **n
    * Ensure sufficient sample sizes for detecting meaningful effect sizes
 
 4. **Multi-Experiment Support**:
-   * Enhance rubric conflict handling when loading multiple experiments
-   * Add multi-experiment comparison tables
+   * Multi-experiment loading is implemented (`scylla/analysis/loader.py:load_all_experiments()`)
+   * Remaining work: rubric conflict handling when the same subtest appears across experiments with differing rubrics
 
 ## **7\. Conclusion and Strategic Research Recommendations**
 


### PR DESCRIPTION
## Summary

Systematic audit of all design docs for "Future Improvements" entries that describe already-implemented features, following up from #759 which only covered `container-architecture.md`.

- **`docs/design/architecture.md`**: All 4 adapters were listed as "Planned" but are fully implemented in `scylla/adapters/`. Updated statuses to "Implemented" and added the missing `GooseAdapter` row. Also corrected the adapter filename (`codex.py` → `openai_codex.py`) and updated the ASCII diagram.
- **`docs/research.md`**: Added Power Analysis functions (`mann_whitney_power`, `kruskal_wallis_power` in `stats.py`) to section 6.1 "Currently Implemented". Updated section 6.3 item 4 (Multi-Experiment Support) to reflect that `load_all_experiments()` is already implemented — narrowing the remaining work to rubric conflict handling only.

## Files reviewed

| File | Had Stale Entries | Action |
|------|------------------|--------|
| `docs/design/architecture.md` | Yes | Fixed |
| `docs/research.md` | Yes | Fixed |
| `docs/design/container-architecture.md` | No (genuinely future) | No change |
| `docs/design/analysis_pipeline.md` | No (genuinely future) | No change |
| `docs/design/judge-protocol.md` | No forward-looking section | No change |
| `docs/design/container-authentication.md` | No forward-looking section | No change |
| `docs/design/grading-scale.md` | No forward-looking section | No change |
| `docs/dev/code-quality-audit-2025-02.md` | Tracked issues (not stale) | No change |

## Test plan

- [x] `grep -n "Planned" docs/design/architecture.md` returns no adapter rows
- [x] `grep -n "Goose" docs/design/architecture.md` shows GooseAdapter in table and diagram
- [x] Pre-commit hooks pass (markdown lint, trailing whitespace)
- [x] No code changes — documentation only

Closes #880