### PR TITLE
docs(docker): align Dockerfile Python version with pyproject.toml classifiers

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -11,7 +11,8 @@
 # Stage 1: Builder - Install Python packages with build dependencies
 # ============================================================================
 # Pinned to SHA256 digest for reproducibility - prevents drift from upstream updates
-FROM python:3.14.2-slim@sha256:1a3c6dbfd2173971abba880c3cc2ec4643690901f6ad6742d0827bae6cefc925 AS builder
+# Python 3.12 aligns with pyproject.toml classifiers (3.10-3.12); requires-python = ">=3.10"
+FROM python:3.12-slim@sha256:f3fa41d74a768c2fce8016b98c191ae8c1bacd8f1152870a3f9f87d350920b7c AS builder
 
 # Set build environment variables
 ENV DEBIAN_FRONTEND=noninteractive \
@@ -40,7 +41,8 @@ RUN pip install --user --no-cache-dir /opt/scylla/
 # Stage 2: Runtime - Minimal production image
 # ============================================================================
 # Pinned to SHA256 digest for reproducibility - prevents drift from upstream updates
-FROM python:3.14.2-slim@sha256:1a3c6dbfd2173971abba880c3cc2ec4643690901f6ad6742d0827bae6cefc925
+# Python 3.12 aligns with pyproject.toml classifiers (3.10-3.12); requires-python = ">=3.10"
+FROM python:3.12-slim@sha256:f3fa41d74a768c2fce8016b98c191ae8c1bacd8f1152870a3f9f87d350920b7c
 
 # Set labels for image metadata
 LABEL org.opencontainers.image.title="scylla-runner"
@@ -49,7 +51,7 @@ LABEL org.opencontainers.image.vendor="ProjectScylla"
 LABEL org.opencontainers.image.version="latest"
 
 # Copy Python packages from builder stage to global location
-COPY --from=builder /root/.local/lib/python3.14/site-packages /usr/local/lib/python3.14/site-packages
+COPY --from=builder /root/.local/lib/python3.12/site-packages /usr/local/lib/python3.12/site-packages
 COPY --from=builder /root/.local/bin /usr/local/bin
 
 # Set environment variables


### PR DESCRIPTION
## Summary
- Replace `python:3.14.2-slim` with `python:3.12-slim` (pinned SHA256) in `docker/Dockerfile`
- Update site-packages `COPY` path from `python3.14` to `python3.12`
- Add inline comments linking Docker version choice to `pyproject.toml` classifiers

All three config files now agree on Python 3.12 (within the `>=3.10` range):
| File | Before | After |
|------|--------|-------|
| `pyproject.toml` | `>=3.10`, classifiers 3.10-3.12 | unchanged |
| `pixi.toml` | `python = ">=3.10"` | unchanged |
| `docker/Dockerfile` | `python:3.14.2-slim` (drift) | `python:3.12-slim` (aligned) |

## Test plan
- [x] All 3185 tests pass (78.36% coverage, above 75% threshold)
- [x] No remaining `python3.14` or `3.14` references in any config file
- [x] Pre-push coverage validation passed

Closes #1118