### PR TITLE
fix(ci): remove restore-keys fallback to prevent stale pip-audit cache

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -34,8 +34,6 @@ jobs:
             .pixi
             ~/.cache/rattler/cache
           key: pixi-lint-${{ runner.os }}-${{ hashFiles('pixi.lock') }}
-          restore-keys: |
-            pixi-lint-${{ runner.os }}-
 
       - name: Run pip-audit
         run: pixi run --environment lint pip-audit


### PR DESCRIPTION
## Problem

The `Dependency vulnerability scan` CI job was failing on PRs with:

```
pip-audit: error: unrecognized arguments: --min-severity
```

The `--min-severity` flag was added in pip-audit 2.8. Our `pixi.lock` correctly pins pip-audit 2.10.0, but the `restore-keys` fallback in the cache step allowed CI to load a stale cached environment from a previous `pixi.lock` hash — one that had an older pip-audit without `--min-severity` support.

## Fix

Remove the `restore-keys` fallback from the "Cache pixi environments" step in `security.yml`. With only an exact-match `key`, CI either hits the correct cache or installs fresh from the current `pixi.lock` — never falling back to a stale environment.

## Verification

The `Dependency vulnerability scan` job will now either:
1. Hit the exact cache (correct pip-audit version) and succeed
2. Miss the cache entirely, install fresh from pixi.lock (pip-audit 2.10.0), and succeed