### PR TITLE
[Fix] Enable mypy warn_return_any — add cast() to 58 return sites

### DIFF
--- a/pixi.lock
+++ b/pixi.lock
@@ -3764,7 +3764,7 @@ packages:
 - pypi: ./
   name: scylla
   version: 0.1.0
-  sha256: 0b053369f0d6b6af5645514dd8e2268661c0cca1f52e0a89ea91864d0a001cce
+  sha256: d03ed20bd69fa8ae00c663719b6fb6cdd809a8a4e9362c85546ca08f03b069bc
   requires_dist:
   - click>=8.0
   - pydantic>=2.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -104,7 +104,7 @@ check_untyped_defs = true
 disallow_untyped_defs = false     # TODO #1084: 32 missing annotations
 disallow_incomplete_defs = false  # TODO #1086: 16 errors
 disallow_any_generics = false     # TODO #1086: 78 errors
-warn_return_any = false           # TODO #1085: 58 errors
+warn_return_any = true
 warn_redundant_casts = true
 warn_unused_ignores = true
 # Allow flexible typing while codebase type coverage improves

--- a/scripts/agents/agent_utils.py
+++ b/scripts/agents/agent_utils.py
@@ -20,7 +20,7 @@ Classes:
 
 import re
 from pathlib import Path
-from typing import Any
+from typing import Any, cast
 
 import yaml
 
