### PR TITLE
[Config] Remove S101 from global ruff ignore list

### DIFF
--- a/pixi.lock
+++ b/pixi.lock
@@ -3764,7 +3764,7 @@ packages:
 - pypi: ./
   name: scylla
   version: 0.1.0
-  sha256: 702f857459de3e49bc535d7dba70f9cd0cba1cf7f2b078d1f69f99ff0e6efdb1
+  sha256: b9ac9bd5fdeb02349822e9562b66e22179132996a5270de587b34c42960d828b
   requires_dist:
   - click>=8.0
   - pydantic>=2.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,6 +68,9 @@ line-length = 100
 target-version = "py310"
 
 [tool.ruff.lint]
+# S101 is selected explicitly (not via the full "S"/bandit group) so that
+# assert statements are flagged as errors in production code.  Tests are
+# exempted below via per-file-ignores, where assert is the pytest idiom.
 select = ["E", "F", "W", "I", "N", "D", "UP", "S101"]
 ignore = [
     "D100",  # Missing docstring in public module
@@ -78,7 +81,8 @@ ignore = [
 ]
 
 [tool.ruff.lint.per-file-ignores]
-"tests/**" = ["S101"]  # assert statements are intentional in test code
+# assert is idiomatic in pytest; S101 suppressed for all test files only
+"tests/**" = ["S101"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]


### PR DESCRIPTION
## Summary

- S101 was already in `select` (not `ignore`) in `pyproject.toml`, enforcing no-assert in production code
- Tests are exempted via `per-file-ignores` for `tests/**` where assert is the pytest idiom
- This PR adds explanatory comments to make the intent unambiguous going forward

## Changes

Updated `/pyproject.toml` `[tool.ruff.lint]` section with documentation comments explaining:
- Why S101 appears in `select` (flag assert in production code, not via full bandit group)
- Why `tests/**` appears in `per-file-ignores` (assert is idiomatic in pytest)

## Verification

- `pixi run ruff check scylla/ scripts/ tests/` passes (no S101 violations in production code)
- `grep -rn 'noqa: S101' scylla/ scripts/` returns empty (no suppressions needed)
- All 3442 tests pass with 79.56% coverage (above 75% threshold)

Closes #1212