### PR TITLE
[Fix] Pin hatchling version in Dockerfile

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -27,7 +27,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && rm -rf /var/lib/apt/lists/*
 
 # Layer 1: Build backend (invalidated only when hatchling version changes)
-RUN pip install --no-cache-dir hatchling
+# Pinned to match pyproject.toml [build-system].requires — see #1141
+RUN pip install --no-cache-dir "hatchling==1.27.0"
 
 # Layer 2: Dependencies (invalidated only when pyproject.toml changes or EXTRAS changes)
 # Copy only pyproject.toml first so dependency installs are cached separately

--- a/tests/unit/e2e/test_dockerfile.py
+++ b/tests/unit/e2e/test_dockerfile.py
@@ -1,0 +1,34 @@
+"""Regression tests for Dockerfile pinning requirements."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+DOCKERFILE = Path(__file__).parents[3] / "docker" / "Dockerfile"
+
+
+class TestHatchlingPinned:
+    """Tests verifying hatchling is pinned in the Dockerfile — see #1141."""
+
+    def test_hatchling_is_pinned(self) -> None:
+        """Hatchling must be pinned with == in the builder stage — see #1141."""
+        content = DOCKERFILE.read_text()
+        match = re.search(r"pip install.*hatchling([^\n]*)", content)
+        assert match is not None, "pip install hatchling line not found in Dockerfile"
+        assert "==" in match.group(0), (
+            "hatchling must be pinned with == (e.g. hatchling==1.27.0); found unpinned install"
+        )
+
+    def test_hatchling_version_format(self) -> None:
+        """Hatchling pin must use a valid PEP 440 exact version specifier."""
+        content = DOCKERFILE.read_text()
+        match = re.search(r'pip install.*["\']?hatchling==(\d+\.\d+\.\d+)["\']?', content)
+        assert match is not None, (
+            "hatchling must be pinned with a full X.Y.Z version "
+            "(e.g. hatchling==1.27.0) in Dockerfile"
+        )
+        version = match.group(1)
+        parts = version.split(".")
+        assert len(parts) == 3, f"Expected X.Y.Z version, got: {version}"
+        assert all(p.isdigit() for p in parts), f"Version parts must be numeric, got: {version}"


### PR DESCRIPTION
## Summary

- Pin `hatchling` to `==1.27.0` in the builder stage of `docker/Dockerfile` (line 30) to ensure reproducible builds and stable Docker layer caching
- Add inline comment referencing `#1141` to document the rationale
- Add regression test `tests/unit/e2e/test_dockerfile.py` that statically parses the Dockerfile and asserts `hatchling` is pinned with an exact `==X.Y.Z` specifier

## Test plan

- [x] `tests/unit/e2e/test_dockerfile.py::TestHatchlingPinned::test_hatchling_is_pinned` — asserts `==` is present in the hatchling install line
- [x] `tests/unit/e2e/test_dockerfile.py::TestHatchlingPinned::test_hatchling_version_format` — asserts the version is a valid `X.Y.Z` numeric specifier
- [x] `pre-commit run --all-files` — all hooks pass
- [x] Full test suite: 3438 passed, coverage 79.60% (above 75% threshold)

Closes #1141

🤖 Generated with [Claude Code](https://claude.com/claude-code)