### PR TITLE
fix(gitignore): anchor worktree/ to root to prevent false positives

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 # Worktrees for parallel development
-worktree/
+/worktree/
 
 # Build artifacts
 build/


### PR DESCRIPTION
## Summary
- Change `worktree/` to `/worktree/` on line 2 of `.gitignore` to anchor the pattern to the repository root
- Prevents false-positive gitignore warnings for `tests/claude-code/shared/skills/worktree/`

## Test plan
- [x] Pre-commit hooks pass on `.gitignore`
- [x] Minimal single-character change (added `/` prefix)

Closes #920

🤖 Generated with [Claude Code](https://claude.com/claude-code)