### PR TITLE
fix(docker): pin hatchling version in builder stage

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -27,7 +27,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && rm -rf /var/lib/apt/lists/*
 
 # Layer 1: Build backend (invalidated only when hatchling version changes)
-RUN pip install --no-cache-dir hatchling
+# Pinned to match pyproject.toml [build-system].requires — see #1141
+RUN pip install --no-cache-dir "hatchling==1.29.0"
 
 # Layer 2: Dependencies (invalidated only when pyproject.toml changes)
 # Copy only pyproject.toml first so dependency installs are cached separately

--- a/tests/unit/e2e/test_dockerfile.py
+++ b/tests/unit/e2e/test_dockerfile.py
@@ -1,0 +1,21 @@
+"""Regression tests for Dockerfile pinning requirements.
+
+Validates that build-critical dependencies are pinned with exact version
+specifiers in docker/Dockerfile to ensure reproducible builds — see #1141.
+"""
+
+import re
+from pathlib import Path
+
+DOCKERFILE = Path(__file__).parents[3] / "docker" / "Dockerfile"
+
+
+def test_hatchling_is_pinned() -> None:
+    """hatchling must be pinned with == in the builder stage — see #1141."""
+    content = DOCKERFILE.read_text()
+    match = re.search(r"pip install[^\n]*hatchling([^\n]*)", content)
+    assert match is not None, "pip install hatchling line not found in Dockerfile"
+    assert "==" in match.group(0), (
+        "hatchling must be pinned with == (e.g. hatchling==1.29.0); "
+        "found unpinned install"
+    )


### PR DESCRIPTION
## Summary

- Pin `hatchling` to `==1.29.0` in `docker/Dockerfile` builder stage to ensure reproducible builds and stable Docker layer caching
- Add inline comment referencing issue #1141
- Add regression test `tests/unit/e2e/test_dockerfile.py` that statically parses the Dockerfile and asserts the `==` pin is present

## Test plan

- [x] `test_hatchling_is_pinned` passes — verifies the exact `==` specifier is present in the `pip install hatchling` line
- [x] Full suite: 3258 tests pass, coverage 78.31% (≥ 75% threshold)
- [x] Pre-commit hooks pass

Closes #1141

🤖 Generated with [Claude Code](https://claude.com/claude-code)