### PR TITLE
test(e2e): Add Test prefix to test class names

### DIFF
--- a/tests/unit/e2e/test_orchestrator.py
+++ b/tests/unit/e2e/test_orchestrator.py
@@ -7,7 +7,7 @@ import pytest
 from scylla.e2e.orchestrator import EvalOrchestrator, OrchestratorConfig
 
 
-class EvalOrchestratorConfig:
+class TestEvalOrchestratorConfig:
     """Tests for OrchestratorConfig."""
 
     def test_defaults(self) -> None:
@@ -78,7 +78,7 @@ class TestEvalOrchestrator:
         assert orchestrator._judge_func is mock_judge
 
 
-class EvalOrchestratorWithFixture:
+class TestEvalOrchestratorWithFixture:
     """Tests for orchestrator with proper test fixture."""
 
     @pytest.fixture


### PR DESCRIPTION
Fixes test classes missing the `Test` prefix required for pytest discovery.

- Rename `EvalOrchestratorConfig` -> `TestEvalOrchestratorConfig`
- Rename `EvalOrchestratorWithFixture` -> `TestEvalOrchestratorWithFixture`

All 604 e2e unit tests pass after the rename.

Closes #962