### PR TITLE
[Docs] Document docker-test.yml secret requirements

### DIFF
--- a/docs/dev/adr/docker-testing-deferred.md
+++ b/docs/dev/adr/docker-testing-deferred.md
@@ -42,3 +42,61 @@ reflect what it does.
 - Docker integration testing remains a known gap, tracked in issue #1113.
 - If Docker integration tests are later implemented, they should be added as a
   separate workflow with appropriate secrets configuration.
+
+## Future Implementation Guide (Option A: Full Integration Tests)
+
+### Required GitHub Actions Secrets
+
+| Secret Name | Description | Source |
+|-------------|-------------|--------|
+| `ANTHROPIC_API_KEY` | API key for Claude model access during container tests | Anthropic Console → API Keys |
+
+The `docker-test.yml` workflow currently performs syntax validation only (no secrets required).
+If Docker integration tests are added, `ANTHROPIC_API_KEY` is the only secret needed for the
+image to run agent workloads.
+
+### Configuring Secrets in GitHub Repository Settings
+
+1. Navigate to **Settings → Secrets and variables → Actions** in the GitHub repository.
+2. Click **New repository secret**.
+3. Set **Name** to `ANTHROPIC_API_KEY`.
+4. Set **Value** to a valid Anthropic API key scoped to the project.
+5. Click **Add secret**.
+
+Do not mount `~/.claude/.credentials.json` into CI containers — environment variables are the
+correct injection method for GitHub Actions runners. The credential file pattern applies only
+to local development environments.
+
+### Skeleton Workflow Step
+
+```yaml
+- name: Run Docker integration tests
+  env:
+    ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+  run: |
+    docker run --rm \
+      -e ANTHROPIC_API_KEY \
+      projectscylla:test \
+      pytest tests/docker/ -v
+```
+
+Notes:
+
+- `--rm` removes the container after the test run.
+- Pass `-e ANTHROPIC_API_KEY` (no value) to forward the env var set in the `env:` block;
+  this avoids echoing the secret in the shell command.
+- If tests write artifacts, add `-v ${{ github.workspace }}/test-results:/results`.
+- Credential files written inside the container are cleaned up automatically by `--rm`;
+  no explicit cleanup step is needed.
+- Gate the step on non-fork PRs to avoid leaking secrets:
+  `if: github.event.pull_request.head.repo.full_name == github.repository`
+- WSL2 local dev note: `/tmp` is not exposed to Docker by default on WSL2; use a home
+  directory path or an explicitly bound path for any temporary credential directories.
+
+### Acceptance Criteria for Option A
+
+- [ ] `ANTHROPIC_API_KEY` secret is configured in repository settings.
+- [ ] `docker-test.yml` includes a step with `-e ANTHROPIC_API_KEY` (env var injection,
+      not file mount).
+- [ ] At least one test in `tests/docker/` makes a real API call and passes in CI.
+- [ ] Workflow step is gated to not run on forks.


### PR DESCRIPTION
## Summary

- Adds a `## Future Implementation Guide (Option A: Full Integration Tests)` section to `docs/dev/adr/docker-testing-deferred.md`
- Documents `ANTHROPIC_API_KEY` as the required GitHub Actions secret for Docker integration tests
- Provides step-by-step instructions for configuring the secret in GitHub repository settings
- Includes a skeleton `docker run` workflow step with correct env-var injection pattern (not file-mount)
- Lists acceptance criteria for implementing full Docker integration tests

Closes #1161

## Test plan

- [ ] Verify `docs/dev/adr/docker-testing-deferred.md` renders correctly in GitHub markdown
- [ ] Confirm no new pre-commit violations are introduced by this change (audit-doc-policy failures are pre-existing in worktree archives)
- [ ] Confirm skeleton YAML step uses `-e ANTHROPIC_API_KEY` (env var forwarding, not echoing secret value)
- [ ] Confirm WSL2 `/tmp` caveat is noted

🤖 Generated with [Claude Code](https://claude.com/claude-code)