### PR TITLE
fix(e2e): skip runs already past --until target state on resume

### DIFF
--- a/scylla/e2e/subtest_executor.py
+++ b/scylla/e2e/subtest_executor.py
@@ -378,14 +378,18 @@ class SubTestExecutor:
                     else None
                 )
 
-                # Skip runs already stopped at --until target state (they are not
+                # Skip runs already at or past the --until target state (they are not
                 # terminal but have completed their allowed work for this invocation).
                 if sm and self.config.until_run_state is not None:
+                    from scylla.e2e.state_machine import is_at_or_past_state
+
                     current_run_state = sm.get_state(tier_id.value, subtest.id, run_num)
-                    if current_run_state == self.config.until_run_state:
+                    if is_at_or_past_state(current_run_state, self.config.until_run_state):
                         logger.debug(
                             f"Skipping run {tier_id.value}/{subtest.id}/run_{run_num:02d} "
-                            f"— already at --until state: {self.config.until_run_state.value}"
+                            f"— already at or past --until state: "
+                            f"{self.config.until_run_state.value} "
+                            f"(current: {current_run_state.value})"
                         )
                         continue
 


### PR DESCRIPTION
## Summary

- Runs that progressed past the `--until` target state (e.g. at `diff_captured` when resuming with `--until replay_generated`) were not being skipped and would crash with `agent_result must be set before finalize_run`
- Root cause: both the pre-loop skip check in `subtest_executor.py` and the in-loop break in `state_machine.py` used exact equality (`==`) to detect the target, but never checked if the run was already **past** it
- Fix adds `is_at_or_past_state()` helper using `_RUN_STATE_INDEX` for O(1) ordering lookups, an early-return guard in `advance_to_completion()`, and changes the pre-loop skip to use the new ordering check

## Test plan
- [x] 5 unit tests for `is_at_or_past_state()` (at target, past, before, FAILED, RATE_LIMITED)
- [x] 1 unit test for `advance_to_completion()` early-return guard
- [x] 1 integration regression test: run at `DIFF_CAPTURED` + `--until replay_generated` → skipped, state unchanged
- [x] All 3172 tests pass at 78.29% coverage
- [x] `pre-commit run --all-files` passes

Closes #1075

🤖 Generated with [Claude Code](https://claude.com/claude-code)