### PR TITLE
feat(docker): optimize Dockerfile layer caching for source-only changes

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -25,16 +25,21 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     build-essential \
     && rm -rf /var/lib/apt/lists/*
 
-# Install Python build dependencies
+# Layer 1: Build backend (invalidated only when hatchling version changes)
 RUN pip install --no-cache-dir hatchling
 
-# Copy project files for building scylla package
+# Layer 2: Dependencies (invalidated only when pyproject.toml changes)
+# Copy only pyproject.toml first so dependency installs are cached separately
+# from source changes. Uses tomllib (stdlib since Python 3.11) to extract deps.
 COPY pyproject.toml /opt/scylla/
+RUN pip install --user --no-cache-dir \
+    $(python3 -c "import tomllib; data=tomllib.load(open('/opt/scylla/pyproject.toml','rb')); print(' '.join(data['project']['dependencies']))")
+
+# Layer 3: Package install (invalidated when scylla/ source changes)
+# Source-only changes hit cached layer 2 and only re-run this install step.
 COPY README.md /opt/scylla/
 COPY scylla/ /opt/scylla/scylla/
-
-# Install scylla package to user directory (will be copied to runtime stage)
-RUN pip install --user --no-cache-dir /opt/scylla/
+RUN pip install --user --no-cache-dir --no-deps /opt/scylla/
 
 # ============================================================================
 # Stage 2: Runtime - Minimal production image


### PR DESCRIPTION
## Summary

- Splits the builder stage `pip install` into two distinct cached layers: one for Python dependencies (from `pyproject.toml` only) and one for the package install (after copying `scylla/` source)
- Uses `tomllib` (Python 3.11+ stdlib, available in the `python:3.14.2-slim` base image) inline to extract `project.dependencies` from `pyproject.toml` and pre-install them before copying source
- Source-only changes now hit the cached dependency layer and only re-run the fast `--no-deps` package install step

## Test plan

- [x] All 3185 unit tests pass (`pixi run python -m pytest tests/unit/ -v`)
- [x] Coverage at 78.36% (above 75% threshold)
- [x] Existing `tests/unit/executor/test_docker.py` (40 tests) continue to pass
- Manual Docker verification: `docker build` with source-only change should show `CACHED` for the deps layer and only re-run `COPY scylla/` + `pip install --no-deps`

Closes #998

🤖 Generated with [Claude Code](https://claude.com/claude-code)