### PR TITLE
build(deps): bump actions/upload-artifact from 6 to 7

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -49,7 +49,7 @@ jobs:
 
       - name: Upload pre-commit diff
         if: failure()
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: pre-commit-diffs
           retention-days: 7


### PR DESCRIPTION
Bumps `actions/upload-artifact` from v6 to v7 in `.github/workflows/pre-commit.yml`.

Supersedes #1228 (Dependabot PR created before the coverage threshold fix landed on main — its integration test CI was failing with `12.63% < 75%`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)