### PR TITLE
[Config] Register 'integration' pytest mark in pyproject.toml

### DIFF
--- a/pixi.lock
+++ b/pixi.lock
@@ -3764,7 +3764,7 @@ packages:
 - pypi: ./
   name: scylla
   version: 0.1.0
-  sha256: 2e24775cdbf2d95c4dcdeca50a367ed0c2248dc4ce2f72612c571ae077d37eff
+  sha256: 0227ee7871feb3e66abc4a48cd88a1f7b39c6542a4d9bd9fcac973ee14919484
   requires_dist:
   - click>=8.0
   - pydantic>=2.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -101,6 +101,9 @@ addopts = [
     "--cov-report=html",
     "--cov-fail-under=9",
 ]
+markers = [
+    "integration: marks tests as integration tests (deselect with '-m \"not integration\"')",
+]
 
 [tool.mypy]
 python_version = "3.10"


### PR DESCRIPTION
## Summary
- Adds `integration` to the `markers` list in `[tool.pytest.ini_options]` in `pyproject.toml`
- Prevents `pytest --strict-markers` from failing when the `@pytest.mark.integration` marker is used
- Regenerates `pixi.lock` to reflect the updated configuration

Closes #1156

## Test plan
- [ ] Verify `pytest --strict-markers` passes with the integration marker defined
- [ ] Confirm `pixi.lock` is up to date

🤖 Generated with [Claude Code](https://claude.com/claude-code)