### PR TITLE
[Fix] Enable all strict mypy settings — fix 104+ errors (#1086)

### DIFF
--- a/pixi.lock
+++ b/pixi.lock
@@ -3764,7 +3764,7 @@ packages:
 - pypi: ./
   name: scylla
   version: 0.1.0
-  sha256: ba0bebf5facdcdc6acf04b9fab6dcefdf791e6af50ee1469ebe1d74448b248e8
+  sha256: 1b18afaac7fa33f54f965085bec0287ce6f86bc630a5fb7d15edcf2e11902d15
   requires_dist:
   - click>=8.0
   - pydantic>=2.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -94,22 +94,20 @@ addopts = [
 
 [tool.mypy]
 python_version = "3.10"
-# Incremental mypy adoption — Phases 1-6 of #687 complete (scylla/ + scripts/ clean).
-# Remaining strict settings: Phase 7a-c (#1083-#1085), Phase 9 (#1086).
+# Incremental mypy adoption — Phases 1-8 of #687 complete (all strict settings enabled).
 warn_unused_configs = true
 ignore_missing_imports = true
 show_error_codes = true
-# Strict settings — enabled as errors are fixed per #687 roadmap
+# Strict settings — all enabled (#687 roadmap complete)
 check_untyped_defs = true
 disallow_untyped_defs = true
-disallow_incomplete_defs = false  # TODO #1086: 16 errors
-disallow_any_generics = false     # TODO #1086: 78 errors
+disallow_incomplete_defs = true
+disallow_any_generics = true
 warn_return_any = true
 warn_redundant_casts = true
 warn_unused_ignores = true
-# Allow flexible typing while codebase type coverage improves
-allow_redefinition = true
-implicit_reexport = true
+allow_redefinition = false
+implicit_reexport = false
 
 # tests/unit/ has 635 unannotated test functions — suppress no-untyped-def
 # until they are annotated in a follow-up issue

--- a/scripts/agents/agent_stats.py
+++ b/scripts/agents/agent_stats.py
@@ -56,8 +56,8 @@ class AgentAnalyzer:
         """
         self.agents_dir = agents_dir
         self.verbose = verbose
-        self.agents: list[dict] = []
-        self.stats: dict = {}
+        self.agents: list[dict[str, Any]] = []
+        self.stats: dict[str, Any] = {}
 
     def load_agents(self) -> None:
         """Load and parse all agent configuration files."""

--- a/scripts/agents/check_frontmatter.py
+++ b/scripts/agents/check_frontmatter.py
@@ -75,7 +75,9 @@ def validate_field_type(field_name: str, value: Any, expected_type: type) -> str
     return None
 
 
-def validate_frontmatter(frontmatter: dict, file_path: Path, verbose: bool = False) -> list[str]:  # noqa: C901  # field validation with many rules
+def validate_frontmatter(
+    frontmatter: dict[str, Any], file_path: Path, verbose: bool = False
+) -> list[str]:  # noqa: C901  # field validation with many rules
     """Validate the frontmatter data.
 
     Args:

--- a/scripts/check_coverage.py
+++ b/scripts/check_coverage.py
@@ -24,7 +24,7 @@ import tomllib  # noqa: E402
 from common import get_repo_root  # noqa: E402
 
 
-def load_coverage_config(config_file: Path | None = None) -> dict:
+def load_coverage_config(config_file: Path | None = None) -> dict[str, Any]:
     """Load coverage configuration from coverage.toml.
 
     Args:
@@ -51,7 +51,7 @@ def load_coverage_config(config_file: Path | None = None) -> dict:
         return {"coverage": {"target": 90.0, "minimum": 80.0}}
 
 
-def get_module_threshold(path: str, config: dict) -> float:
+def get_module_threshold(path: str, config: dict[str, Any]) -> float:
     """Get coverage threshold for a specific module.
 
     Args:

--- a/scripts/check_readmes.py
+++ b/scripts/check_readmes.py
@@ -194,7 +194,7 @@ def validate_all_readmes(directory: Path, verbose: bool = False) -> dict[str, An
     return results
 
 
-def print_summary(results: dict[str, list]) -> None:
+def print_summary(results: dict[str, list[Any]]) -> None:
     """Print validation summary."""
     total = len(results["passed"]) + len(results["failed"])
     passed = len(results["passed"])

--- a/scripts/get_stats.py
+++ b/scripts/get_stats.py
@@ -25,6 +25,7 @@ import subprocess
 import sys
 from datetime import datetime
 from pathlib import Path
+from typing import Any
 
 # Enable importing from repository root and scripts directory
 _SCRIPT_DIR = Path(__file__).parent
@@ -54,7 +55,9 @@ def get_repo_name() -> str:
     return result.stdout.strip()
 
 
-def get_issues_stats(start_date: str, end_date: str, author: str | None, repo: str) -> dict:
+def get_issues_stats(
+    start_date: str, end_date: str, author: str | None, repo: str
+) -> dict[str, Any]:
     """Get issue statistics using gh CLI.
 
     Args:
@@ -105,7 +108,7 @@ def get_issues_stats(start_date: str, end_date: str, author: str | None, repo: s
     }
 
 
-def get_prs_stats(start_date: str, end_date: str, author: str | None, repo: str) -> dict:
+def get_prs_stats(start_date: str, end_date: str, author: str | None, repo: str) -> dict[str, Any]:
     """Get pull request statistics using gh CLI.
 
     Args:
@@ -166,7 +169,9 @@ def get_prs_stats(start_date: str, end_date: str, author: str | None, repo: str)
     }
 
 
-def get_commits_stats(start_date: str, end_date: str, author: str | None, repo: str) -> dict:
+def get_commits_stats(
+    start_date: str, end_date: str, author: str | None, repo: str
+) -> dict[str, Any]:
     """Get commit statistics using gh CLI.
 
     Args:
@@ -214,7 +219,7 @@ def get_commits_stats(start_date: str, end_date: str, author: str | None, repo: 
     return {"total": total}
 
 
-def format_table(stats: dict) -> None:
+def format_table(stats: dict[str, Any]) -> None:
     """Format and print statistics table.
 
     Args:

--- a/scripts/lint_configs.py
+++ b/scripts/lint_configs.py
@@ -179,7 +179,7 @@ class ConfigLinter:
             if line.rstrip() != line:
                 self.warnings.append(f"{filepath}:{i + 1} - Trailing whitespace")
 
-    def _parse_yaml(self, content: str) -> dict | None:
+    def _parse_yaml(self, content: str) -> dict[str, Any] | None:
         """Parse YAML content into dictionary.
 
         Args:
@@ -266,7 +266,7 @@ class ConfigLinter:
 
         return value
 
-    def _check_deprecated_keys(self, config: dict, filepath: Path) -> None:
+    def _check_deprecated_keys(self, config: dict[str, Any], filepath: Path) -> None:
         """Check for deprecated configuration keys.
 
         Args:
@@ -280,7 +280,7 @@ class ConfigLinter:
                     f"{filepath} - Deprecated key '{old_key}' (use '{new_key}' instead)"
                 )
 
-    def _check_required_keys(self, config: dict, filepath: Path) -> None:
+    def _check_required_keys(self, config: dict[str, Any], filepath: Path) -> None:
         """Check for required keys based on config type.
 
         Args:
@@ -295,7 +295,7 @@ class ConfigLinter:
                     if key not in config.get(section, {}):
                         self.warnings.append(f"{filepath} - Missing required key '{section}.{key}'")
 
-    def _check_duplicate_values(self, config: dict, filepath: Path) -> None:
+    def _check_duplicate_values(self, config: dict[str, Any], filepath: Path) -> None:
         """Check for duplicate values that might be errors.
 
         Args:
@@ -326,7 +326,7 @@ class ConfigLinter:
                     f"{filepath} - Value '{value}' appears in: {', '.join(keys[:3])}..."
                 )
 
