### PR TITLE
[CI] Add tests/shell/** trigger path to docker-test.yml

### DIFF
--- a/.github/workflows/docker-test.yml
+++ b/.github/workflows/docker-test.yml
@@ -4,11 +4,13 @@ on:
   pull_request:
     paths:
       - 'docker/**'
+      - 'tests/shell/**'
       - '.github/workflows/docker-test.yml'
   push:
     branches: [main]
     paths:
       - 'docker/**'
+      - 'tests/shell/**'
       - '.github/workflows/docker-test.yml'
 
 jobs:


### PR DESCRIPTION
## Summary

- Adds `tests/shell/**` to the `paths:` trigger in both `pull_request` and `push` blocks of `.github/workflows/docker-test.yml`
- Ensures the Docker Validation workflow fires when shell tests (e.g., future BATS tests for `docker/entrypoint.sh`) change, preventing silent bypass of Docker validation

## Test plan

- [ ] Verify YAML Lint passes (confirmed locally via pre-commit)
- [ ] After merge, confirm that a branch touching only `tests/shell/**` triggers the Docker Validation workflow
- [ ] Confirm a branch touching only `docker/**` still triggers the workflow (existing glob unchanged)

Closes #1160

🤖 Generated with [Claude Code](https://claude.com/claude-code)