### PR TITLE
[Fix] Fix broken mock patch target in analysis conftest

### DIFF
--- a/tests/unit/analysis/conftest.py
+++ b/tests/unit/analysis/conftest.py
@@ -18,11 +18,11 @@ def mock_power_simulations():
     Tests that call compute_statistical_results() only need to assert the *structure*
     of the output (keys, types, list membership) — the exact power values are irrelevant.
     """
-    # Patch in export_data's namespace (it uses `from scylla.analysis.stats import ...`)
+    # Patch in scripts.export_data's namespace (it uses `from scylla.analysis.stats import ...`)
     # and also in scylla.analysis.stats for any direct callers
     with (
-        patch("export_data.mann_whitney_power", return_value=0.8, create=True),
-        patch("export_data.kruskal_wallis_power", return_value=0.75, create=True),
+        patch("scripts.export_data.mann_whitney_power", return_value=0.8),
+        patch("scripts.export_data.kruskal_wallis_power", return_value=0.75),
         patch("scylla.analysis.stats.mann_whitney_power", return_value=0.8),
         patch("scylla.analysis.stats.kruskal_wallis_power", return_value=0.75),
     ):


### PR DESCRIPTION
## Summary
- Replace `patch("export_data.mann_whitney_power", ..., create=True)` with `patch("scripts.export_data.mann_whitney_power", ...)` in the `mock_power_simulations` autouse fixture
- Remove `create=True` since the attribute exists on the properly-imported module
- The old path caused `ModuleNotFoundError: No module named 'export_data'` because `export_data` is a top-level name that requires `scripts/` to already be on `sys.path`, which is not guaranteed at conftest load time

## Root Cause
`scripts/export_data.py` imports `mann_whitney_power` from `scylla.analysis.stats`. The conftest was patching `export_data.mann_whitney_power` (bare module name), which fails because `export_data` is not importable as a standalone module without `scripts/` in `sys.path`. The correct fully-qualified path is `scripts.export_data.mann_whitney_power`.

Closes #1128

🤖 Generated with [Claude Code](https://claude.com/claude-code)