### PR TITLE
[Config] Add scripts/ to pytest pythonpath

### DIFF
--- a/tests/unit/analysis/test_cop_integration.py
+++ b/tests/unit/analysis/test_cop_integration.py
@@ -1,11 +1,5 @@
 """Tests for CoP and Frontier CoP integration (Issue #325)."""
 
-import sys
-from pathlib import Path
-
-# Add scripts directory to path
-sys.path.insert(0, str(Path(__file__).parent.parent.parent.parent / "scripts"))
-
 
 def test_cop_frontier_cop_integration(sample_runs_df):
     """Test that CoP and Frontier CoP are integrated (Issue #325)."""

--- a/tests/unit/analysis/test_duration_integration.py
+++ b/tests/unit/analysis/test_duration_integration.py
@@ -1,11 +1,5 @@
 """Tests for duration_seconds integration (Issue #327 partial)."""
 
-import sys
-from pathlib import Path
-
-# Add scripts directory to path
-sys.path.insert(0, str(Path(__file__).parent.parent.parent.parent / "scripts"))
-
 
 def test_duration_seconds_integration(sample_runs_df):
     """Test that duration_seconds is integrated into statistical tests (Issue #327)."""

--- a/tests/unit/e2e/test_manage_experiment.py
+++ b/tests/unit/e2e/test_manage_experiment.py
@@ -55,16 +55,11 @@ from __future__ import annotations
 
 import json
 import logging
-import sys
 from pathlib import Path
 from typing import Any
 from unittest.mock import patch
 
 import pytest
-
-# Ensure scripts/ is importable
-sys.path.insert(0, str(Path(__file__).parent.parent.parent.parent / "scripts"))
-
 from manage_experiment import MODEL_ALIASES, build_parser, cmd_repair, cmd_visualize
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/scripts/test_validate_model_configs.py
+++ b/tests/unit/scripts/test_validate_model_configs.py
@@ -1,19 +1,11 @@
 """Tests for scripts/validate_model_configs.py."""
 
-import sys
 from pathlib import Path
 from unittest import mock
 
 import pytest
 import yaml
-
-# The script lives in scripts/ which isn't on sys.path by default.
-# Insert it so we can import helper functions directly.
-_SCRIPTS_DIR = Path(__file__).parents[3] / "scripts"
-if str(_SCRIPTS_DIR) not in sys.path:
-    sys.path.insert(0, str(_SCRIPTS_DIR))
-
-from validate_model_configs import (  # noqa: E402
+from validate_model_configs import (
     _collect_mismatches,
     _confirm_rename,
     _fix_mismatch,


### PR DESCRIPTION
## Summary

- `pyproject.toml` already declares `pythonpath = [".", "scripts"]` (added in commit `19ef062`); this PR closes the audit loop for issue #1191
- Removes redundant `sys.path.insert()` calls from four test files that pre-dated the `pyproject.toml` fix
- CI audit confirmed: all `pytest` invocations in `.github/workflows/test.yml` use `pixi run pytest` from the repo root without `--override-ini` or custom `--rootdir`, so `pyproject.toml`'s `pythonpath` applies to both local runs and CI

## Changed files

- `tests/unit/analysis/test_cop_integration.py` — remove manual `sys.path.insert`
- `tests/unit/analysis/test_duration_integration.py` — remove manual `sys.path.insert`
- `tests/unit/scripts/test_validate_model_configs.py` — remove manual `sys.path.insert` guard
- `tests/unit/e2e/test_manage_experiment.py` — remove manual `sys.path.insert` and unused `import sys`

## Test plan

- [ ] Pre-commit hooks pass on changed files (ruff, mypy, format)
- [ ] `pixi run python -m pytest tests/ -x -q --co` collects 3457 tests
- [ ] All 3457 tests pass with 79.57% coverage (above 75% threshold)

Closes #1191