-    def _check_performance(self, config: dict, filepath: Path) -> None:
+    def _check_performance(self, config: dict[str, Any], filepath: Path) -> None:
         """Check for performance-related configuration issues.
 
         Args:
@@ -354,7 +354,7 @@ class ConfigLinter:
             elif lr > max_lr:
                 self.warnings.append(f"{filepath} - Very large learning_rate ({lr})")
 
-    def _check_unused_parameters(self, config: dict, filepath: Path) -> None:
+    def _check_unused_parameters(self, config: dict[str, Any], filepath: Path) -> None:
         """Check for potentially unused parameters.
 
         Args:
@@ -366,7 +366,7 @@ class ConfigLinter:
         if "debug" in config and config.get("debug") and "production" in str(filepath).lower():
             self.warnings.append(f"{filepath} - Debug mode enabled in production config")
 
-    def _has_nested_key(self, config: dict, key_path: str) -> bool:
+    def _has_nested_key(self, config: dict[str, Any], key_path: str) -> bool:
         """Check if nested key exists in config.
 
         Args:
@@ -386,7 +386,7 @@ class ConfigLinter:
                 return False
         return True
 
-    def _get_nested_value(self, config: dict, key_path: str) -> Any:
+    def _get_nested_value(self, config: dict[str, Any], key_path: str) -> Any:
         """Get value of nested key.
 
         Args:

--- a/scripts/manage_experiment.py
+++ b/scripts/manage_experiment.py
@@ -47,6 +47,7 @@ import argparse
 import logging
 import sys
 from pathlib import Path
