### PR TITLE
[Feat] ResumeManager: handle zombie detection inline

### DIFF
--- a/scylla/e2e/resume_manager.py
+++ b/scylla/e2e/resume_manager.py
@@ -11,6 +11,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 from scylla.e2e.checkpoint import E2ECheckpoint, compute_config_hash, save_checkpoint
+from scylla.e2e.health import is_zombie, reset_zombie_checkpoint
 from scylla.e2e.models import ExperimentConfig, RunState, TierID
 
 if TYPE_CHECKING:
@@ -59,6 +60,35 @@ class ResumeManager:
         self.checkpoint = checkpoint
         self.config = config
         self.tier_manager = tier_manager
+
+    def handle_zombie(
+        self,
+        checkpoint_path: Path,
+        experiment_dir: Path | None,
+    ) -> tuple[ExperimentConfig, E2ECheckpoint]:
+        """Check for zombie experiment and reset checkpoint if detected.
+
+        A zombie is a running experiment whose process has died without a clean
+        shutdown. If detected, the checkpoint status is reset to 'interrupted'
+        so the experiment can be safely resumed.
+
+        Args:
+            checkpoint_path: Path to checkpoint file for atomic save on reset.
+            experiment_dir: Path to experiment directory used for zombie detection.
+                If None, this method is a no-op (no checkpoint to inspect).
+
+        Returns:
+            Updated (config, checkpoint) tuple.
+
+        """
+        if experiment_dir is None:
+            return self.config, self.checkpoint
+
+        if is_zombie(self.checkpoint, experiment_dir):
+            logger.warning("Zombie experiment detected — resetting to 'interrupted'")
+            self.checkpoint = reset_zombie_checkpoint(self.checkpoint, checkpoint_path)
+
+        return self.config, self.checkpoint
 
     def restore_cli_args(
         self, cli_ephemeral: dict[str, Any]

--- a/scylla/e2e/runner.py
+++ b/scylla/e2e/runner.py
@@ -326,16 +326,13 @@ class E2ERunner:
                 # STEP 1 (continued): Load checkpoint — overwrites self.config from saved JSON
                 self._load_checkpoint_and_config(checkpoint_path)
 
-                # Check for zombie (crashed) experiment and reset if needed
-                if self.checkpoint and self.experiment_dir:
-                    from scylla.e2e.health import is_zombie, reset_zombie_checkpoint
-
-                    if is_zombie(self.checkpoint, self.experiment_dir):
-                        logger.warning("Zombie experiment detected — resetting to 'interrupted'")
-                        self.checkpoint = reset_zombie_checkpoint(self.checkpoint, checkpoint_path)
-
                 if self.checkpoint:
                     rm = ResumeManager(self.checkpoint, self.config, self.tier_manager)
+
+                    # STEP 1 (continued): Check for zombie (crashed) experiment
+                    self.config, self.checkpoint = rm.handle_zombie(
+                        checkpoint_path, self.experiment_dir
+                    )
 
                     # STEP 2: Restore ephemeral CLI args
                     self.config, self.checkpoint = rm.restore_cli_args(_cli_ephemeral)

--- a/tests/unit/e2e/test_runner.py
+++ b/tests/unit/e2e/test_runner.py
@@ -765,7 +765,7 @@ class TestInitializeOrResumeExperimentFailedReset:
             patch.object(runner, "_find_existing_checkpoint", return_value=checkpoint_path),
             patch.object(runner, "_load_checkpoint_and_config", side_effect=fake_load),
             patch.object(runner, "_write_pid_file"),
-            patch("scylla.e2e.health.is_zombie", return_value=False),
+            patch("scylla.e2e.resume_manager.is_zombie", return_value=False),
         ):
             runner._initialize_or_resume_experiment()
 
