### PR TITLE
[Refactor] Extract TierActionBuilder, ParallelTierRunner, ExperimentResultWriter from runner.py

### DIFF
--- a/scylla/e2e/experiment_result_writer.py
+++ b/scylla/e2e/experiment_result_writer.py
@@ -1,0 +1,250 @@
+"""Experiment result saving and report generation.
+
+Encapsulates _save_tier_result, _save_final_results, _generate_report,
+_find_frontier, _aggregate_token_stats, and _aggregate_results from E2ERunner.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from datetime import datetime, timezone
+from functools import reduce
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from scylla.e2e.models import (
+    ExperimentConfig,
+    ExperimentResult,
+    TierID,
+    TierResult,
+    TokenStats,
+)
+from scylla.e2e.paths import RESULT_FILE
+from scylla.e2e.run_report import (
+    generate_experiment_summary_table,
+    generate_tier_summary_table,
+    save_experiment_report,
+    save_subtest_report,
+    save_tier_report,
+)
+
+if TYPE_CHECKING:
+    from scylla.e2e.tier_manager import TierManager
+
+logger = logging.getLogger(__name__)
+
+
+class ExperimentResultWriter:
+    """Saves experiment results and generates hierarchical reports.
+
+    Encapsulates all file-writing and report-generation concerns for
+    both per-tier and experiment-level results. Stateless beyond the
+    two constructor arguments; safe to instantiate per call if desired.
+    """
+
+    def __init__(
+        self,
+        experiment_dir: Path | None,
+        tier_manager: TierManager,
+    ) -> None:
+        """Initialize ExperimentResultWriter.
+
+        Args:
+            experiment_dir: Root directory for this experiment's outputs (may be None).
+            tier_manager: Provides tier-level operations (currently unused but kept for
+                future extensibility and consistency with other collaborators).
+
+        """
+        self.experiment_dir = experiment_dir
+        self.tier_manager = tier_manager
+
+    def save_tier_result(self, tier_id: TierID, result: TierResult) -> None:
+        """Save tier results to file and generate hierarchical reports.
+
+        Generates:
+        - result.json (detailed data)
+        - report.json (summary with links)
+        - report.md (human-readable)
+        - Per-subtest reports
+        - summary.md
+
+        Args:
+            tier_id: The tier identifier.
+            result: The tier result.
+
+        """
+        if self.experiment_dir:
+            tier_dir = self.experiment_dir / tier_id.value
+            tier_dir.mkdir(parents=True, exist_ok=True)
+
+            # Save detailed result
+            with open(tier_dir / RESULT_FILE, "w") as f:
+                json.dump(result.to_dict(), f, indent=2)
+
+            # Generate subtest reports
+            for subtest_id, subtest_result in result.subtest_results.items():
+                subtest_dir = tier_dir / subtest_id
+                save_subtest_report(subtest_dir, subtest_id, subtest_result)
+
+            # Generate tier report
+            save_tier_report(tier_dir, tier_id.value, result)
+
+            # Generate tier summary table
+            tier_summary = generate_tier_summary_table(
+                tier_id=tier_id.value,
+                subtest_results=result.subtest_results,
+            )
+            (tier_dir / "summary.md").write_text(tier_summary)
+
+    def save_final_results(self, result: ExperimentResult) -> None:
+        """Save final experiment results.
+
+        Saves result.json and tier_comparison.json to experiment root.
+
+        Args:
+            result: The complete experiment result.
+
+        """
+        if self.experiment_dir:
+            # Save to root (not summary/ subdir)
+            result.save(self.experiment_dir / "result.json")
+
+            # Save tier comparison
+            comparison = {
+                tier_id.value: {
+                    "best_subtest": tier_result.best_subtest,
+                    "best_score": tier_result.best_subtest_score,
+                    "total_cost": tier_result.total_cost,
+                    "tiebreaker_needed": tier_result.tiebreaker_needed,
+                }
+                for tier_id, tier_result in result.tier_results.items()
+            }
+
+            with open(self.experiment_dir / "tier_comparison.json", "w") as f:
+                json.dump(comparison, f, indent=2)
+
+    def generate_report(self, result: ExperimentResult) -> None:
+        """Generate hierarchical experiment reports.
+
+        Generates:
+        - report.json (summary with links to tier reports)
+        - report.md (human-readable with links)
+        - summary.md
+
+        Args:
+            result: The complete experiment result.
+
+        """
+        if not self.experiment_dir:
+            return
+
+        # Use the hierarchical report generator
+        save_experiment_report(self.experiment_dir, result)
+
+        # Generate experiment summary table
+        experiment_summary = generate_experiment_summary_table(
+            tier_results=result.tier_results,
+        )
+        (self.experiment_dir / "summary.md").write_text(experiment_summary)
+
+        logger.info(f"Reports saved to {self.experiment_dir / 'report.md'}")
+
+    def find_frontier(
+        self,
+        tier_results: dict[TierID, TierResult],
+    ) -> tuple[TierID | None, float]:
+        """Find the frontier tier (best cost-of-pass).
+
+        Args:
+            tier_results: All tier results.
+
+        Returns:
+            Tuple of (best tier ID, cost-of-pass). Returns (None, inf) for empty input.
+
+        """
+        best_tier: TierID | None = None
+        best_cop = float("inf")
+
+        for tier_id, result in tier_results.items():
+            if not result.subtest_results:
+                continue
+
+            # Get best sub-test results
+            best_subtest = result.subtest_results.get(result.best_subtest or "")
+            if not best_subtest or best_subtest.pass_rate == 0:
+                continue
+
+            # Calculate cost-of-pass
+            cop = best_subtest.mean_cost / best_subtest.pass_rate
+
+            if cop < best_cop:
+                best_cop = cop
+                best_tier = tier_id
+
+        return best_tier, best_cop
+
+    def aggregate_token_stats(self, tier_results: dict[TierID, TierResult]) -> TokenStats:
+        """Aggregate token statistics from all tier results.
+
+        Args:
+            tier_results: Dictionary mapping tier IDs to their results.
+
+        Returns:
+            Aggregated token statistics across all tiers. Returns empty
+            TokenStats if tier_results is empty.
+
+        """
+        if not tier_results:
+            return TokenStats()
+
+        return reduce(
+            lambda a, b: a + b,
+            [t.token_stats for t in tier_results.values()],
+            TokenStats(),
+        )
+
+    def aggregate_results(
+        self,
+        config: ExperimentConfig,
+        tier_results: dict[TierID, TierResult],
+        start_time: datetime,
+    ) -> ExperimentResult:
+        """Create experiment result from accumulated tier results.
+
+        Used for both normal completion and interrupted (partial) results.
+
+        Args:
+            config: Experiment configuration.
+            tier_results: Accumulated tier results.
+            start_time: Experiment start timestamp.
+
+        Returns:
+            ExperimentResult with completed tiers.
+
+        """
+        end_time = datetime.now(timezone.utc)
+        total_duration = (end_time - start_time).total_seconds()
+        total_cost = sum(t.total_cost for t in tier_results.values())
+
+        # Find frontier from completed tiers
+        frontier_tier, frontier_cop = self.find_frontier(tier_results)
+
+        # Aggregate token stats from completed tiers
+        experiment_token_stats = self.aggregate_token_stats(tier_results)
+
+        return ExperimentResult(
+            config=config,
+            tier_results=tier_results,
+            best_overall_tier=frontier_tier,
+            best_overall_subtest=(
+                tier_results[frontier_tier].best_subtest if frontier_tier else None
+            ),
+            frontier_cop=frontier_cop,
+            frontier_cop_tier=frontier_tier,
+            total_cost=total_cost,
+            total_duration_seconds=total_duration,
+            started_at=start_time.isoformat(),
+            completed_at=end_time.isoformat(),
+            token_stats=experiment_token_stats,
+        )

--- a/scylla/e2e/parallel_tier_runner.py
+++ b/scylla/e2e/parallel_tier_runner.py
@@ -1,0 +1,272 @@
+"""Parallel tier execution orchestrator.
+
+Encapsulates _execute_tier_groups, _execute_parallel_tier_group,
+_select_best_baseline_from_group, _execute_single_tier, and
+_create_baseline_from_tier_result from E2ERunner.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Callable
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from scylla.e2e.models import (
+    ExperimentConfig,
+    TierBaseline,
+    TierID,
+    TierResult,
+)
+
+if TYPE_CHECKING:
+    from scylla.e2e.scheduler import ParallelismScheduler
+    from scylla.e2e.tier_manager import TierManager
+
+logger = logging.getLogger(__name__)
+
+
+class ParallelTierRunner:
+    """Orchestrates parallel and sequential tier group execution.
+
+    Encapsulates the logic for executing tier groups — running tiers
+    sequentially within a group of one, or in parallel for larger groups.
+    Also handles baseline selection and creation between tier groups.
+
+    Receives runner state as explicit constructor arguments (no runner reference)
+    to avoid circular coupling.
+    """
+
+    def __init__(
+        self,
+        config: ExperimentConfig,
+        tier_manager: TierManager,
+        experiment_dir: Path | None,
+        run_tier_fn: Callable[
+            [TierID, TierBaseline | None, ParallelismScheduler | None], TierResult
+        ],
+        save_tier_result_fn: Callable[[TierID, TierResult], None],
+    ) -> None:
+        """Initialize ParallelTierRunner with all required collaborators.
+
+        Args:
+            config: Experiment configuration (read-only).
+            tier_manager: Provides baseline retrieval for subtest results.
+            experiment_dir: Root directory for this experiment's outputs (may be None).
+            run_tier_fn: Callable injected from the runner to execute a single tier.
+            save_tier_result_fn: Callable injected from the runner to save tier results.
+
+        """
+        self.config = config
+        self.tier_manager = tier_manager
+        self.experiment_dir = experiment_dir
+        self.run_tier_fn = run_tier_fn
+        self.save_tier_result_fn = save_tier_result_fn
+
+    def execute_tier_groups(
+        self,
+        tier_groups: list[list[TierID]],
+        scheduler: ParallelismScheduler | None,
+        previous_baseline: TierBaseline | None = None,
+    ) -> dict[TierID, TierResult]:
+        """Execute all tier groups with parallel/sequential orchestration.
+
+        Args:
+            tier_groups: List of tier groups for parallel execution.
+            scheduler: ParallelismScheduler for limiting concurrent operations.
+            previous_baseline: Optional baseline from previous tier.
+
+        Returns:
+            Dictionary mapping tier IDs to their results.
+
+        """
+        tier_results: dict[TierID, TierResult] = {}
+
+        for group in tier_groups:
+            # Check for shutdown before starting group (lazy import avoids circular dependency)
+            from scylla.e2e.runner import is_shutdown_requested
+
+            if is_shutdown_requested():
+                logger.warning("Shutdown requested before tier group, stopping...")
+                break
+
+            if len(group) == 1:
+                # Single tier - run sequentially
+                tier_id = group[0]
+                logger.info(f"Starting tier {tier_id.value}")
+
+                tier_result, previous_baseline = self._execute_single_tier(
+                    tier_id, previous_baseline, scheduler
+                )
+                tier_results[tier_id] = tier_result
+
+            else:
+                # Multiple tiers - run in parallel
+                logger.info(f"Starting {len(group)} tiers in parallel: {[t.value for t in group]}")
+
+                group_results = self.execute_parallel_tier_group(
+                    group, previous_baseline, scheduler
+                )
+                tier_results.update(group_results)
+
+                # Select best baseline from group for next tier group
+                previous_baseline = self.select_best_baseline_from_group(group, tier_results)
+
+        return tier_results
+
+    def execute_parallel_tier_group(
+        self,
+        group: list[TierID],
+        previous_baseline: TierBaseline | None,
+        scheduler: ParallelismScheduler | None,
+    ) -> dict[TierID, TierResult]:
+        """Execute multiple tiers in parallel using ThreadPoolExecutor.
+
+        Args:
+            group: List of tier IDs to execute in parallel.
+            previous_baseline: Shared baseline for all tiers.
+            scheduler: ParallelismScheduler for limiting concurrent operations.
+
+        Returns:
+            Dictionary mapping tier IDs to their results.
+
+        Raises:
+            RuntimeError: If all tiers in the group fail.
+
+        """
+        tier_results: dict[TierID, TierResult] = {}
+        errors: dict[TierID, Exception] = {}
+
+        with ThreadPoolExecutor(max_workers=len(group)) as executor:
+            # Submit all tiers in this group
+            futures = {
+                executor.submit(self.run_tier_fn, tier_id, previous_baseline, scheduler): tier_id
+                for tier_id in group
+            }
+
+            # Collect results as they complete
+            for future in as_completed(futures):
+                tier_id = futures[future]
+                try:
+                    tier_result = future.result()
+                    tier_results[tier_id] = tier_result
+
+                    # Save intermediate results
+                    self.save_tier_result_fn(tier_id, tier_result)
+
+                    logger.info(f"Completed tier {tier_id.value} in parallel group")
+                except Exception as e:
+                    logger.error(f"Tier {tier_id.value} failed: {e}")
+                    errors[tier_id] = e
+
+        # Only raise if ALL tiers failed — a single failure should not abort siblings
+        if errors and not tier_results:
+            first_error = next(iter(errors.values()))
+            raise RuntimeError(
+                f"All tiers in parallel group failed. First error: {first_error}"
+            ) from first_error
+        elif errors:
+            for tid, err in errors.items():
+                logger.warning(f"Tier {tid.value} failed but other tiers succeeded: {err}")
+
+        return tier_results
+
+    def select_best_baseline_from_group(
+        self,
+        group: list[TierID],
+        tier_results: dict[TierID, TierResult],
+    ) -> TierBaseline | None:
+        """Select best tier from group based on cost-of-pass for next baseline.
+
+        Only relevant when T5 is in the experiment (for T0-T4 -> T5 transition).
+
+        Args:
+            group: List of tier IDs that were executed in parallel.
+            tier_results: Results from all tiers in the group.
+
+        Returns:
+            TierBaseline for best tier, or None if no valid baseline found.
+
+        """
+        # Only select baseline if T5 is in the experiment
+        if TierID.T5 not in self.config.tiers_to_run:
+            return None
+
+        best_cop = float("inf")
+        best_tier: TierID | None = None
+        for tier_id in group:
+            if tier_id in tier_results and tier_results[tier_id].cost_of_pass < best_cop:
+                best_cop = tier_results[tier_id].cost_of_pass
+                best_tier = tier_id
+
+        if best_tier:
+            baseline = self.create_baseline_from_tier_result(best_tier, tier_results[best_tier])
+            if baseline:
+                logger.info(
+                    f"Selected {best_tier.value} as baseline for next tier group"
+                    f" (CoP: ${best_cop:.4f})"
+                )
+                return baseline
+
+        return None
+
+    def create_baseline_from_tier_result(
+        self,
+        tier_id: TierID,
+        tier_result: TierResult,
+    ) -> TierBaseline | None:
+        """Create a baseline from a tier result's best subtest.
+
+        Args:
+            tier_id: The tier the result belongs to.
+            tier_result: The result from which to derive the baseline.
+
+        Returns:
+            TierBaseline for the best subtest, or None if no best subtest exists.
+
+        Raises:
+            RuntimeError: If experiment_dir is None when a best subtest exists.
+
+        """
+        if not tier_result.best_subtest:
+            return None
+        if self.experiment_dir is None:
+            raise RuntimeError(
+                "experiment_dir must be set before getting baseline for previous tier"
+            )
+        subtest_dir = self.experiment_dir / tier_id.value / tier_result.best_subtest
+        return self.tier_manager.get_baseline_for_subtest(
+            tier_id=tier_id,
+            subtest_id=tier_result.best_subtest,
+            results_dir=subtest_dir,
+        )
+
+    def _execute_single_tier(
+        self,
+        tier_id: TierID,
+        previous_baseline: TierBaseline | None,
+        scheduler: ParallelismScheduler | None,
+    ) -> tuple[TierResult, TierBaseline | None]:
+        """Execute a single tier sequentially and update baseline.
+
+        Args:
+            tier_id: The tier to execute.
+            previous_baseline: Baseline from previous tier (if any).
+            scheduler: ParallelismScheduler for limiting concurrent operations.
+
+        Returns:
+            Tuple of (tier_result, updated_baseline).
+
+        """
+        tier_result = self.run_tier_fn(tier_id, previous_baseline, scheduler)
+
+        # Set baseline for next tier
+        updated_baseline = (
+            self.create_baseline_from_tier_result(tier_id, tier_result) or previous_baseline
+        )
+
+        # Save intermediate results
+        self.save_tier_result_fn(tier_id, tier_result)
+
+        return tier_result, updated_baseline