+from typing import Any
 
 # Configure logging
 logging.basicConfig(
@@ -196,7 +197,7 @@ def cmd_run(args: argparse.Namespace) -> int:
         logging.getLogger().setLevel(logging.ERROR)
 
     # Load test.yaml defaults if present
-    test_config: dict = {}
+    test_config: dict[str, Any] = {}
     if args.tiers_dir and (args.tiers_dir / "test.yaml").exists():
         try:
             from scylla.e2e.models import TestFixture
@@ -216,7 +217,7 @@ def cmd_run(args: argparse.Namespace) -> int:
             test_config = raw
 
     # Load YAML config file if provided
-    yaml_config: dict = {}
+    yaml_config: dict[str, Any] = {}
     if args.config and args.config.exists():
         with open(args.config) as f:
             yaml_config = yaml.safe_load(f) or {}

--- a/scripts/merge_prs.py
+++ b/scripts/merge_prs.py
@@ -51,7 +51,7 @@ def get_repo_name() -> str:
     return result.stdout.strip()
 
 
-def get_open_prs() -> list[dict]:
+def get_open_prs() -> list[dict[str, Any]]:
     """Get list of open pull requests using gh CLI.
 
     Returns:

--- a/scripts/migrate_skills_to_mnemosyne.py
+++ b/scripts/migrate_skills_to_mnemosyne.py
@@ -107,7 +107,7 @@ def parse_args() -> argparse.Namespace:
     return parser.parse_args()
 
 
-def resolve_category(skill_name: str, plugin_data: dict) -> str:
+def resolve_category(skill_name: str, plugin_data: dict[str, Any]) -> str:
     """Resolve category for a skill using multiple strategies.
 
     Priority:
@@ -136,14 +136,14 @@ def resolve_category(skill_name: str, plugin_data: dict) -> str:
     return "tooling"
 
 
-def normalize_author(author_field: Any) -> dict:
+def normalize_author(author_field: Any) -> dict[str, Any]:
     """Normalize author field to dict format."""
     if isinstance(author_field, str):
         return {"name": author_field}
     return cast(dict[Any, Any], author_field)
 
 
-def normalize_date(plugin_data: dict) -> str | None:
+def normalize_date(plugin_data: dict[str, Any]) -> str | None:
     """Normalize date field (created -> date)."""
     if "date" in plugin_data:
         return cast(str, plugin_data["date"])
@@ -152,7 +152,9 @@ def normalize_date(plugin_data: dict) -> str | None:
     return None
 
 
-def inject_yaml_frontmatter(skill_md_content: str, skill_name: str, plugin_data: dict) -> str:
+def inject_yaml_frontmatter(
+    skill_md_content: str, skill_name: str, plugin_data: dict[str, Any]
+) -> str:
     """Inject YAML frontmatter to SKILL.md if missing.
 
     If frontmatter exists, return content as-is.
@@ -186,7 +188,7 @@ def inject_yaml_frontmatter(skill_md_content: str, skill_name: str, plugin_data:
     return "\n".join(frontmatter) + skill_md_content
 
 
-def restructure_plugin_json(plugin_data: dict, skill_name: str) -> dict:
+def restructure_plugin_json(plugin_data: dict[str, Any], skill_name: str) -> dict[str, Any]:
     """Restructure plugin.json to target format.
 
     Target format:
@@ -239,7 +241,7 @@ def should_skip_migration(
     return False, ""
 
 
-def extract_metadata_from_skill_md(skill_md_path: Path, skill_name: str) -> dict:
+def extract_metadata_from_skill_md(skill_md_path: Path, skill_name: str) -> dict[str, Any]:
     """Extract metadata from SKILL.md for skills without plugin.json.
 
     Extracts:

--- a/scripts/run_e2e_batch.py
+++ b/scripts/run_e2e_batch.py
@@ -80,7 +80,7 @@ logger = logging.getLogger(__name__)
 _save_lock = threading.Lock()
 
 
-def load_existing_results(results_dir: Path) -> list[dict]:
+def load_existing_results(results_dir: Path) -> list[dict[str, Any]]:
     """Load existing results from batch_summary.json if it exists.
 
     Args:
@@ -105,7 +105,9 @@ def load_existing_results(results_dir: Path) -> list[dict]:
         return []
 
 
-def save_incremental_result(results_dir: Path, result: dict, config: dict) -> None:
+def save_incremental_result(
+    results_dir: Path, result: dict[str, Any], config: dict[str, Any]
+) -> None:
     """Save a single result incrementally to batch_summary.json.
 
     Loads existing summary, appends the new result, and writes atomically.
@@ -177,7 +179,7 @@ def check_rate_limit() -> tuple[bool, str]:
     return False, ""
 
 
-def discover_tests(tests_dir: Path, test_filter: list[str] | None = None) -> list[dict]:
+def discover_tests(tests_dir: Path, test_filter: list[str] | None = None) -> list[dict[str, Any]]:
     """Find all test-XXX dirs using TestFixture.from_directory() for metadata.
 
     Args:
@@ -224,7 +226,7 @@ def discover_tests(tests_dir: Path, test_filter: list[str] | None = None) -> lis
     return tests
 
 
-def partition_tests(tests: list[dict], num_threads: int) -> list[list[dict]]:
+def partition_tests(tests: list[dict[str, Any]], num_threads: int) -> list[list[dict[str, Any]]]:
     """LPT scheduling: sort by timeout desc, assign to thread with lowest load.
 
     Uses Longest Processing Time First (LPT) algorithm to balance workload
@@ -242,7 +244,7 @@ def partition_tests(tests: list[dict], num_threads: int) -> list[list[dict]]:
     sorted_tests = sorted(tests, key=lambda t: t["timeout_seconds"], reverse=True)
 
     # Initialize thread assignments and load tracking
-    threads: list[list[dict]] = [[] for _ in range(num_threads)]
+    threads: list[list[dict[str, Any]]] = [[] for _ in range(num_threads)]
     thread_loads: list[int] = [0] * num_threads
 
     # Assign each test to the thread with the lowest current load
@@ -265,13 +267,13 @@ def partition_tests(tests: list[dict], num_threads: int) -> list[list[dict]]:
 
 
 def run_single_test(
-    test: dict,
+    test: dict[str, Any],
     thread_id: int,
     log_file: Any,
     args: argparse.Namespace,
-    config: dict,
+    config: dict[str, Any],
     pixi_path: str,
-) -> dict:
+) -> dict[str, Any]:
     """Run one test via subprocess, capture output to log file.
 
     Args:
@@ -388,12 +390,12 @@ def run_single_test(
 
 def run_thread(
     thread_id: int,
-    tests: list[dict],
+    tests: list[dict[str, Any]],
     log_dir: Path,
     args: argparse.Namespace,
-    config: dict,
+    config: dict[str, Any],
     pixi_path: str,
-) -> list[dict]:
+) -> list[dict[str, Any]]:
     """Run all assigned tests sequentially within one thread.
 
     Args:
@@ -462,7 +464,7 @@ def find_result_dir(results_dir: Path, test_id: str) -> Path | None:
     return sorted(matches)[-1]
 
 
-def extract_metrics(result_dir: Path) -> dict | None:
+def extract_metrics(result_dir: Path) -> dict[str, Any] | None:
     """Read report.json and extract summary metrics.
 
     Args:
@@ -503,7 +505,10 @@ def extract_metrics(result_dir: Path) -> dict | None:
 
 
 def write_batch_summary(
-    results_dir: Path, all_results: list[dict], config: dict, threads: list[list[dict]]
+    results_dir: Path,
+    all_results: list[dict[str, Any]],
+    config: dict[str, Any],
+    threads: list[list[dict[str, Any]]],
 ) -> None:
     """Write batch_summary.json with all results.
 
@@ -550,7 +555,7 @@ def write_batch_summary(
     logger.info(f"Wrote batch summary to {summary_path}")
 
 
-def write_analysis_prompt(results_dir: Path, config: dict) -> None:
+def write_analysis_prompt(results_dir: Path, config: dict[str, Any]) -> None:
     """Write ANALYZE_RESULTS.md prompt for post-run analysis.
 
     Args:
@@ -815,7 +820,7 @@ docs/runs/{run_name}/
     logger.info(f"Wrote analysis prompt to {prompt_path}")
 
 
-def print_summary_table(all_results: list[dict]) -> None:
+def print_summary_table(all_results: list[dict[str, Any]]) -> None:
     """Print colored summary table to stdout.
 
     Args:

--- a/scripts/validation.py
+++ b/scripts/validation.py
@@ -8,6 +8,7 @@ validation scripts to avoid duplication and ensure consistency.
 import logging
 import re
 from pathlib import Path
+from typing import Any
 
 logger = logging.getLogger(__name__)
 
@@ -166,7 +167,7 @@ def validate_relative_link(
     return True, None
 
 
-def count_markdown_issues(content: str) -> dict:
+def count_markdown_issues(content: str) -> dict[str, Any]:
     """Count common markdown issues in content.
 
     Args:

--- a/scylla/analysis/figures/token_analysis.py
+++ b/scylla/analysis/figures/token_analysis.py
@@ -70,8 +70,8 @@ def fig07_token_distribution(runs_df: pd.DataFrame, output_dir: Path, render: bo
     token_long["token_type_order"] = token_long["token_type"].map(token_type_sort_order)
 
     # Get colors for token types from centralized palette
-    token_type_labels = ["Input (Fresh)", "Input (Cached)", "Output", "Cache Creation"]
-    domain, range_ = get_color_scale("token_types", token_type_labels)
+    token_type_color_keys = ["Input (Fresh)", "Input (Cached)", "Output", "Cache Creation"]
+    domain, range_ = get_color_scale("token_types", token_type_color_keys)
 
     # Create stacked bar chart with normalized percentages
     # NOTE: stack="normalize" causes very small token counts to become invisible.

--- a/scylla/automation/git_utils.py
+++ b/scylla/automation/git_utils.py
@@ -11,7 +11,6 @@ import logging
 import subprocess
 import time
 from pathlib import Path
-from typing import cast
 
 logger = logging.getLogger(__name__)
 
@@ -22,7 +21,7 @@ def run(
     capture_output: bool = True,
     check: bool = True,
     timeout: int | None = None,
-) -> subprocess.CompletedProcess:
+) -> subprocess.CompletedProcess[str]:
     """Run a subprocess command with consistent error handling.
 
     Args:
@@ -215,7 +214,7 @@ def get_current_branch(repo_root: Path | None = None) -> str:
             capture_output=True,
             check=True,
         )
-        return cast(str, result.stdout.strip())
+        return result.stdout.strip()
     except subprocess.CalledProcessError as e:
         raise RuntimeError(f"Failed to get current branch: {e}") from e
 

--- a/scylla/automation/github_api.py
+++ b/scylla/automation/github_api.py
@@ -32,7 +32,7 @@ def _gh_call(
     check: bool = True,
     retry_on_rate_limit: bool = True,
     max_retries: int = 3,
-) -> subprocess.CompletedProcess:
+) -> subprocess.CompletedProcess[str]:
     """Call gh CLI with rate limit handling.
 
     Args:

--- a/scylla/automation/implementer.py
+++ b/scylla/automation/implementer.py
@@ -19,7 +19,7 @@ import time
 from concurrent.futures import FIRST_COMPLETED, Future, ThreadPoolExecutor, wait
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import cast
+from typing import Any, cast
 
 from .curses_ui import CursesUI, ThreadLogManager
 from .dependency_resolver import DependencyResolver
@@ -261,7 +261,7 @@ class IssueImplementer:
         results: dict[int, WorkerResult] = {}
 
         with ThreadPoolExecutor(max_workers=self.options.max_workers) as executor:
-            futures: dict[Future, int] = {}
+            futures: dict[Future[Any], int] = {}
             active_issues: set[int] = set()
 
             while True:
@@ -575,7 +575,7 @@ class IssueImplementer:
             timeout=600,  # 10 minutes
         )
 
-    def _parse_follow_up_items(self, text: str) -> list[dict]:
+    def _parse_follow_up_items(self, text: str) -> list[dict[str, Any]]:
         """Parse follow-up items from Claude's JSON response.
 
         Args:

--- a/scylla/automation/planner.py
+++ b/scylla/automation/planner.py
@@ -15,6 +15,7 @@ import os
 import subprocess
 import threading
 from concurrent.futures import Future, ThreadPoolExecutor, as_completed
+from typing import Any
 
 from .git_utils import get_repo_root
 from .github_api import (
@@ -71,7 +72,7 @@ class Planner:
 
         # Plan issues in parallel
         with ThreadPoolExecutor(max_workers=self.options.parallel) as executor:
-            futures: dict[Future, int] = {}
+            futures: dict[Future[Any], int] = {}
 
             for issue_num in issues_to_plan:
                 future = executor.submit(self._plan_issue, issue_num)

--- a/scylla/cli/main.py
+++ b/scylla/cli/main.py
@@ -139,7 +139,7 @@ def run(
         sys.exit(1)
 
 
-def _load_results(test_id: str, base_path: Path = Path(".")) -> list[dict]:
+def _load_results(test_id: str, base_path: Path = Path(".")) -> list[dict[str, Any]]:
     """Load all result.json files for a test.
 
     Args:
@@ -164,7 +164,7 @@ def _load_results(test_id: str, base_path: Path = Path(".")) -> list[dict]:
 
 
 def _calculate_tier_metrics(
-    tier_id: str, results: list[dict], t0_pass_rate: float | None = None
+    tier_id: str, results: list[dict[str, Any]], t0_pass_rate: float | None = None
 ) -> TierMetrics:
     """Calculate metrics for a tier from results.
 
@@ -261,7 +261,7 @@ def report(
     click.echo(f"  Found {len(results)} run results")
 
     # Group results by tier
-    by_tier: dict[str, list[dict]] = {}
+    by_tier: dict[str, list[dict[str, Any]]] = {}
     for r in results:
         tier_id = r["tier_id"]
         if tier_id not in by_tier:

--- a/scylla/e2e/judge_runner.py
+++ b/scylla/e2e/judge_runner.py
@@ -48,7 +48,7 @@ def _save_judge_result(judge_dir: Path, result: JudgeResult) -> None:
         json.dump(result_data, f, indent=2)
 
 
-def _load_judge_result(judge_dir: Path) -> dict:
+def _load_judge_result(judge_dir: Path) -> dict[str, Any]:
     """Load judge evaluation result from judge/result.json.
 
     Args:
@@ -138,7 +138,7 @@ def _run_judge(
     rubric_path: Path | None = None,
     judge_models: list[str] | None = None,
     pipeline_baseline: BuildPipelineResult | None = None,
-) -> tuple[dict, list[JudgeResultSummary]]:
+) -> tuple[dict[str, Any], list[JudgeResultSummary]]:
     """Run LLM judge evaluation(s) on the result.
 
     Runs multiple judges if configured, computes consensus.

--- a/scylla/e2e/judge_selection.py
+++ b/scylla/e2e/judge_selection.py
@@ -8,7 +8,7 @@ with an alternate LLM.
 from __future__ import annotations
 
 import json
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from pydantic import BaseModel
 
@@ -32,7 +32,7 @@ class JudgeVote(BaseModel):
     confidence: float
     reasoning: str
 
-    def to_dict(self) -> dict:
+    def to_dict(self) -> dict[str, Any]:
         """Convert to dictionary."""
         return {
             "subtest_id": self.subtest_id,
@@ -62,7 +62,7 @@ class JudgeSelection(BaseModel):
     tiebreaker_needed: bool = False
     tiebreaker_result: JudgeVote | None = None
 
-    def to_dict(self) -> dict:
+    def to_dict(self) -> dict[str, Any]:
         """Convert to dictionary."""
         return {
             "winning_subtest": self.winning_subtest,

--- a/scylla/e2e/orchestrator.py
+++ b/scylla/e2e/orchestrator.py
@@ -62,14 +62,14 @@ class EvalOrchestrator:
             verbose=self.config.verbose,
         )
         self.result_writer = ResultWriter(self.config.base_path / "runs")
-        self._adapter_func: Callable | None = None
-        self._judge_func: Callable | None = None
+        self._adapter_func: Callable[..., Any] | None = None
+        self._judge_func: Callable[..., Any] | None = None
 
-    def set_adapter(self, adapter_func: Callable) -> None:
+    def set_adapter(self, adapter_func: Callable[..., Any]) -> None:
         """Set the adapter function for running agents."""
         self._adapter_func = adapter_func
 
-    def set_judge(self, judge_func: Callable) -> None:
+    def set_judge(self, judge_func: Callable[..., Any]) -> None:
         """Set the judge function for evaluation."""
         self._judge_func = judge_func
 
@@ -200,7 +200,7 @@ class EvalOrchestrator:
         test_case: EvalCase,
         model_id: str,
         tier_id: str,
-    ) -> tuple[dict, float]:
+    ) -> tuple[dict[str, Any], float]:
         """Execute agent and measure duration.
 
         Args:
