### PR TITLE
[Refactor] Reduce compute_statistical_results complexity (C901)

### DIFF
--- a/scripts/export_data.py
+++ b/scripts/export_data.py
@@ -43,36 +43,23 @@ def json_nan_handler(obj: Any) -> Any:
     return obj
 
 
-def compute_statistical_results(runs_df: Any, tier_order: list[str]) -> dict[str, Any]:  # noqa: C901  # comprehensive stats computation pipeline
-    """Compute all statistical test results for export.
-
-    Pairwise comparisons use Holm-Bonferroni correction per model.
-    Both raw and corrected p-values are exported for transparency.
+def _compute_normality_tests(
+    runs_df: Any, models: list[str], tier_order: list[str]
+) -> list[dict[str, Any]]:
+    """Compute Shapiro-Wilk normality tests per (model, tier) for four metrics.
 
     Args:
         runs_df: Runs DataFrame
+        models: Sorted list of model identifiers
         tier_order: List of tier IDs in order
 
     Returns:
-        Dictionary of statistical test results with corrected p-values
+        List of normality test result dicts
 
     """
-    results: dict[str, Any] = {
-        "pipeline_version": config.pipeline_version,
-        "config_version": config.config_version,
-        "normality_tests": [],
-        "omnibus_tests": [],
-        "pairwise_comparisons": [],
-        "effect_sizes": [],
-        "power_analysis": [],  # Post-hoc power estimates for pairwise transitions
-        "correlations": [],
-        "tier_descriptives": [],  # Tier-level descriptive statistics (CoP, etc.)
-        "interaction_tests": [],  # Model x Tier interaction analysis
-    }
+    normality_tests: list[dict[str, Any]] = []
+    metric_cols = ["score", "impl_rate", "cost_usd", "duration_seconds"]
 
-    models = sorted(runs_df["agent_model"].unique())
-
-    # Normality tests (Shapiro-Wilk) per (model, tier)
     for model in models:
         for tier in tier_order:
             tier_data = runs_df[(runs_df["agent_model"] == model) & (runs_df["tier"] == tier)]
@@ -80,305 +67,258 @@ def compute_statistical_results(runs_df: Any, tier_order: list[str]) -> dict[str
             if len(tier_data) < 3:
                 continue
 
-            # Test score distribution
-            scores = tier_data["score"].dropna()
-            if len(scores) >= 3:
-                w_stat, p_value = shapiro_wilk(scores)
-                results["normality_tests"].append(
-                    {
-                        "model": model,
-                        "tier": tier,
-                        "metric": "score",
-                        "n": len(scores),
-                        "w_statistic": float(w_stat),
-                        "p_value": float(p_value),
-                        "is_normal": bool(p_value > 0.05),
-                    }
-                )
+            for metric in metric_cols:
+                values = tier_data[metric].dropna()
+                if len(values) >= 3:
+                    w_stat, p_value = shapiro_wilk(values)
+                    normality_tests.append(
+                        {
+                            "model": model,
+                            "tier": tier,
+                            "metric": metric,
+                            "n": len(values),
+                            "w_statistic": float(w_stat),
+                            "p_value": float(p_value),
+                            "is_normal": bool(p_value > 0.05),
+                        }
+                    )
 
-            # Test impl_rate distribution
-            impl_rates = tier_data["impl_rate"].dropna()
-            if len(impl_rates) >= 3:
-                w_stat, p_value = shapiro_wilk(impl_rates)
-                results["normality_tests"].append(
-                    {
-                        "model": model,
-                        "tier": tier,
-                        "metric": "impl_rate",
-                        "n": len(impl_rates),
-                        "w_statistic": float(w_stat),
-                        "p_value": float(p_value),
-                        "is_normal": bool(p_value > 0.05),
-                    }
-                )
+    return normality_tests
 
-            # Test cost distribution
-            costs = tier_data["cost_usd"].dropna()
-            if len(costs) >= 3:
-                w_stat, p_value = shapiro_wilk(costs)
-                results["normality_tests"].append(
-                    {
-                        "model": model,
-                        "tier": tier,
-                        "metric": "cost_usd",
-                        "n": len(costs),
-                        "w_statistic": float(w_stat),
-                        "p_value": float(p_value),
-                        "is_normal": bool(p_value > 0.05),
-                    }
-                )
 
-            # Test duration distribution
-            durations = tier_data["duration_seconds"].dropna()
-            if len(durations) >= 3:
-                w_stat, p_value = shapiro_wilk(durations)
-                results["normality_tests"].append(
-                    {
-                        "model": model,
-                        "tier": tier,
-                        "metric": "duration_seconds",
-                        "n": len(durations),
-                        "w_statistic": float(w_stat),
-                        "p_value": float(p_value),
-                        "is_normal": bool(p_value > 0.05),
-                    }
-                )
+def _compute_omnibus_tests(
+    runs_df: Any, models: list[str], tier_order: list[str]
+) -> list[dict[str, Any]]:
+    """Compute Kruskal-Wallis omnibus tests across tiers per model for three metrics.
 
