### PR TITLE
[Fix] Enable warn_redundant_casts + warn_unused_ignores; close #687 roadmap

### DIFF
--- a/pixi.lock
+++ b/pixi.lock
@@ -3764,7 +3764,7 @@ packages:
 - pypi: ./
   name: scylla
   version: 0.1.0
-  sha256: 211c4f8c265c962ce4888cb1d5ef35e2a78bc9b06b01ac2c2593fc9a9b3d8661
+  sha256: ad718104a873ec8a4996a815cdeaeed66ed64a81d9ea040ded8c7568b1678f3a
   requires_dist:
   - click>=8.0
   - pydantic>=2.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -94,27 +94,25 @@ addopts = [
 
 [tool.mypy]
 python_version = "3.10"
-# Incremental mypy adoption - start with basic checks
-# Catches syntax errors, undefined names, and import issues
-# Phases 1-6 of #687 complete. See #940 for tests/ and #687 for strict settings.
+# Incremental mypy adoption — Phases 1-6 of #687 complete (scylla/ + scripts/ clean).
+# tests/ override tracks real errors; see #940 for cleanup.
+# Remaining strict settings: Phase 7a-c (#1083-#1085), Phase 9 (#1086).
 warn_unused_configs = true
 ignore_missing_imports = true
 show_error_codes = true
-# Minimal strictness for now - prevents new egregious errors
-check_untyped_defs = false
-disallow_untyped_defs = false
-disallow_incomplete_defs = false
-disallow_any_generics = false
-warn_return_any = false
-warn_redundant_casts = false
-warn_unused_ignores = false
+# Strict settings — enabled as errors are fixed per #687 roadmap
+check_untyped_defs = false        # TODO #1083: 26 errors in scripts/export_data.py
+disallow_untyped_defs = false     # TODO #1084: 32 missing annotations
+disallow_incomplete_defs = false  # TODO #1086: 16 errors
+disallow_any_generics = false     # TODO #1086: 78 errors
+warn_return_any = false           # TODO #1085: 58 errors
+warn_redundant_casts = true
+warn_unused_ignores = true
 # Allow flexible typing while codebase type coverage improves
 allow_redefinition = true
 implicit_reexport = true
-# All error codes fixed in scylla/ and scripts/ — disable_error_code removed (see #687)
 
-# tests/ has additional suppressed errors beyond scylla/ and scripts/
-# Decoupled so scylla/+scripts/ codes can be removed independently as they are fixed
+# tests/ has real errors suppressed while they are fixed incrementally (see #940)
 [[tool.mypy.overrides]]
 module = "tests.*"
 disable_error_code = [
@@ -127,6 +125,7 @@ disable_error_code = [
     "call-arg",        # tests-only, zero in scylla/ and scripts/
     "misc",            # violations in tests/unit/
     "method-assign",   # violations in tests/unit/ (method monkey-patching in test mocks)
+    "unused-ignore",   # type: ignore comments in tests/ suppress the above codes
 ]
 
 

--- a/scripts/check_coverage.py
+++ b/scripts/check_coverage.py
@@ -19,12 +19,8 @@ _REPO_ROOT = _SCRIPT_DIR.parent
 sys.path.insert(0, str(_REPO_ROOT))
 sys.path.insert(0, str(_SCRIPT_DIR))
 
+import tomllib  # noqa: E402
 from common import get_repo_root  # noqa: E402
-
-try:
-    import tomllib
-except ImportError:
-    import tomli as tomllib  # type: ignore
 
 
 def load_coverage_config(config_file: Path | None = None) -> dict:


### PR DESCRIPTION
## Summary

Free-win strict settings from the #687 mypy roadmap:

- Enable `warn_redundant_casts = true` — 0 errors to fix (pure gain)
- Enable `warn_unused_ignores = true` — 1 error fixed
- Fix `scripts/check_coverage.py`: remove dead `try/except ImportError` for `tomli`; Python 3.10+ ships `tomllib` in stdlib and `tomli` is not in project dependencies
- Add `"unused-ignore"` to the `tests.*` override — the existing `# type: ignore` comments in tests/ suppress the codes in the override; enabling `warn_unused_ignores` globally would flag those suppressor comments as stale
- Update `[tool.mypy]` comments to reference new tracking issues (#1083–#1086) for remaining strict settings

## Remaining work (tracked in separate issues)

| Issue | Setting | Errors |
|-------|---------|--------|
| #1083 | `check_untyped_defs` | 26 (all in `scripts/export_data.py`) |
| #1084 | `disallow_untyped_defs` | 32 (missing annotations) |
| #1085 | `warn_return_any` | 58 |
| #1086 | Phase 9 strict mode | 94 (`disallow_incomplete_defs` + `disallow_any_generics`) |
| #940  | tests/ override cleanup | 106 |

## Test plan

- [x] `pixi run mypy scylla/ scripts/ tests/` → 0 errors (306 files)
- [x] `pixi run pytest tests/ -q` → 2950 passed, 77.94% coverage
- [x] Pre-commit hooks all pass

Closes #687

🤖 Generated with [Claude Code](https://claude.com/claude-code)