### PR TITLE
refactor(mypy): remove 5 globally-zero disabled error codes

### DIFF
--- a/MYPY_KNOWN_ISSUES.md
+++ b/MYPY_KNOWN_ISSUES.md
@@ -1,47 +1,37 @@
 # Mypy Known Issues
 
-Tracks suppressed type errors during incremental mypy adoption (see #687). Last updated 2026-02-22.
+Tracks suppressed type errors during incremental mypy adoption (see #687). Last updated 2026-02-23.
 Run `python scripts/check_mypy_counts.py --update` to refresh counts.
 
 ## Error Count Table — scylla/
 
 | Error Code    | Count | Description                              |
 |---------------|-------|------------------------------------------|
-| arg-type      | 22     | Incompatible argument types              |
-| assignment    | 12     | Type mismatches in assignments           |
+| arg-type      | 22    | Incompatible argument types              |
+| assignment    | 12    | Type mismatches in assignments           |
 | attr-defined  | 4     | Attribute not defined                    |
 | call-arg      | 0     | Incorrect function call arguments        |
-| call-overload | 0     | No matching overload variant             |
-| exit-return   | 0     | Context manager \_\_exit\_\_ return type |
 | index         | 3     | Invalid indexing operations              |
 | misc          | 2     | Miscellaneous type issues                |
-| no-redef      | 0     | Name redefinition                        |
-| operator      | 10     | Incompatible operand types               |
-| override      | 0     | Incompatible method override             |
-| return-value  | 0     | Incompatible return value type           |
+| operator      | 10    | Incompatible operand types               |
 | union-attr    | 4     | Accessing attributes on union types      |
 | var-annotated | 8     | Missing type annotations for variables   |
-| **Total**     | **65** |                                          |
+| **Total**     | **65** |                                         |
 
 ## Error Count Table — tests/
 
 | Error Code    | Count | Description                              |
 |---------------|-------|------------------------------------------|
-| arg-type      | 13     | Incompatible argument types              |
+| arg-type      | 13    | Incompatible argument types              |
 | assignment    | 1     | Type mismatches in assignments           |
 | attr-defined  | 7     | Attribute not defined                    |
-| call-arg      | 30     | Incorrect function call arguments        |
-| call-overload | 0     | No matching overload variant             |
-| exit-return   | 0     | Context manager \_\_exit\_\_ return type |
+| call-arg      | 30    | Incorrect function call arguments        |
 | index         | 7     | Invalid indexing operations              |
 | misc          | 3     | Miscellaneous type issues                |
-| no-redef      | 0     | Name redefinition                        |
-| operator      | 12     | Incompatible operand types               |
-| override      | 0     | Incompatible method override             |
-| return-value  | 0     | Incompatible return value type           |
-| union-attr    | 16     | Accessing attributes on union types      |
+| operator      | 12    | Incompatible operand types               |
+| union-attr    | 16    | Accessing attributes on union types      |
 | var-annotated | 7     | Missing type annotations for variables   |
-| **Total**     | **96** |                                          |
+| **Total**     | **96** |                                         |
 
 ## Error Count Table — scripts/
 
@@ -51,14 +41,9 @@ Run `python scripts/check_mypy_counts.py --update` to refresh counts.
 | assignment    | 0     | Type mismatches in assignments           |
 | attr-defined  | 0     | Attribute not defined                    |
 | call-arg      | 0     | Incorrect function call arguments        |
-| call-overload | 0     | No matching overload variant             |
-| exit-return   | 0     | Context manager \_\_exit\_\_ return type |
 | index         | 0     | Invalid indexing operations              |
 | misc          | 2     | Miscellaneous type issues                |
-| no-redef      | 0     | Name redefinition                        |
 | operator      | 3     | Incompatible operand types               |
-| override      | 0     | Incompatible method override             |
-| return-value  | 0     | Incompatible return value type           |
 | union-attr    | 0     | Accessing attributes on union types      |
 | var-annotated | 1     | Missing type annotations for variables   |
 | **Total**     | **7** |                                          |

--- a/pixi.lock
+++ b/pixi.lock
@@ -3764,7 +3764,7 @@ packages:
 - pypi: ./
   name: scylla
   version: 0.1.0
-  sha256: 71178dcd254e585e60e2f980527e9558c456313f00c5e89882fed109f66170a3
+  sha256: 4af79e500fd366644f89d99d67438f6a347111fb92fa0d6ec96e062c957c1f3f
   requires_dist:
   - click>=8.0
   - pydantic>=2.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -115,20 +115,15 @@ implicit_reexport = true
 # Temporarily disable error codes with most violations during initial rollout
 # Re-enable these incrementally as codebase type errors are fixed
 disable_error_code = [
-    "assignment",      # 10 violations - type mismatches in assignments
-    "operator",        # 8 violations - incompatible operand types
-    "arg-type",        # 6 violations - incompatible argument types
+    "assignment",      # 12 violations - type mismatches in assignments
+    "operator",        # 13 violations - incompatible operand types
+    "arg-type",        # 23 violations - incompatible argument types
     "index",           # 3 violations - invalid indexing operations
-    "attr-defined",    # 3 violations - attribute not defined
-    "misc",            # 2 violations - miscellaneous type issues
-    "override",        # 1 violation - incompatible method override
-    "no-redef",        # 1 violation - name redefinition
-    "exit-return",     # 1 violation - context manager __exit__ return type
-    "union-attr",      # Multiple violations - accessing attributes on unions
-    "var-annotated",   # Multiple violations - missing type annotations for variables
+    "attr-defined",    # 4 violations - attribute not defined
+    "misc",            # 4 violations - miscellaneous type issues
+    "union-attr",      # 4 violations - accessing attributes on unions
+    "var-annotated",   # 9 violations - missing type annotations for variables
     "call-arg",        # Multiple violations - incorrect function call arguments
-    "return-value",    # 1 violation - incompatible return value type
-    "call-overload",   # 1 violation - no matching overload variant
 ]
 
 

--- a/scripts/check_mypy_counts.py
+++ b/scripts/check_mypy_counts.py
@@ -38,14 +38,9 @@ DISABLED_ERROR_CODES = [
     "index",
     "attr-defined",
     "misc",
-    "override",
-    "no-redef",
-    "exit-return",
     "union-attr",
     "var-annotated",
     "call-arg",
-    "return-value",
-    "call-overload",
 ]
 
 # Paths mypy checks (must match pre-commit hook file patterns)


### PR DESCRIPTION
## Summary

- Removes `call-overload`, `exit-return`, `no-redef`, `override`, and `return-value` from the global `disable_error_code` list in `pyproject.toml`
- Removes same codes from `DISABLED_ERROR_CODES` in `scripts/check_mypy_counts.py`
- Removes zero-count rows for these codes from all 3 per-directory tables in `MYPY_KNOWN_ISSUES.md`
- Updates `pixi.lock` (SHA256 changes due to `pyproject.toml` edit)

All 5 codes had **zero violations** across `scylla/`, `tests/`, and `scripts/`, making them safe to remove without any code fixes. The disabled list shrinks from 14 → 9 codes.

## Test plan

- [x] `pre-commit run` passes (ruff, mypy, check-mypy-counts, markdownlint all green)
- [x] `pixi run python scripts/check_mypy_counts.py` passes

Part of #687 (Phase 0 — quick win cleanup before substantive fixes).