@@ -159,7 +159,7 @@ class AgentInfo:
         """
         # Check if level is explicitly specified
         if "level" in frontmatter:
-            return frontmatter["level"]
+            return cast(int, frontmatter["level"])
 
         # Infer from name
         name = self.name.lower()

--- a/scripts/check_coverage.py
+++ b/scripts/check_coverage.py
@@ -12,6 +12,7 @@ Usage:
 import argparse
 import sys
 from pathlib import Path
+from typing import Any, cast
 
 # Enable importing from repository root and scripts directory
 _SCRIPT_DIR = Path(__file__).parent
@@ -44,7 +45,7 @@ def load_coverage_config(config_file: Path | None = None) -> dict:
     try:
         with open(config_file, "rb") as f:
             config = tomllib.load(f)
-        return config
+        return cast(dict[Any, Any], config)
     except Exception as e:
         print(f"⚠️  Warning: Failed to load config from {config_file}: {e}", file=sys.stderr)
         return {"coverage": {"target": 90.0, "minimum": 80.0}}
@@ -65,15 +66,15 @@ def get_module_threshold(path: str, config: dict) -> float:
 
     # Try exact match first
     if path in modules:
-        return modules[path].get("minimum", 90.0)
+        return cast(float, modules[path].get("minimum", 90.0))
 
     # Try prefix match
     for module_path in sorted(modules.keys(), key=len, reverse=True):
         if path.startswith(module_path):
-            return modules[module_path].get("minimum", 90.0)
+            return cast(float, modules[module_path].get("minimum", 90.0))
 
     # Default to overall minimum
-    return config.get("coverage", {}).get("minimum", 80.0)
+    return cast(float, config.get("coverage", {}).get("minimum", 80.0))
 
 
 def parse_coverage_report(coverage_file: Path) -> float | None:

--- a/scripts/merge_prs.py
+++ b/scripts/merge_prs.py
@@ -21,6 +21,7 @@ import json
 import subprocess
 import sys
 from pathlib import Path
+from typing import Any, cast
 
 # Enable importing from repository root and scripts directory
 _SCRIPT_DIR = Path(__file__).parent
@@ -76,7 +77,7 @@ def get_open_prs() -> list[dict]:
         print(f"Error: Failed to list PRs: {result.stderr}", file=sys.stderr)
         sys.exit(1)
 
-    return json.loads(result.stdout)
+    return cast(list[dict[Any, Any]], json.loads(result.stdout))
 
 
 def check_pr_status(pr_number: int) -> dict[str, bool]:

--- a/scripts/migrate_skills_to_mnemosyne.py
+++ b/scripts/migrate_skills_to_mnemosyne.py
@@ -23,6 +23,7 @@ import subprocess
 import sys
 from datetime import datetime
 from pathlib import Path
+from typing import Any, cast
 
 # Category normalization map
 CATEGORY_NORMALIZATION = {
@@ -124,7 +125,7 @@ def resolve_category(skill_name: str, plugin_data: dict) -> str:
         category = plugin_data["category"]
         if category in CATEGORY_NORMALIZATION:
             return CATEGORY_NORMALIZATION[category]
-        return category
+        return cast(str, category)
 
     # 3. Heuristic
     for prefix, category in CATEGORY_HEURISTICS.items():
@@ -139,15 +140,15 @@ def normalize_author(author_field) -> dict:
     """Normalize author field to dict format."""
     if isinstance(author_field, str):
         return {"name": author_field}
-    return author_field
+    return cast(dict[Any, Any], author_field)
 
 
 def normalize_date(plugin_data: dict) -> str | None:
     """Normalize date field (created -> date)."""
     if "date" in plugin_data:
-        return plugin_data["date"]
+        return cast(str, plugin_data["date"])
     if "created" in plugin_data:
-        return plugin_data["created"]
+        return cast(str, plugin_data["created"])
     return None
 
 

--- a/scripts/run_e2e_batch.py
+++ b/scripts/run_e2e_batch.py
@@ -21,6 +21,7 @@ import threading
 import time
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
+from typing import Any, cast
 
 # Add scripts/ to path for common utilities
 sys.path.insert(0, str(Path(__file__).parent))
@@ -98,7 +99,7 @@ def load_existing_results(results_dir: Path) -> list[dict]:
             data = json.load(f)
         results = data.get("results", [])
         logger.info(f"Loaded {len(results)} existing results from {summary_path}")
-        return results
+        return cast(list[dict[Any, Any]], results)
     except Exception as e:
         logger.warning(f"Failed to load existing results from {summary_path}: {e}")
         return []

--- a/scylla/adapters/claude_code.py
+++ b/scylla/adapters/claude_code.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 import re
 import subprocess
 from datetime import datetime, timezone
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, cast
 
 from scylla.adapters.base import (
     AdapterConfig,
@@ -331,7 +331,7 @@ class ClaudeCodeAdapter(BaseAdapter):
             # num_turns represents the number of API turn exchanges
             num_turns = data.get("num_turns", 0)
             if num_turns > 0:
-                return num_turns
+                return cast(int, num_turns)
         except (json.JSONDecodeError, AttributeError):
             pass
 
@@ -371,6 +371,6 @@ class ClaudeCodeAdapter(BaseAdapter):
 
         try:
             data = json.loads(stdout.strip())
-            return data.get("total_cost_usd", 0.0)
+            return cast(float, data.get("total_cost_usd", 0.0))
         except (json.JSONDecodeError, AttributeError):
             return 0.0

--- a/scylla/analysis/config.py
+++ b/scylla/analysis/config.py
@@ -7,7 +7,7 @@ Ensures reproducibility by centralizing all tunable parameters.
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Any
+from typing import Any, cast
 
 import yaml
 
@@ -61,177 +61,185 @@ class AnalysisConfig:
     @property
     def alpha(self) -> float:
         """Statistical significance threshold."""
-        return self.get("statistical", "alpha", default=0.05)
+        return cast(float, self.get("statistical", "alpha", default=0.05))
 
     @property
     def bootstrap_resamples(self) -> int:
         """Number of bootstrap resamples."""
-        return self.get("statistical", "bootstrap", "n_resamples", default=10000)
+        return cast(int, self.get("statistical", "bootstrap", "n_resamples", default=10000))
 
     @property
     def bootstrap_random_state(self) -> int:
         """Random state for bootstrap resampling."""
-        return self.get("statistical", "bootstrap", "random_state", default=42)
+        return cast(int, self.get("statistical", "bootstrap", "random_state", default=42))
 
     @property
     def bootstrap_confidence(self) -> float:
         """Bootstrap confidence level."""
-        return self.get("statistical", "bootstrap", "confidence_level", default=0.95)
+        return cast(float, self.get("statistical", "bootstrap", "confidence_level", default=0.95))
 
     @property
     def min_sample_bootstrap(self) -> int:
         """Minimum sample size for bootstrap CI."""
-        return self.get("statistical", "min_samples", "bootstrap_ci", default=2)
+        return cast(int, self.get("statistical", "min_samples", "bootstrap_ci", default=2))
 
     @property
     def min_sample_mann_whitney(self) -> int:
         """Minimum sample size for Mann-Whitney U test."""
-        return self.get("statistical", "min_samples", "mann_whitney", default=2)
+        return cast(int, self.get("statistical", "min_samples", "mann_whitney", default=2))
 
     @property
     def min_sample_normality(self) -> int:
         """Minimum sample size for normality tests."""
-        return self.get("statistical", "min_samples", "normality_test", default=3)
+        return cast(int, self.get("statistical", "min_samples", "normality_test", default=3))
 
     @property
     def min_sample_correlation(self) -> int:
         """Minimum sample size for correlation analysis."""
-        return self.get("statistical", "min_samples", "correlation", default=3)
+        return cast(int, self.get("statistical", "min_samples", "correlation", default=3))
 
     @property
     def min_sample_kruskal_wallis(self) -> int:
         """Minimum sample size for Kruskal-Wallis test."""
-        return self.get("statistical", "min_samples", "kruskal_wallis", default=2)
+        return cast(int, self.get("statistical", "min_samples", "kruskal_wallis", default=2))
 
     @property
     def power_n_simulations(self) -> int:
         """Number of simulations for power analysis."""
-        return self.get("statistical", "power_analysis", "n_simulations", default=10000)
+        return cast(int, self.get("statistical", "power_analysis", "n_simulations", default=10000))
 
     @property
     def power_random_state(self) -> int:
         """Random state for power analysis simulations."""
-        return self.get("statistical", "power_analysis", "random_state", default=42)
+        return cast(int, self.get("statistical", "power_analysis", "random_state", default=42))
 
     @property
     def adequate_power_threshold(self) -> float:
         """Threshold for adequate statistical power."""
-        return self.get("statistical", "power_analysis", "adequate_power_threshold", default=0.80)
+        return cast(
+            float,
+            self.get("statistical", "power_analysis", "adequate_power_threshold", default=0.80),
+        )
 
     @property
     def png_dpi_scale(self) -> float:
         """PNG DPI scale factor (300 DPI / 100 base = 3.0)."""
-        dpi = self.get("figures", "dpi", "png", default=300)
+        dpi = cast(float, self.get("figures", "dpi", "png", default=300))
         return dpi / 100.0
 
     @property
     def figure_width(self) -> int:
         """Default figure width."""
-        return self.get("figures", "default_width", default=400)
+        return cast(int, self.get("figures", "default_width", default=400))
 
     @property
     def figure_height(self) -> int:
         """Default figure height."""
-        return self.get("figures", "default_height", default=300)
+        return cast(int, self.get("figures", "default_height", default=300))
 
     @property
     def pass_threshold(self) -> float:
         """Reference line threshold for acceptable pass-rate."""
-        return self.get("figures", "pass_threshold", default=0.60)
+        return cast(float, self.get("figures", "pass_threshold", default=0.60))
 
     @property
     def grade_order(self) -> list[str]:
         """Canonical grade ordering (S=best, F=worst)."""
-        return self.get("colors", "grade_order", default=["S", "A", "B", "C", "D", "F"])
+        return cast(
+            list[str], self.get("colors", "grade_order", default=["S", "A", "B", "C", "D", "F"])
+        )
 
     @property
     def correlation_metrics(self) -> dict[str, str]:
         """Metric pairs for correlation analysis (column_name: display_name)."""
-        return self.get(
-            "figures",
-            "correlation_metrics",
-            default={
-                "score": "Score",
-                "cost_usd": "Cost (USD)",
-                "total_tokens": "Total Tokens",
-                "duration_seconds": "Duration (s)",
-            },
+        return cast(
+            dict[str, str],
+            self.get(
+                "figures",
+                "correlation_metrics",
+                default={
+                    "score": "Score",
+                    "cost_usd": "Cost (USD)",
+                    "total_tokens": "Total Tokens",
+                    "duration_seconds": "Duration (s)",
+                },
+            ),
         )
 
     @property
     def pipeline_version(self) -> str:
         """Analysis pipeline version."""
-        return self.get("reproducibility", "pipeline_version", default="1.0.0")
+        return cast(str, self.get("reproducibility", "pipeline_version", default="1.0.0"))
 
     @property
     def config_version(self) -> str:
         """Configuration file version."""
-        return self.get("reproducibility", "config_version", default="1.0.0")
+        return cast(str, self.get("reproducibility", "config_version", default="1.0.0"))
 
     @property
     def colors(self) -> dict[str, dict[str, str]]:
         """All color palettes from config."""
-        return self.get("colors", default={})
+        return cast(dict[str, dict[str, str]], self.get("colors", default={}))
 
     @property
     def model_colors(self) -> dict[str, str]:
         """Model color palette."""
-        return self.get("colors", "models", default={})
+        return cast(dict[str, str], self.get("colors", "models", default={}))
 
     @property
     def tier_colors(self) -> dict[str, str]:
         """Tier color palette."""
-        return self.get("colors", "tiers", default={})
+        return cast(dict[str, str], self.get("colors", "tiers", default={}))
 
     @property
     def grade_colors(self) -> dict[str, str]:
         """Grade color palette."""
-        return self.get("colors", "grades", default={})
+        return cast(dict[str, str], self.get("colors", "grades", default={}))
 
     @property
     def judge_colors(self) -> dict[str, str]:
         """Judge color palette."""
-        return self.get("colors", "judges", default={})
+        return cast(dict[str, str], self.get("colors", "judges", default={}))
 
     @property
     def criteria_colors(self) -> dict[str, str]:
         """Criteria color palette."""
-        return self.get("colors", "criteria", default={})
+        return cast(dict[str, str], self.get("colors", "criteria", default={}))
 
     @property
     def precision_p_values(self) -> int:
         """Number of decimal places for p-values."""
-        return self.get("tables", "precision", "p_values", default=4)
+        return cast(int, self.get("tables", "precision", "p_values", default=4))
 
     @property
     def precision_effect_sizes(self) -> int:
         """Number of decimal places for effect sizes."""
-        return self.get("tables", "precision", "effect_sizes", default=3)
+        return cast(int, self.get("tables", "precision", "effect_sizes", default=3))
 
     @property
     def precision_percentages(self) -> int:
         """Number of decimal places for percentages."""
-        return self.get("tables", "precision", "percentages", default=1)
+        return cast(int, self.get("tables", "precision", "percentages", default=1))
 
     @property
     def precision_costs(self) -> int:
         """Number of decimal places for costs."""
-        return self.get("tables", "precision", "costs", default=2)
+        return cast(int, self.get("tables", "precision", "costs", default=2))
 
     @property
     def precision_rates(self) -> int:
         """Number of decimal places for rates."""
-        return self.get("tables", "precision", "rates", default=3)
+        return cast(int, self.get("tables", "precision", "rates", default=3))
 
     @property
     def phase_colors(self) -> dict[str, str]:
         """Phase color palette."""
-        return self.get("colors", "phases", default={})
+        return cast(dict[str, str], self.get("colors", "phases", default={}))
 
     @property
     def token_type_colors(self) -> dict[str, str]:
         """Token type color palette."""
-        return self.get("colors", "token_types", default={})
+        return cast(dict[str, str], self.get("colors", "token_types", default={}))
 
 
 # Global singleton instance

--- a/scylla/analysis/loader.py
+++ b/scylla/analysis/loader.py
@@ -12,7 +12,7 @@ import logging
 import re
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any
+from typing import Any, cast
 
 import jsonschema
 import numpy as np
@@ -396,7 +396,7 @@ def load_agent_result(run_dir: Path) -> dict[str, Any]:
 
     try:
         with agent_result_path.open() as f:
-            return json.load(f)
+            return cast(dict[str, Any], json.load(f))
     except (json.JSONDecodeError, OSError) as e:
         logger.warning("Failed to load agent result %s: %s", agent_result_path, e)
         return {}

--- a/scylla/automation/git_utils.py
+++ b/scylla/automation/git_utils.py
@@ -11,6 +11,7 @@ import logging
 import subprocess
 import time
 from pathlib import Path
+from typing import cast
 
 logger = logging.getLogger(__name__)
 
@@ -214,7 +215,7 @@ def get_current_branch(repo_root: Path | None = None) -> str:
             capture_output=True,
             check=True,
         )
-        return result.stdout.strip()
+        return cast(str, result.stdout.strip())
     except subprocess.CalledProcessError as e:
         raise RuntimeError(f"Failed to get current branch: {e}") from e
 

--- a/scylla/automation/github_api.py
+++ b/scylla/automation/github_api.py
@@ -18,7 +18,7 @@ import subprocess
 import tempfile
 import time
 from pathlib import Path
-from typing import Any
+from typing import Any, cast
 
 from .git_utils import get_repo_info, run
 from .models import IssueInfo, IssueState
@@ -128,7 +128,7 @@ def gh_issue_json(issue_number: int) -> dict[str, Any]:
         result = _gh_call(
             ["issue", "view", str(issue_number), "--json", "number,title,state,labels,body"],
         )
-        return json.loads(result.stdout)
+        return cast(dict[str, Any], json.loads(result.stdout))
     except subprocess.CalledProcessError as e:
         raise RuntimeError(f"Failed to fetch issue #{issue_number}: {e}") from e
 
@@ -343,7 +343,7 @@ def is_issue_closed(issue_number: int, cached_states: dict[int, IssueState] | No
 
     try:
         issue_data = gh_issue_json(issue_number)
-        return issue_data["state"] == "CLOSED"
+        return cast(bool, issue_data["state"] == "CLOSED")
     except Exception as e:
         logger.warning(f"Failed to check if issue #{issue_number} is closed: {e}")
         return False

--- a/scylla/automation/implementer.py
+++ b/scylla/automation/implementer.py
@@ -19,6 +19,7 @@ import time
 from concurrent.futures import FIRST_COMPLETED, Future, ThreadPoolExecutor, wait
 from datetime import datetime, timezone
 from pathlib import Path
+from typing import cast
 
 from .curses_ui import CursesUI, ThreadLogManager
 from .dependency_resolver import DependencyResolver
@@ -931,7 +932,7 @@ class IssueImplementer:
                 log_file = self.state_dir / f"claude-{issue_number}.log"
                 log_file.write_text(result.stdout or "")
 
-                return session_id
+                return cast(str | None, session_id)
             except (json.JSONDecodeError, AttributeError):
                 logger.warning(f"Could not parse session_id for issue #{issue_number}")
                 logger.debug(f"Claude stdout: {result.stdout[:500]}")
@@ -1123,7 +1124,7 @@ Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>
             )
             pr_data = json.loads(result.stdout)
             if pr_data and len(pr_data) > 0:
-                pr_number = pr_data[0]["number"]
+                pr_number = cast(int, pr_data[0]["number"])
                 logger.info(f"✓ PR #{pr_number} already exists")
                 return pr_number
         except Exception as e:

--- a/scylla/e2e/judge_runner.py
+++ b/scylla/e2e/judge_runner.py
@@ -13,7 +13,7 @@ import json
 import logging
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any, cast
 
 from scylla.e2e.llm_judge import run_llm_judge
 from scylla.e2e.models import JudgeResultSummary
@@ -64,7 +64,7 @@ def _load_judge_result(judge_dir: Path) -> dict:
     with open(result_file) as f:
         data = json.load(f)
 
-    return data
+    return cast(dict[Any, Any], data)
 
 
 def _has_valid_judge_result(run_dir: Path) -> bool:

--- a/scylla/e2e/orchestrator.py
+++ b/scylla/e2e/orchestrator.py
@@ -6,6 +6,7 @@ from collections.abc import Callable
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
+from typing import Any, cast
 
 from scylla.cli.progress import ProgressDisplay, RunStatus
 from scylla.config import ConfigLoader, EvalCase, Rubric
@@ -323,11 +324,14 @@ class EvalOrchestrator:
 
         """
         if self._adapter_func:
