### PR TITLE
docs: fix phantom file references in documentation

### DIFF
--- a/docs/analysis-prompt.md
+++ b/docs/analysis-prompt.md
@@ -134,7 +134,7 @@ Analyze ProjectScylla for completeness, quality, and maturity across six dimensi
 **Success Criteria:**
 
 - `pixi.toml` defines reproducible environments with pinned versions
-- `docker/Dockerfile` + `docker-compose.yml` support containerized agent execution
+- `docker/Dockerfile` + `docker/docker-compose.yml` support containerized agent execution
 - `.github/` CI workflows gate on tests and lint
 - `.pre-commit-config.yaml` enforces ruff, mypy, yamllint, markdownlint on commit
 - `.env.example` documents all required environment variables
@@ -142,7 +142,7 @@ Analyze ProjectScylla for completeness, quality, and maturity across six dimensi
 **Tasks to Evaluate:**
 
 1. Check `.github/` for CI workflow files and what they gate on
-2. Verify `docker/Dockerfile` and `docker-compose.yml` are complete and match `docs/design/container-architecture.md`
+2. Verify `docker/Dockerfile` and `docker/docker-compose.yml` are complete and match `docs/design/container-architecture.md`
 3. Check `pixi.toml` for version pinning strategy
 4. Verify `.pre-commit-config.yaml` hooks cover all configured linters
 5. Check `.env.example` lists all API keys needed (Anthropic, GitHub, etc.)

--- a/docs/arxiv-submission.md
+++ b/docs/arxiv-submission.md
@@ -10,7 +10,7 @@ The conversion from `docs/research_paper.tex` to arXiv-ready submission package 
 
 ✅ Python converter script (`scripts/build_arxiv_paper.py`)
 ✅ Build pipeline script (`scripts/build_arxiv_submission.sh`)
-✅ Bibliography updates (`docs/references.bib`) - Added 4 missing @misc entries
+✅ Bibliography updates (`docs/arxiv/dryrun/references.bib`) - Added 4 missing @misc entries
 ✅ Figure handling (25 PDF figures + captions)
 ✅ Table handling (10 generated .tex files)
 ✅ Citation mapping ([1]-[10] → BibTeX keys)


### PR DESCRIPTION
## Summary

- Fix `docker-compose.yml` references in `docs/analysis-prompt.md` to use the correct path `docker/docker-compose.yml` (lines 137, 145)
- Fix `docs/references.bib` reference in `docs/arxiv-submission.md` to use the actual file location `docs/arxiv/dryrun/references.bib` (line 13)

## Test plan

- [x] Pre-commit hooks pass (markdownlint, trim trailing whitespace, end of files)
- [x] Verified `docker/docker-compose.yml` exists at the corrected path
- [x] Verified `docs/arxiv/dryrun/references.bib` exists at the corrected path

Closes #959

🤖 Generated with [Claude Code](https://claude.com/claude-code)