### PR TITLE
feat(ci): increase coverage threshold from 74% to 75%

### DIFF
--- a/pixi.lock
+++ b/pixi.lock
@@ -3764,7 +3764,7 @@ packages:
 - pypi: ./
   name: scylla
   version: 0.1.0
-  sha256: 1b18afaac7fa33f54f965085bec0287ce6f86bc630a5fb7d15edcf2e11902d15
+  sha256: 7d1403909dfe0885d0a97c4a3c762ce41883af53aff849f96b33f577b6b1b997
   requires_dist:
   - click>=8.0
   - pydantic>=2.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -89,7 +89,7 @@ addopts = [
     "--cov=scylla",
     "--cov-report=term-missing",
     "--cov-report=html",
-    "--cov-fail-under=74",
+    "--cov-fail-under=75",
 ]
 
 [tool.mypy]
@@ -125,7 +125,7 @@ omit = [
 ]
 
 [tool.coverage.report]
-fail_under = 74
+fail_under = 75
 precision = 2
 show_missing = true
 skip_covered = false


### PR DESCRIPTION
## Summary

- Raises `--cov-fail-under` (pytest addopts) from 74 → 75
- Raises `[tool.coverage.report] fail_under` from 74 → 75

Current coverage is 78.19%, giving ~3pp headroom above the new threshold.

🤖 Generated with [Claude Code](https://claude.com/claude-code)