### PR TITLE
[Feature] Add /clean-worktrees slash command

### DIFF
--- a/.claude/commands/clean-worktrees.md
+++ b/.claude/commands/clean-worktrees.md
@@ -14,6 +14,7 @@ git worktree list --porcelain
 ```
 
 For each worktree branch:
+
 - If the branch name matches `issue-<N>` or `<N>-*`: check `gh issue view <N> --json state` — if `state == "CLOSED"`, mark as DONE
 - If the branch name matches an agent worktree pattern (e.g. `worktree-agent-*`): mark as DONE (these are always stale)
 - Check if a PR exists: `gh pr list --head <branch> --state merged --json number` — if any result, mark as DONE
@@ -28,6 +29,7 @@ Print a table showing each worktree path, branch, status (DONE/KEEP), and reason
 **Process nested worktrees first, then top-level.**
 
 For each DONE worktree:
+
 1. Check if dirty: `git -C <path> status --short`
 2. If clean: `git worktree remove <path>`
 3. If dirty but DONE (issue closed or PR merged): report it and ask user to confirm before using `--force`
@@ -35,11 +37,13 @@ For each DONE worktree:
 ## Step 5: Delete corresponding local branches
 
 For each removed worktree's branch:
+
 ```bash
 git branch -d <branch>  # prefer -d; only use -D if confirmed merged
 ```
 
 For all local branches tracking `[gone]` remotes:
+
 ```bash
 git branch -vv | grep ': gone]'
 # For each: verify merged via gh pr list --head <branch> --state merged
@@ -49,6 +53,7 @@ git branch -vv | grep ': gone]'
 ## Step 6: Delete stale remote branches
 
 For each remote branch (excluding main) that has a closed issue or merged/closed PR:
+
 ```bash
 # Use gh api to bypass local pre-push hooks:
 gh api --method DELETE "repos/{owner}/{repo}/git/refs/heads/<branch>"
@@ -66,6 +71,7 @@ git remote prune origin
 ## Step 8: Summary report
 
 Print final counts:
+
 - Worktrees removed
 - Local branches deleted
 - Remote branches deleted


### PR DESCRIPTION
## Summary
- Adds `.claude/commands/clean-worktrees.md` — a reusable Claude Code slash command
- The command enumerates worktrees, classifies them by issue/PR status, removes done ones, cleans up local and remote branches, and prints a summary
- Uses `gh api` for remote branch deletion to bypass the local pre-push hook

## Test plan
- [ ] `.claude/commands/clean-worktrees.md` exists
- [ ] Pre-commit hooks pass