### PR TITLE
fix(e2e): Post-merge cleanup from Chief Architect review

### DIFF
--- a/scylla/e2e/tier_state_machine.py
+++ b/scylla/e2e/tier_state_machine.py
@@ -263,8 +263,9 @@ class TierStateMachine:
         """Advance the tier through all states until COMPLETE is reached.
 
         Useful for running a complete tier from start or resuming from any state.
-        On exception, the exception propagates without marking the tier as failed
-        (tier failure is handled at the experiment level).
+        On exception, the tier is marked as FAILED in the checkpoint before the
+        exception re-raises, enabling the experiment level to detect and continue
+        with remaining tiers (partial-failure semantics).
 
         If until_state is specified, the tier stops cleanly when that state is
         reached, enabling incremental validation via --until-tier <state>.


### PR DESCRIPTION
## Summary

Post-merge cleanup implementing the two immediate recommended actions from the Chief Architect review of the 1008-state-machine-refactor (score 4.75/5.0, GO decision).

- **Fix flaky heartbeat tests**: Replace `time.sleep(2)` with polling loops (up to 10s) in `test_heartbeat_updates_periodically` and `test_heartbeat_thread_persists_to_disk`. The `HeartbeatThread.run()` uses `_stop_event.wait(timeout=interval)` meaning the first write happens at t=interval — fixed sleep of 2s was too tight under WSL2 load. All 5 previously-flaky tests now pass (2968 total, up from 2963).
- **Fix stale docstring** in `tier_state_machine.advance_to_completion()` lines 263-267: incorrectly stated "exceptions propagate without marking the tier as failed" — updated to match actual behavior (marks FAILED then re-raises).

## Test plan
- [x] `pytest tests/unit/e2e/test_health.py -k heartbeat` — 15 passed
- [x] Full test suite: 2968 passed, 77.91% coverage (threshold 74%)
- [x] Pre-commit hooks: all 10 passed on changed files

## Tracking
- Remaining post-merge item (low priority): #1078 — TierContext rehydration for fine-grained tier-level crash recovery

🤖 Generated with [Claude Code](https://claude.com/claude-code)