### PR TITLE
[Feat] Add mean_strategic_drift to summary.json export

### DIFF
--- a/scripts/export_data.py
+++ b/scripts/export_data.py
@@ -719,6 +719,9 @@ def main() -> None:
             "mean_pr_revert_rate": float(runs_df["pr_revert_rate"].dropna().mean())
             if not runs_df["pr_revert_rate"].dropna().empty
             else None,
+            "mean_strategic_drift": float(runs_df["strategic_drift"].dropna().mean())
+            if not runs_df["strategic_drift"].dropna().empty
+            else None,
         },
         "by_model": {},
     }
@@ -753,6 +756,7 @@ def main() -> None:
         model_r_prog = model_df["r_prog"].dropna()
         model_cfp = model_df["cfp"].dropna()
         model_pr_revert_rate = model_df["pr_revert_rate"].dropna()
+        model_strategic_drift = model_df["strategic_drift"].dropna()
 
         summary["by_model"][model] = {
             "total_runs": len(model_df),
@@ -783,6 +787,9 @@ def main() -> None:
             "mean_pr_revert_rate": float(model_pr_revert_rate.mean())
             if not model_pr_revert_rate.empty
             else None,
+            "mean_strategic_drift": float(model_strategic_drift.mean())
+            if not model_strategic_drift.empty
+            else None,
         }
 
     # Add by_tier statistics (aggregated across all models)
@@ -803,6 +810,7 @@ def main() -> None:
         tier_r_prog = tier_df["r_prog"].dropna()
         tier_cfp = tier_df["cfp"].dropna()
         tier_pr_revert_rate = tier_df["pr_revert_rate"].dropna()
+        tier_strategic_drift = tier_df["strategic_drift"].dropna()
 
         summary["by_tier"][tier] = {
             "total_runs": len(tier_df),
@@ -821,6 +829,9 @@ def main() -> None:
             "mean_cfp": float(tier_cfp.mean()) if not tier_cfp.empty else None,
             "mean_pr_revert_rate": float(tier_pr_revert_rate.mean())
             if not tier_pr_revert_rate.empty
+            else None,
+            "mean_strategic_drift": float(tier_strategic_drift.mean())
+            if not tier_strategic_drift.empty
             else None,
         }
 

--- a/tests/unit/analysis/conftest.py
+++ b/tests/unit/analysis/conftest.py
@@ -86,6 +86,9 @@ def sample_runs_df():
                     pr_revert_rate = (
                         np.random.uniform(0.0, 0.3) if np.random.random() > 0.1 else np.nan
                     )
+                    strategic_drift = (
+                        np.random.uniform(0.0, 0.3) if np.random.random() > 0.1 else np.nan
+                    )
 
                     data.append(
                         {
@@ -112,6 +115,7 @@ def sample_runs_df():
                             "r_prog": r_prog,
                             "cfp": cfp,
                             "pr_revert_rate": pr_revert_rate,
+                            "strategic_drift": strategic_drift,
                         }
                     )
 

--- a/tests/unit/analysis/test_export_data.py
+++ b/tests/unit/analysis/test_export_data.py
@@ -342,7 +342,12 @@ def test_process_metrics_in_summary(sample_runs_df):
     tier_order = derive_tier_order(sample_runs_df)
 
     # --- overall_stats ---
-    process_metric_keys = ["mean_r_prog", "mean_cfp", "mean_pr_revert_rate"]
+    process_metric_keys = [
+        "mean_r_prog",
+        "mean_cfp",
+        "mean_pr_revert_rate",
+        "mean_strategic_drift",
+    ]
 
     overall_stats: dict[str, Any] = {
         "mean_r_prog": float(sample_runs_df["r_prog"].dropna().mean())
@@ -353,6 +358,9 @@ def test_process_metrics_in_summary(sample_runs_df):
         else None,
         "mean_pr_revert_rate": float(sample_runs_df["pr_revert_rate"].dropna().mean())
         if not sample_runs_df["pr_revert_rate"].dropna().empty
+        else None,
+        "mean_strategic_drift": float(sample_runs_df["strategic_drift"].dropna().mean())
+        if not sample_runs_df["strategic_drift"].dropna().empty
         else None,
     }
 
@@ -376,6 +384,9 @@ def test_process_metrics_in_summary(sample_runs_df):
             "mean_pr_revert_rate": float(model_df["pr_revert_rate"].dropna().mean())
             if not model_df["pr_revert_rate"].dropna().empty
             else None,
+            "mean_strategic_drift": float(model_df["strategic_drift"].dropna().mean())
+            if not model_df["strategic_drift"].dropna().empty
+            else None,
         }
         for key in process_metric_keys:
             assert key in by_model_stats, f"by_model[{model}] missing {key}"
@@ -396,6 +407,9 @@ def test_process_metrics_in_summary(sample_runs_df):
             else None,
             "mean_pr_revert_rate": float(tier_df["pr_revert_rate"].dropna().mean())
             if not tier_df["pr_revert_rate"].dropna().empty
+            else None,
+            "mean_strategic_drift": float(tier_df["strategic_drift"].dropna().mean())
+            if not tier_df["strategic_drift"].dropna().empty
             else None,
         }
         for key in process_metric_keys:


### PR DESCRIPTION
## Summary
- Add `mean_strategic_drift` to `overall_stats`, `by_model`, and `by_tier` sections in `scripts/export_data.py`
- Uses the same `dropna()` + empty-guard + `float()` pattern as the existing `mean_r_prog`, `mean_cfp`, and `mean_pr_revert_rate` fields
- Add `strategic_drift` column to `sample_runs_df` fixture in `tests/unit/analysis/conftest.py`
- Update `test_process_metrics_in_summary` to verify all four process metrics (including the new `mean_strategic_drift`)

## Test plan
- [x] `pre-commit run --files scripts/export_data.py tests/unit/analysis/conftest.py tests/unit/analysis/test_export_data.py` — all hooks pass
- [x] `pixi run python -m pytest tests/unit/analysis/test_export_data.py -v` — all 10 tests pass
- [x] Full suite: 3443 passed, coverage 79.63% (above 75% threshold)

Closes #1185

🤖 Generated with [Claude Code](https://claude.com/claude-code)