### PR TITLE
[Fix] Harden preflight mock and add BATS regression tests

### DIFF
--- a/tests/shell/skills/github/gh-implement-issue/mocks/gh
+++ b/tests/shell/skills/github/gh-implement-issue/mocks/gh
@@ -3,7 +3,7 @@
 # Behavior is controlled by environment variables:
 #   GH_MOCK_ISSUE_STATE    - JSON for `gh issue view <N> --json state,title,closedAt`
 #   GH_MOCK_PR_JSON        - JSON for `gh pr list ...`
-#   GH_MOCK_PR_CLOSES      - issue number a PR closes (default: 800)
+#   GH_MOCK_PR_CLOSES      - issue number a PR closes (default: 800); empty string → no closing ref
 #   GH_MOCK_ISSUE_COMMENTS - output for `gh issue view <N> --comments`
 
 _DEFAULT_ISSUE_STATE='{"state":"OPEN","title":"Test Issue","closedAt":null}'
@@ -24,8 +24,13 @@ case "$1 $2" in
     "pr view")
         # Return closing issue references for the PR.
         # When --jq flag is present, extract and return just the issue number(s).
-        _closes="${GH_MOCK_PR_CLOSES:-$_DEFAULT_PR_CLOSES}"
-        _full_json="{\"closingIssuesReferences\":[{\"number\":${_closes}}]}"
+        # Use ${GH_MOCK_PR_CLOSES-$_DEFAULT_PR_CLOSES} (not :-) so explicit empty string is honoured.
+        _closes="${GH_MOCK_PR_CLOSES-$_DEFAULT_PR_CLOSES}"
+        if [[ -n "$_closes" ]]; then
+            _full_json="{\"closingIssuesReferences\":[{\"number\":${_closes}}]}"
+        else
+            _full_json="{\"closingIssuesReferences\":[]}"
+        fi
         if [[ "${*}" == *"--jq"* ]]; then
             # Extract the jq filter from args and apply it
             _jq_filter=""

--- a/tests/shell/skills/github/gh-implement-issue/test_preflight_check.bats
+++ b/tests/shell/skills/github/gh-implement-issue/test_preflight_check.bats
@@ -124,3 +124,31 @@ setup() {
     [ "$status" -eq 0 ]
     [[ "$output" == *"SAFE TO PROCEED"* ]]
 }
+
+# ---------------------------------------------------------------------------
+# Test 9: Merged PR mentions issue in title but has no closingRef → PASS (#909)
+# ---------------------------------------------------------------------------
+@test "merged PR with title mention but no closingRef passes check 3" {
+    export GH_MOCK_ISSUE_STATE='{"state":"OPEN","title":"My Issue","closedAt":null}'
+    export GH_MOCK_PR_JSON='[{"number":55,"title":"Fix issue 800 typo","state":"MERGED"}]'
+    export GH_MOCK_PR_CLOSES=""   # explicit empty → closingIssuesReferences:[]
+
+    run bash "$SCRIPT" 800
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"[PASS]"* ]]
+}
+
+# ---------------------------------------------------------------------------
+# Test 10: Merged PR with formal closingRef triggers STOP for check 3 (#909)
+# ---------------------------------------------------------------------------
+@test "merged PR with formal closingRef triggers STOP for check 3" {
+    export GH_MOCK_ISSUE_STATE='{"state":"OPEN","title":"My Issue","closedAt":null}'
+    export GH_MOCK_PR_JSON='[{"number":42,"title":"Fix it","state":"MERGED"}]'
+    export GH_MOCK_PR_CLOSES=800  # formal close reference
+
+    run bash "$SCRIPT" 800
+
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"[STOP]"* ]]
+}


### PR DESCRIPTION
## Summary

- Fix malformed JSON bug in `tests/shell/skills/github/gh-implement-issue/mocks/gh`: when `GH_MOCK_PR_CLOSES=""` (explicit empty string), the mock previously emitted `{"closingIssuesReferences":[{"number":}]}`. Switch expansion from `${var:-default}` to `${var-default}` and add an `if/else` guard so an empty value produces `{"closingIssuesReferences":[]}` instead.
- Add Test 9: MERGED PR with no formal `closingRef` does **not** trigger a false-positive STOP on Check 3 (exercises the mock fix directly).
- Add Test 10: MERGED PR with `GH_MOCK_PR_CLOSES=800` triggers the expected STOP on Check 3.

## Test plan

- [x] All 10 BATS tests pass locally (`pixi run test-shell`)
- [x] Test 9 would have failed before the mock fix (malformed JSON → jq parse error → undefined behaviour)
- [x] Test 10 confirms the positive-detection path is preserved

Closes #909