### PR TITLE
fix(docker): pin hatchling version in builder stage

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -30,7 +30,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 # Pinned to match pyproject.toml [build-system].requires — see #1141
 # Audit (#1209): all static pip installs are pinned; dynamic Layer 2 install
 # (from pyproject.toml via tomllib) is intentionally version-spec controlled there.
-RUN pip install --no-cache-dir "hatchling==1.27.0"
+RUN pip install --no-cache-dir "hatchling==1.29.0"
 
 # Layer 2: Dependencies (invalidated only when pyproject.toml changes or EXTRAS changes)
 # Copy only pyproject.toml first so dependency installs are cached separately

--- a/tests/unit/e2e/test_dockerfile.py
+++ b/tests/unit/e2e/test_dockerfile.py
@@ -17,7 +17,7 @@ class TestHatchlingPinned:
         match = re.search(r"pip install.*hatchling([^\n]*)", content)
         assert match is not None, "pip install hatchling line not found in Dockerfile"
         assert "==" in match.group(0), (
-            "hatchling must be pinned with == (e.g. hatchling==1.27.0); found unpinned install"
+            "hatchling must be pinned with == (e.g. hatchling==1.29.0); found unpinned install"
         )
 
     def test_hatchling_version_format(self) -> None:
@@ -26,7 +26,7 @@ class TestHatchlingPinned:
         match = re.search(r'pip install.*["\']?hatchling==(\d+\.\d+\.\d+)["\']?', content)
         assert match is not None, (
             "hatchling must be pinned with a full X.Y.Z version "
-            "(e.g. hatchling==1.27.0) in Dockerfile"
+            "(e.g. hatchling==1.29.0) in Dockerfile"
         )
         version = match.group(1)
         parts = version.split(".")


### PR DESCRIPTION
## Summary

- Bump `hatchling` pin from `==1.27.0` to `==1.29.0` (latest release, within the `>=1.27.0,<2` constraint in `pyproject.toml`) in the `docker/Dockerfile` builder stage
- Update test error messages in `tests/unit/e2e/test_dockerfile.py` to reference the new version

## Test plan

- [x] `test_hatchling_is_pinned` passes — verifies the exact `==` specifier is present
- [x] `test_hatchling_version_format` passes — verifies valid X.Y.Z format
- [x] `test_no_unpinned_static_pip_installs` passes — verifies all static pip installs are pinned
- [x] Full suite: 3505 tests pass, coverage 67.36% (≥ 9% combined threshold, ≥ 75% unit threshold)
- [x] Pre-commit hooks pass on changed files

Closes #1141

Supersedes #1203 (rebased on post-#1266 main).

🤖 Generated with [Claude Code](https://claude.com/claude-code)