### PR TITLE
[Test] Mock time.sleep in remaining tests using real delays

### DIFF
--- a/tests/unit/automation/test_retry.py
+++ b/tests/unit/automation/test_retry.py
@@ -68,7 +68,8 @@ class TestRetryWithBackoff:
         mock_func = MagicMock(side_effect=[ValueError("fail"), ValueError("fail"), "success"])
         decorated = retry_with_backoff(max_retries=3, initial_delay=0.01)(mock_func)
 
-        result = decorated()
+        with patch("scylla.automation.retry.time.sleep"):
+            result = decorated()
 
         assert result == "success"
         assert mock_func.call_count == 3
@@ -78,8 +79,9 @@ class TestRetryWithBackoff:
         mock_func = MagicMock(side_effect=ValueError("fail"))
         decorated = retry_with_backoff(max_retries=2, initial_delay=0.01)(mock_func)
 
-        with pytest.raises(ValueError, match="fail"):
-            decorated()
+        with patch("scylla.automation.retry.time.sleep"):
+            with pytest.raises(ValueError, match="fail"):
+                decorated()
 
         assert mock_func.call_count == 3  # initial + 2 retries
 
@@ -108,8 +110,9 @@ class TestRetryWithBackoff:
             mock_func
         )
 
-        with pytest.raises(TypeError):
-            decorated()
+        with patch("scylla.automation.retry.time.sleep"):
+            with pytest.raises(TypeError):
+                decorated()
 
         # Should not retry since TypeError is not in retry_on
         assert mock_func.call_count == 1
@@ -122,7 +125,8 @@ class TestRetryWithBackoff:
             mock_func
         )
 
-        result = decorated()
+        with patch("scylla.automation.retry.time.sleep"):
+            result = decorated()
 
         assert result == "success"
         assert mock_logger.call_count == 1
@@ -161,7 +165,8 @@ class TestRetryOnNetworkError:
         mock_func = MagicMock(side_effect=[ConnectionError("connection refused"), "success"])
         decorated = retry_on_network_error(max_retries=2)(mock_func)
 
-        result = decorated()
+        with patch("scylla.automation.retry.time.sleep"):
+            result = decorated()
 
         assert result == "success"
         assert mock_func.call_count == 2
@@ -171,7 +176,8 @@ class TestRetryOnNetworkError:
         mock_func = MagicMock(side_effect=[TimeoutError("timed out"), "success"])
         decorated = retry_on_network_error(max_retries=2)(mock_func)
 
-        result = decorated()
+        with patch("scylla.automation.retry.time.sleep"):
+            result = decorated()
 
         assert result == "success"
         assert mock_func.call_count == 2


### PR DESCRIPTION
## Summary
- Patch `scylla.automation.retry.time.sleep` in six test methods that previously allowed real delays to execute
- Four tests in `TestRetryWithBackoff`: `test_retries_on_failure`, `test_raises_after_max_retries`, `test_respects_retry_on_parameter`, `test_logger_called_on_retry`
- Two tests in `TestRetryOnNetworkError`: `test_retries_connection_error`, `test_retries_timeout_error` (these used the 2.0s default network delay)

## Test plan
- [x] `pixi run python -m pytest tests/unit/automation/test_retry.py -v` — all 26 tests pass
- [x] `pre-commit run --all-files` — all hooks pass

Closes #1218

🤖 Generated with [Claude Code](https://claude.com/claude-code)