### PR TITLE
feat(analysis): Wire process-metrics figures into report pipeline

### DIFF
--- a/scripts/generate_figures.py
+++ b/scripts/generate_figures.py
@@ -40,6 +40,11 @@ from scylla.analysis.figures.judge_analysis import (
     fig17_judge_variance_overall,
 )
 from scylla.analysis.figures.model_comparison import fig11_tier_uplift, fig12_consistency
+from scylla.analysis.figures.process_metrics import (
+    fig_cfp_by_tier,
+    fig_pr_revert_by_tier,
+    fig_r_prog_by_tier,
+)
 from scylla.analysis.figures.spec_builder import apply_publication_theme
 from scylla.analysis.figures.subtest_detail import (
     fig13_latency,
@@ -93,6 +98,9 @@ FIGURES: dict[str, tuple[str, Any]] = {
     "fig25_impl_rate_by_tier": ("impl_rate", fig25_impl_rate_by_tier),
     "fig26_impl_rate_vs_pass_rate": ("impl_rate", fig26_impl_rate_vs_pass_rate),
     "fig27_impl_rate_distribution": ("impl_rate", fig27_impl_rate_distribution),
+    "fig_r_prog_by_tier": ("tier", fig_r_prog_by_tier),
+    "fig_cfp_by_tier": ("tier", fig_cfp_by_tier),
+    "fig_pr_revert_by_tier": ("tier", fig_pr_revert_by_tier),
 }
 
 

--- a/tests/unit/analysis/test_figures.py
+++ b/tests/unit/analysis/test_figures.py
@@ -631,6 +631,24 @@ def test_compute_dynamic_domain():
     assert domain[1] <= 0.8
 
 
+def test_generate_figures_registry_includes_process_metrics() -> None:
+    """FIGURES registry contains the three process-metrics figures."""
+    from scripts.generate_figures import FIGURES
+
+    assert "fig_r_prog_by_tier" in FIGURES
+    assert "fig_cfp_by_tier" in FIGURES
+    assert "fig_pr_revert_by_tier" in FIGURES
+
+
+def test_generate_figures_process_metrics_use_tier_category() -> None:
+    """Process-metrics figures are registered under the 'tier' category."""
+    from scripts.generate_figures import FIGURES
+
+    assert FIGURES["fig_r_prog_by_tier"][0] == "tier"
+    assert FIGURES["fig_cfp_by_tier"][0] == "tier"
+    assert FIGURES["fig_pr_revert_by_tier"][0] == "tier"
+
+
 def test_compute_dynamic_domain_padding():
     """Test padding behavior."""
     import pandas as pd


### PR DESCRIPTION
## Summary

- Imported `fig_r_prog_by_tier`, `fig_cfp_by_tier`, and `fig_pr_revert_by_tier` from `scylla/analysis/figures/process_metrics.py` into `scripts/generate_figures.py`
- Registered all three figures in the `FIGURES` dict under the `"tier"` dispatch category (correct call signature: `func(runs_df, output_dir, render=render)`)
- Added 2 registry tests to `tests/unit/analysis/test_figures.py` verifying presence and category

## Test plan
- [x] 2 new tests added: `test_generate_figures_registry_includes_process_metrics`, `test_generate_figures_process_metrics_use_tier_category`
- [x] All 3259 tests pass (up from 3257)
- [x] Coverage maintained at 78.38% (above 75% threshold)
- [x] Pre-commit hooks pass (black, ruff, mypy, all linters)

Closes #1136

🤖 Generated with [Claude Code](https://claude.com/claude-code)