### PR TITLE
test(e2e): Add tests verifying ExperimentConfig defaults use constants

### DIFF
--- a/tests/unit/e2e/test_models.py
+++ b/tests/unit/e2e/test_models.py
@@ -424,3 +424,33 @@ class TestExperimentConfig:
             assert loaded.experiment_id == "test-002"
             assert loaded.runs_per_subtest == 5
             assert loaded.tiers_to_run == [TierID.T0, TierID.T1, TierID.T2]
+
+
+class TestExperimentConfigDefaults:
+    """Tests verifying ExperimentConfig defaults use the published constants."""
+
+    def test_default_models_use_constant(self) -> None:
+        """ExperimentConfig().models defaults to [DEFAULT_AGENT_MODEL]."""
+        from scylla.config.constants import DEFAULT_AGENT_MODEL
+
+        config = ExperimentConfig(
+            experiment_id="test-defaults",
+            task_repo="https://github.com/test/repo",
+            task_commit="abc123",
+            task_prompt_file=Path("prompt.md"),
+            language="python",
+        )
+        assert config.models == [DEFAULT_AGENT_MODEL]
+
+    def test_default_judge_models_use_constant(self) -> None:
+        """ExperimentConfig().judge_models defaults to [DEFAULT_JUDGE_MODEL]."""
+        from scylla.config.constants import DEFAULT_JUDGE_MODEL
+
+        config = ExperimentConfig(
+            experiment_id="test-defaults",
+            task_repo="https://github.com/test/repo",
+            task_commit="abc123",
+            task_prompt_file=Path("prompt.md"),
+            language="python",
+        )
+        assert config.judge_models == [DEFAULT_JUDGE_MODEL]

--- a/tests/unit/executor/test_agent_container.py
+++ b/tests/unit/executor/test_agent_container.py
@@ -9,6 +9,7 @@ from unittest.mock import Mock, patch
 
 import pytest
 
+from scylla.config.constants import DEFAULT_AGENT_MODEL
 from scylla.executor.agent_container import (
     AgentContainerConfig,
     AgentContainerManager,
@@ -53,7 +54,7 @@ def test_agent_container_config_defaults():
         task_prompt_path=Path("/tmp/task.md"),
     )
 
-    assert config.model == "claude-sonnet-4-5-20250929"
+    assert config.model == DEFAULT_AGENT_MODEL
     assert config.timeout_seconds == 600
     assert config.image == "scylla-runner:latest"
     assert config.container_name is None

--- a/tests/unit/executor/test_judge_container.py
+++ b/tests/unit/executor/test_judge_container.py
@@ -3,6 +3,7 @@
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
+from scylla.config.constants import DEFAULT_JUDGE_MODEL
 from scylla.executor.docker import ContainerResult
 from scylla.executor.judge_container import (
     JudgeContainerConfig,
@@ -27,7 +28,7 @@ class TestJudgeContainerConfig:
 
         assert config.agent_workspace == workspace
         assert config.output_dir == output
-        assert config.judge_model == "claude-opus-4-5-20251101"
+        assert config.judge_model == DEFAULT_JUDGE_MODEL
         assert config.timeout_seconds == 600
         assert config.image == "scylla-runner:latest"
 


### PR DESCRIPTION
## Summary
- Add `TestExperimentConfigDefaults` class to `tests/unit/e2e/test_models.py` with two tests asserting `ExperimentConfig.models` and `ExperimentConfig.judge_models` default to `DEFAULT_AGENT_MODEL` and `DEFAULT_JUDGE_MODEL` constants
- Update `test_agent_container_config_defaults` in `tests/unit/executor/test_agent_container.py` to use `DEFAULT_AGENT_MODEL` constant instead of a hardcoded string
- Update `TestJudgeContainerConfig.test_minimal_config` in `tests/unit/executor/test_judge_container.py` to use `DEFAULT_JUDGE_MODEL` constant instead of a hardcoded string

## Test plan
- [x] `pixi run python -m pytest tests/unit/e2e/test_models.py -q --no-cov -v` passes (22/22)
- [x] `pixi run python -m pytest tests/unit/executor/test_agent_container.py tests/unit/executor/test_judge_container.py -q --no-cov -v` passes (30/30)
- [x] `pre-commit run --files ...` passes all hooks

Closes #979

🤖 Generated with [Claude Code](https://claude.com/claude-code)