### PR TITLE
test(audit): verify inline comment skips push-to-main check

### DIFF
--- a/tests/unit/scripts/test_audit_doc_examples.py
+++ b/tests/unit/scripts/test_audit_doc_examples.py
@@ -305,6 +305,21 @@ class TestScanFilePassesCleanExamples:
         )
         assert scan_file(md, tmp_path) == []
 
+    def test_passes_push_to_main_with_inline_comment(self, tmp_path: Path) -> None:
+        """Git push origin main with an inline comment (e.g. # BLOCKED) should not be flagged."""
+        md = make_md(
+            tmp_path,
+            "good.md",
+            """\
+            # Doc
+
+            ```bash
+            git push origin main  # BLOCKED
+            ```
+            """,
+        )
+        assert scan_file(md, tmp_path) == []
+
 
 # ---------------------------------------------------------------------------
 # scan_file — finding metadata


### PR DESCRIPTION
## Summary
- Adds `test_passes_push_to_main_with_inline_comment` to `TestScanFilePassesCleanExamples`
- Verifies that `git push origin main  # BLOCKED` (with inline comment) is NOT flagged by the audit script
- The `push-direct-to-main` rule regex uses `(?![^#]*#)` to skip commented lines; this test exercises that path

## Test plan
- [ ] Pre-commit passes on `tests/unit/scripts/test_audit_doc_examples.py`
- [ ] All 37 tests in `tests/unit/scripts/test_audit_doc_examples.py` pass
- [ ] New test `test_passes_push_to_main_with_inline_comment` correctly asserts no violations for inline-commented push command

Closes #930