### PR TITLE
[feat] Additive CLI args with checkpoint state

### DIFF
--- a/scylla/e2e/checkpoint.py
+++ b/scylla/e2e/checkpoint.py
@@ -583,6 +583,7 @@ def compute_config_hash(config: ExperimentConfig) -> str:
     # Remove fields that don't affect results
     config_dict.pop("parallel_subtests", None)  # Just parallelization setting
     config_dict.pop("max_subtests", None)  # Development/testing only
+    config_dict.pop("tiers_to_run", None)  # Tiers are additive across resumes
     # Remove ephemeral --until flags (changing these between runs must not break resume)
     config_dict.pop("until_run_state", None)
     config_dict.pop("until_tier_state", None)


### PR DESCRIPTION
## Summary

- CLI args are now additive when resuming from a checkpoint: new `--tiers` are merged in regardless of checkpoint state (not just `failed`/`interrupted`)
- `--until` / `--max-subtests` passed on CLI survive the config reload from the saved checkpoint
- Experiments/tiers/subtests in terminal states are reset to `running` when CLI-requested tiers have incomplete runs (e.g. stopped mid-sequence by `--until`)
- `tiers_to_run` excluded from config hash so adding tiers between invocations no longer triggers a mismatch
- `--from` and `--retry-errors` in single mode now use timestamp-prefixed glob (`*-{experiment_id}`) to find checkpoints, matching runner behaviour
- `--retry-errors` scoped to CLI-requested `--tiers` via `tier_filter`

## Test plan

- [x] `pixi run python -m pytest tests/unit/e2e/test_runner.py tests/unit/e2e/test_manage_experiment.py -v` — 143 passed
- [x] Full suite: 3100 passed
- [x] `pre-commit run --all-files` — all hooks pass (ruff, mypy, etc.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)