### PR TITLE
feat(docker): optimize Dockerfile layer caching for source-only changes

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -25,16 +25,21 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     build-essential \
     && rm -rf /var/lib/apt/lists/*
 
-# Install Python build dependencies
+# Layer 1: Build backend (invalidated only when hatchling version changes)
 RUN pip install --no-cache-dir hatchling
 
-# Copy project files for building scylla package
+# Layer 2: Dependencies (invalidated only when pyproject.toml changes)
+# Copy only pyproject.toml first so dependency installs are cached separately
+# from source changes. Uses tomllib (stdlib since Python 3.11) to extract deps.
 COPY pyproject.toml /opt/scylla/
+RUN pip install --user --no-cache-dir \
+    $(python3 -c "import tomllib; data=tomllib.load(open('/opt/scylla/pyproject.toml','rb')); print(' '.join(data['project']['dependencies']))")
+
+# Layer 3: Package install (invalidated when scylla/ source changes)
+# Source-only changes hit cached layer 2 and only re-run this install step.
 COPY README.md /opt/scylla/
 COPY scylla/ /opt/scylla/scylla/
-
-# Install scylla package to user directory (will be copied to runtime stage)
-RUN pip install --user --no-cache-dir /opt/scylla/
+RUN pip install --user --no-cache-dir --no-deps /opt/scylla/
 
 # ============================================================================
 # Stage 2: Runtime - Minimal production image


### PR DESCRIPTION
## Summary

Restructures the builder stage in `docker/Dockerfile` to cache Python dependency installation separately from the `scylla/` source tree.

**Problem**: Previously, `pyproject.toml` and `scylla/` source were copied together before `pip install`, so any source change invalidated the (expensive) dependency install layer.

**Fix**: Split installation into three distinct cached layers:
- **Layer 1**: Install hatchling build backend (cached until hatchling version changes)
- **Layer 2**: Copy `pyproject.toml` only + install dependencies via `tomllib` inline extraction (cached until `pyproject.toml` changes)
- **Layer 3**: Copy `README.md` + `scylla/` source + `pip install --no-deps` (invalidated only by source changes)

Source-only changes now skip the expensive dependency install step entirely.

## Changes

- `docker/Dockerfile`: Split single `pip install` into dep-only install (layer 2) + `--no-deps` package install (layer 3), with `pyproject.toml` copied before `scylla/` source

## Test plan

- [x] All 3127 unit tests pass (`78.29%` coverage, above 75% threshold)
- [ ] Manual verification: `docker build` with source-only change shows `CACHED` for layer 2
- [ ] CI build time reduced by ≥30% for source-only changes (measured by CI job duration)

Closes #998

🤖 Generated with [Claude Code](https://claude.com/claude-code)