### PR TITLE
[CI] Add CI check for tests/unit/ structure enforcement

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -80,6 +80,10 @@ jobs:
         if: matrix.test-group.name == 'unit'
         run: pixi run python scripts/check_doc_config_consistency.py --verbose
 
+      - name: Enforce tests/unit/ structure conventions
+        if: matrix.test-group.name == 'unit'
+        run: pixi run python scripts/check_unit_test_structure.py
+
       - name: Run ${{ matrix.test-group.name }} tests
         env:
           TEST_PATH: ${{ matrix.test-group.path }}


### PR DESCRIPTION
## Summary
- Adds a new step **"Enforce tests/unit/ structure conventions"** to `.github/workflows/test.yml`
- Runs `python scripts/check_unit_test_structure.py` (already existed from #967) in CI
- Step is gated on `matrix.test-group.name == 'unit'` to run only once per push
- Blocks merging if any `test_*.py` file is placed directly under `tests/unit/` instead of a mirrored sub-package

## Test plan
- [ ] CI passes with no violations on this PR
- [ ] Verify the step appears in the Actions run for the unit test matrix job
- [ ] Manually confirm: adding a `test_foo.py` directly under `tests/unit/` would cause `check_unit_test_structure.py` to exit 1

Closes #1123