-    # Omnibus tests (Kruskal-Wallis) across tiers per model
+    Args:
+        runs_df: Runs DataFrame
+        models: Sorted list of model identifiers
+        tier_order: List of tier IDs in order
+
+    Returns:
+        List of omnibus test result dicts
+
+    """
+    omnibus_tests: list[dict[str, Any]] = []
+
     for model in models:
         model_runs = runs_df[runs_df["agent_model"] == model]
 
-        # Collect tier groups for passed metric
-        tier_groups = [
-            model_runs[model_runs["tier"] == tier]["passed"].astype(int) for tier in tier_order
+        metric_configs = [
+            (
+                "pass_rate",
+                [model_runs[model_runs["tier"] == t]["passed"].astype(int) for t in tier_order],
+            ),
+            (
+                "impl_rate",
+                [model_runs[model_runs["tier"] == t]["impl_rate"].dropna() for t in tier_order],
+            ),
+            (
+                "duration_seconds",
+                [
+                    model_runs[model_runs["tier"] == t]["duration_seconds"].dropna()
+                    for t in tier_order
+                ],
+            ),
         ]
-        tier_groups = [g for g in tier_groups if len(g) > 0]
 
-        if len(tier_groups) >= 2:
-            h_stat, p_value = kruskal_wallis(*tier_groups)
-            results["omnibus_tests"].append(
-                {
-                    "model": model,
-                    "metric": "pass_rate",
-                    "n_groups": len(tier_groups),
-                    "h_statistic": float(h_stat),
-                    "p_value": float(p_value),
-                    "is_significant": bool(p_value < 0.05),
-                }
-            )
+        for metric_name, tier_groups_raw in metric_configs:
+            tier_groups = [g for g in tier_groups_raw if len(g) > 0]
+            if len(tier_groups) >= 2:
+                h_stat, p_value = kruskal_wallis(*tier_groups)
+                omnibus_tests.append(
+                    {
+                        "model": model,
+                        "metric": metric_name,
+                        "n_groups": len(tier_groups),
+                        "h_statistic": float(h_stat),
+                        "p_value": float(p_value),
+                        "is_significant": bool(p_value < 0.05),
+                    }
+                )
 
-        # Collect tier groups for impl_rate metric
-        tier_groups_impl = [
-            model_runs[model_runs["tier"] == tier]["impl_rate"].dropna() for tier in tier_order
-        ]
-        tier_groups_impl = [g for g in tier_groups_impl if len(g) > 0]
+    return omnibus_tests
 
-        if len(tier_groups_impl) >= 2:
-            h_stat, p_value = kruskal_wallis(*tier_groups_impl)
-            results["omnibus_tests"].append(
-                {
-                    "model": model,
-                    "metric": "impl_rate",
-                    "n_groups": len(tier_groups_impl),
-                    "h_statistic": float(h_stat),
-                    "p_value": float(p_value),
-                    "is_significant": bool(p_value < 0.05),
-                }
-            )
 
-        # Collect tier groups for duration_seconds metric
-        tier_groups_duration = [
-            model_runs[model_runs["tier"] == tier]["duration_seconds"].dropna()
-            for tier in tier_order
-        ]
-        tier_groups_duration = [g for g in tier_groups_duration if len(g) > 0]
+def _collect_pairwise_pass_rate(
+    model_runs: Any, model: str, tier_order: list[str]
+) -> tuple[list[float], list[dict[str, Any]]]:
+    """Collect raw p-values and metadata for pass_rate pairwise comparisons.
 
-        if len(tier_groups_duration) >= 2:
-            h_stat, p_value = kruskal_wallis(*tier_groups_duration)
-            results["omnibus_tests"].append(
-                {
-                    "model": model,
-                    "metric": "duration_seconds",
-                    "n_groups": len(tier_groups_duration),
-                    "h_statistic": float(h_stat),
-                    "p_value": float(p_value),
-                    "is_significant": bool(p_value < 0.05),
-                }
-            )
+    Includes consecutive tier pairs plus overall first->last contrast.
 
