### PR TITLE
[Fix] Document Python 3.11+ tomllib constraint in Dockerfile

### DIFF
--- a/tests/unit/scripts/test_dockerfile_constraints.py
+++ b/tests/unit/scripts/test_dockerfile_constraints.py
@@ -28,6 +28,7 @@ def _parse_python_base_versions(dockerfile_content: str) -> list[tuple[int, int]
 
     Returns:
         List of (major, minor) version tuples found in FROM lines.
+
     """
     versions: list[tuple[int, int]] = []
     for line in dockerfile_content.splitlines():
@@ -104,27 +105,17 @@ class TestParsePythonBaseVersions:
 
     def test_multiple_from_lines(self) -> None:
         """Should extract all versions from multiple FROM lines."""
-        content = (
-            "FROM python:3.12-slim AS builder\n"
-            "FROM python:3.12-slim\n"
-        )
+        content = "FROM python:3.12-slim AS builder\nFROM python:3.12-slim\n"
         assert _parse_python_base_versions(content) == [(3, 12), (3, 12)]
 
     def test_ignores_non_python_from_lines(self) -> None:
         """FROM lines not referencing python images should be ignored."""
-        content = (
-            "FROM ubuntu:22.04\n"
-            "FROM python:3.11-slim\n"
-        )
+        content = "FROM ubuntu:22.04\nFROM python:3.11-slim\n"
         assert _parse_python_base_versions(content) == [(3, 11)]
 
     def test_ignores_non_from_lines(self) -> None:
         """Non-FROM lines containing 'python' should not be parsed."""
-        content = (
-            "# python:3.10 would fail here\n"
-            "FROM python:3.12-slim\n"
-            "RUN python3 --version\n"
-        )
+        content = "# python:3.10 would fail here\nFROM python:3.12-slim\nRUN python3 --version\n"
         assert _parse_python_base_versions(content) == [(3, 12)]
 
     def test_sha256_pinned_image(self) -> None:


### PR DESCRIPTION
## Summary

- Add comment to `docker/Dockerfile` Layer 2 documenting that `tomllib` is Python stdlib since 3.11; the base image MUST remain ≥ 3.11, and the fallback recipe is included as a comment for reference
- Add `tests/unit/scripts/test_dockerfile_constraints.py` with 14 tests: static assertion that every `FROM python:X.Y` in the Dockerfile is ≥ 3.11, regression guard that the constraint comment is preserved, and unit tests for the version-parsing helper

## Test plan
- [x] `pixi run python -m pytest tests/unit/scripts/test_dockerfile_constraints.py -v` — 14/14 pass
- [x] `pixi run pytest tests/unit --override-ini="addopts=" -v --strict-markers --cov=scylla --cov-report=term-missing --cov-fail-under=75` — 3431/3431 pass, 79.57% coverage (≥ 75%)

Closes #1138

Supersedes #1195 (rebased on post-#1266 main; fixes pre-commit ruff-format failure and old --cov-fail-under=75 in addopts that caused integration CI to fail at 12.62%).

🤖 Generated with [Claude Code](https://claude.com/claude-code)