--- a/scylla/e2e/runner.py
+++ b/scylla/e2e/runner.py
@@ -6,12 +6,10 @@ coordinating tier execution, inheritance, result aggregation, and report generat
 
 from __future__ import annotations
 
-import json
 import logging
 import os
 import tempfile
 from collections.abc import Callable
-from concurrent.futures import ThreadPoolExecutor, as_completed
 from concurrent.futures.process import BrokenProcessPool
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
@@ -30,7 +28,7 @@ from scylla.e2e.checkpoint import (
     save_checkpoint,
     validate_checkpoint_config,
 )
-from scylla.e2e.judge_selection import save_selection, select_best_subtest
+from scylla.e2e.experiment_result_writer import ExperimentResultWriter
 
 # Note: Judge prompts are now generated dynamically via scylla.judge.prompts.build_task_prompt()
 from scylla.e2e.models import (
@@ -44,17 +42,9 @@ from scylla.e2e.models import (
     TierState,
     TokenStats,
 )
-from scylla.e2e.paths import RESULT_FILE
-from scylla.e2e.rate_limit import wait_for_rate_limit
+from scylla.e2e.parallel_tier_runner import ParallelTierRunner
 from scylla.e2e.resume_manager import ResumeManager
-from scylla.e2e.run_report import (
-    generate_experiment_summary_table,
-    generate_tier_summary_table,
-    save_experiment_report,
-    save_subtest_report,
-    save_tier_report,
-)
-from scylla.e2e.subtest_executor import run_tier_subtests_parallel
+from scylla.e2e.tier_action_builder import TierActionBuilder
 from scylla.e2e.tier_manager import TierManager
 from scylla.e2e.workspace_manager import WorkspaceManager
 
@@ -163,6 +153,18 @@ class E2ERunner:
         self.checkpoint: E2ECheckpoint | None = None
         self._fresh = fresh
         self._last_experiment_result: ExperimentResult | None = None
+
+    def _result_writer(self) -> ExperimentResultWriter:
+        """Create an ExperimentResultWriter bound to current state.
+
+        Returns:
+            ExperimentResultWriter with current experiment_dir and tier_manager.
+
+        """
+        return ExperimentResultWriter(
+            experiment_dir=self.experiment_dir,
+            tier_manager=self.tier_manager,
+        )
 
     @staticmethod
     def _get_tier_groups(tiers_to_run: list[TierID]) -> list[list[TierID]]:
@@ -481,37 +483,13 @@ class E2ERunner:
             Dictionary mapping tier IDs to their results
 
         """
-        tier_results: dict[TierID, TierResult] = {}
-
-        for group in tier_groups:
-            # Check for shutdown before starting group
-            if is_shutdown_requested():
-                logger.warning("Shutdown requested before tier group, stopping...")
-                break
-
-            if len(group) == 1:
-                # Single tier - run sequentially
-                tier_id = group[0]
-                logger.info(f"Starting tier {tier_id.value}")
-
-                tier_result, previous_baseline = self._execute_single_tier(
-                    tier_id, previous_baseline, scheduler
-                )
-                tier_results[tier_id] = tier_result
-
-            else:
-                # Multiple tiers - run in parallel
-                logger.info(f"Starting {len(group)} tiers in parallel: {[t.value for t in group]}")
-
-                group_results = self._execute_parallel_tier_group(
-                    group, previous_baseline, scheduler
-                )
-                tier_results.update(group_results)
-
-                # Select best baseline from group for next tier group
-                previous_baseline = self._select_best_baseline_from_group(group, tier_results)
-
-        return tier_results
+        return ParallelTierRunner(
+            config=self.config,
+            tier_manager=self.tier_manager,
+            experiment_dir=self.experiment_dir,
+            run_tier_fn=self._run_tier,
+            save_tier_result_fn=self._save_tier_result,
+        ).execute_tier_groups(tier_groups, scheduler, previous_baseline)
 
     def _create_baseline_from_tier_result(
         self,
@@ -528,140 +506,13 @@ class E2ERunner:
             TierBaseline for the best subtest, or None if no best subtest exists.
 
         """
-        if not tier_result.best_subtest:
-            return None
-        if self.experiment_dir is None:
-            raise RuntimeError(
-                "experiment_dir must be set before getting baseline for previous tier"
-            )
-        subtest_dir = self.experiment_dir / tier_id.value / tier_result.best_subtest
-        return self.tier_manager.get_baseline_for_subtest(
-            tier_id=tier_id,
-            subtest_id=tier_result.best_subtest,
-            results_dir=subtest_dir,
-        )
-
-    def _execute_single_tier(
-        self,
-        tier_id: TierID,
-        previous_baseline: TierBaseline | None,
-        scheduler: ParallelismScheduler | None,
-    ) -> tuple[TierResult, TierBaseline | None]:
-        """Execute a single tier sequentially and update baseline.
-
-        Args:
-            tier_id: The tier to execute
-            previous_baseline: Baseline from previous tier (if any)
-            scheduler: ParallelismScheduler for limiting concurrent operations
-
-        Returns:
-            Tuple of (tier_result, updated_baseline)
-
-        """
-        tier_result = self._run_tier(tier_id, previous_baseline, scheduler)
-
-        # Set baseline for next tier
-        updated_baseline = (
-            self._create_baseline_from_tier_result(tier_id, tier_result) or previous_baseline
-        )
-
-        # Save intermediate results
-        self._save_tier_result(tier_id, tier_result)
-
-        return tier_result, updated_baseline
-
-    def _execute_parallel_tier_group(
-        self,
-        group: list[TierID],
-        previous_baseline: TierBaseline | None,
-        scheduler: ParallelismScheduler | None,
-    ) -> dict[TierID, TierResult]:
-        """Execute multiple tiers in parallel using ThreadPoolExecutor.
-
-        Args:
-            group: List of tier IDs to execute in parallel
-            previous_baseline: Shared baseline for all tiers
-            scheduler: ParallelismScheduler for limiting concurrent operations
-
-        Returns:
-            Dictionary mapping tier IDs to their results
-
-        """
-        tier_results: dict[TierID, TierResult] = {}
-        errors: dict[TierID, Exception] = {}
-
-        with ThreadPoolExecutor(max_workers=len(group)) as executor:
-            # Submit all tiers in this group
-            futures = {
-                executor.submit(self._run_tier, tier_id, previous_baseline, scheduler): tier_id
-                for tier_id in group
-            }
-
-            # Collect results as they complete
-            for future in as_completed(futures):
-                tier_id = futures[future]
-                try:
-                    tier_result = future.result()
-                    tier_results[tier_id] = tier_result
-
-                    # Save intermediate results
-                    self._save_tier_result(tier_id, tier_result)
-
-                    logger.info(f"Completed tier {tier_id.value} in parallel group")
-                except Exception as e:
-                    logger.error(f"Tier {tier_id.value} failed: {e}")
-                    errors[tier_id] = e
-
-        # Only raise if ALL tiers failed — a single failure should not abort siblings
-        if errors and not tier_results:
-            first_error = next(iter(errors.values()))
-            raise RuntimeError(
-                f"All tiers in parallel group failed. First error: {first_error}"
-            ) from first_error
-        elif errors:
-            for tid, err in errors.items():
-                logger.warning(f"Tier {tid.value} failed but other tiers succeeded: {err}")
-
-        return tier_results
-
-    def _select_best_baseline_from_group(
-        self,
-        group: list[TierID],
-        tier_results: dict[TierID, TierResult],
-    ) -> TierBaseline | None:
-        """Select best tier from group based on cost-of-pass for next baseline.
-
-        Only relevant when T5 is in the experiment (for T0-T4 → T5 transition).
-
-        Args:
-            group: List of tier IDs that were executed in parallel
-            tier_results: Results from all tiers in the group
-
-        Returns:
-            TierBaseline for best tier, or None if no valid baseline found
-
-        """
-        # Only select baseline if T5 is in the experiment
-        if TierID.T5 not in self.config.tiers_to_run:
-            return None
-
-        best_cop = float("inf")
-        best_tier = None
-        for tier_id in group:
-            if tier_id in tier_results and tier_results[tier_id].cost_of_pass < best_cop:
-                best_cop = tier_results[tier_id].cost_of_pass
-                best_tier = tier_id
-
-        if best_tier:
-            baseline = self._create_baseline_from_tier_result(best_tier, tier_results[best_tier])
-            if baseline:
-                logger.info(
-                    f"Selected {best_tier.value} as baseline for next tier group"
-                    f" (CoP: ${best_cop:.4f})"
-                )
-                return baseline
-
-        return None
+        return ParallelTierRunner(
+            config=self.config,
+            tier_manager=self.tier_manager,
+            experiment_dir=self.experiment_dir,
+            run_tier_fn=self._run_tier,
+            save_tier_result_fn=self._save_tier_result,
+        ).create_baseline_from_tier_result(tier_id, tier_result)
 
     def _aggregate_results(
         self,
@@ -680,31 +531,7 @@ class E2ERunner:
             ExperimentResult with completed tiers
 
         """
-        end_time = datetime.now(timezone.utc)
-        total_duration = (end_time - start_time).total_seconds()
-        total_cost = sum(t.total_cost for t in tier_results.values())
-
-        # Find frontier from completed tiers
-        frontier_tier, frontier_cop = self._find_frontier(tier_results)
-
-        # Aggregate token stats from completed tiers
-        experiment_token_stats = self._aggregate_token_stats(tier_results)
-
-        return ExperimentResult(
-            config=self.config,
-            tier_results=tier_results,
-            best_overall_tier=frontier_tier,
-            best_overall_subtest=(
-                tier_results[frontier_tier].best_subtest if frontier_tier else None
-            ),
-            frontier_cop=frontier_cop,
-            frontier_cop_tier=frontier_tier,
-            total_cost=total_cost,
-            total_duration_seconds=total_duration,
-            started_at=start_time.isoformat(),
-            completed_at=end_time.isoformat(),
-            token_stats=experiment_token_stats,
-        )
+        return self._result_writer().aggregate_results(self.config, tier_results, start_time)
 
     def _build_experiment_actions(
         self,
@@ -983,29 +810,6 @@ class E2ERunner:
         if self.experiment_dir:
             self.config.save(self.experiment_dir / "config" / "experiment.json")
 
-    def _check_rate_limit_before_tier(self, tier_id: TierID) -> None:
-        """Check for active rate limit before starting tier execution.
-
-        Makes a lightweight API call to verify we're not rate-limited.
-        If rate limited, waits until limit expires.
-
-        Args:
-            tier_id: The tier about to be executed
-
-        """
-        from scylla.e2e.rate_limit import check_api_rate_limit_status
-
-        rate_limit_info = check_api_rate_limit_status()
-        if rate_limit_info:
-            logger.warning(f"Pre-flight rate limit detected for {tier_id.value}")
-            if self.checkpoint and self.experiment_dir:
-                checkpoint_path = self.experiment_dir / "checkpoint.json"
-                wait_for_rate_limit(
-                    rate_limit_info.retry_after_seconds,
-                    self.checkpoint,
-                    checkpoint_path,
-                )
-
     def _build_tier_actions(
         self,
         tier_id: TierID,
@@ -1028,127 +832,18 @@ class E2ERunner:
             Dict mapping TierState to callable
 
         """
-
-        def action_pending() -> None:
-            """PENDING -> CONFIG_LOADED: Load config, limit subtests, create tier dir."""
-            tier_config = self.tier_manager.load_tier_config(tier_id, self.config.skip_agent_teams)
-
-            if self.config.max_subtests is not None:
-                original_count = len(tier_config.subtests)
-                tier_config.subtests = tier_config.subtests[: self.config.max_subtests]
-                if len(tier_config.subtests) < original_count:
-                    logger.info(
-                        f"Limiting sub-tests from {original_count} to {len(tier_config.subtests)}"
-                    )
-
-            logger.info(f"Tier {tier_id.value}: {len(tier_config.subtests)} sub-tests")
-
-            if self.experiment_dir is None:
-                raise RuntimeError("experiment_dir must be set before loading tier config")
-            tier_dir = self.experiment_dir / tier_id.value
-            tier_dir.mkdir(parents=True, exist_ok=True)
-
-            self._check_rate_limit_before_tier(tier_id)
-
-            tier_ctx.tier_config = tier_config
-            tier_ctx.tier_dir = tier_dir
-
-        def action_config_loaded() -> None:
-            """CONFIG_LOADED -> SUBTESTS_RUNNING: Execute all subtests in parallel."""
-            if tier_ctx.tier_config is None:
-                raise RuntimeError("tier_config must be set before running subtests")
-            if tier_ctx.tier_dir is None:
-                raise RuntimeError("tier_dir must be set before running subtests")
-            if self.experiment_dir is None:
-                raise RuntimeError("experiment_dir must be set before running subtests")
-            checkpoint_path = self.experiment_dir / "checkpoint.json" if self.checkpoint else None
-            subtest_results = run_tier_subtests_parallel(
-                config=self.config,
-                tier_id=tier_id,
-                tier_config=tier_ctx.tier_config,
-                tier_manager=self.tier_manager,
-                workspace_manager=self.workspace_manager,
-                baseline=baseline,
-                results_dir=tier_ctx.tier_dir,
-                checkpoint=self.checkpoint,
-                checkpoint_path=checkpoint_path,
-                scheduler=scheduler,
-                experiment_dir=self.experiment_dir,
-            )
-            tier_ctx.subtest_results = subtest_results
-
-        def action_subtests_running() -> None:
-            """SUBTESTS_RUNNING -> SUBTESTS_COMPLETE: Select best subtest."""
-            if tier_ctx.tier_dir is None:
-                raise RuntimeError("tier_dir must be set before selecting best subtest")
-            subtest_results = tier_ctx.subtest_results
-
-            selection = select_best_subtest(
-                subtest_results,
-                judge_models=self.config.judge_models,
-            )
-
-            if selection.winning_subtest in subtest_results:
-                subtest_results[selection.winning_subtest].selected_as_best = True
-                subtest_results[selection.winning_subtest].selection_reason = (
-                    selection.tiebreaker_result.reasoning
-                    if selection.tiebreaker_result
-                    else f"Highest median score ({selection.winning_score:.3f})"
-                )
-
-            save_selection(selection, str(tier_ctx.tier_dir / "best_subtest.json"))
-            tier_ctx.selection = selection
-
-        def action_subtests_complete() -> None:
-            """SUBTESTS_COMPLETE -> BEST_SELECTED: Aggregate token stats, build TierResult."""
-            from functools import reduce
-
-            if tier_ctx.selection is None:
-                raise RuntimeError("selection must be set before aggregating subtest results")
-            subtest_results = tier_ctx.subtest_results
-            selection = tier_ctx.selection
-            start_time = tier_ctx.start_time
-
-            end_time = datetime.now(timezone.utc)
-            duration = (end_time - start_time).total_seconds()
-
-            token_stats = reduce(
-                lambda a, b: a + b,
-                [s.token_stats for s in subtest_results.values()],
-                TokenStats(),
-            )
-
-            tier_result = TierResult(
-                tier_id=tier_id,
-                subtest_results=subtest_results,
-                best_subtest=selection.winning_subtest,
-                best_subtest_score=selection.winning_score,
-                inherited_from=baseline,
-                tiebreaker_needed=selection.tiebreaker_needed,
-                total_cost=sum(s.total_cost for s in subtest_results.values()),
-                total_duration=duration,
-                token_stats=token_stats,
-            )
-            tier_ctx.tier_result = tier_result
-
-        def action_best_selected() -> None:
-            """BEST_SELECTED -> REPORTS_GENERATED: Save tier result and generate reports."""
-            if tier_ctx.tier_result is None:
-                raise RuntimeError("tier_result must be set before saving reports")
-            self._save_tier_result(tier_id, tier_ctx.tier_result)
-
-        def action_reports_generated() -> None:
-            """REPORTS_GENERATED -> COMPLETE: No-op (state machine marks complete)."""
-            pass
-
-        return {
-            TierState.PENDING: action_pending,
-            TierState.CONFIG_LOADED: action_config_loaded,
-            TierState.SUBTESTS_RUNNING: action_subtests_running,
-            TierState.SUBTESTS_COMPLETE: action_subtests_complete,
-            TierState.BEST_SELECTED: action_best_selected,
-            TierState.REPORTS_GENERATED: action_reports_generated,
-        }
+        return TierActionBuilder(
+            tier_id=tier_id,
+            baseline=baseline,
+            scheduler=scheduler,
+            tier_ctx=tier_ctx,
+            config=self.config,
+            tier_manager=self.tier_manager,
+            workspace_manager=self.workspace_manager,
+            checkpoint=self.checkpoint,
+            experiment_dir=self.experiment_dir,
+            save_tier_result_fn=self._save_tier_result,
+        ).build()
 
     def _run_tier(
         self,
@@ -1279,147 +974,30 @@ class E2ERunner:
     def _save_tier_result(self, tier_id: TierID, result: TierResult) -> None:
         """Save tier results to file and generate hierarchical reports.
 
-        Generates:
-        - result.json (detailed data)
-        - report.json (summary with links)
-        - report.md (human-readable)
-        - Per-subtest reports
-
         Args:
             tier_id: The tier identifier
             result: The tier result
 
         """
-        if self.experiment_dir:
-            tier_dir = self.experiment_dir / tier_id.value
-            tier_dir.mkdir(parents=True, exist_ok=True)
-
-            # Save detailed result
-            with open(tier_dir / RESULT_FILE, "w") as f:
-                json.dump(result.to_dict(), f, indent=2)
-
-            # Generate subtest reports
-            for subtest_id, subtest_result in result.subtest_results.items():
-                subtest_dir = tier_dir / subtest_id
-                save_subtest_report(subtest_dir, subtest_id, subtest_result)
-
-            # Generate tier report
-            save_tier_report(tier_dir, tier_id.value, result)
-
-            # Generate tier summary table
-            tier_summary = generate_tier_summary_table(
-                tier_id=tier_id.value,
-                subtest_results=result.subtest_results,
-            )
-            (tier_dir / "summary.md").write_text(tier_summary)
-
-    def _find_frontier(
-        self,
-        tier_results: dict[TierID, TierResult],
-    ) -> tuple[TierID | None, float]:
-        """Find the frontier tier (best cost-of-pass).
-
-        Args:
-            tier_results: All tier results
-
-        Returns:
-            Tuple of (best tier, cost-of-pass).
-
-        """
-        best_tier: TierID | None = None
-        best_cop = float("inf")
-
-        for tier_id, result in tier_results.items():
-            if not result.subtest_results:
-                continue
-
-            # Get best sub-test results
-            best_subtest = result.subtest_results.get(result.best_subtest or "")
-            if not best_subtest or best_subtest.pass_rate == 0:
-                continue
-
-            # Calculate cost-of-pass
-            cop = best_subtest.mean_cost / best_subtest.pass_rate
-
-            if cop < best_cop:
-                best_cop = cop
-                best_tier = tier_id
-
-        return best_tier, best_cop
-
-    def _aggregate_token_stats(self, tier_results: dict[TierID, TierResult]) -> TokenStats:
-        """Aggregate token statistics from all tier results.
-
-        Args:
-            tier_results: Dictionary mapping tier IDs to their results
-
-        Returns:
-            Aggregated token statistics across all tiers. Returns empty
-            TokenStats if tier_results is empty.
-
-        """
-        from functools import reduce
-
-        if not tier_results:
-            return TokenStats()
-
-        return reduce(
-            lambda a, b: a + b,
-            [t.token_stats for t in tier_results.values()],
-            TokenStats(),
-        )
+        self._result_writer().save_tier_result(tier_id, result)
 
     def _save_final_results(self, result: ExperimentResult) -> None:
         """Save final experiment results.
 
-        Saves result.json and tier_comparison.json to experiment root.
-
         Args:
             result: The complete experiment result
 
         """
-        if self.experiment_dir:
-            # Save to root (not summary/ subdir)
-            result.save(self.experiment_dir / "result.json")
-
-            # Save tier comparison
-            comparison = {
-                tier_id.value: {
-                    "best_subtest": tier_result.best_subtest,
-                    "best_score": tier_result.best_subtest_score,
-                    "total_cost": tier_result.total_cost,
-                    "tiebreaker_needed": tier_result.tiebreaker_needed,
-                }
-                for tier_id, tier_result in result.tier_results.items()
-            }
-
-            with open(self.experiment_dir / "tier_comparison.json", "w") as f:
-                json.dump(comparison, f, indent=2)
+        self._result_writer().save_final_results(result)
 
     def _generate_report(self, result: ExperimentResult) -> None:
         """Generate hierarchical experiment reports.
 
-        Generates:
-        - report.json (summary with links to tier reports)
-        - report.md (human-readable with links)
-
         Args:
             result: The complete experiment result
 
         """
-        if not self.experiment_dir:
-            return
-
-        # Use the hierarchical report generator
-        save_experiment_report(self.experiment_dir, result)
-
-        # Generate experiment summary table
-        experiment_summary = generate_experiment_summary_table(
-            tier_results=result.tier_results,
-        )
-        (self.experiment_dir / "summary.md").write_text(experiment_summary)
-
-        logger.info(f"Reports saved to {self.experiment_dir / 'report.md'}")
+        self._result_writer().generate_report(result)
 
     def _find_existing_checkpoint(self) -> Path | None:
         """Find existing checkpoint file in results directory.

--- a/scylla/e2e/tier_action_builder.py
+++ b/scylla/e2e/tier_action_builder.py
@@ -1,0 +1,236 @@
+"""Tier state machine action builder.
+
+Encapsulates the _build_tier_actions() logic from E2ERunner, building the
+TierState -> Callable action map for TierStateMachine execution.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Callable
+from datetime import datetime, timezone
+from functools import reduce
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from scylla.e2e.judge_selection import save_selection, select_best_subtest
+from scylla.e2e.models import (
+    ExperimentConfig,
+    TierBaseline,
+    TierID,
+    TierResult,
+    TierState,
+    TokenStats,
+)
+from scylla.e2e.rate_limit import check_api_rate_limit_status, wait_for_rate_limit
+from scylla.e2e.subtest_executor import run_tier_subtests_parallel
+
+if TYPE_CHECKING:
+    from scylla.e2e.checkpoint import E2ECheckpoint
+    from scylla.e2e.runner import TierContext
+    from scylla.e2e.scheduler import ParallelismScheduler
+    from scylla.e2e.tier_manager import TierManager
+    from scylla.e2e.workspace_manager import WorkspaceManager
+
+logger = logging.getLogger(__name__)
+
+
+class TierActionBuilder:
+    """Builds the TierState -> Callable action map for a single tier execution.
+
+    Encapsulates all six closure-based action functions that drive the
+    TierStateMachine through PENDING -> COMPLETE. State is accumulated
+    progressively into the shared TierContext.
+
+    Receives runner state as explicit constructor arguments (no runner reference)
+    to avoid circular coupling.
+    """
+
+    def __init__(
+        self,
+        tier_id: TierID,
+        baseline: TierBaseline | None,
+        scheduler: ParallelismScheduler | None,
+        tier_ctx: TierContext,
+        config: ExperimentConfig,
+        tier_manager: TierManager,
+        workspace_manager: WorkspaceManager | None,
+        checkpoint: E2ECheckpoint | None,
+        experiment_dir: Path | None,
+        save_tier_result_fn: Callable[[TierID, TierResult], None],
+    ) -> None:
+        """Initialize TierActionBuilder with all required collaborators.
+
+        Args:
+            tier_id: The tier to run.
+            baseline: Previous tier's winning baseline (may be None).
+            scheduler: ParallelismScheduler for concurrent operation limits (may be None).
+            tier_ctx: Mutable TierContext for inter-action state accumulation.
+            config: Experiment configuration (read-only).
+            tier_manager: Provides tier config loading and baseline retrieval.
+            workspace_manager: Workspace lifecycle manager (may be None).
+            checkpoint: Current E2ECheckpoint for persistence (may be None).
+            experiment_dir: Root directory for this experiment's outputs (may be None).
+            save_tier_result_fn: Callable injected from the runner to save tier results.
+
+        """
+        self.tier_id = tier_id
+        self.baseline = baseline
+        self.scheduler = scheduler
+        self.tier_ctx = tier_ctx
+        self.config = config
+        self.tier_manager = tier_manager
+        self.workspace_manager = workspace_manager
+        self.checkpoint = checkpoint
+        self.experiment_dir = experiment_dir
+        self.save_tier_result_fn = save_tier_result_fn
+
+    def build(self) -> dict[TierState, Callable[[], None]]:
+        """Build and return the TierState -> Callable action map.
+
+        Each returned callable is a closure over this builder's attributes.
+        Actions are executed in state order by TierStateMachine.
+
+        Returns:
+            Dict mapping each TierState to its corresponding action callable.
+
+        """
+        tier_id = self.tier_id
+        baseline = self.baseline
+        scheduler = self.scheduler
+        tier_ctx = self.tier_ctx
+        config = self.config
+        tier_manager = self.tier_manager
+        workspace_manager = self.workspace_manager
+        checkpoint = self.checkpoint
+        experiment_dir = self.experiment_dir
+        save_tier_result_fn = self.save_tier_result_fn
+
+        def action_pending() -> None:
+            # PENDING -> CONFIG_LOADED: Load config, limit subtests, create tier dir.
+            tier_config = tier_manager.load_tier_config(tier_id, config.skip_agent_teams)
+
+            if config.max_subtests is not None:
+                original_count = len(tier_config.subtests)
+                tier_config.subtests = tier_config.subtests[: config.max_subtests]
+                if len(tier_config.subtests) < original_count:
+                    logger.info(
+                        f"Limiting sub-tests from {original_count} to {len(tier_config.subtests)}"
+                    )
+
+            logger.info(f"Tier {tier_id.value}: {len(tier_config.subtests)} sub-tests")
+
+            if experiment_dir is None:
+                raise RuntimeError("experiment_dir must be set before loading tier config")
+            tier_dir = experiment_dir / tier_id.value
+            tier_dir.mkdir(parents=True, exist_ok=True)
+
+            # Check for active rate limit before starting this tier
+            rate_limit_info = check_api_rate_limit_status()
+            if rate_limit_info:
+                logger.warning(f"Pre-flight rate limit detected for {tier_id.value}")
+                if checkpoint and experiment_dir:
+                    checkpoint_path = experiment_dir / "checkpoint.json"
+                    wait_for_rate_limit(
+                        rate_limit_info.retry_after_seconds,
+                        checkpoint,
+                        checkpoint_path,
+                    )
+
+            tier_ctx.tier_config = tier_config
+            tier_ctx.tier_dir = tier_dir
+
+        def action_config_loaded() -> None:
+            # CONFIG_LOADED -> SUBTESTS_RUNNING: Execute all subtests in parallel.
+            if tier_ctx.tier_config is None:
+                raise RuntimeError("tier_config must be set before running subtests")
+            if tier_ctx.tier_dir is None:
+                raise RuntimeError("tier_dir must be set before running subtests")
+            if experiment_dir is None:
+                raise RuntimeError("experiment_dir must be set before running subtests")
+            checkpoint_path = experiment_dir / "checkpoint.json" if checkpoint else None
+            subtest_results = run_tier_subtests_parallel(
+                config=config,
+                tier_id=tier_id,
+                tier_config=tier_ctx.tier_config,
+                tier_manager=tier_manager,
+                workspace_manager=workspace_manager,
+                baseline=baseline,
+                results_dir=tier_ctx.tier_dir,
+                checkpoint=checkpoint,
+                checkpoint_path=checkpoint_path,
+                scheduler=scheduler,
+                experiment_dir=experiment_dir,
+            )
+            tier_ctx.subtest_results = subtest_results
+
+        def action_subtests_running() -> None:
+            # SUBTESTS_RUNNING -> SUBTESTS_COMPLETE: Select best subtest.
+            if tier_ctx.tier_dir is None:
+                raise RuntimeError("tier_dir must be set before selecting best subtest")
+            subtest_results = tier_ctx.subtest_results
+
+            selection = select_best_subtest(
+                subtest_results,
+                judge_models=config.judge_models,
+            )
+
+            if selection.winning_subtest in subtest_results:
+                subtest_results[selection.winning_subtest].selected_as_best = True
+                subtest_results[selection.winning_subtest].selection_reason = (
+                    selection.tiebreaker_result.reasoning
+                    if selection.tiebreaker_result
+                    else f"Highest median score ({selection.winning_score:.3f})"
+                )
+
+            save_selection(selection, str(tier_ctx.tier_dir / "best_subtest.json"))
+            tier_ctx.selection = selection
+
+        def action_subtests_complete() -> None:
+            # SUBTESTS_COMPLETE -> BEST_SELECTED: Aggregate token stats, build TierResult.
+            if tier_ctx.selection is None:
+                raise RuntimeError("selection must be set before aggregating subtest results")
+            subtest_results = tier_ctx.subtest_results
+            selection = tier_ctx.selection
+            start_time = tier_ctx.start_time
+
+            end_time = datetime.now(timezone.utc)
+            duration = (end_time - start_time).total_seconds()
+
+            token_stats = reduce(
+                lambda a, b: a + b,
+                [s.token_stats for s in subtest_results.values()],
+                TokenStats(),
+            )
+
+            tier_result = TierResult(
+                tier_id=tier_id,
+                subtest_results=subtest_results,
+                best_subtest=selection.winning_subtest,
+                best_subtest_score=selection.winning_score,
+                inherited_from=baseline,
+                tiebreaker_needed=selection.tiebreaker_needed,
+                total_cost=sum(s.total_cost for s in subtest_results.values()),
+                total_duration=duration,
+                token_stats=token_stats,
+            )
+            tier_ctx.tier_result = tier_result
+
+        def action_best_selected() -> None:
+            # BEST_SELECTED -> REPORTS_GENERATED: Save tier result and generate reports.
+            if tier_ctx.tier_result is None:
+                raise RuntimeError("tier_result must be set before saving reports")
+            save_tier_result_fn(tier_id, tier_ctx.tier_result)
+
+        def action_reports_generated() -> None:
+            # REPORTS_GENERATED -> COMPLETE: No-op (state machine marks complete).
+            pass
+
+        return {
+            TierState.PENDING: action_pending,
+            TierState.CONFIG_LOADED: action_config_loaded,
+            TierState.SUBTESTS_RUNNING: action_subtests_running,
+            TierState.SUBTESTS_COMPLETE: action_subtests_complete,
+            TierState.BEST_SELECTED: action_best_selected,
+            TierState.REPORTS_GENERATED: action_reports_generated,
+        }

--- a/tests/unit/e2e/test_experiment_result_writer.py
+++ b/tests/unit/e2e/test_experiment_result_writer.py
@@ -1,0 +1,483 @@
+"""Unit tests for ExperimentResultWriter.
+
+Tests the extracted experiment result saving/reporting class,
+which encapsulates _save_tier_result, _save_final_results,
+_generate_report, _find_frontier, _aggregate_token_stats,
+and _aggregate_results from E2ERunner.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from scylla.e2e.experiment_result_writer import ExperimentResultWriter
+from scylla.e2e.models import (
+    ExperimentConfig,
+    ExperimentResult,
+    SubTestResult,
+    TierID,
+    TierResult,
+    TokenStats,
+)
+from scylla.e2e.paths import RESULT_FILE
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_config() -> ExperimentConfig:
+    """Minimal ExperimentConfig."""
+    return ExperimentConfig(
+        experiment_id="test-exp",
+        task_repo="https://github.com/test/repo",
+        task_commit="abc123",
+        task_prompt_file=Path("/tmp/prompt.md"),
+        language="python",
+        tiers_to_run=[TierID.T0],
+    )
+
+
+def _make_subtest_result(
+    subtest_id: str = "00",
+    tier_id: TierID = TierID.T0,
+    pass_rate: float = 0.5,
+    mean_cost: float = 1.0,
+    total_cost: float = 1.0,
+    token_stats: TokenStats | None = None,
+) -> SubTestResult:
+    """Create a minimal SubTestResult."""
+    return SubTestResult(
+        subtest_id=subtest_id,
+        tier_id=tier_id,
+        runs=[],
+        pass_rate=pass_rate,
+        mean_cost=mean_cost,
+        total_cost=total_cost,
+        token_stats=token_stats or TokenStats(),
+    )
+
+
+def _make_tier_result(
+    tier_id: TierID = TierID.T0,
+    best_subtest: str | None = "00",
+    total_cost: float = 1.0,
+    pass_rate: float = 0.5,
+    token_stats: TokenStats | None = None,
+) -> TierResult:
+    """Create a minimal TierResult."""
+    subtest_results: dict[str, SubTestResult] = {}
+    if best_subtest:
+        subtest_results[best_subtest] = _make_subtest_result(
+            subtest_id=best_subtest,
+            tier_id=tier_id,
+            pass_rate=pass_rate,
+            mean_cost=total_cost,
+            total_cost=total_cost,
+            token_stats=token_stats,
+        )
+    return TierResult(
+        tier_id=tier_id,
+        subtest_results=subtest_results,
+        best_subtest=best_subtest,
+        best_subtest_score=0.8,
+        total_cost=total_cost,
+        token_stats=token_stats or TokenStats(),
+    )
+
+
+def _make_writer(
+    experiment_dir: Path | None = None,
+    tier_manager: MagicMock | None = None,
+) -> ExperimentResultWriter:
+    """Create ExperimentResultWriter with sensible defaults."""
+    if tier_manager is None:
+        tier_manager = MagicMock()
+    return ExperimentResultWriter(
+        experiment_dir=experiment_dir,
+        tier_manager=tier_manager,
+    )
+
+
+# ---------------------------------------------------------------------------
+# TestExperimentResultWriterConstruct
+# ---------------------------------------------------------------------------
+
+
+class TestExperimentResultWriterConstruct:
+    """Tests for ExperimentResultWriter constructor."""
+
+    def test_stores_experiment_dir(self, tmp_path: Path) -> None:
+        """Constructor stores experiment_dir."""
+        writer = _make_writer(experiment_dir=tmp_path)
+        assert writer.experiment_dir == tmp_path
+
+    def test_stores_tier_manager(self) -> None:
+        """Constructor stores tier_manager."""
+        mgr = MagicMock()
+        writer = _make_writer(tier_manager=mgr)
+        assert writer.tier_manager is mgr
+
+    def test_experiment_dir_can_be_none(self) -> None:
+        """experiment_dir may be None."""
+        writer = _make_writer(experiment_dir=None)
+        assert writer.experiment_dir is None
+
+
+# ---------------------------------------------------------------------------
+# TestSaveTierResult
+# ---------------------------------------------------------------------------
+
+
+class TestSaveTierResult:
+    """Tests for ExperimentResultWriter.save_tier_result()."""
+
+    def test_writes_result_json(self, tmp_path: Path) -> None:
+        """save_tier_result writes result.json to tier directory."""
+        writer = _make_writer(experiment_dir=tmp_path)
+        result = _make_tier_result(TierID.T0)
+
+        with (
+            patch("scylla.e2e.experiment_result_writer.save_tier_report"),
+            patch("scylla.e2e.experiment_result_writer.save_subtest_report"),
+            patch(
+                "scylla.e2e.experiment_result_writer.generate_tier_summary_table",
+                return_value="table",
+            ),
+        ):
+            writer.save_tier_result(TierID.T0, result)
+
+        result_file = tmp_path / TierID.T0.value / RESULT_FILE
+        assert result_file.exists()
+        data = json.loads(result_file.read_text())
+        assert data["tier_id"] == "T0"
+
+    def test_creates_tier_dir_if_missing(self, tmp_path: Path) -> None:
+        """save_tier_result creates the tier directory."""
+        writer = _make_writer(experiment_dir=tmp_path)
+        result = _make_tier_result(TierID.T0)
+
+        with (
+            patch("scylla.e2e.experiment_result_writer.save_tier_report"),
+            patch("scylla.e2e.experiment_result_writer.save_subtest_report"),
+            patch(
+                "scylla.e2e.experiment_result_writer.generate_tier_summary_table", return_value="t"
+            ),
+        ):
+            writer.save_tier_result(TierID.T0, result)
+
+        assert (tmp_path / TierID.T0.value).is_dir()
+
+    def test_writes_summary_md(self, tmp_path: Path) -> None:
+        """save_tier_result writes summary.md."""
+        writer = _make_writer(experiment_dir=tmp_path)
+        result = _make_tier_result(TierID.T0)
+
+        with (
+            patch("scylla.e2e.experiment_result_writer.save_tier_report"),
+            patch("scylla.e2e.experiment_result_writer.save_subtest_report"),
+            patch(
+                "scylla.e2e.experiment_result_writer.generate_tier_summary_table",
+                return_value="summary_content",
+            ),
+        ):
+            writer.save_tier_result(TierID.T0, result)
+
+        summary_file = tmp_path / TierID.T0.value / "summary.md"
+        assert summary_file.exists()
+        assert summary_file.read_text() == "summary_content"
+
+    def test_noop_when_experiment_dir_is_none(self) -> None:
+        """save_tier_result is a no-op when experiment_dir is None."""
+        writer = _make_writer(experiment_dir=None)
+        result = _make_tier_result(TierID.T0)
+
+        # Should not raise
+        writer.save_tier_result(TierID.T0, result)
+
+
+# ---------------------------------------------------------------------------
+# TestSaveFinalResults
+# ---------------------------------------------------------------------------
+
+
+class TestSaveFinalResults:
+    """Tests for ExperimentResultWriter.save_final_results()."""
+
+    def _make_experiment_result(self, config: ExperimentConfig, tmp_path: Path) -> ExperimentResult:
+        """Create a minimal ExperimentResult."""
+        tier_results = {TierID.T0: _make_tier_result(TierID.T0)}
+        return ExperimentResult(
+            config=config,
+            tier_results=tier_results,
+            best_overall_tier=TierID.T0,
+            best_overall_subtest="00",
+            frontier_cop=1.0,
+            frontier_cop_tier=TierID.T0,
+            total_cost=1.0,
+            total_duration_seconds=10.0,
+            started_at=datetime.now(timezone.utc).isoformat(),
+            completed_at=datetime.now(timezone.utc).isoformat(),
+            token_stats=TokenStats(),
+        )
+
+    def test_writes_result_json(self, tmp_path: Path) -> None:
+        """save_final_results writes result.json to experiment root."""
+        config = _make_config()
+        writer = _make_writer(experiment_dir=tmp_path)
+        result = self._make_experiment_result(config, tmp_path)
+
+        writer.save_final_results(result)
+
+        assert (tmp_path / "result.json").exists()
+
+    def test_writes_tier_comparison_json(self, tmp_path: Path) -> None:
+        """save_final_results writes tier_comparison.json."""
+        config = _make_config()
+        writer = _make_writer(experiment_dir=tmp_path)
+        result = self._make_experiment_result(config, tmp_path)
+
+        writer.save_final_results(result)
+
+        comparison_file = tmp_path / "tier_comparison.json"
+        assert comparison_file.exists()
+        data = json.loads(comparison_file.read_text())
+        assert "T0" in data
+
+    def test_tier_comparison_has_correct_structure(self, tmp_path: Path) -> None:
+        """tier_comparison.json contains expected keys per tier."""
+        config = _make_config()
+        writer = _make_writer(experiment_dir=tmp_path)
+        result = self._make_experiment_result(config, tmp_path)
+
+        writer.save_final_results(result)
+
+        data = json.loads((tmp_path / "tier_comparison.json").read_text())
+        assert "best_subtest" in data["T0"]
+        assert "best_score" in data["T0"]
+        assert "total_cost" in data["T0"]
+        assert "tiebreaker_needed" in data["T0"]
+
+    def test_noop_when_experiment_dir_is_none(self) -> None:
+        """save_final_results is a no-op when experiment_dir is None."""
+        config = _make_config()
+        writer = _make_writer(experiment_dir=None)
+        result = ExperimentResult(
+            config=config,
+            tier_results={},
+            best_overall_tier=None,
+            best_overall_subtest=None,
+            frontier_cop=float("inf"),
+            frontier_cop_tier=None,
+            total_cost=0.0,
+            total_duration_seconds=0.0,
+            started_at=datetime.now(timezone.utc).isoformat(),
+            completed_at=datetime.now(timezone.utc).isoformat(),
+            token_stats=TokenStats(),
+        )
+
+        # Should not raise
+        writer.save_final_results(result)
+
+
+# ---------------------------------------------------------------------------
+# TestGenerateReport
+# ---------------------------------------------------------------------------
+
+
+class TestGenerateReport:
+    """Tests for ExperimentResultWriter.generate_report()."""
+
+    def test_writes_summary_md(self, tmp_path: Path) -> None:
+        """generate_report writes summary.md to experiment root."""
+        config = _make_config()
+        writer = _make_writer(experiment_dir=tmp_path)
+        result = ExperimentResult(
+            config=config,
+            tier_results={TierID.T0: _make_tier_result(TierID.T0)},
+            best_overall_tier=TierID.T0,
+            best_overall_subtest="00",
+            frontier_cop=1.0,
+            frontier_cop_tier=TierID.T0,
+            total_cost=1.0,
+            total_duration_seconds=10.0,
+            started_at=datetime.now(timezone.utc).isoformat(),
+            completed_at=datetime.now(timezone.utc).isoformat(),
+            token_stats=TokenStats(),
+        )
+
+        with (
+            patch("scylla.e2e.experiment_result_writer.save_experiment_report"),
+            patch(
+                "scylla.e2e.experiment_result_writer.generate_experiment_summary_table",
+                return_value="exp_summary",
+            ),
+        ):
+            writer.generate_report(result)
+
+        assert (tmp_path / "summary.md").read_text() == "exp_summary"
+
+    def test_early_return_when_experiment_dir_is_none(self) -> None:
+        """generate_report returns early when experiment_dir is None."""
+        writer = _make_writer(experiment_dir=None)
+        config = _make_config()
+        result = ExperimentResult(
+            config=config,
+            tier_results={},
+            best_overall_tier=None,
+            best_overall_subtest=None,
+            frontier_cop=float("inf"),
+            frontier_cop_tier=None,
+            total_cost=0.0,
+            total_duration_seconds=0.0,
+            started_at=datetime.now(timezone.utc).isoformat(),
+            completed_at=datetime.now(timezone.utc).isoformat(),
+            token_stats=TokenStats(),
+        )
+
+        # Should not raise or attempt file writes
+        writer.generate_report(result)
+
+
+# ---------------------------------------------------------------------------
+# TestFindFrontier
+# ---------------------------------------------------------------------------
+
+
+class TestFindFrontier:
+    """Tests for ExperimentResultWriter.find_frontier()."""
+
+    def test_returns_none_none_for_empty_dict(self) -> None:
+        """Returns (None, inf) for empty tier_results."""
+        writer = _make_writer()
+        tier_id, cop = writer.find_frontier({})
+        assert tier_id is None
+        assert cop == float("inf")
+
+    def test_returns_lowest_cop_tier(self) -> None:
+        """Returns tier with lowest cost_of_pass."""
+        writer = _make_writer()
+        t0_result = _make_tier_result(TierID.T0, pass_rate=0.5, total_cost=2.0)
+        t1_result = _make_tier_result(TierID.T1, pass_rate=0.5, total_cost=0.5)
+
+        tier_id, cop = writer.find_frontier({TierID.T0: t0_result, TierID.T1: t1_result})
+
+        # T1 has CoP = mean_cost / pass_rate = 0.5 / 0.5 = 1.0
+        # T0 has CoP = 2.0 / 0.5 = 4.0
+        assert tier_id == TierID.T1
+
+    def test_skips_zero_pass_rate(self) -> None:
+        """Skips tiers with pass_rate=0."""
+        writer = _make_writer()
+        t0_result = _make_tier_result(TierID.T0, pass_rate=0.0, total_cost=1.0)
+        t1_result = _make_tier_result(TierID.T1, pass_rate=0.5, total_cost=1.0)
+
+        tier_id, _cop = writer.find_frontier({TierID.T0: t0_result, TierID.T1: t1_result})
+
+        assert tier_id == TierID.T1
+
+    def test_skips_empty_subtest_results(self) -> None:
+        """Skips tiers with no subtest_results."""
+        writer = _make_writer()
+        empty_result = _make_tier_result(TierID.T0, best_subtest=None)
+        good_result = _make_tier_result(TierID.T1, pass_rate=0.5, total_cost=1.0)
+
+        tier_id, _cop = writer.find_frontier({TierID.T0: empty_result, TierID.T1: good_result})
+
+        assert tier_id == TierID.T1
+
+
+# ---------------------------------------------------------------------------
+# TestAggregateTokenStats
+# ---------------------------------------------------------------------------
+
+
+class TestAggregateTokenStats:
+    """Tests for ExperimentResultWriter.aggregate_token_stats()."""
+
+    def test_returns_empty_stats_for_empty_dict(self) -> None:
+        """Returns empty TokenStats for empty tier_results."""
+        writer = _make_writer()
+        stats = writer.aggregate_token_stats({})
+        assert stats == TokenStats()
+
+    def test_sums_stats_from_all_tiers(self) -> None:
+        """Sums token_stats across all tier results."""
+        writer = _make_writer()
+        t0_result = _make_tier_result(
+            TierID.T0, token_stats=TokenStats(input_tokens=100, output_tokens=50)
+        )
+        t1_result = _make_tier_result(
+            TierID.T1, token_stats=TokenStats(input_tokens=200, output_tokens=75)
+        )
+
+        stats = writer.aggregate_token_stats({TierID.T0: t0_result, TierID.T1: t1_result})
+
+        assert stats.input_tokens == 300
+        assert stats.output_tokens == 125
+
+    def test_single_tier(self) -> None:
+        """Returns stats from single tier unchanged."""
+        writer = _make_writer()
+        t0_result = _make_tier_result(
+            TierID.T0, token_stats=TokenStats(input_tokens=50, output_tokens=25)
+        )
+
+        stats = writer.aggregate_token_stats({TierID.T0: t0_result})
+
+        assert stats.input_tokens == 50
+        assert stats.output_tokens == 25
+
+
+# ---------------------------------------------------------------------------
+# TestAggregateResults
+# ---------------------------------------------------------------------------
+
+
+class TestAggregateResults:
+    """Tests for ExperimentResultWriter.aggregate_results()."""
+
+    def test_returns_experiment_result(self) -> None:
+        """aggregate_results returns an ExperimentResult."""
+        config = _make_config()
+        writer = _make_writer()
+        tier_results = {TierID.T0: _make_tier_result(TierID.T0)}
+        start_time = datetime.now(timezone.utc)
+
+        result = writer.aggregate_results(config, tier_results, start_time)
+
+        assert isinstance(result, ExperimentResult)
+
+    def test_includes_all_tier_results(self) -> None:
+        """aggregate_results includes all tier results."""
+        config = _make_config()
+        writer = _make_writer()
+        tier_results = {
+            TierID.T0: _make_tier_result(TierID.T0),
+            TierID.T1: _make_tier_result(TierID.T1),
+        }
+        start_time = datetime.now(timezone.utc)
+
+        result = writer.aggregate_results(config, tier_results, start_time)
+
+        assert TierID.T0 in result.tier_results
+        assert TierID.T1 in result.tier_results
+
+    def test_aggregates_total_cost(self) -> None:
+        """aggregate_results sums total_cost from all tiers."""
+        config = _make_config()
+        writer = _make_writer()
+        tier_results = {
+            TierID.T0: _make_tier_result(TierID.T0, total_cost=1.5),
+            TierID.T1: _make_tier_result(TierID.T1, total_cost=2.5),
+        }
+        start_time = datetime.now(timezone.utc)
+
+        result = writer.aggregate_results(config, tier_results, start_time)
+
+        assert result.total_cost == pytest.approx(4.0)

--- a/tests/unit/e2e/test_parallel_tier_runner.py
+++ b/tests/unit/e2e/test_parallel_tier_runner.py
@@ -1,0 +1,418 @@
+"""Unit tests for ParallelTierRunner.
+
+Tests the extracted parallel/sequential tier execution class,
+which encapsulates _execute_tier_groups, _execute_parallel_tier_group,
+_select_best_baseline_from_group, _execute_single_tier, and
+_create_baseline_from_tier_result from E2ERunner.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from scylla.e2e.models import (
+    ExperimentConfig,
+    SubTestResult,
+    TierBaseline,
+    TierID,
+    TierResult,
+    TokenStats,
+)
+from scylla.e2e.parallel_tier_runner import ParallelTierRunner
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def base_config() -> ExperimentConfig:
+    """Minimal ExperimentConfig for testing."""
+    return ExperimentConfig(
+        experiment_id="test-exp",
+        task_repo="https://github.com/test/repo",
+        task_commit="abc123",
+        task_prompt_file=Path("/tmp/prompt.md"),
+        language="python",
+        tiers_to_run=[TierID.T0, TierID.T1],
+        judge_models=["claude-haiku-4-5-20251001"],
+    )
+
+
+@pytest.fixture()
+def mock_tier_manager() -> MagicMock:
+    """Mock TierManager."""
+    return MagicMock()
+
+
+def _make_tier_result(
+    tier_id: TierID = TierID.T0,
+    best_subtest: str = "00",
+    cost_of_pass: float = 1.0,
+) -> TierResult:
+    """Create a minimal TierResult for testing."""
+    subtest_result = SubTestResult(
+        subtest_id=best_subtest,
+        tier_id=tier_id,
+        runs=[],
+        pass_rate=0.5,
+        mean_cost=cost_of_pass * 0.5,
+        total_cost=cost_of_pass,
+        token_stats=TokenStats(),
+    )
+    return TierResult(
+        tier_id=tier_id,
+        subtest_results={best_subtest: subtest_result},
+        best_subtest=best_subtest,
+        best_subtest_score=0.8,
+        total_cost=cost_of_pass,
+    )
+
+
+def _make_runner(
+    config: ExperimentConfig | None = None,
+    tier_manager: MagicMock | None = None,
+    experiment_dir: Path | None = None,
+    run_tier_fn: Callable[..., TierResult] | MagicMock | None = None,
+    save_tier_result_fn: Callable[..., None] | MagicMock | None = None,
+) -> ParallelTierRunner:
+    """Create a ParallelTierRunner with sensible defaults."""
+    if config is None:
+        config = ExperimentConfig(
+            experiment_id="test-exp",
+            task_repo="https://github.com/test/repo",
+            task_commit="abc123",
+            task_prompt_file=Path("/tmp/prompt.md"),
+            language="python",
+            tiers_to_run=[TierID.T0, TierID.T1],
+        )
+    if tier_manager is None:
+        tier_manager = MagicMock()
+    if run_tier_fn is None:
+        run_tier_fn = MagicMock(return_value=_make_tier_result())
+    if save_tier_result_fn is None:
+        save_tier_result_fn = MagicMock()
+    return ParallelTierRunner(
+        config=config,
+        tier_manager=tier_manager,
+        experiment_dir=experiment_dir,
+        run_tier_fn=run_tier_fn,
+        save_tier_result_fn=save_tier_result_fn,
+    )
+
+
+# ---------------------------------------------------------------------------
+# TestParallelTierRunnerConstruct
+# ---------------------------------------------------------------------------
+
+
+class TestParallelTierRunnerConstruct:
+    """Tests for ParallelTierRunner constructor."""
+
+    def test_stores_config(self, base_config: ExperimentConfig) -> None:
+        """Constructor stores config."""
+        runner = _make_runner(config=base_config)
+        assert runner.config is base_config
+
+    def test_stores_tier_manager(self, mock_tier_manager: MagicMock) -> None:
+        """Constructor stores tier_manager."""
+        runner = _make_runner(tier_manager=mock_tier_manager)
+        assert runner.tier_manager is mock_tier_manager
+
+    def test_stores_experiment_dir(self, tmp_path: Path) -> None:
+        """Constructor stores experiment_dir."""
+        runner = _make_runner(experiment_dir=tmp_path)
+        assert runner.experiment_dir == tmp_path
+
+    def test_stores_run_tier_fn(self) -> None:
+        """Constructor stores run_tier_fn callable."""
+        fn = MagicMock()
+        runner = _make_runner(run_tier_fn=fn)
+        assert runner.run_tier_fn is fn
+
+    def test_stores_save_tier_result_fn(self) -> None:
+        """Constructor stores save_tier_result_fn callable."""
+        fn = MagicMock()
+        runner = _make_runner(save_tier_result_fn=fn)
+        assert runner.save_tier_result_fn is fn
+
+
+# ---------------------------------------------------------------------------
+# TestExecuteTierGroups
+# ---------------------------------------------------------------------------
+
+
+class TestExecuteTierGroups:
+    """Tests for ParallelTierRunner.execute_tier_groups()."""
+
+    def test_single_group_single_tier_calls_run_tier(self, tmp_path: Path) -> None:
+        """Single-tier group delegates to run_tier_fn."""
+        tier_result = _make_tier_result(TierID.T0)
+        run_tier_fn = MagicMock(return_value=tier_result)
+        mock_tier_manager = MagicMock()
+        mock_tier_manager.get_baseline_for_subtest.return_value = MagicMock(spec=TierBaseline)
+        runner = _make_runner(
+            run_tier_fn=run_tier_fn,
+            tier_manager=mock_tier_manager,
+            experiment_dir=tmp_path,
+        )
+
+        results = runner.execute_tier_groups([[TierID.T0]], scheduler=None)
+
+        assert TierID.T0 in results
+        run_tier_fn.assert_called_once()
+
+    def test_returns_all_tier_results(self, tmp_path: Path) -> None:
+        """execute_tier_groups returns results for each tier group."""
+        t0_result = _make_tier_result(TierID.T0)
+        t1_result = _make_tier_result(TierID.T1)
+
+        call_count = [0]
+
+        def run_tier(tier_id: TierID, *args: object) -> TierResult:
+            call_count[0] += 1
+            return t0_result if tier_id == TierID.T0 else t1_result
+
+        mock_tier_manager = MagicMock()
+        mock_tier_manager.get_baseline_for_subtest.return_value = MagicMock(spec=TierBaseline)
+        runner = _make_runner(
+            run_tier_fn=run_tier,
+            tier_manager=mock_tier_manager,
+            experiment_dir=tmp_path,
+        )
+        results = runner.execute_tier_groups([[TierID.T0], [TierID.T1]], scheduler=None)
+
+        assert TierID.T0 in results
+        assert TierID.T1 in results
+        assert call_count[0] == 2
+
+    def test_stops_on_shutdown(self) -> None:
+        """execute_tier_groups stops early when shutdown is requested."""
+        run_tier_fn = MagicMock(return_value=_make_tier_result())
+
+        with patch("scylla.e2e.runner.is_shutdown_requested", return_value=True):
+            runner = _make_runner(run_tier_fn=run_tier_fn)
+            results = runner.execute_tier_groups([[TierID.T0], [TierID.T1]], scheduler=None)
+
+        assert results == {}
+        run_tier_fn.assert_not_called()
+
+    def test_parallel_group_submits_multiple_tiers(self) -> None:
+        """Parallel group runs both tiers."""
+        t1_result = _make_tier_result(TierID.T1)
+        t2_result = _make_tier_result(TierID.T2)
+
+        def run_tier(tier_id: TierID, *args: object) -> TierResult:
+            return t1_result if tier_id == TierID.T1 else t2_result
+
+        config = ExperimentConfig(
+            experiment_id="test-exp",
+            task_repo="https://github.com/test/repo",
+            task_commit="abc123",
+            task_prompt_file=Path("/tmp/prompt.md"),
+            language="python",
+            tiers_to_run=[TierID.T1, TierID.T2],
+        )
+        runner = _make_runner(config=config, run_tier_fn=run_tier)
+        results = runner.execute_tier_groups([[TierID.T1, TierID.T2]], scheduler=None)
+
+        assert TierID.T1 in results
+        assert TierID.T2 in results
+
+
+# ---------------------------------------------------------------------------
+# TestExecuteParallelTierGroup
+# ---------------------------------------------------------------------------
+
+
+class TestExecuteParallelTierGroup:
+    """Tests for ParallelTierRunner.execute_parallel_tier_group()."""
+
+    def test_both_tiers_succeed(self) -> None:
+        """Both tiers in parallel group are returned."""
+        t1_result = _make_tier_result(TierID.T1)
+        t2_result = _make_tier_result(TierID.T2)
+
+        def run_tier(tier_id: TierID, *args: object) -> TierResult:
+            return t1_result if tier_id == TierID.T1 else t2_result
+
+        runner = _make_runner(run_tier_fn=run_tier)
+        results = runner.execute_parallel_tier_group(
+            [TierID.T1, TierID.T2], previous_baseline=None, scheduler=None
+        )
+
+        assert TierID.T1 in results
+        assert TierID.T2 in results
+
+    def test_partial_failure_other_tier_succeeds(self) -> None:
+        """One failure doesn't abort sibling tiers."""
+        t1_result = _make_tier_result(TierID.T1)
+
+        def run_tier(tier_id: TierID, *args: object) -> TierResult:
+            if tier_id == TierID.T2:
+                raise RuntimeError("T2 failed")
+            return t1_result
+
+        runner = _make_runner(run_tier_fn=run_tier)
+        results = runner.execute_parallel_tier_group(
+            [TierID.T1, TierID.T2], previous_baseline=None, scheduler=None
+        )
+
+        assert TierID.T1 in results
+        assert TierID.T2 not in results
+
+    def test_all_fail_raises_runtime_error(self) -> None:
+        """All tiers failing raises RuntimeError."""
+
+        def run_tier(tier_id: TierID, *args: object) -> TierResult:
+            raise RuntimeError(f"{tier_id.value} failed")
+
+        runner = _make_runner(run_tier_fn=run_tier)
+
+        with pytest.raises(RuntimeError, match="All tiers in parallel group failed"):
+            runner.execute_parallel_tier_group(
+                [TierID.T1, TierID.T2], previous_baseline=None, scheduler=None
+            )
+
+    def test_calls_save_tier_result_fn_on_success(self) -> None:
+        """save_tier_result_fn is called for each successful tier."""
+        save_fn = MagicMock()
+        t0_result = _make_tier_result(TierID.T0)
+        run_tier_fn = MagicMock(return_value=t0_result)
+
+        runner = _make_runner(run_tier_fn=run_tier_fn, save_tier_result_fn=save_fn)
+        runner.execute_parallel_tier_group([TierID.T0], previous_baseline=None, scheduler=None)
+
+        save_fn.assert_called_once_with(TierID.T0, t0_result)
+
+
+# ---------------------------------------------------------------------------
+# TestSelectBestBaselineFromGroup
+# ---------------------------------------------------------------------------
+
+
+class TestSelectBestBaselineFromGroup:
+    """Tests for ParallelTierRunner.select_best_baseline_from_group()."""
+
+    def test_returns_none_when_t5_not_in_config(self, tmp_path: Path) -> None:
+        """Returns None when T5 is not in tiers_to_run."""
+        config = ExperimentConfig(
+            experiment_id="test-exp",
+            task_repo="https://github.com/test/repo",
+            task_commit="abc123",
+            task_prompt_file=Path("/tmp/prompt.md"),
+            language="python",
+            tiers_to_run=[TierID.T0, TierID.T1],
+        )
+        runner = _make_runner(config=config, experiment_dir=tmp_path)
+        tier_results = {TierID.T0: _make_tier_result(TierID.T0, cost_of_pass=1.0)}
+
+        result = runner.select_best_baseline_from_group([TierID.T0], tier_results)
+
+        assert result is None
+
+    def test_returns_none_when_no_results(self, tmp_path: Path) -> None:
+        """Returns None when tier_results is empty."""
+        config = ExperimentConfig(
+            experiment_id="test-exp",
+            task_repo="https://github.com/test/repo",
+            task_commit="abc123",
+            task_prompt_file=Path("/tmp/prompt.md"),
+            language="python",
+            tiers_to_run=[TierID.T0, TierID.T5],
+        )
+        runner = _make_runner(config=config, experiment_dir=tmp_path)
+
+        result = runner.select_best_baseline_from_group([TierID.T0], {})
+
+        assert result is None
+
+    def test_selects_lowest_cop_when_t5_in_config(self, tmp_path: Path) -> None:
+        """Selects tier with lowest cost_of_pass as baseline."""
+        config = ExperimentConfig(
+            experiment_id="test-exp",
+            task_repo="https://github.com/test/repo",
+            task_commit="abc123",
+            task_prompt_file=Path("/tmp/prompt.md"),
+            language="python",
+            tiers_to_run=[TierID.T0, TierID.T1, TierID.T5],
+        )
+        mock_tier_manager = MagicMock()
+        mock_baseline = MagicMock(spec=TierBaseline)
+        mock_tier_manager.get_baseline_for_subtest.return_value = mock_baseline
+
+        t0_result = _make_tier_result(TierID.T0, cost_of_pass=2.0)
+        t1_result = _make_tier_result(TierID.T1, cost_of_pass=0.5)
+
+        runner = _make_runner(
+            config=config,
+            tier_manager=mock_tier_manager,
+            experiment_dir=tmp_path,
+        )
+        result = runner.select_best_baseline_from_group(
+            [TierID.T0, TierID.T1],
+            {TierID.T0: t0_result, TierID.T1: t1_result},
+        )
+
+        # T1 has lower CoP (0.5 vs 2.0), so it should be selected
+        assert result is mock_baseline
+        mock_tier_manager.get_baseline_for_subtest.assert_called_once_with(
+            tier_id=TierID.T1,
+            subtest_id="00",
+            results_dir=tmp_path / TierID.T1.value / "00",
+        )
+
+
+# ---------------------------------------------------------------------------
+# TestCreateBaselineFromTierResult
+# ---------------------------------------------------------------------------
+
+
+class TestCreateBaselineFromTierResult:
+    """Tests for ParallelTierRunner.create_baseline_from_tier_result()."""
+
+    def test_returns_none_when_no_best_subtest(self, tmp_path: Path) -> None:
+        """Returns None when tier_result has no best_subtest."""
+        tier_result = TierResult(
+            tier_id=TierID.T0,
+            subtest_results={},
+            best_subtest=None,
+        )
+        runner = _make_runner(experiment_dir=tmp_path)
+
+        result = runner.create_baseline_from_tier_result(TierID.T0, tier_result)
+
+        assert result is None
+
+    def test_calls_tier_manager_with_correct_args(self, tmp_path: Path) -> None:
+        """Calls tier_manager.get_baseline_for_subtest with correct args."""
+        mock_tier_manager = MagicMock()
+        mock_baseline = MagicMock(spec=TierBaseline)
+        mock_tier_manager.get_baseline_for_subtest.return_value = mock_baseline
+
+        tier_result = _make_tier_result(TierID.T0, best_subtest="01")
+        runner = _make_runner(
+            tier_manager=mock_tier_manager,
+            experiment_dir=tmp_path,
+        )
+
+        result = runner.create_baseline_from_tier_result(TierID.T0, tier_result)
+
+        assert result is mock_baseline
+        mock_tier_manager.get_baseline_for_subtest.assert_called_once_with(
+            tier_id=TierID.T0,
+            subtest_id="01",
+            results_dir=tmp_path / TierID.T0.value / "01",
+        )
+
+    def test_raises_when_experiment_dir_is_none(self) -> None:
+        """Raises RuntimeError when experiment_dir is None."""
+        tier_result = _make_tier_result(TierID.T0)
+        runner = _make_runner(experiment_dir=None)
+
+        with pytest.raises(RuntimeError, match="experiment_dir must be set"):
+            runner.create_baseline_from_tier_result(TierID.T0, tier_result)

--- a/tests/unit/e2e/test_runner_state_machine.py
+++ b/tests/unit/e2e/test_runner_state_machine.py
@@ -282,20 +282,11 @@ class TestRunTierUsesTierStateMachine:
             # Mock _build_tier_actions to return empty actions dict
             mock_build_actions.return_value = {}
 
-            # We need tier_results populated, so mock _execute_tier_groups
-            # Instead, test via _execute_single_tier which calls _run_tier
-            with patch.object(runner, "_run_tier") as mock_run_tier:
-                from scylla.e2e.models import TierResult
-
-                mock_tier_result = TierResult(
-                    tier_id=TierID.T0,
-                    subtest_results={},
-                    best_subtest="01",
-                    best_subtest_score=0.8,
-                )
-                mock_run_tier.return_value = mock_tier_result
-                result = runner._execute_single_tier(TierID.T0, None, None)
-                assert result[0] == mock_tier_result
+            # Test that _run_tier calls advance_to_completion via TierStateMachine
+            result = runner._run_tier(TierID.T0, None, None)
+            # advance_to_completion was called via the state machine
+            mock_advance.assert_called_once()
+            assert isinstance(result, TierResult)
 
     def test_until_tier_state_passed_to_advance(self, config: ExperimentConfig) -> None:
         """until_tier_state should be passed to TierStateMachine.advance_to_completion()."""

--- a/tests/unit/e2e/test_tier_action_builder.py
+++ b/tests/unit/e2e/test_tier_action_builder.py
@@ -1,0 +1,631 @@
+"""Unit tests for TierActionBuilder.
+
+Tests the extracted tier state machine action builder class,
+which encapsulates the _build_tier_actions() logic from E2ERunner.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import TYPE_CHECKING
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from scylla.e2e.models import (
+    ExperimentConfig,
+    SubTestResult,
+    TierBaseline,
+    TierID,
+    TierResult,
+    TierState,
+    TokenStats,
+)
+from scylla.e2e.runner import TierContext
+from scylla.e2e.tier_action_builder import TierActionBuilder
+
+if TYPE_CHECKING:
+    pass
+
+# Patch target for rate limit check (used in action_pending tests)
+_RATE_LIMIT_PATCH = "scylla.e2e.tier_action_builder.check_api_rate_limit_status"
+
+
+def _make_subtest_result(
+    subtest_id: str = "00",
+    tier_id: TierID = TierID.T0,
+    total_cost: float = 0.01,
+    token_stats: TokenStats | None = None,
+) -> SubTestResult:
+    """Create a minimal SubTestResult for testing."""
+    return SubTestResult(
+        subtest_id=subtest_id,
+        tier_id=tier_id,
+        runs=[],
+        total_cost=total_cost,
+        token_stats=token_stats or TokenStats(),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def base_config() -> ExperimentConfig:
+    """Minimal ExperimentConfig for testing."""
+    return ExperimentConfig(
+        experiment_id="test-exp",
+        task_repo="https://github.com/test/repo",
+        task_commit="abc123",
+        task_prompt_file=Path("/tmp/prompt.md"),
+        language="python",
+        tiers_to_run=[TierID.T0],
+        judge_models=["claude-haiku-4-5-20251001"],
+    )
+
+
+@pytest.fixture()
+def mock_tier_manager() -> MagicMock:
+    """Mock TierManager."""
+    mgr = MagicMock()
+    tier_config = MagicMock()
+    tier_config.subtests = ["00", "01", "02"]
+    mgr.load_tier_config.return_value = tier_config
+    return mgr
+
+
+@pytest.fixture()
+def mock_workspace_manager() -> MagicMock:
+    """Mock WorkspaceManager."""
+    return MagicMock()
+
+
+@pytest.fixture()
+def mock_checkpoint() -> MagicMock:
+    """Mock E2ECheckpoint."""
+    return MagicMock()
+
+
+@pytest.fixture()
+def tier_ctx() -> TierContext:
+    """Fresh TierContext."""
+    return TierContext()
+
+
+@pytest.fixture()
+def mock_save_tier_result_fn() -> MagicMock:
+    """Mock callable for _save_tier_result."""
+    return MagicMock()
+
+
+def _make_builder(
+    tier_id: TierID = TierID.T0,
+    config: ExperimentConfig | None = None,
+    tier_manager: MagicMock | None = None,
+    workspace_manager: MagicMock | None = None,
+    checkpoint: MagicMock | None = None,
+    tier_ctx: TierContext | None = None,
+    save_tier_result_fn: MagicMock | None = None,
+    experiment_dir: Path | None = None,
+    baseline: TierBaseline | None = None,
+    scheduler: MagicMock | None = None,
+) -> TierActionBuilder:
+    """Create a TierActionBuilder with sensible defaults for testing."""
+    if config is None:
+        config = ExperimentConfig(
+            experiment_id="test-exp",
+            task_repo="https://github.com/test/repo",
+            task_commit="abc123",
+            task_prompt_file=Path("/tmp/prompt.md"),
+            language="python",
+            tiers_to_run=[TierID.T0],
+            judge_models=["claude-haiku-4-5-20251001"],
+        )
+    if tier_manager is None:
+        mgr = MagicMock()
+        tier_config = MagicMock()
+        tier_config.subtests = ["00", "01"]
+        mgr.load_tier_config.return_value = tier_config
+        tier_manager = mgr
+    if workspace_manager is None:
+        workspace_manager = MagicMock()
+    if checkpoint is None:
+        checkpoint = MagicMock()
+    if tier_ctx is None:
+        tier_ctx = TierContext()
+    if save_tier_result_fn is None:
+        save_tier_result_fn = MagicMock()
+
+    return TierActionBuilder(
+        tier_id=tier_id,
+        baseline=baseline,
+        scheduler=scheduler,
+        tier_ctx=tier_ctx,
+        config=config,
+        tier_manager=tier_manager,
+        workspace_manager=workspace_manager,
+        checkpoint=checkpoint,
+        experiment_dir=experiment_dir,
+        save_tier_result_fn=save_tier_result_fn,
+    )
+
+
+# ---------------------------------------------------------------------------
+# TestTierActionBuilderConstruct
+# ---------------------------------------------------------------------------
+
+
+class TestTierActionBuilderConstruct:
+    """Tests for TierActionBuilder constructor."""
+
+    def test_stores_tier_id(self) -> None:
+        """Constructor stores tier_id."""
+        builder = _make_builder(tier_id=TierID.T1)
+        assert builder.tier_id == TierID.T1
+
+    def test_stores_baseline(self) -> None:
+        """Constructor stores baseline."""
+        baseline = MagicMock(spec=TierBaseline)
+        builder = _make_builder(baseline=baseline)
+        assert builder.baseline is baseline
+
+    def test_stores_tier_ctx(self, tier_ctx: TierContext) -> None:
+        """Constructor stores tier_ctx."""
+        builder = _make_builder(tier_ctx=tier_ctx)
+        assert builder.tier_ctx is tier_ctx
+
+    def test_stores_save_tier_result_fn(self) -> None:
+        """Constructor stores save_tier_result_fn callable."""
+        fn = MagicMock()
+        builder = _make_builder(save_tier_result_fn=fn)
+        assert builder.save_tier_result_fn is fn
+
+    def test_stores_experiment_dir(self, tmp_path: Path) -> None:
+        """Constructor stores experiment_dir."""
+        builder = _make_builder(experiment_dir=tmp_path)
+        assert builder.experiment_dir == tmp_path
+
+
+# ---------------------------------------------------------------------------
+# TestBuildReturnsDict
+# ---------------------------------------------------------------------------
+
+
+class TestBuildReturnsDict:
+    """Tests for TierActionBuilder.build() return value."""
+
+    def test_returns_dict(self) -> None:
+        """build() returns a dict."""
+        builder = _make_builder()
+        result = builder.build()
+        assert isinstance(result, dict)
+
+    def test_has_all_six_tier_state_keys(self) -> None:
+        """build() returns dict with all 6 TierState keys."""
+        builder = _make_builder()
+        result = builder.build()
+        expected = {
+            TierState.PENDING,
+            TierState.CONFIG_LOADED,
+            TierState.SUBTESTS_RUNNING,
+            TierState.SUBTESTS_COMPLETE,
+            TierState.BEST_SELECTED,
+            TierState.REPORTS_GENERATED,
+        }
+        assert set(result.keys()) == expected
+
+    def test_all_values_are_callable(self) -> None:
+        """All values in the returned dict are callable."""
+        builder = _make_builder()
+        result = builder.build()
+        for key, val in result.items():
+            assert callable(val), f"Value for {key} is not callable"
+
+
+# ---------------------------------------------------------------------------
+# TestActionPending
+# ---------------------------------------------------------------------------
+
+
+class TestActionPending:
+    """Tests for the action_pending closure (PENDING -> CONFIG_LOADED)."""
+
+    def test_sets_tier_config_on_ctx(self, tmp_path: Path) -> None:
+        """action_pending sets tier_ctx.tier_config from tier_manager."""
+        tier_ctx = TierContext()
+        tier_manager = MagicMock()
+        tier_config = MagicMock()
+        tier_config.subtests = ["00"]
+        tier_manager.load_tier_config.return_value = tier_config
+
+        builder = _make_builder(
+            tier_ctx=tier_ctx,
+            tier_manager=tier_manager,
+            experiment_dir=tmp_path,
+        )
+        actions = builder.build()
+        with patch(_RATE_LIMIT_PATCH, return_value=None):
+            actions[TierState.PENDING]()
+
+        assert tier_ctx.tier_config is tier_config
+
+    def test_sets_tier_dir_on_ctx(self, tmp_path: Path) -> None:
+        """action_pending sets tier_ctx.tier_dir under experiment_dir."""
+        tier_ctx = TierContext()
+        builder = _make_builder(
+            tier_id=TierID.T0,
+            tier_ctx=tier_ctx,
+            experiment_dir=tmp_path,
+        )
+        actions = builder.build()
+        with patch(_RATE_LIMIT_PATCH, return_value=None):
+            actions[TierState.PENDING]()
+
+        assert tier_ctx.tier_dir is not None
+        assert tier_ctx.tier_dir == tmp_path / TierID.T0.value
+        assert tier_ctx.tier_dir.exists()
+
+    def test_limits_subtests_when_max_subtests_set(self, tmp_path: Path) -> None:
+        """action_pending trims subtests to max_subtests."""
+        tier_ctx = TierContext()
+        config = ExperimentConfig(
+            experiment_id="test-exp",
+            task_repo="https://github.com/test/repo",
+            task_commit="abc123",
+            task_prompt_file=Path("/tmp/prompt.md"),
+            language="python",
+            tiers_to_run=[TierID.T0],
+            judge_models=["claude-haiku-4-5-20251001"],
+            max_subtests=2,
+        )
+        tier_manager = MagicMock()
+        tier_config = MagicMock()
+        tier_config.subtests = ["00", "01", "02", "03"]
+        tier_manager.load_tier_config.return_value = tier_config
+
+        builder = _make_builder(
+            config=config,
+            tier_ctx=tier_ctx,
+            tier_manager=tier_manager,
+            experiment_dir=tmp_path,
+        )
+        actions = builder.build()
+        with patch(_RATE_LIMIT_PATCH, return_value=None):
+            actions[TierState.PENDING]()
+
+        assert tier_config.subtests == ["00", "01"]
+
+    def test_raises_when_experiment_dir_is_none(self) -> None:
+        """action_pending raises RuntimeError when experiment_dir is None."""
+        builder = _make_builder(experiment_dir=None)
+        actions = builder.build()
+
+        with (
+            patch(_RATE_LIMIT_PATCH, return_value=None),
+            pytest.raises(RuntimeError, match="experiment_dir must be set"),
+        ):
+            actions[TierState.PENDING]()
+
+    def test_calls_load_tier_config_with_correct_args(self, tmp_path: Path) -> None:
+        """action_pending calls tier_manager.load_tier_config with tier_id and skip_agent_teams."""
+        tier_manager = MagicMock()
+        tier_config = MagicMock()
+        tier_config.subtests = ["00"]
+        tier_manager.load_tier_config.return_value = tier_config
+        config = ExperimentConfig(
+            experiment_id="test-exp",
+            task_repo="https://github.com/test/repo",
+            task_commit="abc123",
+            task_prompt_file=Path("/tmp/prompt.md"),
+            language="python",
+            tiers_to_run=[TierID.T0],
+            judge_models=["claude-haiku-4-5-20251001"],
+        )
+
+        builder = _make_builder(
+            tier_id=TierID.T0,
+            config=config,
+            tier_manager=tier_manager,
+            experiment_dir=tmp_path,
+        )
+        actions = builder.build()
+        with patch(_RATE_LIMIT_PATCH, return_value=None):
+            actions[TierState.PENDING]()
+
+        tier_manager.load_tier_config.assert_called_once_with(TierID.T0, config.skip_agent_teams)
+
+
+# ---------------------------------------------------------------------------
+# TestActionConfigLoaded
+# ---------------------------------------------------------------------------
+
+
+class TestActionConfigLoaded:
+    """Tests for the action_config_loaded closure (CONFIG_LOADED -> SUBTESTS_RUNNING)."""
+
+    def test_sets_subtest_results_on_ctx(self, tmp_path: Path) -> None:
+        """action_config_loaded sets tier_ctx.subtest_results from run_tier_subtests_parallel."""
+        tier_ctx = TierContext()
+        tier_config = MagicMock()
+        tier_ctx.tier_config = tier_config
+        tier_ctx.tier_dir = tmp_path / "T0"
+        tier_ctx.tier_dir.mkdir()
+
+        expected_results = {"00": MagicMock()}
+
+        builder = _make_builder(
+            tier_ctx=tier_ctx,
+            experiment_dir=tmp_path,
+        )
+        actions = builder.build()
+
+        with patch(
+            "scylla.e2e.tier_action_builder.run_tier_subtests_parallel",
+            return_value=expected_results,
+        ):
+            actions[TierState.CONFIG_LOADED]()
+
+        assert tier_ctx.subtest_results == expected_results
+
+    def test_raises_when_tier_config_is_none(self, tmp_path: Path) -> None:
+        """action_config_loaded raises RuntimeError when tier_ctx.tier_config is None."""
+        tier_ctx = TierContext()
+        tier_ctx.tier_config = None
+        tier_ctx.tier_dir = tmp_path
+
+        builder = _make_builder(tier_ctx=tier_ctx, experiment_dir=tmp_path)
+        actions = builder.build()
+
+        with pytest.raises(RuntimeError, match="tier_config must be set"):
+            actions[TierState.CONFIG_LOADED]()
+
+    def test_raises_when_tier_dir_is_none(self, tmp_path: Path) -> None:
+        """action_config_loaded raises RuntimeError when tier_ctx.tier_dir is None."""
+        tier_ctx = TierContext()
+        tier_ctx.tier_config = MagicMock()
+        tier_ctx.tier_dir = None
+
+        builder = _make_builder(tier_ctx=tier_ctx, experiment_dir=tmp_path)
+        actions = builder.build()
+
+        with pytest.raises(RuntimeError, match="tier_dir must be set"):
+            actions[TierState.CONFIG_LOADED]()
+
+    def test_raises_when_experiment_dir_is_none(self) -> None:
+        """action_config_loaded raises RuntimeError when experiment_dir is None."""
+        tier_ctx = TierContext()
+        tier_ctx.tier_config = MagicMock()
+        tier_ctx.tier_dir = Path("/some/dir")
+
+        builder = _make_builder(tier_ctx=tier_ctx, experiment_dir=None)
+        actions = builder.build()
+
+        with pytest.raises(RuntimeError, match="experiment_dir must be set"):
+            actions[TierState.CONFIG_LOADED]()
+
+
+# ---------------------------------------------------------------------------
+# TestActionSubtestsRunning
+# ---------------------------------------------------------------------------
+
+
+class TestActionSubtestsRunning:
+    """Tests for action_subtests_running closure (SUBTESTS_RUNNING -> SUBTESTS_COMPLETE)."""
+
+    def test_sets_selection_on_ctx(self, tmp_path: Path) -> None:
+        """action_subtests_running sets tier_ctx.selection."""
+        tier_ctx = TierContext()
+        tier_ctx.tier_dir = tmp_path
+        subtest_result = MagicMock()
+        subtest_result.selected_as_best = False
+        tier_ctx.subtest_results = {"00": subtest_result}
+
+        mock_selection = MagicMock()
+        mock_selection.winning_subtest = "00"
+        mock_selection.winning_score = 0.9
+        mock_selection.tiebreaker_result = None
+
+        builder = _make_builder(tier_ctx=tier_ctx, experiment_dir=tmp_path)
+        actions = builder.build()
+
+        with (
+            patch(
+                "scylla.e2e.tier_action_builder.select_best_subtest",
+                return_value=mock_selection,
+            ),
+            patch("scylla.e2e.tier_action_builder.save_selection"),
+        ):
+            actions[TierState.SUBTESTS_RUNNING]()
+
+        assert tier_ctx.selection is mock_selection
+
+    def test_marks_winning_subtest_as_best(self, tmp_path: Path) -> None:
+        """action_subtests_running marks winning subtest as selected_as_best."""
+        tier_ctx = TierContext()
+        tier_ctx.tier_dir = tmp_path
+        subtest_result = MagicMock()
+        subtest_result.selected_as_best = False
+        subtest_result.selection_reason = None
+        tier_ctx.subtest_results = {"00": subtest_result}
+
+        mock_selection = MagicMock()
+        mock_selection.winning_subtest = "00"
+        mock_selection.winning_score = 0.9
+        mock_selection.tiebreaker_result = None
+
+        builder = _make_builder(tier_ctx=tier_ctx, experiment_dir=tmp_path)
+        actions = builder.build()
+
+        with (
+            patch(
+                "scylla.e2e.tier_action_builder.select_best_subtest",
+                return_value=mock_selection,
+            ),
+            patch("scylla.e2e.tier_action_builder.save_selection"),
+        ):
+            actions[TierState.SUBTESTS_RUNNING]()
+
+        assert subtest_result.selected_as_best is True
+
+    def test_raises_when_tier_dir_is_none(self) -> None:
+        """action_subtests_running raises RuntimeError when tier_ctx.tier_dir is None."""
+        tier_ctx = TierContext()
+        tier_ctx.tier_dir = None
+
+        builder = _make_builder(tier_ctx=tier_ctx, experiment_dir=Path("/some"))
+        actions = builder.build()
+
+        with pytest.raises(RuntimeError, match="tier_dir must be set"):
+            actions[TierState.SUBTESTS_RUNNING]()
+
+
+# ---------------------------------------------------------------------------
+# TestActionSubtestsComplete
+# ---------------------------------------------------------------------------
+
+
+class TestActionSubtestsComplete:
+    """Tests for action_subtests_complete closure (SUBTESTS_COMPLETE -> BEST_SELECTED)."""
+
+    def test_sets_tier_result_on_ctx(self, tmp_path: Path) -> None:
+        """action_subtests_complete sets tier_ctx.tier_result."""
+        tier_ctx = TierContext()
+        tier_ctx.start_time = datetime.now(timezone.utc)
+        mock_selection = MagicMock()
+        mock_selection.winning_subtest = "00"
+        mock_selection.winning_score = 0.9
+        mock_selection.tiebreaker_needed = False
+        tier_ctx.selection = mock_selection
+
+        tier_ctx.subtest_results = {"00": _make_subtest_result("00")}
+
+        builder = _make_builder(
+            tier_id=TierID.T0,
+            tier_ctx=tier_ctx,
+            experiment_dir=tmp_path,
+        )
+        actions = builder.build()
+        actions[TierState.SUBTESTS_COMPLETE]()
+
+        assert tier_ctx.tier_result is not None
+        assert isinstance(tier_ctx.tier_result, TierResult)
+
+    def test_tier_result_has_correct_tier_id(self, tmp_path: Path) -> None:
+        """action_subtests_complete builds TierResult with correct tier_id."""
+        tier_ctx = TierContext()
+        tier_ctx.start_time = datetime.now(timezone.utc)
+        mock_selection = MagicMock()
+        mock_selection.winning_subtest = "00"
+        mock_selection.winning_score = 0.8
+        mock_selection.tiebreaker_needed = False
+        tier_ctx.selection = mock_selection
+
+        tier_ctx.subtest_results = {"00": _make_subtest_result("00", tier_id=TierID.T1)}
+
+        builder = _make_builder(
+            tier_id=TierID.T1,
+            tier_ctx=tier_ctx,
+            experiment_dir=tmp_path,
+        )
+        actions = builder.build()
+        actions[TierState.SUBTESTS_COMPLETE]()
+
+        assert tier_ctx.tier_result is not None
+        assert tier_ctx.tier_result.tier_id == TierID.T1
+
+    def test_raises_when_selection_is_none(self, tmp_path: Path) -> None:
+        """action_subtests_complete raises RuntimeError when selection is None."""
+        tier_ctx = TierContext()
+        tier_ctx.selection = None
+
+        builder = _make_builder(tier_ctx=tier_ctx, experiment_dir=tmp_path)
+        actions = builder.build()
+
+        with pytest.raises(RuntimeError, match="selection must be set"):
+            actions[TierState.SUBTESTS_COMPLETE]()
+
+    def test_accumulates_token_stats(self, tmp_path: Path) -> None:
+        """action_subtests_complete sums token_stats from all subtests."""
+        tier_ctx = TierContext()
+        tier_ctx.start_time = datetime.now(timezone.utc)
+        mock_selection = MagicMock()
+        mock_selection.winning_subtest = "00"
+        mock_selection.winning_score = 0.9
+        mock_selection.tiebreaker_needed = False
+        tier_ctx.selection = mock_selection
+
+        stats_a = TokenStats(input_tokens=100, output_tokens=50)
+        stats_b = TokenStats(input_tokens=200, output_tokens=75)
+        tier_ctx.subtest_results = {
+            "00": _make_subtest_result("00", total_cost=0.01, token_stats=stats_a),
+            "01": _make_subtest_result("01", total_cost=0.02, token_stats=stats_b),
+        }
+
+        builder = _make_builder(
+            tier_id=TierID.T0,
+            tier_ctx=tier_ctx,
+            experiment_dir=tmp_path,
+        )
+        actions = builder.build()
+        actions[TierState.SUBTESTS_COMPLETE]()
+
+        assert tier_ctx.tier_result is not None
+        assert tier_ctx.tier_result.token_stats.input_tokens == 300
+        assert tier_ctx.tier_result.token_stats.output_tokens == 125
+
+
+# ---------------------------------------------------------------------------
+# TestActionBestSelected
+# ---------------------------------------------------------------------------
+
+
+class TestActionBestSelected:
+    """Tests for action_best_selected closure (BEST_SELECTED -> REPORTS_GENERATED)."""
+
+    def test_calls_save_tier_result_fn(self, tmp_path: Path) -> None:
+        """action_best_selected calls save_tier_result_fn with tier_id and tier_result."""
+        save_fn = MagicMock()
+        tier_ctx = TierContext()
+        tier_result = MagicMock(spec=TierResult)
+        tier_ctx.tier_result = tier_result
+
+        builder = _make_builder(
+            tier_id=TierID.T0,
+            tier_ctx=tier_ctx,
+            save_tier_result_fn=save_fn,
+            experiment_dir=tmp_path,
+        )
+        actions = builder.build()
+        actions[TierState.BEST_SELECTED]()
+
+        save_fn.assert_called_once_with(TierID.T0, tier_result)
+
+    def test_raises_when_tier_result_is_none(self, tmp_path: Path) -> None:
+        """action_best_selected raises RuntimeError when tier_ctx.tier_result is None."""
+        tier_ctx = TierContext()
+        tier_ctx.tier_result = None
+
+        builder = _make_builder(tier_ctx=tier_ctx, experiment_dir=tmp_path)
+        actions = builder.build()
+
+        with pytest.raises(RuntimeError, match="tier_result must be set"):
+            actions[TierState.BEST_SELECTED]()
+
+
+# ---------------------------------------------------------------------------
+# TestActionReportsGenerated
+# ---------------------------------------------------------------------------
+
+
+class TestActionReportsGenerated:
+    """Tests for action_reports_generated closure (REPORTS_GENERATED -> COMPLETE)."""
+
+    def test_is_noop(self, tmp_path: Path) -> None:
+        """action_reports_generated completes without error (no-op)."""
+        builder = _make_builder(experiment_dir=tmp_path)
+        actions = builder.build()
+        # Should not raise
+        actions[TierState.REPORTS_GENERATED]()


### PR DESCRIPTION
## Summary

Reduces `runner.py` from 1527 lines to 1105 lines (-422 lines, -28%) by extracting three method groups into dedicated collaborator classes following TDD pattern.

**Extracted classes:**
- `TierActionBuilder` (`scylla/e2e/tier_action_builder.py`) — encapsulates `_build_tier_actions()` and its 6 action closures for tier state machine wiring
- `ParallelTierRunner` (`scylla/e2e/parallel_tier_runner.py`) — encapsulates parallel/sequential tier orchestration (`execute_tier_groups`, `execute_parallel_tier_group`, `select_best_baseline_from_group`, `_execute_single_tier`, `create_baseline_from_tier_result`)
- `ExperimentResultWriter` (`scylla/e2e/experiment_result_writer.py`) — encapsulates result serialization and report generation (`save_tier_result`, `save_final_results`, `generate_report`, `find_frontier`, `aggregate_token_stats`, `aggregate_results`)

Each extracted class receives runner state as explicit constructor arguments (no runner reference) to avoid circular coupling. Lazy local import of `is_shutdown_requested()` in `ParallelTierRunner` avoids circular import.

## Test plan

- [ ] 69 new unit tests across 3 new test files (`test_tier_action_builder.py`, `test_parallel_tier_runner.py`, `test_experiment_result_writer.py`)
- [ ] All 3326 tests pass at 79.27% coverage (above 75% threshold)
- [ ] All pre-commit checks pass (ruff, mypy, black)
- [ ] `runner.py` reduced from 1527 to 1105 lines (-28%)

Closes #1146

🤖 Generated with [Claude Code](https://claude.com/claude-code)