### PR TITLE
[Config] Pin hatchling version in build-system requires

### DIFF
--- a/pixi.lock
+++ b/pixi.lock
@@ -3764,7 +3764,7 @@ packages:
 - pypi: ./
   name: scylla
   version: 0.1.0
-  sha256: aed57b045aa5a7cba6f2b6acc74c0b3ddea2b8612997f3ccaf0e9934426358eb
+  sha256: b9b78dd8f97ead460f79f6b7a3d7fd4b64ce207bcb1de289f12b3e8085bee453
   requires_dist:
   - click>=8.0
   - pydantic>=2.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["hatchling"]
+requires = ["hatchling>=1.27.0,<2"]
 build-backend = "hatchling.build"
 
 [project]


### PR DESCRIPTION
## Summary
- Pin `hatchling` to `>=1.27.0,<2` in `[build-system].requires` in `pyproject.toml`
- Aligns with the `hatchling==1.27.0` pin already present in `docker/Dockerfile` (added in #1236)
- Allows patch-level updates while bounding the major version

## Test plan
- [x] Pre-commit hooks pass (ruff, mypy, yaml/markdown lint, pip-audit)
- [x] Full test suite passes (3491 tests, 79.57% coverage >= 75% threshold)

Closes #1207

> Note: This replaces PR #1262 which had merge conflicts with main.