### PR TITLE
[Fix] load_rubric_weights() returns {} instead of None

### DIFF
--- a/scylla/analysis/loader.py
+++ b/scylla/analysis/loader.py
@@ -821,7 +821,7 @@ def load_rubric_weights(
     data_dir: Path,
     exclude: list[str] | None = None,
     rubric_conflict: RubricConflict = "error",
-) -> dict[str, float] | None:
+) -> dict[str, float]:
     """Load and merge category weights from all experiments' rubric.yaml files.
 
     Scans every experiment directory for rubric.yaml and parses
@@ -842,7 +842,7 @@ def load_rubric_weights(
         rubric_conflict: Policy for handling conflicting rubric weights.
 
     Returns:
-        Dictionary mapping category names to weights, or ``None`` if no
+        Dictionary mapping category names to weights, or ``{}`` if no
         rubric.yaml was found in any experiment.
 
     Raises:
@@ -915,6 +915,6 @@ def load_rubric_weights(
                 accumulated[cat_name] = (new_weight, exp_name)
 
     if not found_any:
-        return None
+        return {}
 
     return {cat: weight for cat, (weight, _) in accumulated.items()}

--- a/tests/unit/analysis/test_loader.py
+++ b/tests/unit/analysis/test_loader.py
@@ -881,8 +881,8 @@ def test_load_rubric_weights_from_rubric_yaml(tmp_path):
     assert weights["proportionality"] == pytest.approx(3.0)
 
 
-def test_load_rubric_weights_returns_none_if_missing(tmp_path):
-    """Test load_rubric_weights() returns None if no rubric.yaml found."""
+def test_load_rubric_weights_returns_empty_dict_if_missing(tmp_path):
+    """Test load_rubric_weights() returns {} if no rubric.yaml found."""
     from scylla.analysis.loader import load_rubric_weights
 
     # Create empty data directory
@@ -892,8 +892,8 @@ def test_load_rubric_weights_returns_none_if_missing(tmp_path):
     # Load weights from empty directory
     weights = load_rubric_weights(data_dir)
 
-    # Should return None
-    assert weights is None
+    # Should return empty dict (never None)
+    assert weights == {}
 
 
 def test_load_rubric_weights_excludes_experiments(tmp_path):


### PR DESCRIPTION
## Summary
- Fix `load_rubric_weights()` in `scylla/analysis/loader.py` to return `{}` instead of `None` when no rubric.yaml files are found in any experiment directory
- Update return type annotation from `dict[str, float] | None` to `dict[str, float]`
- Update docstring to reflect the new return value
- Update the test `test_load_rubric_weights_returns_none_if_missing` → `test_load_rubric_weights_returns_empty_dict_if_missing` to assert `weights == {}` instead of `weights is None`

## Test plan
- [x] `pixi run python -m pytest tests/ -k "rubric" -v` — 63 rubric tests pass
- [x] `pre-commit run --all-files` — all hooks pass
- [x] Full test suite: 3444 tests pass, 79.68% coverage (above 75% threshold)

Closes #1130

🤖 Generated with [Claude Code](https://claude.com/claude-code)