@@ -230,8 +230,8 @@ class EvalOrchestrator:
         tier_id: str,
         model_id: str,
         run_number: int,
-        execution_result: dict,
-        judgment: dict,
+        execution_result: dict[str, Any],
+        judgment: dict[str, Any],
         duration: float,
     ) -> ReportingRunResult:
         """Create ReportingRunResult from execution and judgment.
@@ -310,7 +310,7 @@ class EvalOrchestrator:
         test_case: EvalCase,
         model_id: str,
         tier_id: str,
-    ) -> dict:
+    ) -> dict[str, Any]:
         """Run the adapter to execute the agent.
 
         Args:
@@ -349,8 +349,8 @@ class EvalOrchestrator:
         workspace: Path,
         test_case: EvalCase,
         rubric: Rubric,
-        execution_result: dict,
-    ) -> dict:
+        execution_result: dict[str, Any],
+    ) -> dict[str, Any]:
         """Run the judge to evaluate results.
 
         Args:
@@ -385,8 +385,8 @@ class EvalOrchestrator:
     def _write_run_logs(
         self,
         result_dir: Path,
-        execution_result: dict,
-        judgment: dict,
+        execution_result: dict[str, Any],
+        judgment: dict[str, Any],
         test_case: EvalCase,
         tier_id: str,
     ) -> None:

--- a/scylla/e2e/rerun_base.py
+++ b/scylla/e2e/rerun_base.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 import logging
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from pydantic import BaseModel, ConfigDict
 
@@ -103,8 +103,8 @@ def load_rerun_context(experiment_dir: Path) -> RerunContext:
 
 
 def print_dry_run_summary(
-    items_by_status: dict,
-    status_names: dict,
+    items_by_status: dict[Any, Any],
+    status_names: dict[Any, str],
     max_preview: int = 10,
 ) -> None:
     """Print dry-run summary for runs or judge slots.

