### PR TITLE
fix(pytest): add scripts/ to pythonpath for analysis test coverage

### DIFF
--- a/pixi.lock
+++ b/pixi.lock
@@ -3764,7 +3764,7 @@ packages:
 - pypi: ./
   name: scylla
   version: 0.1.0
-  sha256: 7d1403909dfe0885d0a97c4a3c762ce41883af53aff849f96b33f577b6b1b997
+  sha256: 702f857459de3e49bc535d7dba70f9cd0cba1cf7f2b078d1f69f99ff0e6efdb1
   requires_dist:
   - click>=8.0
   - pydantic>=2.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,7 +82,7 @@ ignore = [
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
-pythonpath = ["."]
+pythonpath = [".", "scripts"]
 addopts = [
     "-v",
     "--strict-markers",

--- a/tests/unit/analysis/test_export_data.py
+++ b/tests/unit/analysis/test_export_data.py
@@ -1,12 +1,7 @@
 """Tests for export_data.py script."""
 
 import json
-import sys
-from pathlib import Path
 from typing import Any
-
-# Add scripts directory to path
-sys.path.insert(0, str(Path(__file__).parent.parent.parent.parent / "scripts"))
 
 
 def test_compute_statistical_results(sample_runs_df, tmp_path):


### PR DESCRIPTION
## Summary

- Add `"scripts"` to `pythonpath` in `[tool.pytest.ini_options]` in `pyproject.toml` so all pytest invocations (local, CI, pre-push hook) can import `export_data` without a shell workaround
- Remove the now-redundant `sys.path.insert` workaround from `tests/unit/analysis/test_export_data.py` along with the unused `sys` and `Path` imports

This raises the visible test count from ~1691 to ~3257 and prevents coverage regressions from being masked by collection errors.

Closes #1137

## Test plan

- [x] `tests/unit/analysis/test_export_data.py` — 9 tests collected and pass (no collection errors)
- [x] Full suite: 3257 passed, coverage 78.31% (≥75% threshold met)
- [x] Pre-commit hooks: all pass (ruff, mypy, shellcheck, etc.)
- [x] Pre-push hook simulation: exits 0 with 3257 tests collected

🤖 Generated with [Claude Code](https://claude.com/claude-code)