### PR TITLE
docs(e2e): Document EvalOrchestrator in e2e module docstring

### DIFF
--- a/scylla/e2e/__init__.py
+++ b/scylla/e2e/__init__.py
@@ -4,7 +4,11 @@ This module provides a progressive optimization framework for evaluating
 AI agent capabilities across tiers T0-T6. Each tier can have multiple
 sub-tests, and the best-performing sub-test becomes the baseline for
 the next tier.
-and LLM API calls for judging.
+
+Primary class:
+    EvalOrchestrator: Coordinates end-to-end experiment execution,
+        managing tier progression, checkpoint persistence, rate limiting,
+        and LLM API calls for judging.
 """
 
 from scylla.e2e.checkpoint import (


### PR DESCRIPTION
Adds `EvalOrchestrator` mention to the `scylla/e2e/__init__.py` module docstring so users know the primary class available in this subpackage.

Also fixes a dangling sentence fragment ("and LLM API calls for judging.") that was left disconnected from the rest of the docstring — that text is now incorporated into the new `EvalOrchestrator` description.

Closes #963