--- a/scylla/e2e/run_report.py
+++ b/scylla/e2e/run_report.py
@@ -291,7 +291,7 @@ def _generate_criteria_scores_section(criteria_scores: dict[str, dict[str, Any]]
 
 
 def _generate_judge_section(
-    judges: list | None,
+    judges: list[Any] | None,
     score: float,
     grade: str,
     passed: bool,
@@ -384,7 +384,7 @@ def generate_run_report(
     exit_code: int,
     task_prompt: str,
     workspace_path: Path,
-    judges: list | None = None,
+    judges: list[Any] | None = None,
     criteria_scores: dict[str, dict[str, Any]] | None = None,
     agent_output: str | None = None,
     token_stats: dict[str, int] | None = None,
@@ -708,7 +708,7 @@ def save_run_report(
     exit_code: int,
     task_prompt: str,
     workspace_path: Path,
-    judges: list | None = None,
+    judges: list[Any] | None = None,
     criteria_scores: dict[str, dict[str, Any]] | None = None,
     agent_output: str | None = None,
     token_stats: dict[str, int] | None = None,

--- a/scylla/e2e/subtest_executor.py
+++ b/scylla/e2e/subtest_executor.py
@@ -19,7 +19,7 @@ import json
 import logging
 import statistics
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
     from scylla.e2e.llm_judge import BuildPipelineResult
@@ -540,7 +540,7 @@ class SubTestExecutor:
         return result if result is not None else self._aggregate_results(tier_id, subtest.id, runs)
 
     def _compute_judge_consensus(
-        self, judges: list
+        self, judges: list[Any]
     ) -> tuple[float | None, bool | None, str | None]:
         """Compute consensus score from multiple judges using simple average.
 

--- a/scylla/judge/evaluator.py
+++ b/scylla/judge/evaluator.py
@@ -16,7 +16,7 @@ from pydantic import BaseModel, Field
 
 from scylla.config.constants import DEFAULT_JUDGE_MODEL
 from scylla.judge.utils import extract_json_from_llm_response
-from scylla.metrics.grading import assign_letter_grade
+from scylla.metrics.grading import assign_letter_grade as assign_letter_grade
 
 logger = logging.getLogger(__name__)
 

--- a/tests/claude-code/shared/compose/generate_subtiers.py
+++ b/tests/claude-code/shared/compose/generate_subtiers.py
@@ -230,7 +230,7 @@ def run_compose_claude_md(preset: str, output: Path, dry_run: bool = False) -> N
         subprocess.run(cmd, check=True, capture_output=True)
 
 
-def run_compose_agents(config: str | dict, output: Path, dry_run: bool = False) -> None:
+def run_compose_agents(config: str | dict[str, Any], output: Path, dry_run: bool = False) -> None:
     """Run compose_agents.py with the given configuration."""
     cmd = [sys.executable, str(COMPOSE_DIR / "compose_agents.py")]
 
@@ -251,7 +251,7 @@ def run_compose_agents(config: str | dict, output: Path, dry_run: bool = False) 
         subprocess.run(cmd, check=True, capture_output=True)
 
 
-def run_compose_skills(config: str | dict, output: Path, dry_run: bool = False) -> None:
+def run_compose_skills(config: str | dict[str, Any], output: Path, dry_run: bool = False) -> None:
     """Run compose_skills.py with the given configuration."""
     cmd = [sys.executable, str(COMPOSE_DIR / "compose_skills.py")]
 
@@ -273,7 +273,7 @@ def run_compose_skills(config: str | dict, output: Path, dry_run: bool = False) 
         subprocess.run(cmd, check=True, capture_output=True)
 
 
-def create_test_yaml(subtier_path: Path, tier: str, subtier: str, config: dict) -> None:
+def create_test_yaml(subtier_path: Path, tier: str, subtier: str, config: dict[str, Any]) -> None:
     """Create test.yaml file for the subtier."""
     test_id = f"{tier}-{subtier}".lower().replace("_", "-")
     content = f"""# Test configuration for {tier}/{subtier}
@@ -391,7 +391,7 @@ thresholds:
 
 
 def generate_subtier(
-    model: str, tier: str, subtier: str, config: dict, dry_run: bool = False
+    model: str, tier: str, subtier: str, config: dict[str, Any], dry_run: bool = False
 ) -> None:
     """Generate a single subtier configuration."""
     subtier_path = TESTS_DIR / model / tier / subtier

--- a/tests/unit/analysis/test_export_data.py
+++ b/tests/unit/analysis/test_export_data.py
@@ -3,6 +3,7 @@
 import json
 import sys
 from pathlib import Path
+from typing import Any
 
 # Add scripts directory to path
 sys.path.insert(0, str(Path(__file__).parent.parent.parent.parent / "scripts"))
@@ -129,7 +130,7 @@ def test_enhanced_summary_json(sample_runs_df, tmp_path):
         assert "tiers" in stats
 
     # Build by_tier section
-    by_tier = {}
+    by_tier: dict[str, dict[str, Any]] = {}
     for tier in tier_order:
         tier_df = sample_runs_df[sample_runs_df["tier"] == tier]
         scores = tier_df["score"].dropna()

--- a/tests/unit/analysis/test_stats.py
+++ b/tests/unit/analysis/test_stats.py
@@ -199,9 +199,9 @@ def test_mann_whitney_u_degenerate_input():
     assert p_value == pytest.approx(1.0)
 
     # Empty group
-    g1: list[int] = []
+    g1_empty: list[int] = []
     g2 = [1, 2, 3]
-    u_stat, p_value = mann_whitney_u(g1, g2)
+    u_stat, p_value = mann_whitney_u(g1_empty, g2)
     assert u_stat == pytest.approx(0.0)
     assert p_value == pytest.approx(1.0)
 

--- a/tests/unit/e2e/test_agent_runner.py
+++ b/tests/unit/e2e/test_agent_runner.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
+from typing import Any
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -41,7 +42,7 @@ def _make_result(
     )
 
 
-def _write_result_json(agent_dir: Path, data: dict) -> None:
+def _write_result_json(agent_dir: Path, data: dict[str, Any]) -> None:
     """Write result.json to agent_dir."""
     agent_dir.mkdir(parents=True, exist_ok=True)
     (agent_dir / RESULT_FILE).write_text(json.dumps(data))

--- a/tests/unit/e2e/test_judge_runner.py
+++ b/tests/unit/e2e/test_judge_runner.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
+from typing import Any
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -25,7 +26,7 @@ def _make_judge_result(
     grade: str = "B",
     reasoning: str = "Good work",
     is_valid: bool = True,
-    criteria_scores: dict | None = None,
+    criteria_scores: dict[str, Any] | None = None,
 ) -> MagicMock:
     """Create a mock JudgeResult."""
     result = MagicMock()
@@ -58,7 +59,7 @@ def _make_summary(
     )
 
 
-def _write_judge_result(judge_dir: Path, data: dict) -> None:
+def _write_judge_result(judge_dir: Path, data: dict[str, Any]) -> None:
     """Write result.json to judge_dir."""
     judge_dir.mkdir(parents=True, exist_ok=True)
     (judge_dir / RESULT_FILE).write_text(json.dumps(data))

--- a/tests/unit/e2e/test_llm_judge.py
+++ b/tests/unit/e2e/test_llm_judge.py
@@ -7,6 +7,7 @@ import os
 import subprocess
 import tempfile
 from pathlib import Path
+from typing import Any
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -1281,7 +1282,9 @@ class TestRunLlmJudgeRetry:
         ("scylla.e2e.llm_judge._get_deleted_files", []),
     ]
 
-    def _run_with_call_side_effects(self, tmp_path: Path, call_side_effects: list) -> tuple:
+    def _run_with_call_side_effects(
+        self, tmp_path: Path, call_side_effects: list[Any]
+    ) -> tuple[Any, ...]:
         """Call run_llm_judge with mocked _call_claude_judge return values/exceptions."""
         workspace = tmp_path / "ws"
         workspace.mkdir()

--- a/tests/unit/e2e/test_manage_experiment.py
+++ b/tests/unit/e2e/test_manage_experiment.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 import json
 import sys
 from pathlib import Path
+from typing import Any
 from unittest.mock import patch
 
 import pytest
@@ -290,7 +291,9 @@ class TestCmdRunUntilValidation:
 class TestCmdRepair:
     """Tests for cmd_repair() — checkpoint repair logic."""
 
-    def _make_checkpoint_file(self, path: Path, run_states: dict, completed_runs: dict) -> Path:
+    def _make_checkpoint_file(
+        self, path: Path, run_states: dict[str, Any], completed_runs: dict[str, Any]
+    ) -> Path:
         """Write a minimal checkpoint JSON file.
 
         Args:

--- a/tests/unit/e2e/test_parallel_executor.py
+++ b/tests/unit/e2e/test_parallel_executor.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 import threading
 from datetime import datetime, timezone
 from pathlib import Path
+from typing import Any
 from unittest.mock import MagicMock, patch
 
 from scylla.e2e.parallel_executor import RateLimitCoordinator
@@ -232,7 +233,7 @@ class TestRunTierSubtestsParallelSingleSubtest:
         subtest.id = subtest_id
         return subtest
 
-    def _make_tier_config(self, subtests: list) -> MagicMock:
+    def _make_tier_config(self, subtests: list[Any]) -> MagicMock:
         """Create a mock TierConfig with given subtests."""
         tier_config = MagicMock()
         tier_config.subtests = subtests
@@ -417,7 +418,7 @@ class TestRunSubtestInProcessSafe:
             description="A sub-test used in unit tests",
         )
 
-    def _make_call_args(self, tmp_path) -> dict:
+    def _make_call_args(self, tmp_path: Path) -> dict[str, Any]:
         """Build the keyword arguments for _run_subtest_in_process_safe.
 
         Uses MagicMock for complex objects since _run_subtest_in_process is mocked.

--- a/tests/unit/e2e/test_runner.py
+++ b/tests/unit/e2e/test_runner.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from pathlib import Path
+from typing import Any
 from unittest.mock import MagicMock, call, patch
 
 import pytest
@@ -602,7 +603,7 @@ class TestResumeTierConfigPreload:
         )
         runner.checkpoint = checkpoint
 
-        def noop_complete(tier_id_str: str, actions: dict, until_state: object) -> None:
+        def noop_complete(tier_id_str: str, actions: dict[str, Any], until_state: object) -> None:
             pass
 
         with patch.object(TierStateMachine, "advance_to_completion", side_effect=noop_complete):
@@ -644,7 +645,7 @@ class TestResumeTierConfigPreload:
         )
         runner.checkpoint = checkpoint
 
-        def noop_complete(tier_id_str: str, actions: dict, until_state: object) -> None:
+        def noop_complete(tier_id_str: str, actions: dict[str, Any], until_state: object) -> None:
             pass
 
         with patch.object(TierStateMachine, "advance_to_completion", side_effect=noop_complete):
@@ -685,7 +686,7 @@ class TestResumeTierConfigPreload:
         )
         runner.checkpoint = checkpoint
 
