### PR TITLE
fix(scripts): Handle backtick-quoted error codes in mypy counts regex

### DIFF
--- a/scripts/check_mypy_counts.py
+++ b/scripts/check_mypy_counts.py
@@ -62,7 +62,7 @@ _FILE_PATH_RE = re.compile(r"^([^:]+\.py):\d+")
 # Regex to parse table rows from MYPY_KNOWN_ISSUES.md
 # Matches: | error-code | 42 | description |
 # Skips header rows, separator rows, and the Total row
-_TABLE_ROW_RE = re.compile(r"^\|\s*([a-z][a-z0-9-]+)\s*\|\s*(\d+)\s*\|")
+_TABLE_ROW_RE = re.compile(r"^\|\s*`?([a-z][a-z0-9-]+)`?\s*\|\s*(\d+)\s*\|")
 
 # Regex to match the Total row for updating
 _TOTAL_ROW_RE = re.compile(r"(\|\s*\*\*Total\*\*\s*\|\s*\*\*)\d+(\*\*\s*\|)")


### PR DESCRIPTION
Closes #933

## Summary
- Updated `_TABLE_ROW_RE` regex in `scripts/check_mypy_counts.py` to optionally match backtick-wrapped error codes
- Changed from `([a-z][a-z0-9-]+)` to `` `?([a-z][a-z0-9-]+)`? `` so rows like `` | `assignment` | 10 | `` are now parsed correctly

## Test plan
- [x] Pre-commit hooks pass (`ruff`, `mypy`, `check_mypy_counts`)
- [x] All 26 mypy unit tests pass (`pytest tests/unit/ -k "mypy"`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)