-            return self._adapter_func(
-                workspace=workspace,
-                test_case=test_case,
-                model_id=model_id,
-                tier_id=tier_id,
+            return cast(
+                dict[Any, Any],
+                self._adapter_func(
+                    workspace=workspace,
+                    test_case=test_case,
+                    model_id=model_id,
+                    tier_id=tier_id,
+                ),
             )
 
         # Default: return mock execution
@@ -360,11 +364,14 @@ class EvalOrchestrator:
 
         """
         if self._judge_func:
-            return self._judge_func(
-                workspace=workspace,
-                test_case=test_case,
-                rubric=rubric,
-                execution_result=execution_result,
+            return cast(
+                dict[Any, Any],
+                self._judge_func(
+                    workspace=workspace,
+                    test_case=test_case,
+                    rubric=rubric,
+                    execution_result=execution_result,
+                ),
             )
 
         # Default: return mock judgment

--- a/scylla/e2e/tier_manager.py
+++ b/scylla/e2e/tier_manager.py
@@ -12,7 +12,7 @@ import os
 import shutil
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, cast
 
 import yaml
 
@@ -314,7 +314,7 @@ class TierManager:
         with open(config_path) as f:
             config = yaml.safe_load(f) or {}
 
-        return config.get("resources", {})
+        return cast(dict[str, Any], config.get("resources", {}))
 
     def _create_symlinks(  # noqa: C901  # symlink creation with many source/target patterns
         self,

--- a/scylla/judge/utils.py
+++ b/scylla/judge/utils.py
@@ -2,7 +2,7 @@
 
 import json
 import re
-from typing import Any
+from typing import Any, cast
 
 
 def extract_json_from_llm_response(output: str) -> dict[str, Any] | None:
@@ -41,7 +41,7 @@ def extract_json_from_llm_response(output: str) -> dict[str, Any] | None:
     json_block = re.search(r"```(?:json)?\s*(\{[\s\S]*?\})\s*```", output)
     if json_block:
         try:
-            return json.loads(json_block.group(1))
+            return cast(dict[str, Any], json.loads(json_block.group(1)))
         except json.JSONDecodeError:
             pass
 
@@ -66,6 +66,6 @@ def extract_json_from_llm_response(output: str) -> dict[str, Any] | None:
         return None
 
     try:
-        return json.loads(output[start:end])
+        return cast(dict[str, Any], json.loads(output[start:end]))
     except json.JSONDecodeError:
         return None


### PR DESCRIPTION
## Summary
- Enables `warn_return_any = true` in mypy config
- Fixes all 58 `no-any-return` errors by wrapping return values with `cast()` from `typing`

## Key Changes
- `scylla/analysis/config.py`: 33 property returns (`self.get()` results)
- `scripts/check_coverage.py`: 3 `dict.get()` returns  
- 13 other files: 1-2 `cast()` wraps each for `json.loads()`, `dict.get()`, and similar Any-typed expressions

Closes #1085