### PR TITLE
feat(scripts): add tracked pre-push hook and install_hooks.sh

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -2,6 +2,28 @@
 
 This directory contains utility scripts for running ProjectScylla experiments.
 
+## Git Hooks
+
+### `install_hooks.sh`
+
+Installs tracked git hooks from `scripts/hooks/` into `.git/hooks/`.
+
+Run once after cloning or whenever hook files change:
+
+```bash
+bash scripts/install_hooks.sh
+```
+
+Hooks installed:
+
+| Hook | Trigger | What it does |
+|------|---------|--------------|
+| `pre-push` | Every `git push` | Runs `pytest` with coverage; aborts push if tests fail or coverage drops below the threshold in `pyproject.toml` |
+
+The coverage threshold is read directly from `pyproject.toml` (`[tool.coverage.report] fail_under`) so there is a single source of truth — update the threshold there and the hook message updates automatically.
+
+---
+
 ## Main Scripts
 
 ### `manage_experiment.py`

--- a/scripts/hooks/pre-push
+++ b/scripts/hooks/pre-push
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# Pre-push hook: validates test coverage before pushing to remote.
+#
+# Coverage threshold is read from pyproject.toml so there is a single
+# source of truth. The hook delegates all coverage flags to pytest via
+# pyproject.toml [tool.pytest.ini_options] addopts — no duplication.
+#
+# Install:
+#   bash scripts/install_hooks.sh
+#
+# Exit codes:
+#   0 = all checks passed
+#   1 = tests or coverage failed — push aborted
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+
+# Read threshold from pyproject.toml for the status message
+THRESHOLD=$(grep -m1 'fail_under' "${REPO_ROOT}/pyproject.toml" 2>/dev/null \
+    | grep -o '[0-9]*' | head -1)
+THRESHOLD=${THRESHOLD:-"??"}
+
+echo "Running pytest coverage validation before push (threshold: ${THRESHOLD}%)..."
+
+# Coverage flags come from pyproject.toml addopts — no duplication here
+if pixi run pytest -x; then
+    echo "✅ Coverage validation passed (threshold: ${THRESHOLD}%). Proceeding with push."
+    exit 0
+else
+    echo "❌ Coverage validation failed (threshold: ${THRESHOLD}%). Push aborted."
+    echo "   Fix failing tests or coverage gaps, then push again."
+    exit 1
+fi

--- a/scripts/install_hooks.sh
+++ b/scripts/install_hooks.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# Install git hooks from scripts/hooks/ into .git/hooks/.
+#
+# Usage:
+#   bash scripts/install_hooks.sh
+#
+# Hooks installed:
+#   pre-push  — runs pytest with coverage check before every push
+#
+# Exit codes:
+#   0 = all hooks installed successfully
+#   1 = must be run from repository root or git repo not found
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+HOOKS_SRC="${SCRIPT_DIR}/hooks"
+HOOKS_DST="${REPO_ROOT}/.git/hooks"
+
+# Verify we're inside a git repo
+if [[ ! -d "${HOOKS_DST}" ]]; then
+    echo "Error: .git/hooks not found — run this script from the repository root."
+    exit 1
+fi
+
+installed=0
+for src in "${HOOKS_SRC}"/*; do
+    hook_name="$(basename "${src}")"
+    dst="${HOOKS_DST}/${hook_name}"
+
+    if [[ -e "${dst}" && ! -L "${dst}" ]]; then
+        echo "Backing up existing ${hook_name} → ${dst}.bak"
+        cp "${dst}" "${dst}.bak"
+    fi
+
+    cp "${src}" "${dst}"
+    chmod +x "${dst}"
+    echo "✅ Installed ${hook_name} → .git/hooks/${hook_name}"
+    installed=$((installed + 1))
+done
+
+echo ""
+echo "Installed ${installed} hook(s). Run 'git push' to verify."


### PR DESCRIPTION
## Summary

- Adds `scripts/hooks/pre-push` — a tracked version of the git pre-push hook
- Adds `scripts/install_hooks.sh` — one-shot installer that copies hooks from `scripts/hooks/` into `.git/hooks/` (backs up any existing hook first)
- Updates `scripts/README.md` with a Git Hooks section

## Key design decisions

- **Single source of truth for threshold**: the hook reads `fail_under` from `pyproject.toml` at runtime rather than hardcoding a value, so the status message stays accurate when the threshold changes
- **No duplicated coverage flags**: coverage configuration lives entirely in `pyproject.toml` addopts; the hook just runs `pixi run pytest -x`
- **Non-destructive install**: `install_hooks.sh` backs up any pre-existing `.git/hooks/pre-push` before overwriting

## Usage

```bash
bash scripts/install_hooks.sh
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)