### PR TITLE
[Fix] Apply February 2026 quality audit findings

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -26,8 +26,6 @@
 
 # Docker configuration
 /docker/ @HomericIntelligence/projectscylla-maintainers
-/Dockerfile @HomericIntelligence/projectscylla-maintainers
-/docker-compose.yml @HomericIntelligence/projectscylla-maintainers
 
 # Agent configurations and hierarchy
 /.claude/ @HomericIntelligence/projectscylla-maintainers

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,6 +15,7 @@ jobs:
       matrix:
         test-group:
           - { name: "unit", path: "tests/unit" }
+          - { name: "integration", path: "tests/integration" }
 
     steps:
       - uses: actions/checkout@v6

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,7 +9,7 @@ the performance and cost-efficiency of agentic AI workflows. Named after the myt
 Scylla represents the challenge of navigating trade-offs between capability gains and operational costs.
 
 **Current Status**: Operational - active research with full evaluation infrastructure, running T0–T6 ablation
-studies across 120+ YAML subtests with published results and 73%+ test coverage enforced in CI.
+studies across 120 YAML subtests with published results and 75%+ test coverage enforced in CI.
 
 **Ecosystem Context**: Part of a three-project ecosystem:
 
@@ -145,7 +145,7 @@ Relevant links:
 
 ## Testing Tiers (Ablation Study Framework)
 
-ProjectScylla benchmarks AI agent architectures across 7 testing tiers with ~114+ sub-tests:
+ProjectScylla benchmarks AI agent architectures across 7 testing tiers with 120 sub-tests:
 
 | Tier | Name | Sub-tests | Description |
 |------|------|-----------|-------------|

--- a/docs/research.md
+++ b/docs/research.md
@@ -83,7 +83,7 @@ Table 2.1: Incremental Agent Capability Testing Matrix (Ablation Study Framework
 | T1 | Skills | 10 | Domain expertise via installed skills by category | Context Bloat (Mitigated) | Excellent CoP, High Efficacy |
 | T2 | Tooling | 15 | External tools and MCP servers | Schema Token Overhead | High Efficacy, Poor CoP |
 | T3 | Delegation | 41 | Flat multi-agent with specialist agents (L2-L5) | Orchestration Latency | High Efficacy, Moderate CoP |
-| T4 | Hierarchy | 7 | Nested orchestration with orchestrator agents (L0-L1) | Iterative Verification Cost | Very High Efficacy, High CoP |
+| T4 | Hierarchy | 14 | Nested orchestration with orchestrator agents (L0-L1) | Iterative Verification Cost | Very High Efficacy, High CoP |
 | T5 | Hybrid | 15 | Best combinations and permutations from all tiers | Synergistic Overhead | Maximized CoP/Efficacy Ratio |
 | T6 | Super | 1 | Everything enabled at maximum capability | Maximum Overhead | Theoretical Upper Bound |
 

--- a/scylla/e2e/runner.py
+++ b/scylla/e2e/runner.py
@@ -1,8 +1,7 @@
 """Main E2E experiment runner.
 
 This module provides the main entry point for running E2E experiments,
-coordinating tier execution, inheritance, and result aggregation.
-and report generation.
+coordinating tier execution, inheritance, result aggregation, and report generation.
 """
 
 from __future__ import annotations
@@ -10,6 +9,7 @@ from __future__ import annotations
 import json
 import logging
 import os
+import tempfile
 from collections.abc import Callable
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from concurrent.futures.process import BrokenProcessPool
@@ -1294,7 +1294,7 @@ class E2ERunner:
         if checkpoint is None:
             checkpoint = E2ECheckpoint(
                 experiment_id=self.config.experiment_id,
-                experiment_dir=str(self.experiment_dir or "/tmp"),
+                experiment_dir=str(self.experiment_dir or tempfile.gettempdir()),
                 config_hash="",
                 completed_runs={},
                 started_at=datetime.now(timezone.utc).isoformat(),


### PR DESCRIPTION
## Summary

Applies all directly-actionable findings from the February 2026 quality audit (overall grade: 81/100, B-). This PR covers P1/P2/P3 fixes that can be made without architectural changes.

### Changes

| File | Change | Audit Finding |
|------|--------|---------------|
| `docs/research.md:86` | T4 sub-test count 7 → 14 | P1: Discrepancy vs CLAUDE.md and filesystem |
| `.github/workflows/test.yml` | Add `tests/integration/` to CI matrix | P1: Integration tests never ran in CI |
| `.github/CODEOWNERS` | Remove stale `/Dockerfile` and `/docker-compose.yml` | P1: Paths don't exist at root; `/docker/` already covers them |
| `CLAUDE.md` | Sub-test count `~114+` → `120`; coverage `73%+` → `75%+` | P2: Stale numbers (tracked in #1112) |
| `scylla/e2e/runner.py` | Fix docstring grammar (duplicate sentence fragment) | P2: Audit finding |
| `scylla/e2e/runner.py` | Replace hardcoded `"/tmp"` with `tempfile.gettempdir()` | P3: Platform portability |

### Issues Filed (new findings not previously tracked)

- #1115 — Fix T4 subtest count in research.md (7 → 14)
- #1116 — Add tests/integration/ to CI test matrix
- #1117 — Fix CODEOWNERS stale /Dockerfile and /docker-compose.yml paths
- #1118 — Standardize Python version specification across configs
- #1119 — Add upper bounds to PyPI dependencies in pixi.toml
- #1120 — Annotate test functions for mypy compliance

### Issues Not Fixed Here (tracked separately)

- #1114 — Implement or remove Docker tests (tests/docker/ missing)
- #1112 — Full doc discrepancy cleanup (broader scope)
- #1110 — Decompose runner.py _initialize_or_resume_experiment()

## Test plan
- [x] All 3172 tests pass (78.29% coverage, above 75% threshold)
- [x] All pre-commit hooks pass (ruff, mypy, markdownlint, yaml-lint)
- [x] Integration tests verified green locally before adding to CI matrix

Closes #1115
Closes #1116
Closes #1117

🤖 Generated with [Claude Code](https://claude.com/claude-code)