### PR TITLE
[Test] Add parametrized test for all valid TierID values

### DIFF
--- a/tests/unit/e2e/test_models.py
+++ b/tests/unit/e2e/test_models.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import tempfile
 from pathlib import Path
 
+import pytest
+
 from scylla.e2e.models import (
     E2ERunResult,
     ExperimentConfig,
@@ -36,6 +38,13 @@ class TestTierID:
         assert TierID.T0 < TierID.T1
         assert TierID.T1 < TierID.T6
         assert not TierID.T3 < TierID.T2
+
+    @pytest.mark.parametrize("tier_str", ["T0", "T1", "T2", "T3", "T4", "T5", "T6"])
+    def test_all_valid_tier_ids_can_be_constructed(self, tier_str: str) -> None:
+        """Each valid TierID value can be constructed and resolves to the correct member."""
+        tier = TierID(tier_str)
+        assert tier == TierID[tier_str]
+        assert tier.value == tier_str
 
 
 class TestSubTestConfig:


### PR DESCRIPTION
## Summary
- Add a `@pytest.mark.parametrize` test to `TestTierID` in `tests/unit/e2e/test_models.py` that asserts all 7 valid `TierID` values (T0–T6) can be constructed via `TierID(tier_str)` and resolve to the correct enum member
- Guards against silent breakage if the `TierID` enum is modified (values added, renamed, or removed)
- No production code changes; pure test addition in the most appropriate existing test class

## Test plan
- [ ] All 7 parametrized cases (`[T0]` through `[T6]`) pass
- [ ] All pre-commit hooks pass (ruff, mypy, black, etc.)
- [ ] No regressions in the existing `TestTierID` tests

Closes #1165