-    # Pairwise comparisons (Mann-Whitney U) between consecutive tiers
-    # plus overall first->last contrast. Holm-Bonferroni is applied to all 7
-    # comparisons together so the family size matches the pairwise table in the paper.
+    Args:
+        model_runs: Runs DataFrame filtered to one model
+        model: Model identifier
+        tier_order: List of tier IDs in order
+
+    Returns:
+        Tuple of (raw_p_values, test_metadata)
+
+    """
+    raw_p_values: list[float] = []
+    test_metadata: list[dict[str, Any]] = []
+
+    for i in range(len(tier_order) - 1):
+        tier1, tier2 = tier_order[i], tier_order[i + 1]
+        tier1_data = model_runs[model_runs["tier"] == tier1]
+        tier2_data = model_runs[model_runs["tier"] == tier2]
+
+        if len(tier1_data) == 0 or len(tier2_data) == 0:
+            continue
+
+        u_stat, p_value_raw = mann_whitney_u(
+            tier1_data["passed"].astype(int), tier2_data["passed"].astype(int)
+        )
+        raw_p_values.append(p_value_raw)
+        test_metadata.append(
+            {
+                "model": model,
+                "tier1": tier1,
+                "tier2": tier2,
+                "n1": len(tier1_data),
+                "n2": len(tier2_data),
+                "u_statistic": float(u_stat),
+            }
+        )
+
+    # Add overall first->last tier contrast to the correction family
+    first_tier, last_tier = tier_order[0], tier_order[-1]
+    first_data = model_runs[model_runs["tier"] == first_tier]
+    last_data = model_runs[model_runs["tier"] == last_tier]
+    if len(first_data) > 0 and len(last_data) > 0:
+        u_stat_fl, p_value_fl = mann_whitney_u(
+            first_data["passed"].astype(int), last_data["passed"].astype(int)
+        )
+        raw_p_values.append(p_value_fl)
+        test_metadata.append(
+            {
+                "model": model,
+                "tier1": first_tier,
+                "tier2": last_tier,
+                "n1": len(first_data),
+                "n2": len(last_data),
+                "u_statistic": float(u_stat_fl),
+                "overall_contrast": True,
+            }
+        )
+
+    return raw_p_values, test_metadata
+
+
+def _compute_pairwise_comparisons(
+    runs_df: Any, models: list[str], tier_order: list[str]
+) -> list[dict[str, Any]]:
+    """Compute Mann-Whitney pairwise comparisons with Holm-Bonferroni correction.
+
+    Covers pass_rate (with first->last contrast), impl_rate, and duration_seconds.
+
+    Args:
+        runs_df: Runs DataFrame
+        models: Sorted list of model identifiers
+        tier_order: List of tier IDs in order
+
+    Returns:
+        List of pairwise comparison result dicts
+
+    """
+    pairwise: list[dict[str, Any]] = []
+
     for model in models:
         model_runs = runs_df[runs_df["agent_model"] == model]
-        raw_p_values = []
-        test_metadata = []
 
-        for i in range(len(tier_order) - 1):
-            tier1, tier2 = tier_order[i], tier_order[i + 1]
-            tier1_data = model_runs[model_runs["tier"] == tier1]
-            tier2_data = model_runs[model_runs["tier"] == tier2]
-
-            if len(tier1_data) == 0 or len(tier2_data) == 0:
-                continue
-
-            u_stat, p_value_raw = mann_whitney_u(
-                tier1_data["passed"].astype(int), tier2_data["passed"].astype(int)
-            )
-
-            raw_p_values.append(p_value_raw)
-            test_metadata.append(
-                {
-                    "model": model,
-                    "tier1": tier1,
-                    "tier2": tier2,
-                    "n1": len(tier1_data),
-                    "n2": len(tier2_data),
-                    "u_statistic": float(u_stat),
-                }
-            )
-
-        # Add overall first->last tier contrast (T0->T6) to the correction family
-        first_tier = tier_order[0]
-        last_tier = tier_order[-1]
-        first_data = model_runs[model_runs["tier"] == first_tier]
-        last_data = model_runs[model_runs["tier"] == last_tier]
-        if len(first_data) > 0 and len(last_data) > 0:
-            u_stat_fl, p_value_fl = mann_whitney_u(
-                first_data["passed"].astype(int), last_data["passed"].astype(int)
-            )
-            raw_p_values.append(p_value_fl)
-            test_metadata.append(
-                {
-                    "model": model,
-                    "tier1": first_tier,
-                    "tier2": last_tier,
-                    "n1": len(first_data),
-                    "n2": len(last_data),
-                    "u_statistic": float(u_stat_fl),
-                    "overall_contrast": True,
-                }
-            )
-
-        # Apply Holm-Bonferroni correction to all pairwise tests for this model
+        # pass_rate: consecutive pairs + first->last contrast
+        raw_p_values, test_metadata = _collect_pairwise_pass_rate(model_runs, model, tier_order)
         if raw_p_values:
-            corrected_p_values = holm_bonferroni_correction(raw_p_values)
-
+            corrected = holm_bonferroni_correction(raw_p_values)
             for i, metadata in enumerate(test_metadata):
-                results["pairwise_comparisons"].append(
+                pairwise.append(
                     {
                         **metadata,
                         "metric": "pass_rate",
                         "p_value_raw": float(raw_p_values[i]),
-                        "p_value": float(corrected_p_values[i]),
-                        "is_significant": bool(corrected_p_values[i] < 0.05),
+                        "p_value": float(corrected[i]),
+                        "is_significant": bool(corrected[i] < 0.05),
                     }
                 )
 
-    # Pairwise comparisons for impl_rate between consecutive tiers
-    for model in models:
-        model_runs = runs_df[runs_df["agent_model"] == model]
-        raw_p_values = []
-        test_metadata = []
+        # impl_rate and duration_seconds: consecutive pairs only
+        for metric in ("impl_rate", "duration_seconds"):
+            raw_p_values = []
+            test_metadata = []
 
-        for i in range(len(tier_order) - 1):
-            tier1, tier2 = tier_order[i], tier_order[i + 1]
-            tier1_data = model_runs[model_runs["tier"] == tier1]["impl_rate"].dropna()
-            tier2_data = model_runs[model_runs["tier"] == tier2]["impl_rate"].dropna()
+            for i in range(len(tier_order) - 1):
+                tier1, tier2 = tier_order[i], tier_order[i + 1]
+                d1 = model_runs[model_runs["tier"] == tier1][metric].dropna()
+                d2 = model_runs[model_runs["tier"] == tier2][metric].dropna()
 
-            if len(tier1_data) < 2 or len(tier2_data) < 2:
-                continue
+                if len(d1) < 2 or len(d2) < 2:
+                    continue
 
-            u_stat, p_value_raw = mann_whitney_u(tier1_data, tier2_data)
-
-            raw_p_values.append(p_value_raw)
-            test_metadata.append(
-                {
-                    "model": model,
-                    "tier1": tier_order[i],
-                    "tier2": tier_order[i + 1],
-                    "n1": len(tier1_data),
-                    "n2": len(tier2_data),
-                    "u_statistic": float(u_stat),
-                }
-            )
-
-        # Apply Holm-Bonferroni correction
-        if raw_p_values:
-            corrected_p_values = holm_bonferroni_correction(raw_p_values)
-
-            for i, metadata in enumerate(test_metadata):
-                results["pairwise_comparisons"].append(
+                u_stat, p_value_raw = mann_whitney_u(d1, d2)
+                raw_p_values.append(p_value_raw)
+                test_metadata.append(
                     {
-                        **metadata,
-                        "metric": "impl_rate",
-                        "p_value_raw": float(raw_p_values[i]),
-                        "p_value": float(corrected_p_values[i]),
-                        "is_significant": bool(corrected_p_values[i] < 0.05),
+                        "model": model,
+                        "tier1": tier1,
+                        "tier2": tier2,
+                        "n1": len(d1),
+                        "n2": len(d2),
+                        "u_statistic": float(u_stat),
                     }
                 )
 
-    # Pairwise comparisons for duration_seconds between consecutive tiers
-    for model in models:
-        model_runs = runs_df[runs_df["agent_model"] == model]
-        raw_p_values = []
-        test_metadata = []
+            if raw_p_values:
+                corrected = holm_bonferroni_correction(raw_p_values)
+                for i, metadata in enumerate(test_metadata):
+                    pairwise.append(
+                        {
+                            **metadata,
+                            "metric": metric,
+                            "p_value_raw": float(raw_p_values[i]),
+                            "p_value": float(corrected[i]),
+                            "is_significant": bool(corrected[i] < 0.05),
+                        }
+                    )
 
-        for i in range(len(tier_order) - 1):
-            tier1, tier2 = tier_order[i], tier_order[i + 1]
-            tier1_data = model_runs[model_runs["tier"] == tier1]["duration_seconds"].dropna()
-            tier2_data = model_runs[model_runs["tier"] == tier2]["duration_seconds"].dropna()
+    return pairwise
 
-            if len(tier1_data) < 2 or len(tier2_data) < 2:
-                continue
 
-            u_stat, p_value_raw = mann_whitney_u(tier1_data, tier2_data)
+def _compute_effect_sizes(
+    runs_df: Any, models: list[str], tier_order: list[str]
+) -> list[dict[str, Any]]:
+    """Compute Cliff's delta effect sizes with CIs for tier transitions.
 
