### PR TITLE
feat(config): Export validate_defaults_filename

### DIFF
--- a/scylla/config/__init__.py
+++ b/scylla/config/__init__.py
@@ -42,6 +42,7 @@ from .pricing import (
     calculate_cost,
     get_model_pricing,
 )
+from .validation import validate_defaults_filename
 
 __all__ = [
     # Constants
@@ -80,4 +81,6 @@ __all__ = [
     "CleanupConfig",
     # Merged Config
     "ScyllaConfig",
+    # Validation
+    "validate_defaults_filename",
 ]


### PR DESCRIPTION
Adds `validate_defaults_filename` to the public API of `scylla/config` by importing it from `.validation` and including it in `__all__` in `scylla/config/__init__.py`.

## Changes

- `/home/mvillmow/Scylla3/scylla/config/__init__.py`: Added `from .validation import validate_defaults_filename` import and `"validate_defaults_filename"` to `__all__`

## Verification

- All pre-commit hooks pass (ruff, mypy, yaml-lint, etc.)
- All 2572 unit tests pass

Closes #944