### PR TITLE
feat(mypy): Enable type checking for tests/ and scripts/ directories

### DIFF
--- a/MYPY_KNOWN_ISSUES.md
+++ b/MYPY_KNOWN_ISSUES.md
@@ -3,23 +3,65 @@
 Tracks suppressed type errors during incremental mypy adoption (see #687).
 Run `python scripts/check_mypy_counts.py --update` to refresh counts.
 
-## Error Count Table
+## Error Count Table — scylla/
 
 | Error Code    | Count | Description                              |
 |---------------|-------|------------------------------------------|
-| arg-type      | 27     | Incompatible argument types              |
-| assignment    | 14     | Type mismatches in assignments           |
+| arg-type      | 15     | Incompatible argument types              |
+| assignment    | 13     | Type mismatches in assignments           |
 | attr-defined  | 3     | Attribute not defined                    |
-| call-arg      | 28     | Incorrect function call arguments        |
-| call-overload | 1     | No matching overload variant             |
+| call-arg      | 0     | Incorrect function call arguments        |
+| call-overload | 0     | No matching overload variant             |
 | exit-return   | 1     | Context manager \_\_exit\_\_ return type |
-| index         | 10     | Invalid indexing operations              |
-| misc          | 3     | Miscellaneous type issues                |
+| index         | 3     | Invalid indexing operations              |
+| misc          | 2     | Miscellaneous type issues                |
 | no-redef      | 1     | Name redefinition                        |
-| operator      | 21     | Incompatible operand types               |
+| operator      | 9     | Incompatible operand types               |
 | override      | 1     | Incompatible method override             |
 | return-value  | 0     | Incompatible return value type           |
-| union-attr    | 18     | Accessing attributes on union types      |
+| union-attr    | 2     | Accessing attributes on union types      |
 | valid-type    | 2     | Invalid type annotations                 |
-| var-annotated | 16     | Missing type annotations for variables   |
-| **Total**     | **146** |                                          |
+| var-annotated | 9     | Missing type annotations for variables   |
+| **Total**     | **61** |                                          |
+
+## Error Count Table — tests/
+
+| Error Code    | Count | Description                              |
+|---------------|-------|------------------------------------------|
+| arg-type      | 12     | Incompatible argument types              |
+| assignment    | 1     | Type mismatches in assignments           |
+| attr-defined  | 0     | Attribute not defined                    |
+| call-arg      | 28     | Incorrect function call arguments        |
+| call-overload | 1     | No matching overload variant             |
+| exit-return   | 0     | Context manager \_\_exit\_\_ return type |
+| index         | 7     | Invalid indexing operations              |
+| misc          | 1     | Miscellaneous type issues                |
+| no-redef      | 0     | Name redefinition                        |
+| operator      | 12     | Incompatible operand types               |
+| override      | 0     | Incompatible method override             |
+| return-value  | 0     | Incompatible return value type           |
+| union-attr    | 16     | Accessing attributes on union types      |
+| valid-type    | 0     | Invalid type annotations                 |
+| var-annotated | 7     | Missing type annotations for variables   |
+| **Total**     | **85** |                                          |
+
+## Error Count Table — scripts/
+
+| Error Code    | Count | Description                              |
+|---------------|-------|------------------------------------------|
+| arg-type      | 2     | Incompatible argument types              |
+| assignment    | 1     | Type mismatches in assignments           |
+| attr-defined  | 0     | Attribute not defined                    |
+| call-arg      | 0     | Incorrect function call arguments        |
+| call-overload | 0     | No matching overload variant             |
+| exit-return   | 0     | Context manager \_\_exit\_\_ return type |
+| index         | 0     | Invalid indexing operations              |
+| misc          | 4     | Miscellaneous type issues                |
+| no-redef      | 0     | Name redefinition                        |
+| operator      | 3     | Incompatible operand types               |
+| override      | 0     | Incompatible method override             |
+| return-value  | 1     | Incompatible return value type           |
+| union-attr    | 0     | Accessing attributes on union types      |
+| valid-type    | 0     | Invalid type annotations                 |
+| var-annotated | 2     | Missing type annotations for variables   |
+| **Total**     | **13** |                                          |

--- a/pixi.lock
+++ b/pixi.lock
@@ -3615,7 +3615,7 @@ packages:
 - pypi: ./
   name: scylla
   version: 0.1.0
-  sha256: 07bec542c4748707b9f28fb19acc43dd0f7b51536f143f805daf6e94626e86e4
+  sha256: 009ac7c00ee692310f9039ea3ca64f1b34c23fb4ec568d28097179625d05a719
   requires_dist:
   - click>=8.0
   - pydantic>=2.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -93,7 +93,7 @@ python_version = "3.10"
 # Incremental mypy adoption - start with basic checks
 # Catches syntax errors, undefined names, and import issues
 # TODO #687: Gradually enable stricter checks as existing type errors are fixed
-# See MYPY_KNOWN_ISSUES.md for current baseline (159 errors as of 2026-02-14)
+# See MYPY_KNOWN_ISSUES.md for current baseline (scylla/, tests/, scripts/ tracked separately)
 warn_unused_configs = true
 ignore_missing_imports = true
 show_error_codes = true
@@ -128,15 +128,6 @@ disable_error_code = [
     "call-overload",   # 1 violation - no matching overload variant
 ]
 
-[[tool.mypy.overrides]]
-module = "tests.*"
-# Skip type checking for tests - focus on source code first
-ignore_errors = true
-
-[[tool.mypy.overrides]]
-module = "scripts.*"
-# Skip type checking for scripts - focus on source code first
-ignore_errors = true
 
 [tool.coverage.run]
 branch = true


### PR DESCRIPTION
## Summary

- Remove `ignore_errors = true` mypy overrides for `tests.*` and `scripts.*` modules in `pyproject.toml`
- Extend `scripts/check_mypy_counts.py` with per-directory mypy invocation and filtering:
  - `run_mypy_per_dir()` — runs mypy once per directory, filtering error lines to only count files within the target path
  - `parse_known_issues_per_dir()` — parses new multi-section `## Error Count Table — <dir>/` format
  - `update_table_per_dir()` — writes per-directory counts into each section independently
  - Backward-compatible: legacy flat format still works for validation and update
- Restructure `MYPY_KNOWN_ISSUES.md` with three per-directory sections and populated baselines:
  - `scylla/`: 61 errors
  - `tests/`: 85 errors
  - `scripts/`: 13 errors
- Add 26 unit tests covering all new per-directory functions

## Test plan
- [x] All 26 `test_check_mypy_counts.py` tests pass
- [x] Full test suite passes (2446 tests, 74.16% coverage ≥ 73% threshold)
- [x] `python scripts/check_mypy_counts.py` exits 0 (regression guard passes)
- [x] All pre-commit hooks pass (ruff-format, ruff-check, mypy, check-mypy-counts, markdownlint)

Closes #889