-            raw_p_values.append(p_value_raw)
-            test_metadata.append(
-                {
-                    "model": model,
-                    "tier1": tier_order[i],
-                    "tier2": tier_order[i + 1],
-                    "n1": len(tier1_data),
-                    "n2": len(tier2_data),
-                    "u_statistic": float(u_stat),
-                }
-            )
+    Covers pass_rate, impl_rate, and duration_seconds for consecutive tier pairs.
 
-        # Apply Holm-Bonferroni correction
-        if raw_p_values:
-            corrected_p_values = holm_bonferroni_correction(raw_p_values)
+    Args:
+        runs_df: Runs DataFrame
+        models: Sorted list of model identifiers
+        tier_order: List of tier IDs in order
 
-            for i, metadata in enumerate(test_metadata):
-                results["pairwise_comparisons"].append(
-                    {
-                        **metadata,
-                        "metric": "duration_seconds",
-                        "p_value_raw": float(raw_p_values[i]),
-                        "p_value": float(corrected_p_values[i]),
-                        "is_significant": bool(corrected_p_values[i] < 0.05),
-                    }
-                )
+    Returns:
+        List of effect size result dicts
 
-    # Effect sizes (Cliff's delta with CI) for tier transitions
+    """
+    effect_sizes: list[dict[str, Any]] = []
+
     for model in models:
         model_runs = runs_df[runs_df["agent_model"] == model]
 
         for i in range(len(tier_order) - 1):
             tier1, tier2 = tier_order[i], tier_order[i + 1]
-            tier1_data = model_runs[model_runs["tier"] == tier1]
-            tier2_data = model_runs[model_runs["tier"] == tier2]
+            t1 = model_runs[model_runs["tier"] == tier1]
+            t2 = model_runs[model_runs["tier"] == tier2]
 
-            if len(tier1_data) < 2 or len(tier2_data) < 2:
+            if len(t1) < 2 or len(t2) < 2:
                 continue
 
-            # Effect size for pass_rate
+            # pass_rate
             delta, ci_low, ci_high = cliffs_delta_ci(
-                tier2_data["passed"].astype(int), tier1_data["passed"].astype(int)
+                t2["passed"].astype(int), t1["passed"].astype(int)
             )
-
-            results["effect_sizes"].append(
+            effect_sizes.append(
                 {
                     "model": model,
                     "metric": "pass_rate",
@@ -391,83 +331,78 @@ def compute_statistical_results(runs_df: Any, tier_order: list[str]) -> dict[str
                 }
             )
 
-            # Effect size for impl_rate
-            tier1_impl = tier1_data["impl_rate"].dropna()
-            tier2_impl = tier2_data["impl_rate"].dropna()
+            # impl_rate and duration_seconds
+            for metric in ("impl_rate", "duration_seconds"):
+                d1 = t1[metric].dropna()
+                d2 = t2[metric].dropna()
+                if len(d1) >= 2 and len(d2) >= 2:
+                    delta, ci_low, ci_high = cliffs_delta_ci(d2, d1)
+                    effect_sizes.append(
+                        {
+                            "model": model,
+                            "metric": metric,
+                            "tier1": tier1,
+                            "tier2": tier2,
+                            "cliffs_delta": float(delta),
+                            "ci_low": float(ci_low),
+                            "ci_high": float(ci_high),
+                            "is_significant": bool(not (ci_low <= 0 <= ci_high)),
+                        }
+                    )
 
-            if len(tier1_impl) >= 2 and len(tier2_impl) >= 2:
-                delta, ci_low, ci_high = cliffs_delta_ci(tier2_impl, tier1_impl)
+    return effect_sizes
 
-                results["effect_sizes"].append(
-                    {
-                        "model": model,
-                        "metric": "impl_rate",
-                        "tier1": tier1,
-                        "tier2": tier2,
-                        "cliffs_delta": float(delta),
-                        "ci_low": float(ci_low),
-                        "ci_high": float(ci_high),
-                        "is_significant": bool(not (ci_low <= 0 <= ci_high)),
-                    }
-                )
 
-            # Effect size for duration_seconds
-            tier1_duration = tier1_data["duration_seconds"].dropna()
-            tier2_duration = tier2_data["duration_seconds"].dropna()
+def _compute_power_analysis(
+    runs_df: Any,
+    models: list[str],
+    tier_order: list[str],
+    effect_sizes: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    """Compute post-hoc power estimates for pairwise Mann-Whitney transitions.
 
-            if len(tier1_duration) >= 2 and len(tier2_duration) >= 2:
-                delta, ci_low, ci_high = cliffs_delta_ci(tier2_duration, tier1_duration)
+    Uses simulation-based power estimation (10,000 iterations, seed=42).
+    Also includes KW omnibus power at medium effect (eta^2 = 0.06) per model.
 
-                results["effect_sizes"].append(
-                    {
-                        "model": model,
-                        "metric": "duration_seconds",
-                        "tier1": tier1,
-                        "tier2": tier2,
-                        "cliffs_delta": float(delta),
-                        "ci_low": float(ci_low),
-                        "ci_high": float(ci_high),
-                        "is_significant": bool(not (ci_low <= 0 <= ci_high)),
-                    }
-                )
+    Args:
+        runs_df: Runs DataFrame
+        models: Sorted list of model identifiers
+        tier_order: List of tier IDs in order
+        effect_sizes: Previously computed effect size results
 
