### PR TITLE
[CI] Add doc consistency check to CI test matrix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -76,6 +76,10 @@ jobs:
           restore-keys: |
             pixi-${{ runner.os }}-
 
+      - name: Check doc/config consistency
+        if: matrix.test-group.name == 'unit'
+        run: pixi run python scripts/check_doc_config_consistency.py --verbose
+
       - name: Run ${{ matrix.test-group.name }} tests
         env:
           TEST_PATH: ${{ matrix.test-group.path }}


### PR DESCRIPTION
## Summary
- Adds a `Check doc/config consistency` step to `.github/workflows/test.yml` that runs `scripts/check_doc_config_consistency.py --verbose`
- The step runs only for the `unit` test matrix job to avoid duplicate execution
- The step is placed after pixi installation (required for Python) and before the test run

## Test plan
- [ ] CI passes on this PR with the new step visible in the unit job
- [ ] The doc consistency check step reports `PASS` for both coverage threshold and `--cov` path checks
- [ ] The integration job is unaffected (step is skipped via `if: matrix.test-group.name == 'unit'`)

Closes #1229

🤖 Generated with [Claude Code](https://claude.com/claude-code)