### PR TITLE
fix(ci): remove unsupported --min-severity flag from pip-audit task

### DIFF
--- a/pixi.toml
+++ b/pixi.toml
@@ -56,7 +56,7 @@ pre-commit = ">=3.0"
 pip-audit = ">=2.8"
 
 [feature.lint.tasks]
-pip-audit = "pip-audit --min-severity high"
+pip-audit = "pip-audit"
 
 [environments]
 default = { features = ["dev"], solve-group = "default" }


### PR DESCRIPTION
## Summary
- Removes unsupported `--min-severity high` flag from pip-audit task in `pixi.toml`
- This flag does not exist in pip-audit and causes every Security workflow check to fail
- All 8 open PRs are blocked by this CI failure

## Test plan
- [ ] Security workflow passes on this PR
- [ ] All open PRs unblocked after merge