### PR TITLE
fix(ci): remove dead pytest tests/docker/ step from docker-test.yml

### DIFF
--- a/.github/workflows/docker-test.yml
+++ b/.github/workflows/docker-test.yml
@@ -1,4 +1,4 @@
-name: Docker Build Test
+name: Docker Validation
 
 on:
   pull_request:
@@ -30,16 +30,5 @@ jobs:
           # Validate docker-compose.yml configuration
           docker compose -f docker/docker-compose.yml config --quiet
 
-      - name: Install pixi
-        uses: prefix-dev/setup-pixi@v0.9.4
-        with:
-          pixi-version: v0.62.2
-          cache: true
-
-      - name: Run Docker tests
-        run: |
-          # Install package in dev mode
-          pixi run pip install -e .
-
-          # Run tests
-          pixi run pytest tests/docker/ -v --no-cov
+      # Docker integration tests are deferred — see docs/dev/adr/docker-testing-deferred.md
+      # Entrypoint script testing is tracked in GitHub issue #1113

--- a/docs/dev/adr/docker-testing-deferred.md
+++ b/docs/dev/adr/docker-testing-deferred.md
@@ -1,0 +1,44 @@
+# ADR: Docker Integration Testing Deferred
+
+**Date**: 2026-02-27
+**Status**: Accepted
+**Issue**: [#1114](https://github.com/HomericIntelligence/ProjectScylla/issues/1114)
+
+## Context
+
+The `.github/workflows/docker-test.yml` CI workflow contained a step that ran
+`pixi run pytest tests/docker/ -v --no-cov`, but `tests/docker/` never existed.
+This created a false sense of Docker test coverage while wasting CI resources on
+a step that would fail immediately if it ever ran against an empty directory.
+
+## Decision
+
+Remove the dead `pytest tests/docker/` step from the CI workflow. Retain the two
+genuine validation steps:
+
+1. **Dockerfile syntax check** — `docker build --check docker/` validates syntax
+   without building the image.
+2. **docker-compose config check** — `docker compose config --quiet` validates the
+   compose file structure.
+
+Rename the workflow from "Docker Build Test" to "Docker Validation" to accurately
+reflect what it does.
+
+## Reasons
+
+- The Docker image requires `ANTHROPIC_API_KEY` and Claude Code credentials.
+  Meaningful integration tests cannot run in standard CI without injecting secrets.
+- `docker/entrypoint.sh` contains 457 lines of shell logic. Shell script testing
+  belongs in `tests/shell/` using BATS, not in `tests/docker/` using pytest.
+- Issue #1113 already tracks the shell script test gap and is the correct scope
+  for entrypoint coverage.
+- The two retained validation steps provide genuine value (catch Dockerfile syntax
+  errors and compose file misconfigurations) with zero maintenance overhead.
+
+## Consequences
+
+- `tests/docker/` is not created; it remains absent.
+- The CI workflow no longer references non-existent test files.
+- Docker integration testing remains a known gap, tracked in issue #1113.
+- If Docker integration tests are later implemented, they should be added as a
+  separate workflow with appropriate secrets configuration.


### PR DESCRIPTION
## Summary

- Removes the `Run Docker tests` step from `.github/workflows/docker-test.yml` that referenced the non-existent `tests/docker/` directory
- Removes the `Install pixi` step that was only needed to support the dead test step
- Renames the workflow from "Docker Build Test" to "Docker Validation" to accurately reflect its purpose
- Creates `docs/dev/adr/docker-testing-deferred.md` documenting why Docker integration testing was deferred

## Why Option B (Remove)

Docker integration tests require `ANTHROPIC_API_KEY` and Claude Code credentials, making them infeasible in standard CI. The entrypoint script (`docker/entrypoint.sh`) is 457 lines of shell logic better tested via BATS in `tests/shell/`, which is tracked in issue #1113. The two retained steps (Dockerfile syntax check + compose config validation) provide genuine value with zero maintenance overhead.

## Test plan

- [x] All 3185 existing tests pass (78.36% coverage, above 75% threshold)
- [x] `.github/workflows/docker-test.yml` no longer references `tests/docker/`
- [x] Dockerfile syntax validation step retained
- [x] docker-compose config validation step retained
- [x] `docs/dev/adr/docker-testing-deferred.md` created with decision rationale
- [x] `README.md` has no Docker CI badge references (confirmed clean)

Closes #1114

🤖 Generated with [Claude Code](https://claude.com/claude-code)