### PR TITLE
[Fix] Pin tomllib extraction to specific pyproject.toml key path

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -55,8 +55,9 @@ RUN pip install --user --no-cache-dir \
     $(python3 -c "
 import tomllib, os
 data = tomllib.load(open('/opt/scylla/pyproject.toml', 'rb'))
-deps = list(data['project']['dependencies'])
-opt = data['project'].get('optional-dependencies', {})
+project = data.get('project', {})
+deps = list(project.get('dependencies', []))
+opt = project.get('optional-dependencies', {})
 for group in [g.strip() for g in os.environ.get('EXTRAS', '').split(',') if g.strip()]:
     deps.extend(opt.get(group, []))
 print(' '.join(deps))


### PR DESCRIPTION
Closes #1176

## Summary
- Replace direct key access `data['project']['dependencies']` with chained `.get()` calls to handle missing keys gracefully
- `data.get('project', {})` prevents `KeyError` if the `[project]` table is absent from `pyproject.toml`
- `project.get('dependencies', [])` prevents `KeyError` if the `dependencies` key is missing, returning an empty list instead

## Test plan
- [ ] Pre-commit hooks pass (all checks green)
- [ ] Docker build proceeds without crash when `pyproject.toml` has no `[project]` section
- [ ] Normal build path unchanged — existing `pyproject.toml` values extracted correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)