### PR TITLE
[Test] Add process metric columns to test structure check

### DIFF
--- a/scylla/analysis/dataframes.py
+++ b/scylla/analysis/dataframes.py
@@ -272,6 +272,18 @@ def build_subtests_df(runs_df: pd.DataFrame) -> pd.DataFrame:
         mode_result = group["grade"].mode()
         modal_grade = mode_result[0] if len(mode_result) > 0 else "F"
 
+        # Process metrics (median across runs; NaN when column absent or all-null)
+        def _median_process(col: str) -> float:
+            if col not in group.columns:
+                return np.nan
+            vals = group[col].dropna()
+            return float(vals.median()) if len(vals) > 0 else np.nan
+
+        median_r_prog = _median_process("r_prog")
+        median_cfp = _median_process("cfp")
+        median_pr_revert_rate = _median_process("pr_revert_rate")
+        median_strategic_drift = _median_process("strategic_drift")
+
         return pd.Series(
             {
                 "pass_rate": pass_rate,
@@ -293,6 +305,10 @@ def build_subtests_df(runs_df: pd.DataFrame) -> pd.DataFrame:
                 "grade_D": grade_d,
                 "grade_F": grade_f,
                 "modal_grade": modal_grade,
+                "median_r_prog": median_r_prog,
+                "median_cfp": median_cfp,
+                "median_pr_revert_rate": median_pr_revert_rate,
+                "median_strategic_drift": median_strategic_drift,
             }
         )
 

--- a/tests/unit/analysis/conftest.py
+++ b/tests/unit/analysis/conftest.py
@@ -261,6 +261,13 @@ def sample_subtests_df(sample_runs_df):
         mode_result = group["grade"].mode()
         modal_grade = mode_result[0] if len(mode_result) > 0 else "F"
 
+        # Process metrics (median across runs; NaN when column absent or all-null)
+        def _median_process(col: str) -> float:
+            if col not in group.columns:
+                return np.nan
+            vals = group[col].dropna()
+            return float(vals.median()) if len(vals) > 0 else np.nan
+
         return pd.Series(
             {
                 "pass_rate": pass_rate,
@@ -282,6 +289,10 @@ def sample_subtests_df(sample_runs_df):
                 "grade_D": grade_d,
                 "grade_F": grade_f,
                 "modal_grade": modal_grade,
+                "median_r_prog": _median_process("r_prog"),
+                "median_cfp": _median_process("cfp"),
+                "median_pr_revert_rate": _median_process("pr_revert_rate"),
+                "median_strategic_drift": _median_process("strategic_drift"),
             }
         )
 

--- a/tests/unit/analysis/test_dataframes.py
+++ b/tests/unit/analysis/test_dataframes.py
@@ -144,6 +144,11 @@ def test_build_subtests_df_structure(sample_subtests_df):
         "grade_D",
         "grade_F",
         "modal_grade",
+        # Process metrics (median per subtest; NaN when not available)
+        "median_r_prog",
+        "median_cfp",
+        "median_pr_revert_rate",
+        "median_strategic_drift",
     ]
 
     for col in required_cols:


### PR DESCRIPTION
## Summary
- Extends `build_subtests_df()` in `scylla/analysis/dataframes.py` to aggregate process metrics (`median_r_prog`, `median_cfp`, `median_pr_revert_rate`, `median_strategic_drift`) from `runs_df`
- Updates the `sample_subtests_df` fixture in `tests/unit/analysis/conftest.py` to compute and include these columns, keeping fixture in sync with production
- Adds the four process metric columns to the `test_build_subtests_df_structure` structure check in `tests/unit/analysis/test_dataframes.py`

## Test plan
- [x] `test_build_subtests_df_structure` now asserts all four process metric columns are present
- [x] All 349 analysis unit tests pass
- [x] All 3480 tests pass with 79.64% coverage (above 75% threshold)
- [x] All pre-commit hooks pass (ruff, mypy, black, shellcheck, etc.)

Closes #1188