### PR TITLE
[Fix] Pin all pip install versions in Dockerfile

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -28,6 +28,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 # Layer 1: Build backend (invalidated only when hatchling version changes)
 # Pinned to match pyproject.toml [build-system].requires — see #1141
+# Audit (#1209): all static pip installs are pinned; dynamic Layer 2 install
+# (from pyproject.toml via tomllib) is intentionally version-spec controlled there.
 RUN pip install --no-cache-dir "hatchling==1.27.0"
 
 # Layer 2: Dependencies (invalidated only when pyproject.toml changes or EXTRAS changes)

--- a/tests/unit/e2e/test_dockerfile.py
+++ b/tests/unit/e2e/test_dockerfile.py
@@ -32,3 +32,68 @@ class TestHatchlingPinned:
         parts = version.split(".")
         assert len(parts) == 3, f"Expected X.Y.Z version, got: {version}"
         assert all(p.isdigit() for p in parts), f"Version parts must be numeric, got: {version}"
+
+
+class TestAllStaticPipInstallsPinned:
+    """Regression tests ensuring all static pip installs are pinned — see #1209.
+
+    A "static pip install" is any ``RUN pip install <package-name>`` line that
+    names a PyPI package literally (not a local path, not a shell-substitution).
+    Dynamic installs (e.g. ``pip install $(python3 -c "...")``) are excluded
+    because their version constraints come from pyproject.toml.
+    Local-path installs (e.g. ``pip install /opt/scylla/``) are also excluded.
+    Comment lines are excluded.
+    """
+
+    # Regex to find a static RUN pip install line: must start with RUN, must not
+    # contain a shell substitution $( or a path-based token.
+    _STATIC_PIP_RUN_RE = re.compile(r"^RUN\s+pip\s+install\b")
+
+    def _collect_static_pip_install_lines(self) -> list[str]:
+        """Return RUN pip install lines that install named packages statically."""
+        content = DOCKERFILE.read_text()
+        static_lines: list[str] = []
+        for raw_line in content.splitlines():
+            stripped = raw_line.strip()
+            # Must be an actual RUN instruction (not a comment)
+            if not self._STATIC_PIP_RUN_RE.match(stripped):
+                continue
+            # Exclude dynamic shell substitution installs
+            if "$(" in stripped:
+                continue
+            # Exclude local path installs (token starting with / or ./)
+            if re.search(r"[\s'](?:/|\./)[\w/.]", stripped):
+                continue
+            # Exclude continuation lines with no package name (just flags + backslash)
+            # i.e. lines that only contain pip install flags and end with backslash
+            rest = re.sub(r"\bRUN\s+pip\s+install\b", "", stripped).strip()
+            # rest is everything after "pip install"; strip flags
+            rest_no_flags = re.sub(r"--\S+", "", rest).strip().rstrip("\\").strip()
+            if not rest_no_flags:
+                continue
+            static_lines.append(stripped)
+        return static_lines
+
+    def test_no_unpinned_static_pip_installs(self) -> None:
+        """Every static pip install must include an == version pin — see #1209."""
+        static_lines = self._collect_static_pip_install_lines()
+        assert static_lines, "Expected at least one static pip install line in Dockerfile"
+        unpinned: list[str] = []
+        for line in static_lines:
+            # Extract package tokens after stripping flags (--foo) and the RUN prefix
+            rest = re.sub(r"\bRUN\s+pip\s+install\b", "", line).strip()
+            rest_no_flags = re.sub(r"--\S+", "", rest).strip()
+            # Each remaining token should be a package with ==
+            tokens = rest_no_flags.split()
+            for token in tokens:
+                # Allow quoted tokens like "pkg==1.2.3" or 'pkg==1.2.3'
+                token_clean = token.strip("\"'\\")
+                if not token_clean:
+                    continue
+                if "==" not in token_clean:
+                    unpinned.append(line)
+                    break
+        assert not unpinned, (
+            "Found static pip install(s) without == pin — see #1209:\n"
+            + "\n".join(f"  {ln}" for ln in unpinned)
+        )


### PR DESCRIPTION
## Summary
- Audits all `pip install` lines in `docker/Dockerfile` for issue #1209
- Confirms `hatchling==1.27.0` is the only static pip install and is already pinned (fixed by #1141)
- Adds an audit comment to the Dockerfile documenting that all static installs are pinned
- Adds `TestAllStaticPipInstallsPinned` regression test class to prevent future unpinned static pip installs

## Test plan
- [ ] `TestAllStaticPipInstallsPinned::test_no_unpinned_static_pip_installs` verifies no static pip install in the Dockerfile lacks a `==` pin
- [ ] Existing `TestHatchlingPinned` tests continue to pass
- [ ] Pre-commit hooks pass (`ruff-format`, `ruff-check`, `mypy`)
- [ ] Coverage threshold met (79.68% > 75% required)

Closes #1209

🤖 Generated with [Claude Code](https://claude.com/claude-code)