-        def noop_complete(tier_id_str: str, actions: dict, until_state: object) -> None:
+        def noop_complete(tier_id_str: str, actions: dict[str, Any], until_state: object) -> None:
             pass
 
         with patch.object(TierStateMachine, "advance_to_completion", side_effect=noop_complete):

--- a/tests/unit/e2e/test_runner_state_machine.py
+++ b/tests/unit/e2e/test_runner_state_machine.py
@@ -11,6 +11,7 @@ Covers:
 from __future__ import annotations
 
 from pathlib import Path
+from typing import Any
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -19,6 +20,7 @@ from scylla.e2e.models import (
     ExperimentConfig,
     ExperimentState,
     TierID,
+    TierResult,
     TierState,
 )
 from scylla.e2e.runner import E2ERunner
@@ -55,9 +57,9 @@ class TestBuildExperimentActions:
         """All non-terminal ExperimentStates should have actions."""
         runner.experiment_dir = Path("/tmp/exp")
         runner.checkpoint = MagicMock()
-        tier_groups: list = [[TierID.T0]]
+        tier_groups: list[Any] = [[TierID.T0]]
         scheduler = MagicMock()
-        tier_results: dict = {}
+        tier_results: dict[TierID, TierResult] = {}
         start_time = MagicMock()
 
         actions = runner._build_experiment_actions(
@@ -81,9 +83,9 @@ class TestBuildExperimentActions:
         """All returned actions should be callable."""
         runner.experiment_dir = Path("/tmp/exp")
         runner.checkpoint = MagicMock()
-        tier_groups: list = [[TierID.T0]]
+        tier_groups: list[Any] = [[TierID.T0]]
         scheduler = MagicMock()
-        tier_results: dict = {}
+        tier_results: dict[TierID, TierResult] = {}
         start_time = MagicMock()
 
         actions = runner._build_experiment_actions(

--- a/tests/unit/e2e/test_subtest_executor.py
+++ b/tests/unit/e2e/test_subtest_executor.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from pathlib import Path
+from typing import Any
 from unittest.mock import MagicMock
 
 import pytest
@@ -302,7 +303,7 @@ class TestParseJudgeResponse:
 class TestCheckpointResumeWithNullCriteriaScores:
     """Tests for checkpoint resume when criteria_scores is null in stored data."""
 
-    def _make_report_data(self, criteria_scores_value: object) -> dict:
+    def _make_report_data(self, criteria_scores_value: object) -> dict[str, Any]:
         """Build a minimal report_data dict with the given criteria_scores value."""
         from scylla.e2e.models import TokenStats
 


### PR DESCRIPTION
## Summary
- Enables all 4 remaining strict mypy settings, completing the #687 roadmap
- Fixes 104+ type errors surfaced by the new strict checks

## Settings Enabled
| Setting | Errors | Notes |
|---------|--------|-------|
| `disallow_incomplete_defs = true` | 0 | Already clean |
| `disallow_any_generics = true` | 100 | Bare generics across 22 files |
| `allow_redefinition = false` | 3 | Variable rebinding fixes |
| `implicit_reexport = false` | 1 | Re-export fix in `judge/evaluator.py` |

## Key Changes
- `scylla/judge/evaluator.py`: use `import X as X` for `assign_letter_grade` to make re-export explicit
- 22 files: parameterize bare generics (`dict→dict[str,Any]`, `list→list[Any]`, `Callable→Callable[...,Any]`, `CompletedProcess→CompletedProcess[str]`, `Future→Future[Any]`)
- `scylla/analysis/figures/token_analysis.py`: rename rebound variable to fix `allow_redefinition=false`
- `pyproject.toml`: enable all 4 settings, update comment to reflect complete roadmap

Closes #1086