@@ -917,7 +917,7 @@ class TestInitializeOrResumeExperimentFailedReset:
         with (
             patch.object(runner, "_find_existing_checkpoint", return_value=checkpoint_path),
             patch.object(runner, "_write_pid_file"),
-            patch("scylla.e2e.health.is_zombie", return_value=False),
+            patch("scylla.e2e.resume_manager.is_zombie", return_value=False),
         ):
             runner._initialize_or_resume_experiment()
 
@@ -987,7 +987,7 @@ class TestInitializeOrResumeExperimentFailedReset:
         with (
             patch.object(runner, "_find_existing_checkpoint", return_value=checkpoint_path),
             patch.object(runner, "_write_pid_file"),
-            patch("scylla.e2e.health.is_zombie", return_value=False),
+            patch("scylla.e2e.resume_manager.is_zombie", return_value=False),
         ):
             runner._initialize_or_resume_experiment()
 
@@ -1058,7 +1058,7 @@ class TestInitializeOrResumeExperimentFailedReset:
         with (
             patch.object(runner, "_find_existing_checkpoint", return_value=checkpoint_path),
             patch.object(runner, "_write_pid_file"),
-            patch("scylla.e2e.health.is_zombie", return_value=False),
+            patch("scylla.e2e.resume_manager.is_zombie", return_value=False),
         ):
             runner._initialize_or_resume_experiment()
 
@@ -1127,7 +1127,7 @@ class TestInitializeOrResumeExperimentFailedReset:
         with (
             patch.object(runner, "_find_existing_checkpoint", return_value=checkpoint_path),
             patch.object(runner, "_write_pid_file"),
-            patch("scylla.e2e.health.is_zombie", return_value=False),
+            patch("scylla.e2e.resume_manager.is_zombie", return_value=False),
         ):
             runner._initialize_or_resume_experiment()
 
@@ -1202,7 +1202,7 @@ class TestInitializeOrResumeExperimentFailedReset:
         with (
             patch.object(runner, "_find_existing_checkpoint", return_value=checkpoint_path),
             patch.object(runner, "_write_pid_file"),
-            patch("scylla.e2e.health.is_zombie", return_value=False),
+            patch("scylla.e2e.resume_manager.is_zombie", return_value=False),
         ):
             runner._initialize_or_resume_experiment()
 


### PR DESCRIPTION
## Summary

- Moves the inline zombie detection block from `_initialize_or_resume_experiment()` in `runner.py` into a new `ResumeManager.handle_zombie()` method
- Removes the last piece of resume logic that was not delegated to `ResumeManager`, completing the clean sequential call chain
- Updates mock paths in `test_runner.py` to match the new import location

## Changes

| File | Change |
|------|--------|
| `scylla/e2e/resume_manager.py` | Add `handle_zombie(checkpoint_path, experiment_dir)` as first public method; import `is_zombie`/`reset_zombie_checkpoint` at module level |
| `scylla/e2e/runner.py` | Remove inline zombie detection block; delegate to `rm.handle_zombie()` as first step in ResumeManager call chain |
| `tests/unit/e2e/test_resume_manager.py` | Add `TestHandleZombie` with 3 test cases: zombie detected, no zombie, `experiment_dir=None` |
| `tests/unit/e2e/test_runner.py` | Update 6 mock paths from `scylla.e2e.health.is_zombie` → `scylla.e2e.resume_manager.is_zombie` |

## Test plan

- [x] `TestHandleZombie.test_zombie_detected_resets_checkpoint` — asserts `reset_zombie_checkpoint` called and `rm.checkpoint` updated
- [x] `TestHandleZombie.test_no_zombie_checkpoint_unchanged` — asserts `reset_zombie_checkpoint` NOT called
- [x] `TestHandleZombie.test_experiment_dir_none_is_noop` — asserts neither `is_zombie` nor reset are called when dir is None
- [x] All 3260 tests pass, 78.41% coverage (above 75% threshold)
- [x] All pre-commit hooks pass (ruff, mypy, black, custom validators)

Closes #1148

🤖 Generated with [Claude Code](https://claude.com/claude-code)