### PR TITLE
feat(ci): add pre-commit check for doc/config metric drift

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -99,6 +99,13 @@ repos:
         files: \.md$
         types: [markdown]
         pass_filenames: false
+      - id: check-doc-config-consistency
+        name: Check Doc/Config Metric Consistency
+        description: Fails if coverage threshold in CLAUDE.md or README.md --cov path diverges from pyproject.toml
+        entry: pixi run python scripts/check_doc_config_consistency.py
+        language: system
+        files: ^(CLAUDE\.md|README\.md|pyproject\.toml)$
+        pass_filenames: false
 
   # Markdown linting
   - repo: https://github.com/DavidAnson/markdownlint-cli2

--- a/scripts/check_doc_config_consistency.py
+++ b/scripts/check_doc_config_consistency.py
@@ -1,0 +1,236 @@
+#!/usr/bin/env python3
+"""Enforce consistency between documentation metric values and authoritative config sources.
+
+Checks:
+1. Coverage threshold in CLAUDE.md matches ``fail_under`` in ``pyproject.toml``.
+2. ``--cov=<path>`` in README.md matches ``addopts`` in ``pyproject.toml``.
+
+Usage:
+    python scripts/check_doc_config_consistency.py
+    python scripts/check_doc_config_consistency.py --repo-root /path/to/repo
+    python scripts/check_doc_config_consistency.py --verbose
+
+Exit codes:
+    0: All checks pass
+    1: One or more checks failed
+"""
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+import tomllib
+
+_REPO_ROOT = Path(__file__).parent.parent
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+
+def load_pyproject_coverage_threshold(repo_root: Path) -> int:
+    """Read ``fail_under`` from ``[tool.coverage.report]`` in ``pyproject.toml``.
+
+    Args:
+        repo_root: Path to the repository root containing ``pyproject.toml``.
+
+    Returns:
+        The integer value of ``fail_under``.
+
+    Raises:
+        SystemExit: If ``pyproject.toml`` is missing, unreadable, or lacks the key.
+
+    """
+    pyproject = repo_root / "pyproject.toml"
+    if not pyproject.exists():
+        print(f"ERROR: pyproject.toml not found at {pyproject}", file=sys.stderr)
+        sys.exit(1)
+
+    try:
+        with open(pyproject, "rb") as f:
+            data = tomllib.load(f)
+    except Exception as exc:
+        print(f"ERROR: Failed to parse pyproject.toml: {exc}", file=sys.stderr)
+        sys.exit(1)
+
+    try:
+        threshold = data["tool"]["coverage"]["report"]["fail_under"]
+    except KeyError:
+        print(
+            "ERROR: [tool.coverage.report].fail_under not found in pyproject.toml",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    return int(threshold)
+
+
+def extract_cov_path_from_pyproject(repo_root: Path) -> str:
+    """Read the ``--cov=<path>`` value from ``[tool.pytest.ini_options].addopts``.
+
+    Args:
+        repo_root: Path to the repository root containing ``pyproject.toml``.
+
+    Returns:
+        The package path string (e.g. ``"scylla"``).
+
+    Raises:
+        SystemExit: If the key is missing or no ``--cov=`` flag is found.
+
+    """
+    pyproject = repo_root / "pyproject.toml"
+    try:
+        with open(pyproject, "rb") as f:
+            data = tomllib.load(f)
+    except Exception as exc:
+        print(f"ERROR: Failed to parse pyproject.toml: {exc}", file=sys.stderr)
+        sys.exit(1)
+
+    addopts = data.get("tool", {}).get("pytest", {}).get("ini_options", {}).get("addopts", [])
+
+    # addopts may be a list or a string
+    if isinstance(addopts, str):
+        addopts_items: list[str] = addopts.split()
+    else:
+        addopts_items = list(addopts)
+
+    for item in addopts_items:
+        m = re.match(r"^--cov=(.+)$", item)
+        if m:
+            return m.group(1)
+
+    print(
+        "ERROR: No --cov=<path> found in [tool.pytest.ini_options].addopts in pyproject.toml",
+        file=sys.stderr,
+    )
+    sys.exit(1)
+
+
+def check_claude_md_threshold(repo_root: Path, expected_threshold: int) -> list[str]:
+    """Check that CLAUDE.md documents the correct coverage threshold.
+
+    Searches for the pattern ``<N>%+ test coverage`` in CLAUDE.md and verifies
+    the integer ``<N>`` matches *expected_threshold*.
+
+    Args:
+        repo_root: Path to the repository root.
+        expected_threshold: The authoritative threshold value from ``pyproject.toml``.
+
+    Returns:
+        List of error strings (empty if all checks pass).
+
+    """
+    claude_md = repo_root / "CLAUDE.md"
+    if not claude_md.exists():
+        return [f"CLAUDE.md not found at {claude_md}"]
+
+    text = claude_md.read_text(encoding="utf-8")
+    # Match patterns like "75%+ test coverage" or "75% test coverage"
+    matches = re.findall(r"(\d+)%\+?\s+test coverage", text)
+
+    if not matches:
+        return [
+            "CLAUDE.md: No coverage threshold mention found "
+            "(expected pattern: '<N>%+ test coverage')"
+        ]
+
+    errors: list[str] = []
+    for raw in matches:
+        found = int(raw)
+        if found != expected_threshold:
+            errors.append(
+                f"CLAUDE.md: Coverage threshold mismatch — "
+                f"CLAUDE.md says {found}%, pyproject.toml says {expected_threshold}%"
+            )
+    return errors
+
+
+def check_readme_cov_path(repo_root: Path, expected_path: str) -> list[str]:
+    """Check that all ``--cov=<path>`` occurrences in README.md match *expected_path*.
+
+    Args:
+        repo_root: Path to the repository root.
+        expected_path: The authoritative ``--cov`` path from ``pyproject.toml``.
+
+    Returns:
+        List of error strings (empty if all checks pass).
+
+    """
+    readme = repo_root / "README.md"
+    if not readme.exists():
+        return [f"README.md not found at {readme}"]
+
+    text = readme.read_text(encoding="utf-8")
+    occurrences = re.findall(r"--cov=(\S+)", text)
+
+    if not occurrences:
+        # No --cov= in README is acceptable — nothing to validate
+        return []
+
+    errors: list[str] = []
+    for path in occurrences:
+        if path != expected_path:
+            errors.append(
+                f"README.md: --cov path mismatch — "
+                f"README.md has '--cov={path}', pyproject.toml uses '--cov={expected_path}'"
+            )
+    return errors
+
+
+def main() -> int:
+    """Run all doc/config consistency checks.
+
+    Returns:
+        Exit code: 0 if all checks pass, 1 if any fail.
+
+    """
+    parser = argparse.ArgumentParser(
+        description="Enforce consistency between doc metric values and pyproject.toml",
+        epilog="Example: %(prog)s --repo-root /path/to/repo",
+    )
+    parser.add_argument(
+        "--repo-root",
+        type=Path,
+        default=_REPO_ROOT,
+        help="Path to repository root (default: parent of this script)",
+    )
+    parser.add_argument(
+        "--verbose",
+        "-v",
+        action="store_true",
+        help="Print passing check names",
+    )
+    args = parser.parse_args()
+    repo_root: Path = args.repo_root
+
+    all_errors: list[str] = []
+
+    # --- Check 1: Coverage threshold ---
+    expected_threshold = load_pyproject_coverage_threshold(repo_root)
+    threshold_errors = check_claude_md_threshold(repo_root, expected_threshold)
+    if threshold_errors:
+        all_errors.extend(threshold_errors)
+    elif args.verbose:
+        print(f"PASS: CLAUDE.md coverage threshold matches pyproject.toml ({expected_threshold}%)")
+
+    # --- Check 2: --cov path ---
+    expected_cov_path = extract_cov_path_from_pyproject(repo_root)
+    cov_errors = check_readme_cov_path(repo_root, expected_cov_path)
+    if cov_errors:
+        all_errors.extend(cov_errors)
+    elif args.verbose:
+        print(f"PASS: README.md --cov path matches pyproject.toml (--cov={expected_cov_path})")
+
+    if all_errors:
+        for error in all_errors:
+            print(error, file=sys.stderr)
+        print(
+            f"\nFound {len(all_errors)} doc/config consistency violation(s).",
+            file=sys.stderr,
+        )
+        return 1
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/unit/scripts/test_check_doc_config_consistency.py
+++ b/tests/unit/scripts/test_check_doc_config_consistency.py
@@ -1,0 +1,350 @@
+"""Tests for scripts/check_doc_config_consistency.py."""
+
+import textwrap
+from pathlib import Path
+
+import pytest
+
+from scripts.check_doc_config_consistency import (
+    check_claude_md_threshold,
+    check_readme_cov_path,
+    extract_cov_path_from_pyproject,
+    load_pyproject_coverage_threshold,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def write_pyproject(tmp_path: Path, content: str) -> Path:
+    """Write a pyproject.toml to *tmp_path* and return its path."""
+    path = tmp_path / "pyproject.toml"
+    path.write_text(textwrap.dedent(content), encoding="utf-8")
+    return path
+
+
+def write_claude_md(tmp_path: Path, content: str) -> Path:
+    """Write a CLAUDE.md to *tmp_path* and return its path."""
+    path = tmp_path / "CLAUDE.md"
+    path.write_text(textwrap.dedent(content), encoding="utf-8")
+    return path
+
+
+def write_readme(tmp_path: Path, content: str) -> Path:
+    """Write a README.md to *tmp_path* and return its path."""
+    path = tmp_path / "README.md"
+    path.write_text(textwrap.dedent(content), encoding="utf-8")
+    return path
+
+
+PYPROJECT_THRESHOLD_75 = """\
+    [tool.coverage.report]
+    fail_under = 75
+"""
+
+PYPROJECT_THRESHOLD_80 = """\
+    [tool.coverage.report]
+    fail_under = 80
+"""
+
+PYPROJECT_COV_SCYLLA = """\
+    [tool.pytest.ini_options]
+    addopts = ["--cov=scylla", "--cov-report=term-missing"]
+"""
+
+PYPROJECT_FULL = """\
+    [tool.coverage.report]
+    fail_under = 75
+
+    [tool.pytest.ini_options]
+    addopts = ["--cov=scylla", "--cov-report=term-missing"]
+"""
+
+
+# ---------------------------------------------------------------------------
+# load_pyproject_coverage_threshold
+# ---------------------------------------------------------------------------
+
+
+class TestLoadPyprojectCoverageThreshold:
+    """Tests for load_pyproject_coverage_threshold()."""
+
+    def test_reads_threshold(self, tmp_path: Path) -> None:
+        """Should return the integer fail_under value."""
+        write_pyproject(tmp_path, PYPROJECT_THRESHOLD_75)
+        assert load_pyproject_coverage_threshold(tmp_path) == 75
+
+    def test_reads_different_threshold(self, tmp_path: Path) -> None:
+        """Should return 80 when fail_under is 80."""
+        write_pyproject(tmp_path, PYPROJECT_THRESHOLD_80)
+        assert load_pyproject_coverage_threshold(tmp_path) == 80
+
+    def test_missing_pyproject_exits(self, tmp_path: Path) -> None:
+        """Should exit 1 when pyproject.toml is absent."""
+        with pytest.raises(SystemExit) as exc_info:
+            load_pyproject_coverage_threshold(tmp_path)
+        assert exc_info.value.code == 1
+
+    def test_missing_fail_under_key_exits(self, tmp_path: Path) -> None:
+        """Should exit 1 when the fail_under key is absent."""
+        write_pyproject(tmp_path, "[tool.coverage.run]\nbranch = true\n")
+        with pytest.raises(SystemExit) as exc_info:
+            load_pyproject_coverage_threshold(tmp_path)
+        assert exc_info.value.code == 1
+
+    def test_invalid_toml_exits(self, tmp_path: Path) -> None:
+        """Should exit 1 on malformed TOML."""
+        (tmp_path / "pyproject.toml").write_bytes(b"not = valid [ toml }")
+        with pytest.raises(SystemExit) as exc_info:
+            load_pyproject_coverage_threshold(tmp_path)
+        assert exc_info.value.code == 1
+
+
+# ---------------------------------------------------------------------------
+# extract_cov_path_from_pyproject
+# ---------------------------------------------------------------------------
+
+
+class TestExtractCovPathFromPyproject:
+    """Tests for extract_cov_path_from_pyproject()."""
+
+    def test_extracts_path(self, tmp_path: Path) -> None:
+        """Should return the package path from --cov=<path>."""
+        write_pyproject(tmp_path, PYPROJECT_COV_SCYLLA)
+        assert extract_cov_path_from_pyproject(tmp_path) == "scylla"
+
+    def test_extracts_different_path(self, tmp_path: Path) -> None:
+        """Should return the correct path for a different package."""
+        write_pyproject(
+            tmp_path,
+            '[tool.pytest.ini_options]\naddopts = ["--cov=mypackage"]\n',
+        )
+        assert extract_cov_path_from_pyproject(tmp_path) == "mypackage"
+
+    def test_addopts_as_string(self, tmp_path: Path) -> None:
+        """Should handle addopts as a plain string."""
+        write_pyproject(
+            tmp_path,
+            '[tool.pytest.ini_options]\naddopts = "--cov=scylla --cov-report=term"\n',
+        )
+        assert extract_cov_path_from_pyproject(tmp_path) == "scylla"
+
+    def test_no_cov_flag_exits(self, tmp_path: Path) -> None:
+        """Should exit 1 when no --cov= flag is present in addopts."""
+        write_pyproject(
+            tmp_path,
+            '[tool.pytest.ini_options]\naddopts = ["-v", "--tb=short"]\n',
+        )
+        with pytest.raises(SystemExit) as exc_info:
+            extract_cov_path_from_pyproject(tmp_path)
+        assert exc_info.value.code == 1
+
+    def test_missing_addopts_exits(self, tmp_path: Path) -> None:
+        """Should exit 1 when addopts is entirely absent."""
+        write_pyproject(tmp_path, "[tool.pytest.ini_options]\ntestpaths = ['tests']\n")
+        with pytest.raises(SystemExit) as exc_info:
+            extract_cov_path_from_pyproject(tmp_path)
+        assert exc_info.value.code == 1
+
+
+# ---------------------------------------------------------------------------
+# check_claude_md_threshold
+# ---------------------------------------------------------------------------
+
+
+class TestCheckClaudeMdThreshold:
+    """Tests for check_claude_md_threshold()."""
+
+    def test_matching_threshold_returns_no_errors(self, tmp_path: Path) -> None:
+        """Should return empty list when CLAUDE.md matches expected threshold."""
+        write_claude_md(
+            tmp_path,
+            "studies with 75%+ test coverage enforced in CI.\n",
+        )
+        assert check_claude_md_threshold(tmp_path, 75) == []
+
+    def test_matching_threshold_without_plus_returns_no_errors(self, tmp_path: Path) -> None:
+        """Should also match '75% test coverage' (without '+')."""
+        write_claude_md(
+            tmp_path,
+            "requires 75% test coverage in this project.\n",
+        )
+        assert check_claude_md_threshold(tmp_path, 75) == []
+
+    def test_mismatched_threshold_returns_error(self, tmp_path: Path) -> None:
+        """Should return an error when CLAUDE.md has a different threshold."""
+        write_claude_md(
+            tmp_path,
+            "studies with 80%+ test coverage enforced in CI.\n",
+        )
+        errors = check_claude_md_threshold(tmp_path, 75)
+        assert len(errors) == 1
+        assert "80%" in errors[0]
+        assert "75%" in errors[0]
+
+    def test_missing_claude_md_returns_error(self, tmp_path: Path) -> None:
+        """Should return an error when CLAUDE.md does not exist."""
+        errors = check_claude_md_threshold(tmp_path, 75)
+        assert len(errors) == 1
+        assert "not found" in errors[0]
+
+    def test_no_coverage_mention_returns_error(self, tmp_path: Path) -> None:
+        """Should return an error when CLAUDE.md has no coverage threshold mention."""
+        write_claude_md(tmp_path, "No mention of coverage here.\n")
+        errors = check_claude_md_threshold(tmp_path, 75)
+        assert len(errors) == 1
+        assert "No coverage threshold mention" in errors[0]
+
+    def test_multiple_matching_occurrences_no_errors(self, tmp_path: Path) -> None:
+        """Multiple matching occurrences should all pass."""
+        write_claude_md(
+            tmp_path,
+            "75%+ test coverage enforced. Also: 75%+ test coverage required.\n",
+        )
+        assert check_claude_md_threshold(tmp_path, 75) == []
+
+    def test_multiple_occurrences_one_mismatch_returns_error(self, tmp_path: Path) -> None:
+        """If any occurrence mismatches, an error should be returned."""
+        write_claude_md(
+            tmp_path,
+            "75%+ test coverage enforced. Also: 80%+ test coverage elsewhere.\n",
+        )
+        errors = check_claude_md_threshold(tmp_path, 75)
+        assert len(errors) == 1
+        assert "80%" in errors[0]
+
+
+# ---------------------------------------------------------------------------
+# check_readme_cov_path
+# ---------------------------------------------------------------------------
+
+
+class TestCheckReadmeCovPath:
+    """Tests for check_readme_cov_path()."""
+
+    def test_matching_path_returns_no_errors(self, tmp_path: Path) -> None:
+        """Should return empty list when README.md --cov path matches."""
+        write_readme(
+            tmp_path,
+            "Run: pytest tests/ --cov=scylla --cov-report=html\n",
+        )
+        assert check_readme_cov_path(tmp_path, "scylla") == []
+
+    def test_mismatched_path_returns_error(self, tmp_path: Path) -> None:
+        """Should return an error when README.md has the wrong --cov path."""
+        write_readme(
+            tmp_path,
+            "Run: pytest tests/ --cov=wrong_pkg --cov-report=html\n",
+        )
+        errors = check_readme_cov_path(tmp_path, "scylla")
+        assert len(errors) == 1
+        assert "wrong_pkg" in errors[0]
+        assert "scylla" in errors[0]
+
+    def test_no_cov_in_readme_returns_no_errors(self, tmp_path: Path) -> None:
+        """README.md with no --cov= occurrences should pass without error."""
+        write_readme(tmp_path, "Just run pytest to execute tests.\n")
+        assert check_readme_cov_path(tmp_path, "scylla") == []
+
+    def test_missing_readme_returns_error(self, tmp_path: Path) -> None:
+        """Should return an error when README.md does not exist."""
+        errors = check_readme_cov_path(tmp_path, "scylla")
+        assert len(errors) == 1
+        assert "not found" in errors[0]
+
+    def test_multiple_matching_occurrences_no_errors(self, tmp_path: Path) -> None:
+        """Multiple correct --cov=scylla occurrences should all pass."""
+        write_readme(
+            tmp_path,
+            "pytest --cov=scylla\nalso pytest --cov=scylla --cov-report=html\n",
+        )
+        assert check_readme_cov_path(tmp_path, "scylla") == []
+
+    def test_multiple_occurrences_one_mismatch_returns_errors(self, tmp_path: Path) -> None:
+        """Should report each mismatched --cov occurrence."""
+        write_readme(
+            tmp_path,
+            "pytest --cov=scylla\npytest --cov=wrong_pkg\n",
+        )
+        errors = check_readme_cov_path(tmp_path, "scylla")
+        assert len(errors) == 1
+        assert "wrong_pkg" in errors[0]
+
+
+# ---------------------------------------------------------------------------
+# Integration: main() via subprocess
+# ---------------------------------------------------------------------------
+
+
+class TestMainIntegration:
+    """Integration tests for the main() function using tmp_path repos."""
+
+    def _make_repo(
+        self,
+        tmp_path: Path,
+        threshold: int = 75,
+        cov_path: str = "scylla",
+        claude_threshold: int = 75,
+        readme_cov: str = "scylla",
+    ) -> Path:
+        """Create a minimal fake repo with all required files."""
+        write_pyproject(
+            tmp_path,
+            f"[tool.coverage.report]\nfail_under = {threshold}\n\n"
+            f'[tool.pytest.ini_options]\naddopts = ["--cov={cov_path}"]\n',
+        )
+        write_claude_md(
+            tmp_path,
+            f"This project requires {claude_threshold}%+ test coverage enforced in CI.\n",
+        )
+        write_readme(
+            tmp_path,
+            f"Run tests: pytest --cov={readme_cov} --cov-report=html\n",
+        )
+        return tmp_path
+
+    def test_all_matching_exits_zero(self, tmp_path: Path) -> None:
+        """All matching values should produce exit code 0."""
+        import sys
+
+        from scripts.check_doc_config_consistency import main
+
+        repo = self._make_repo(tmp_path)
+        original_argv = sys.argv
+        sys.argv = ["check_doc_config_consistency.py", "--repo-root", str(repo)]
+        try:
+            result = main()
+            assert result == 0
+        finally:
+            sys.argv = original_argv
+
+    def test_threshold_mismatch_exits_one(self, tmp_path: Path) -> None:
+        """Coverage threshold mismatch should produce exit code 1."""
+        import sys
+
+        from scripts.check_doc_config_consistency import main
+
+        repo = self._make_repo(tmp_path, threshold=75, claude_threshold=80)
+        original_argv = sys.argv
+        sys.argv = ["check_doc_config_consistency.py", "--repo-root", str(repo)]
+        try:
+            result = main()
+            assert result == 1
+        finally:
+            sys.argv = original_argv
+
+    def test_cov_path_mismatch_exits_one(self, tmp_path: Path) -> None:
+        """--cov path mismatch should produce exit code 1."""
+        import sys
+
+        from scripts.check_doc_config_consistency import main
+
+        repo = self._make_repo(tmp_path, cov_path="scylla", readme_cov="wrong_pkg")
+        original_argv = sys.argv
+        sys.argv = ["check_doc_config_consistency.py", "--repo-root", str(repo)]
+        try:
+            result = main()
+            assert result == 1
+        finally:
+            sys.argv = original_argv


### PR DESCRIPTION
## Summary

- Adds `scripts/check_doc_config_consistency.py` — a lightweight enforcement script that detects drift between documented metric values and authoritative config sources
- Check 1: Coverage threshold in `CLAUDE.md` (`75%+ test coverage`) must match `[tool.coverage.report].fail_under` in `pyproject.toml`
- Check 2: All `--cov=<path>` occurrences in `README.md` must match `[tool.pytest.ini_options].addopts` in `pyproject.toml`
- Wired as a pre-commit hook in `.pre-commit-config.yaml` (fires on changes to `CLAUDE.md`, `README.md`, or `pyproject.toml`)

## Test plan

- [ ] 26 unit tests in `tests/unit/scripts/test_check_doc_config_consistency.py` — all pass
- [ ] Script runs clean against the real repo: both checks pass with `--verbose`
- [ ] Full test suite: 3283 passed, coverage 78.31% (above 75% threshold)
- [ ] Pre-commit hooks (ruff-format, ruff-check, mypy) pass on new files

Closes #1151

🤖 Generated with [Claude Code](https://claude.com/claude-code)