-    # Post-hoc power analysis for pairwise Mann-Whitney transitions (pass_rate)
-    # Uses simulation-based power estimation (10,000 iterations, seed=42).
-    # Also includes a representative medium-effect scenario (delta=0.3) for context.
+    Returns:
+        List of power analysis result dicts
+
+    """
+    power_analysis: list[dict[str, Any]] = []
+
     for model in models:
         model_runs = runs_df[runs_df["agent_model"] == model]
 
         for i in range(len(tier_order) - 1):
             tier1, tier2 = tier_order[i], tier_order[i + 1]
-            tier1_data = model_runs[model_runs["tier"] == tier1]
-            tier2_data = model_runs[model_runs["tier"] == tier2]
+            n1 = len(model_runs[model_runs["tier"] == tier1])
+            n2 = len(model_runs[model_runs["tier"] == tier2])
 
-            n1, n2 = len(tier1_data), len(tier2_data)
             if n1 < 2 or n2 < 2:
                 continue
 
-            # Observed effect size from effect_sizes (pass_rate)
-            observed_delta = None
-            for es in results["effect_sizes"]:
-                if (
-                    es["model"] == model
+            observed_delta = next(
+                (
+                    es["cliffs_delta"]
+                    for es in effect_sizes
+                    if es["model"] == model
                     and es["metric"] == "pass_rate"
                     and es["tier1"] == tier1
                     and es["tier2"] == tier2
-                ):
-                    observed_delta = es["cliffs_delta"]
-                    break
+                ),
+                None,
+            )
 
             if observed_delta is None:
                 continue
 
-            # Power at observed effect size
-            power_observed = mann_whitney_power(n1, n2, abs(observed_delta))
-
-            # Power at medium effect size (delta=0.3) for reference
-            power_medium = mann_whitney_power(n1, n2, 0.3)
-
-            results["power_analysis"].append(
+            power_analysis.append(
                 {
                     "model": model,
                     "metric": "pass_rate",
@@ -476,20 +411,20 @@ def compute_statistical_results(runs_df: Any, tier_order: list[str]) -> dict[str
                     "n1": n1,
                     "n2": n2,
                     "observed_delta": float(observed_delta),
-                    "power_at_observed": float(power_observed),
-                    "power_at_medium_0_3": float(power_medium),
+                    "power_at_observed": float(mann_whitney_power(n1, n2, abs(observed_delta))),
+                    "power_at_medium_0_3": float(mann_whitney_power(n1, n2, 0.3)),
                 }
             )
 
         # Overall KW power for pass_rate across all tiers
         tier_groups = [
-            model_runs[model_runs["tier"] == tier]["passed"].astype(int) for tier in tier_order
+            g
+            for g in (model_runs[model_runs["tier"] == t]["passed"].astype(int) for t in tier_order)
+            if len(g) > 0
         ]
-        tier_groups = [g for g in tier_groups if len(g) > 0]
         if len(tier_groups) >= 2:
-            # Use medium effect (eta^2 = 0.06) as reference
             kw_power = kruskal_wallis_power([len(g) for g in tier_groups], effect_size=0.06)
-            results["power_analysis"].append(
+            power_analysis.append(
                 {
                     "model": model,
                     "metric": "pass_rate_omnibus",
@@ -503,8 +438,21 @@ def compute_statistical_results(runs_df: Any, tier_order: list[str]) -> dict[str
                 }
             )
 
-    # Correlations between key metrics
-    metrics = [
+    return power_analysis
+
+
+def _compute_correlations(runs_df: Any, models: list[str]) -> list[dict[str, Any]]:
+    """Compute Spearman correlations between key metric pairs per model.
+
+    Args:
+        runs_df: Runs DataFrame
+        models: Sorted list of model identifiers
+
+    Returns:
+        List of correlation result dicts
+
+    """
+    metric_pairs = [
         ("score", "cost_usd"),
         ("score", "total_tokens"),
         ("score", "duration_seconds"),
@@ -513,15 +461,15 @@ def compute_statistical_results(runs_df: Any, tier_order: list[str]) -> dict[str
         ("impl_rate", "duration_seconds"),
         ("cost_usd", "total_tokens"),
     ]
+    correlations: list[dict[str, Any]] = []
 
     for model in models:
         model_data = runs_df[runs_df["agent_model"] == model]
 
-        for metric1, metric2 in metrics:
+        for metric1, metric2 in metric_pairs:
             if metric1 not in model_data.columns or metric2 not in model_data.columns:
                 continue
 
-            # Get valid data (drop NaN)
             valid_idx = model_data[[metric1, metric2]].dropna().index
             if len(valid_idx) < 3:
                 continue
@@ -529,8 +477,7 @@ def compute_statistical_results(runs_df: Any, tier_order: list[str]) -> dict[str
             rho, p_value = spearman_correlation(
                 model_data.loc[valid_idx, metric1], model_data.loc[valid_idx, metric2]
             )
-
-            results["correlations"].append(
+            correlations.append(
                 {
                     "model": model,
                     "metric1": metric1,
@@ -542,48 +489,59 @@ def compute_statistical_results(runs_df: Any, tier_order: list[str]) -> dict[str
                 }
             )
 
-    # Tier-level descriptive statistics (CoP analysis)
+    return correlations
+
+
+def _compute_tier_descriptives(
+    runs_df: Any, models: list[str], tier_order: list[str]
+) -> list[dict[str, Any]]:
+    """Compute tier-level descriptive statistics including CoP and Frontier CoP.
+
+    Args:
+        runs_df: Runs DataFrame
+        models: Sorted list of model identifiers
+        tier_order: List of tier IDs in order
+
+    Returns:
+        List of tier descriptive stat dicts
+
+    """
+    tier_descriptives: list[dict[str, Any]] = []
+
     for model in models:
         model_runs = runs_df[runs_df["agent_model"] == model]
-        tier_cops = []
+        tier_cops: list[float | None] = []
 
         for tier in tier_order:
             tier_data = model_runs[model_runs["tier"] == tier]
-
             if len(tier_data) == 0:
                 continue
 
             pass_rate = float(tier_data["passed"].mean())
             mean_cost = float(tier_data["cost_usd"].mean())
-            median_cost = float(tier_data["cost_usd"].median())
             cop = compute_cop(mean_cost, pass_rate)
-
             tier_cops.append(cop if cop != float("inf") else None)
 
-            results["tier_descriptives"].append(
+            tier_descriptives.append(
                 {
                     "model": model,
                     "tier": tier,
                     "n": len(tier_data),
                     "pass_rate": pass_rate,
                     "mean_cost": mean_cost,
-                    "median_cost": median_cost,
+                    "median_cost": float(tier_data["cost_usd"].median()),
                     "cop": float(cop) if cop != float("inf") else None,
                 }
             )
 
-        # Add Frontier CoP for this model
         valid_cops = [c for c in tier_cops if c is not None]
         if valid_cops:
             frontier = compute_frontier_cop(valid_cops)
-            # Find which tier achieved the frontier
-            frontier_tier = None
-            for _i, (tier, tier_cop) in enumerate(zip(tier_order, tier_cops, strict=False)):
-                if tier_cop == frontier:
-                    frontier_tier = tier
-                    break
-
-            results["tier_descriptives"].append(
+            frontier_tier = next(
+                (t for t, c in zip(tier_order, tier_cops, strict=False) if c == frontier),
+                None,
+            )
+            tier_descriptives.append(
                 {
                     "model": model,
                     "tier": "frontier",
@@ -596,25 +554,34 @@ def compute_statistical_results(runs_df: Any, tier_order: list[str]) -> dict[str
                 }
             )
 
-    # Model x Tier interaction tests (Scheirer-Ray-Hare)
-    # Test for interaction effects on key metrics
+    return tier_descriptives
+
+
+def _compute_interaction_tests(runs_df: Any) -> list[dict[str, Any]]:
+    """Compute Scheirer-Ray-Hare model x tier interaction tests for four metrics.
+
+    Args:
+        runs_df: Runs DataFrame
+
+    Returns:
+        List of interaction test result dicts
+
+    """
+    interaction_tests: list[dict[str, Any]] = []
     interaction_metrics = ["score", "impl_rate", "cost_usd", "duration_seconds"]
 
     for metric in interaction_metrics:
-        # Prepare data for interaction test
         metric_data = runs_df[["agent_model", "tier", metric]].dropna()
 
-        if len(metric_data) < 10:  # Minimum sample size for meaningful test
+        if len(metric_data) < 10:
             continue
 
-        # Run Scheirer-Ray-Hare test
         srh_results = scheirer_ray_hare(
             metric_data, value_col=metric, factor_a_col="agent_model", factor_b_col="tier"
         )
 
-        # Store results for each effect
         for effect_name, effect_result in srh_results.items():
-            results["interaction_tests"].append(
+            interaction_tests.append(
                 {
                     "metric": metric,
                     "effect": effect_name,
@@ -625,7 +592,39 @@ def compute_statistical_results(runs_df: Any, tier_order: list[str]) -> dict[str
                 }
             )
 
-    return results
+    return interaction_tests
+
+
+def compute_statistical_results(runs_df: Any, tier_order: list[str]) -> dict[str, Any]:
+    """Compute all statistical test results for export.
+
+    Pairwise comparisons use Holm-Bonferroni correction per model.
+    Both raw and corrected p-values are exported for transparency.
+
+    Args:
+        runs_df: Runs DataFrame
+        tier_order: List of tier IDs in order
+
+    Returns:
+        Dictionary of statistical test results with corrected p-values
+
+    """
+    models = sorted(runs_df["agent_model"].unique())
+
+    effect_sizes = _compute_effect_sizes(runs_df, models, tier_order)
+
+    return {
+        "pipeline_version": config.pipeline_version,
+        "config_version": config.config_version,
+        "normality_tests": _compute_normality_tests(runs_df, models, tier_order),
+        "omnibus_tests": _compute_omnibus_tests(runs_df, models, tier_order),
+        "pairwise_comparisons": _compute_pairwise_comparisons(runs_df, models, tier_order),
+        "effect_sizes": effect_sizes,
+        "power_analysis": _compute_power_analysis(runs_df, models, tier_order, effect_sizes),
+        "correlations": _compute_correlations(runs_df, models),
+        "tier_descriptives": _compute_tier_descriptives(runs_df, models, tier_order),
+        "interaction_tests": _compute_interaction_tests(runs_df),
+    }
 
 
 def main() -> None:

--- a/tests/unit/analysis/test_export_data.py
+++ b/tests/unit/analysis/test_export_data.py
@@ -451,3 +451,349 @@ def test_process_metrics_in_summary(sample_runs_df):
     partial_mean = float(r_prog_clean.mean()) if not r_prog_clean.empty else None
     assert partial_mean is not None
     assert abs(partial_mean - 0.4) < 1e-9, f"Partial NaN mean should be 0.4, got {partial_mean}"
+
+
+# ---------------------------------------------------------------------------
+# Unit tests for extracted helper functions
+# ---------------------------------------------------------------------------
+
+
+def test_compute_normality_tests_structure(sample_runs_df):
+    """_compute_normality_tests returns dicts with required fields for each metric."""
+    from export_data import _compute_normality_tests
+
+    from scylla.analysis.figures import derive_tier_order
+
+    tier_order = derive_tier_order(sample_runs_df)
+    models = sorted(sample_runs_df["agent_model"].unique())
+    results = _compute_normality_tests(sample_runs_df, models, tier_order)
+
+    assert isinstance(results, list)
+    assert len(results) > 0
+
+    required_fields = {"model", "tier", "metric", "n", "w_statistic", "p_value", "is_normal"}
+    for entry in results:
+        assert required_fields <= entry.keys(), f"Missing fields in normality entry: {entry.keys()}"
+        assert isinstance(entry["is_normal"], bool)
+        assert entry["n"] >= 3
+
+
+def test_compute_normality_tests_all_four_metrics(sample_runs_df):
+    """_compute_normality_tests covers score, impl_rate, cost_usd, duration_seconds."""
+    from export_data import _compute_normality_tests
+
+    from scylla.analysis.figures import derive_tier_order
+
+    tier_order = derive_tier_order(sample_runs_df)
+    models = sorted(sample_runs_df["agent_model"].unique())
+    results = _compute_normality_tests(sample_runs_df, models, tier_order)
+
+    metrics_present = {entry["metric"] for entry in results}
+    assert "score" in metrics_present
+    assert "impl_rate" in metrics_present
+    assert "cost_usd" in metrics_present
+    assert "duration_seconds" in metrics_present
+
+
+def test_compute_omnibus_tests_structure(sample_runs_df):
+    """_compute_omnibus_tests returns dicts with required fields."""
+    from export_data import _compute_omnibus_tests
+
+    from scylla.analysis.figures import derive_tier_order
+
+    tier_order = derive_tier_order(sample_runs_df)
+    models = sorted(sample_runs_df["agent_model"].unique())
+    results = _compute_omnibus_tests(sample_runs_df, models, tier_order)
+
+    assert isinstance(results, list)
+    assert len(results) > 0
+
+    required_fields = {"model", "metric", "n_groups", "h_statistic", "p_value", "is_significant"}
+    for entry in results:
+        assert required_fields <= entry.keys()
+        assert isinstance(entry["is_significant"], bool)
+        assert entry["n_groups"] >= 2
+
+
+def test_compute_omnibus_tests_three_metrics(sample_runs_df):
+    """_compute_omnibus_tests covers pass_rate, impl_rate, duration_seconds."""
+    from export_data import _compute_omnibus_tests
+
+    from scylla.analysis.figures import derive_tier_order
+
+    tier_order = derive_tier_order(sample_runs_df)
+    models = sorted(sample_runs_df["agent_model"].unique())
+    results = _compute_omnibus_tests(sample_runs_df, models, tier_order)
+
+    metrics_present = {entry["metric"] for entry in results}
+    assert "pass_rate" in metrics_present
+    assert "impl_rate" in metrics_present
+    assert "duration_seconds" in metrics_present
+
+
+def test_collect_pairwise_pass_rate_includes_overall_contrast(sample_runs_df):
+    """_collect_pairwise_pass_rate adds the first->last overall contrast."""
+    from export_data import _collect_pairwise_pass_rate
+
+    from scylla.analysis.figures import derive_tier_order
+
+    tier_order = derive_tier_order(sample_runs_df)
+    model = sorted(sample_runs_df["agent_model"].unique())[0]
+    model_runs = sample_runs_df[sample_runs_df["agent_model"] == model]
+
+    raw_p_values, test_metadata = _collect_pairwise_pass_rate(model_runs, model, tier_order)
+
+    # Should have consecutive pairs + 1 overall contrast
+    expected_consecutive = len(tier_order) - 1
+    assert len(raw_p_values) == expected_consecutive + 1
+
+    # Last entry should be the overall contrast
+    last = test_metadata[-1]
+    assert last.get("overall_contrast") is True
+    assert last["tier1"] == tier_order[0]
+    assert last["tier2"] == tier_order[-1]
+
+
+def test_compute_pairwise_comparisons_metrics(sample_runs_df):
+    """_compute_pairwise_comparisons covers pass_rate, impl_rate, duration_seconds."""
+    from export_data import _compute_pairwise_comparisons
+
+    from scylla.analysis.figures import derive_tier_order
+
+    tier_order = derive_tier_order(sample_runs_df)
+    models = sorted(sample_runs_df["agent_model"].unique())
+    results = _compute_pairwise_comparisons(sample_runs_df, models, tier_order)
+
+    assert isinstance(results, list)
+    assert len(results) > 0
+
+    metrics_present = {entry["metric"] for entry in results}
+    assert "pass_rate" in metrics_present
+    assert "impl_rate" in metrics_present
+    assert "duration_seconds" in metrics_present
+
+    # Every entry must have corrected and raw p-values
+    for entry in results:
+        assert "p_value_raw" in entry
+        assert "p_value" in entry
+        assert "is_significant" in entry
+
+
+def test_compute_effect_sizes_structure(sample_runs_df):
+    """_compute_effect_sizes returns Cliff's delta entries with CI bounds."""
+    from export_data import _compute_effect_sizes
+
+    from scylla.analysis.figures import derive_tier_order
+
+    tier_order = derive_tier_order(sample_runs_df)
+    models = sorted(sample_runs_df["agent_model"].unique())
+    results = _compute_effect_sizes(sample_runs_df, models, tier_order)
+
+    assert isinstance(results, list)
+    assert len(results) > 0
+
+    required_fields = {
+        "model",
+        "metric",
+        "tier1",
+        "tier2",
+        "cliffs_delta",
+        "ci_low",
+        "ci_high",
+        "is_significant",
+    }
+    for entry in results:
+        assert required_fields <= entry.keys()
+        assert -1.0 <= entry["cliffs_delta"] <= 1.0
+        assert entry["ci_low"] <= entry["ci_high"]
+
+
+def test_compute_effect_sizes_three_metrics(sample_runs_df):
+    """_compute_effect_sizes covers pass_rate, impl_rate, and duration_seconds."""
+    from export_data import _compute_effect_sizes
+
+    from scylla.analysis.figures import derive_tier_order
+
+    tier_order = derive_tier_order(sample_runs_df)
+    models = sorted(sample_runs_df["agent_model"].unique())
+    results = _compute_effect_sizes(sample_runs_df, models, tier_order)
+
+    metrics_present = {entry["metric"] for entry in results}
+    assert "pass_rate" in metrics_present
+    assert "impl_rate" in metrics_present
+    assert "duration_seconds" in metrics_present
+
+
+def test_compute_power_analysis_structure(sample_runs_df):
+    """_compute_power_analysis returns entries with required power fields."""
+    from export_data import _compute_effect_sizes, _compute_power_analysis
+
+    from scylla.analysis.figures import derive_tier_order
+
+    tier_order = derive_tier_order(sample_runs_df)
+    models = sorted(sample_runs_df["agent_model"].unique())
+    effect_sizes = _compute_effect_sizes(sample_runs_df, models, tier_order)
+    results = _compute_power_analysis(sample_runs_df, models, tier_order, effect_sizes)
+
+    assert isinstance(results, list)
+    assert len(results) > 0
+
+    required_fields = {"model", "metric", "tier1", "tier2", "n1", "power_at_medium_0_3"}
+    for entry in results:
+        assert required_fields <= entry.keys()
+
+
+def test_compute_power_analysis_includes_omnibus(sample_runs_df):
+    """_compute_power_analysis includes pass_rate_omnibus KW power entries."""
+    from export_data import _compute_effect_sizes, _compute_power_analysis
+
+    from scylla.analysis.figures import derive_tier_order
+
+    tier_order = derive_tier_order(sample_runs_df)
+    models = sorted(sample_runs_df["agent_model"].unique())
+    effect_sizes = _compute_effect_sizes(sample_runs_df, models, tier_order)
+    results = _compute_power_analysis(sample_runs_df, models, tier_order, effect_sizes)
+
+    omnibus_entries = [e for e in results if e["metric"] == "pass_rate_omnibus"]
+    # One omnibus entry per model
+    assert len(omnibus_entries) == len(models)
+
+
+def test_compute_correlations_structure(sample_runs_df):
+    """_compute_correlations returns Spearman rho entries with required fields."""
+    from export_data import _compute_correlations
+
+    models = sorted(sample_runs_df["agent_model"].unique())
+    results = _compute_correlations(sample_runs_df, models)
+
+    assert isinstance(results, list)
+    assert len(results) > 0
+
+    required_fields = {
+        "model",
+        "metric1",
+        "metric2",
+        "n",
+        "spearman_rho",
+        "p_value",
+        "is_significant",
+    }
+    for entry in results:
+        assert required_fields <= entry.keys()
+        assert -1.0 <= entry["spearman_rho"] <= 1.0
+        assert entry["n"] >= 3
+
+
+def test_compute_correlations_includes_impl_rate(sample_runs_df):
+    """_compute_correlations includes impl_rate pairs."""
+    from export_data import _compute_correlations
+
+    models = sorted(sample_runs_df["agent_model"].unique())
+    results = _compute_correlations(sample_runs_df, models)
+
+    impl_rate_entries = [
+        e for e in results if e["metric1"] == "impl_rate" or e["metric2"] == "impl_rate"
+    ]
+    assert len(impl_rate_entries) > 0
+
+
+def test_compute_tier_descriptives_structure(sample_runs_df):
+    """_compute_tier_descriptives returns tier stats including frontier row."""
+    from export_data import _compute_tier_descriptives
+
+    from scylla.analysis.figures import derive_tier_order
+
+    tier_order = derive_tier_order(sample_runs_df)
+    models = sorted(sample_runs_df["agent_model"].unique())
+    results = _compute_tier_descriptives(sample_runs_df, models, tier_order)
+
+    assert isinstance(results, list)
+    assert len(results) > 0
+
+    required_fields = {"model", "tier", "n", "pass_rate", "mean_cost", "median_cost", "cop"}
+    tier_entries = [e for e in results if e["tier"] != "frontier"]
+    for entry in tier_entries:
+        assert required_fields <= entry.keys()
+
+
+def test_compute_tier_descriptives_frontier_row(sample_runs_df):
+    """_compute_tier_descriptives includes one frontier row per model."""
+    from export_data import _compute_tier_descriptives
+
+    from scylla.analysis.figures import derive_tier_order
+
+    tier_order = derive_tier_order(sample_runs_df)
+    models = sorted(sample_runs_df["agent_model"].unique())
+    results = _compute_tier_descriptives(sample_runs_df, models, tier_order)
+
+    frontier_entries = [e for e in results if e["tier"] == "frontier"]
+    assert len(frontier_entries) == len(models)
+    for entry in frontier_entries:
+        assert "frontier_tier" in entry
+        assert entry["cop"] is not None
+
+
+def test_compute_interaction_tests_structure(sample_runs_df):
+    """_compute_interaction_tests returns SRH results for four metrics."""
+    from export_data import _compute_interaction_tests
+
+    results = _compute_interaction_tests(sample_runs_df)
+
+    assert isinstance(results, list)
+    assert len(results) > 0
+
+    required_fields = {"metric", "effect", "h_statistic", "df", "p_value", "is_significant"}
+    for entry in results:
+        assert required_fields <= entry.keys()
+        assert isinstance(entry["is_significant"], bool)
+
+
+def test_compute_interaction_tests_four_metrics(sample_runs_df):
+    """_compute_interaction_tests covers score, impl_rate, cost_usd, duration_seconds."""
+    from export_data import _compute_interaction_tests
+
+    results = _compute_interaction_tests(sample_runs_df)
+
+    metrics_present = {entry["metric"] for entry in results}
+    assert "score" in metrics_present
+    assert "impl_rate" in metrics_present
+    assert "cost_usd" in metrics_present
+    assert "duration_seconds" in metrics_present
+
+
+def test_helpers_compose_to_same_result(sample_runs_df):
+    """compute_statistical_results output matches direct helper composition."""
+    from export_data import (
+        _compute_correlations,
+        _compute_effect_sizes,
+        _compute_interaction_tests,
+        _compute_normality_tests,
+        _compute_omnibus_tests,
+        _compute_pairwise_comparisons,
+        _compute_tier_descriptives,
+        compute_statistical_results,
+    )
+
+    from scylla.analysis.figures import derive_tier_order
+
+    tier_order = derive_tier_order(sample_runs_df)
+    models = sorted(sample_runs_df["agent_model"].unique())
+
+    orchestrated = compute_statistical_results(sample_runs_df, tier_order)
+    effect_sizes = _compute_effect_sizes(sample_runs_df, models, tier_order)
+
+    assert orchestrated["normality_tests"] == _compute_normality_tests(
+        sample_runs_df, models, tier_order
+    )
+    assert orchestrated["omnibus_tests"] == _compute_omnibus_tests(
+        sample_runs_df, models, tier_order
+    )
+    assert orchestrated["pairwise_comparisons"] == _compute_pairwise_comparisons(
+        sample_runs_df, models, tier_order
+    )
+    assert orchestrated["effect_sizes"] == effect_sizes
+    assert orchestrated["correlations"] == _compute_correlations(sample_runs_df, models)
+    assert orchestrated["tier_descriptives"] == _compute_tier_descriptives(
+        sample_runs_df, models, tier_order
+    )
+    assert orchestrated["interaction_tests"] == _compute_interaction_tests(sample_runs_df)


### PR DESCRIPTION
## Summary
- Refactors `compute_statistical_results` in `scripts/export_data.py` to reduce cyclomatic complexity from 45 to <10
- Extracts helper functions to handle sub-computations

## Test plan
- [ ] `ruff` C901 check passes on `compute_statistical_results`
- [ ] Unit tests in `tests/unit/analysis/test_export_data.py` pass
- [ ] Pre-commit hooks pass

Closes #969