### PR TITLE
fix(e2e): replace bare assert guards with RuntimeError raises

### DIFF
--- a/scylla/e2e/stages.py
+++ b/scylla/e2e/stages.py
@@ -447,7 +447,8 @@ def stage_execute_agent(ctx: RunContext) -> None:
 
     agent_dir = get_agent_dir(ctx.run_dir)
     adapter_config = ctx.adapter_config
-    assert adapter_config is not None  # noqa: S101
+    if adapter_config is None:
+        raise RuntimeError("adapter_config must be set before writing replay script")
     replay_script = agent_dir / "replay.sh"
 
     logger.info(f"[AGENT] Running agent with model[{ctx.config.models[0]}]")
@@ -874,8 +875,10 @@ def stage_finalize_run(ctx: RunContext) -> None:
     """
     from scylla.e2e.rate_limit import RateLimitError, detect_rate_limit
 
-    assert ctx.agent_result is not None, "agent_result must be set before finalize_run"  # noqa: S101
-    assert ctx.judgment is not None, "judgment must be set before finalize_run"  # noqa: S101
+    if ctx.agent_result is None:
+        raise RuntimeError("agent_result must be set before finalize_run")
+    if ctx.judgment is None:
+        raise RuntimeError("judgment must be set before finalize_run")
 
     agent_dir = get_agent_dir(ctx.run_dir)
 
@@ -955,9 +958,12 @@ def stage_write_report(ctx: RunContext) -> None:
     """
     from scylla.e2e.run_report import save_run_report, save_run_report_json
 
-    assert ctx.run_result is not None, "run_result must be set before write_report"  # noqa: S101
-    assert ctx.agent_result is not None, "agent_result must be set before write_report"  # noqa: S101
-    assert ctx.judgment is not None, "judgment must be set before write_report"  # noqa: S101
+    if ctx.run_result is None:
+        raise RuntimeError("run_result must be set before write_report")
+    if ctx.agent_result is None:
+        raise RuntimeError("agent_result must be set before write_report")
+    if ctx.judgment is None:
+        raise RuntimeError("judgment must be set before write_report")
 
     token_stats = ctx.run_result.token_stats
 


### PR DESCRIPTION
## Summary

- Replace all `assert x is not None  # noqa: S101` statements in `scylla/e2e/runner.py` and `scylla/e2e/stages.py` with explicit `if x is None: raise RuntimeError(...)` patterns
- Remove all `# noqa: S101` suppression comments from those files
- Eliminates Ruff S101 violations while ensuring guards are always enforced (even with `python -O`)

## Changes

**`scylla/e2e/runner.py`** — 10 asserts replaced:
- `self.checkpoint` (×3), `self.experiment_dir` (×5), `tier_ctx.tier_config`, `tier_ctx.tier_dir` (×2), `tier_ctx.selection`, `tier_ctx.tier_result`

**`scylla/e2e/stages.py`** — 6 asserts replaced:
- `adapter_config`, `ctx.agent_result` (×2), `ctx.judgment` (×2), `ctx.run_result`

## Test plan

- [x] All 3185 tests pass (`pixi run python -m pytest tests/ -v`)
- [x] Coverage at 78.09% (threshold: 75%)
- [x] All pre-commit hooks pass (`pre-commit run --all-files`)
- [x] No remaining `# noqa: S101` in either file
- [x] No remaining `assert` with `noqa` in either file

Closes #1066

🤖 Generated with [Claude Code](https://claude.com/claude-code)