### PR TITLE
[Feature] Automate test count badge validation

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -84,6 +84,15 @@ jobs:
         if: matrix.test-group.name == 'unit'
         run: pixi run python scripts/check_unit_test_structure.py
 
+      - name: Check test count documentation
+        if: matrix.test-group.name == 'unit'
+        run: |
+          pixi run python scripts/check_test_counts.py \
+            --readme README.md \
+            --test-dir tests \
+            --tolerance-tests 100 \
+            --tolerance-files 5
+
       - name: Run ${{ matrix.test-group.name }} tests
         env:
           TEST_PATH: ${{ matrix.test-group.path }}

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Python](https://img.shields.io/badge/python-3.10+-blue.svg)](https://python.org)
 [![License](https://img.shields.io/badge/license-BSD--3--Clause-blue.svg)](LICENSE)
-[![Tests](https://img.shields.io/badge/tests-2026%2B-brightgreen.svg)](#)
+[![Tests](https://img.shields.io/badge/tests-3500%2B-brightgreen.svg)](#)
 [![Status](https://img.shields.io/badge/status-stable-brightgreen.svg)](#)
 
 ## 📑 Table of Contents
@@ -339,11 +339,11 @@ Schema: `scylla/analysis/schemas/run_result_schema.json`
 
 ### 🧪 Testing
 
-ProjectScylla has a comprehensive test suite with **127+ test files** covering all functionality.
+ProjectScylla has a comprehensive test suite with **137+ test files** covering all functionality.
 
 #### Test Categories
 
-- **Unit Tests** (127+ files): Analysis (incl. integration-style tests), adapters, config, executors, judges, metrics, reporting
+- **Unit Tests** (137+ files): Analysis (incl. integration-style tests), adapters, config, executors, judges, metrics, reporting
 - **E2E Tests** (1 file): Full pipeline validation
 - **Test Fixtures** (47+ scenarios): Complete test cases with expected outputs
 
@@ -489,7 +489,7 @@ TypeError: unsupported operand type(s) for +: 'float' and 'str'
 
 ✅ **Reproducible configuration** (all parameters in config.yaml)
 
-✅ **Comprehensive test suite** (3,000+ tests, all passing)
+✅ **Comprehensive test suite** (3,500+ tests, all passing)
 
 ✅ **Documented methodology** with citations
 

--- a/scripts/check_test_counts.py
+++ b/scripts/check_test_counts.py
@@ -1,0 +1,254 @@
+#!/usr/bin/env python3
+"""Check that README test count documentation matches actual test counts.
+
+Prevents README values like '3,000+ tests' and '129+ test files' from
+going stale by comparing documented floors against actual collected counts.
+
+CI fails when:
+  - The documented floor exceeds the actual count (README overclaims).
+  - The actual count exceeds the documented floor by more than the
+    configured tolerance (README is significantly out of date).
+
+Usage:
+    python scripts/check_test_counts.py --readme README.md --test-dir tests
+    python scripts/check_test_counts.py
+        --readme README.md --test-dir tests
+        --tolerance-tests 100 --tolerance-files 5
+"""
+
+import argparse
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+# ---------------------------------------------------------------------------
+# Regex patterns for parsing README documented values
+# ---------------------------------------------------------------------------
+
+# Matches "3,000+" or "3000+" before the word "test" (not "test file")
+_RE_TEST_COUNT = re.compile(r"([\d,]+)\+\s*tests(?!\s*file)", re.IGNORECASE)
+
+# Matches "129+" before "test file"
+_RE_FILE_COUNT = re.compile(r"([\d,]+)\+\s*test\s*file", re.IGNORECASE)
+
+
+def _parse_int(raw: str) -> int:
+    """Strip commas and convert to int."""
+    return int(raw.replace(",", ""))
+
+
+def parse_readme_counts(readme: Path) -> tuple[int, int]:
+    """Return (test_floor, file_floor) parsed from README documented values.
+
+    Searches all occurrences of the patterns and returns the maximum found
+    value for each metric, which is the most conservative documented floor.
+
+    Args:
+        readme: Path to README.md.
+
+    Returns:
+        Tuple of (test_floor, file_floor).
+
+    Raises:
+        ValueError: If either count cannot be found in the README.
+
+    """
+    text = readme.read_text(encoding="utf-8")
+
+    test_matches = _RE_TEST_COUNT.findall(text)
+    file_matches = _RE_FILE_COUNT.findall(text)
+
+    if not test_matches:
+        raise ValueError(f"No test count pattern (e.g. '3,000+ tests') found in {readme}")
+    if not file_matches:
+        raise ValueError(f"No test file count pattern (e.g. '129+ test files') found in {readme}")
+
+    test_floor = max(_parse_int(m) for m in test_matches)
+    file_floor = max(_parse_int(m) for m in file_matches)
+
+    return test_floor, file_floor
+
+
+def collect_actual_counts(
+    test_dir: Path,
+    pytest_cmd: list[str] | None = None,
+) -> tuple[int, int]:
+    """Return (actual_tests, actual_files) from the test suite.
+
+    Args:
+        test_dir: Root directory for test discovery (e.g. ``tests/``).
+        pytest_cmd: pytest executable command list. Defaults to
+            ``[sys.executable, "-m", "pytest"]``.
+
+    Returns:
+        Tuple of (collected_test_count, test_file_count).
+
+    Raises:
+        RuntimeError: If pytest collection fails.
+
+    """
+    if pytest_cmd is None:
+        pytest_cmd = [sys.executable, "-m", "pytest"]
+
+    # Collect test count via pytest
+    result = subprocess.run(
+        [*pytest_cmd, str(test_dir), "--collect-only", "-q", "--no-header"],
+        capture_output=True,
+        text=True,
+    )
+
+    # pytest exits with 5 when no tests are collected, 0/1/2 otherwise.
+    # Any exit code other than 0 or 5 indicates a collection error.
+    if result.returncode not in (0, 1, 5):
+        raise RuntimeError(
+            f"pytest --collect-only failed (exit {result.returncode}):\n{result.stderr}"
+        )
+
+    # The last non-empty line of stdout is like "3257 tests collected in 11s"
+    # or "no tests ran" when collection is empty.
+    actual_tests = 0
+    output = (result.stdout + result.stderr).strip()
+    for line in reversed(output.splitlines()):
+        line = line.strip()
+        m = re.search(r"(\d+)\s+test", line)
+        if m:
+            actual_tests = int(m.group(1))
+            break
+
+    # Count test files using glob
+    actual_files = len(list(test_dir.rglob("test_*.py")))
+
+    return actual_tests, actual_files
+
+
+def check_counts(
+    actual: int,
+    documented_floor: int,
+    tolerance: int,
+    label: str,
+) -> tuple[bool, str]:
+    """Compare actual count against documented floor with tolerance.
+
+    Fails when:
+    - actual < documented_floor  (README overclaims)
+    - actual > documented_floor + tolerance  (README is too stale)
+
+    Args:
+        actual: True collected count.
+        documented_floor: The ``N+`` value from README.
+        tolerance: Maximum allowed excess above documented_floor.
+        label: Human-readable name for the metric (e.g. "tests").
+
+    Returns:
+        Tuple of (passed: bool, message: str).
+
+    """
+    upper_bound = documented_floor + tolerance
+
+    if actual < documented_floor:
+        msg = (
+            f"❌ {label}: README documents {documented_floor}+ "
+            f"but only {actual} were found (README overclaims by "
+            f"{documented_floor - actual})"
+        )
+        return False, msg
+
+    if actual > upper_bound:
+        msg = (
+            f"❌ {label}: {actual} found but README only documents "
+            f"{documented_floor}+ (gap {actual - documented_floor} > "
+            f"tolerance {tolerance}). Update README to {actual}+."
+        )
+        return False, msg
+
+    msg = (
+        f"✅ {label}: {actual} found, README documents {documented_floor}+ "
+        f"(within tolerance {tolerance})"
+    )
+    return True, msg
+
+
+def main() -> None:
+    """Parse args, collect counts, compare, and exit 0/1."""
+    parser = argparse.ArgumentParser(
+        description="Check README test count documentation against actual counts."
+    )
+    parser.add_argument(
+        "--readme",
+        type=Path,
+        default=Path("README.md"),
+        help="Path to README.md (default: README.md)",
+    )
+    parser.add_argument(
+        "--test-dir",
+        type=Path,
+        default=Path("tests"),
+        help="Root directory for test discovery (default: tests)",
+    )
+    parser.add_argument(
+        "--tolerance-tests",
+        type=int,
+        default=100,
+        help="Max allowed excess of actual tests above documented floor (default: 100)",
+    )
+    parser.add_argument(
+        "--tolerance-files",
+        type=int,
+        default=5,
+        help="Max allowed excess of actual files above documented floor (default: 5)",
+    )
+    parser.add_argument(
+        "--pytest-cmd",
+        nargs="+",
+        default=None,
+        help="pytest command to use (default: sys.executable -m pytest)",
+    )
+    args = parser.parse_args()
+
+    if not args.readme.exists():
+        print(f"❌ README not found: {args.readme}", file=sys.stderr)
+        sys.exit(1)
+
+    if not args.test_dir.exists():
+        print(f"❌ Test directory not found: {args.test_dir}", file=sys.stderr)
+        sys.exit(1)
+
+    # Parse documented floors
+    try:
+        test_floor, file_floor = parse_readme_counts(args.readme)
+    except ValueError as exc:
+        print(f"❌ Failed to parse README: {exc}", file=sys.stderr)
+        sys.exit(1)
+
+    print(f"\n📋 README documented floors: {test_floor}+ tests, {file_floor}+ files")
+
+    # Collect actual counts
+    try:
+        actual_tests, actual_files = collect_actual_counts(
+            args.test_dir,
+            pytest_cmd=args.pytest_cmd,
+        )
+    except RuntimeError as exc:
+        print(f"❌ Collection failed: {exc}", file=sys.stderr)
+        sys.exit(1)
+
+    print(f"🔍 Actual counts: {actual_tests} tests, {actual_files} files\n")
+
+    # Compare
+    tests_ok, tests_msg = check_counts(actual_tests, test_floor, args.tolerance_tests, "tests")
+    files_ok, files_msg = check_counts(actual_files, file_floor, args.tolerance_files, "test files")
+
+    print(tests_msg)
+    print(files_msg)
+
+    if tests_ok and files_ok:
+        print("\n✅ All test count checks passed.")
+        sys.exit(0)
+    else:
+        print("\n❌ Test count check failed. Update README.md to reflect actual counts.")
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/unit/scripts/test_check_test_counts.py
+++ b/tests/unit/scripts/test_check_test_counts.py
@@ -1,0 +1,265 @@
+"""Tests for scripts/check_test_counts.py."""
+
+import textwrap
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from scripts.check_test_counts import (
+    check_counts,
+    collect_actual_counts,
+    parse_readme_counts,
+)
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+README_TEMPLATE = textwrap.dedent(
+    """\
+    # ProjectScylla
+
+    [![Tests](https://img.shields.io/badge/tests-3000%2B-brightgreen.svg)](#)
+
+    ## Publication Readiness
+
+    ✅ **Comprehensive test suite** (3,000+ tests, all passing)
+
+    ## Development
+
+    ProjectScylla has a comprehensive test suite with **{file_count}+ test files**.
+
+    - **Unit Tests** ({file_count}+ files): Analysis
+    """
+)
+
+
+def make_readme(tmp_path: Path, test_count: str = "3,000", file_count: str = "129") -> Path:
+    """Write a minimal README with the given documented counts."""
+    readme = tmp_path / "README.md"
+    readme.write_text(README_TEMPLATE.format(file_count=file_count).replace("3,000", test_count))
+    return readme
+
+
+# ---------------------------------------------------------------------------
+# parse_readme_counts
+# ---------------------------------------------------------------------------
+
+
+class TestParseReadmeCounts:
+    """Tests for parse_readme_counts()."""
+
+    def test_parses_comma_separated_test_count(self, tmp_path: Path) -> None:
+        """Should parse '3,000+ tests' as 3000."""
+        readme = make_readme(tmp_path, test_count="3,000", file_count="129")
+        test_floor, file_floor = parse_readme_counts(readme)
+        assert test_floor == 3000
+
+    def test_parses_file_count(self, tmp_path: Path) -> None:
+        """Should parse '129+ test files' as 129."""
+        readme = make_readme(tmp_path, file_count="129")
+        _, file_floor = parse_readme_counts(readme)
+        assert file_floor == 129
+
+    def test_parses_no_comma_test_count(self, tmp_path: Path) -> None:
+        """Should parse '500+ tests' (no comma) as 500."""
+        readme = make_readme(tmp_path, test_count="500", file_count="50")
+        test_floor, _ = parse_readme_counts(readme)
+        assert test_floor == 500
+
+    def test_returns_maximum_when_multiple_occurrences(self, tmp_path: Path) -> None:
+        """When there are multiple matches, the maximum is returned."""
+        # README has two occurrences: badge says 3,000+ and body also says 3,000+
+        readme = make_readme(tmp_path, test_count="3,000", file_count="127")
+        test_floor, file_floor = parse_readme_counts(readme)
+        assert test_floor == 3000
+        assert file_floor == 127
+
+    def test_raises_when_test_count_missing(self, tmp_path: Path) -> None:
+        """Should raise ValueError when no test count pattern is found."""
+        readme = tmp_path / "README.md"
+        readme.write_text("# No counts here\n\nSome test files exist.\n")
+        with pytest.raises(ValueError, match="No test count pattern"):
+            parse_readme_counts(readme)
+
+    def test_raises_when_file_count_missing(self, tmp_path: Path) -> None:
+        """Should raise ValueError when no file count pattern is found."""
+        readme = tmp_path / "README.md"
+        readme.write_text("# Counts\n\n3,000+ tests, all passing.\n")
+        with pytest.raises(ValueError, match="No test file count pattern"):
+            parse_readme_counts(readme)
+
+    def test_case_insensitive_matching(self, tmp_path: Path) -> None:
+        """Pattern matching should be case-insensitive."""
+        readme = tmp_path / "README.md"
+        readme.write_text("2,000+ Tests, all passing.\n129+ Test Files covered.\n")
+        test_floor, file_floor = parse_readme_counts(readme)
+        assert test_floor == 2000
+        assert file_floor == 129
+
+
+# ---------------------------------------------------------------------------
+# check_counts
+# ---------------------------------------------------------------------------
+
+
+class TestCheckCounts:
+    """Tests for check_counts()."""
+
+    def test_passes_when_actual_equals_floor(self) -> None:
+        """Exact match with documented floor should pass."""
+        passed, msg = check_counts(3000, 3000, 100, "tests")
+        assert passed is True
+        assert "✅" in msg
+
+    def test_passes_when_actual_within_tolerance(self) -> None:
+        """Actual count within tolerance above floor should pass."""
+        passed, msg = check_counts(3050, 3000, 100, "tests")
+        assert passed is True
+        assert "✅" in msg
+
+    def test_passes_at_tolerance_boundary(self) -> None:
+        """Actual count exactly at floor + tolerance should pass."""
+        passed, msg = check_counts(3100, 3000, 100, "tests")
+        assert passed is True
+
+    def test_fails_when_actual_below_floor(self) -> None:
+        """Actual count below floor means README overclaims — must fail."""
+        passed, msg = check_counts(2999, 3000, 100, "tests")
+        assert passed is False
+        assert "overclaims" in msg
+        assert "❌" in msg
+
+    def test_fails_when_actual_exceeds_tolerance(self) -> None:
+        """Actual count exceeding floor + tolerance means README is stale."""
+        passed, msg = check_counts(3101, 3000, 100, "tests")
+        assert passed is False
+        assert "tolerance" in msg
+        assert "❌" in msg
+
+    def test_message_includes_label(self) -> None:
+        """The returned message should contain the metric label."""
+        _, msg = check_counts(100, 100, 10, "test files")
+        assert "test files" in msg
+
+    def test_zero_tolerance(self) -> None:
+        """With tolerance=0, only exact match passes."""
+        passed, _ = check_counts(3000, 3000, 0, "tests")
+        assert passed is True
+        passed, _ = check_counts(3001, 3000, 0, "tests")
+        assert passed is False
+
+    @pytest.mark.parametrize(
+        "actual,floor,tolerance,expected",
+        [
+            (50, 50, 5, True),
+            (54, 50, 5, True),  # within tolerance
+            (55, 50, 5, True),  # at boundary
+            (56, 50, 5, False),  # exceeds tolerance
+            (49, 50, 5, False),  # below floor
+        ],
+    )
+    def test_boundary_conditions(
+        self, actual: int, floor: int, tolerance: int, expected: bool
+    ) -> None:
+        """Parametrized boundary condition checks."""
+        passed, _ = check_counts(actual, floor, tolerance, "tests")
+        assert passed is expected
+
+
+# ---------------------------------------------------------------------------
+# collect_actual_counts
+# ---------------------------------------------------------------------------
+
+
+class TestCollectActualCounts:
+    """Tests for collect_actual_counts()."""
+
+    def _make_test_tree(self, tmp_path: Path, n_files: int = 3) -> Path:
+        """Create a minimal test directory with n test files."""
+        test_dir = tmp_path / "tests"
+        test_dir.mkdir()
+        for i in range(n_files):
+            (test_dir / f"test_module_{i}.py").write_text("def test_something(): pass\n")
+        return test_dir
+
+    def test_counts_test_files(self, tmp_path: Path) -> None:
+        """Should count test_*.py files under test_dir."""
+        test_dir = self._make_test_tree(tmp_path, n_files=4)
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(
+                returncode=0,
+                stdout="4 tests collected in 0.1s\n",
+                stderr="",
+            )
+            _, actual_files = collect_actual_counts(test_dir)
+        assert actual_files == 4
+
+    def test_counts_nested_test_files(self, tmp_path: Path) -> None:
+        """Should recursively count test files in subdirectories."""
+        test_dir = tmp_path / "tests"
+        (test_dir / "unit").mkdir(parents=True)
+        (test_dir / "integration").mkdir(parents=True)
+        (test_dir / "unit" / "test_a.py").write_text("def test_a(): pass\n")
+        (test_dir / "integration" / "test_b.py").write_text("def test_b(): pass\n")
+
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(
+                returncode=0,
+                stdout="2 tests collected in 0.1s\n",
+                stderr="",
+            )
+            _, actual_files = collect_actual_counts(test_dir)
+        assert actual_files == 2
+
+    def test_extracts_test_count_from_pytest_output(self, tmp_path: Path) -> None:
+        """Should parse test count from pytest --collect-only output."""
+        test_dir = self._make_test_tree(tmp_path, n_files=2)
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(
+                returncode=0,
+                stdout="3257 tests collected in 11.46s\n",
+                stderr="",
+            )
+            actual_tests, _ = collect_actual_counts(test_dir)
+        assert actual_tests == 3257
+
+    def test_raises_on_pytest_failure(self, tmp_path: Path) -> None:
+        """Should raise RuntimeError when pytest exits with error code."""
+        test_dir = self._make_test_tree(tmp_path)
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(
+                returncode=3,
+                stdout="",
+                stderr="Internal error\n",
+            )
+            with pytest.raises(RuntimeError, match="pytest --collect-only failed"):
+                collect_actual_counts(test_dir)
+
+    def test_accepts_exit_code_5_no_tests(self, tmp_path: Path) -> None:
+        """Exit code 5 (no tests collected) should not raise."""
+        test_dir = tmp_path / "tests"
+        test_dir.mkdir()
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(
+                returncode=5,
+                stdout="no tests ran\n",
+                stderr="",
+            )
+            actual_tests, _ = collect_actual_counts(test_dir)
+        assert actual_tests == 0
+
+    def test_uses_custom_pytest_cmd(self, tmp_path: Path) -> None:
+        """Should pass custom pytest_cmd to subprocess.run."""
+        test_dir = self._make_test_tree(tmp_path)
+        custom_cmd = ["pixi", "run", "pytest"]
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(
+                returncode=0,
+                stdout="10 tests collected in 0.2s\n",
+                stderr="",
+            )
+            collect_actual_counts(test_dir, pytest_cmd=custom_cmd)
+            call_args = mock_run.call_args[0][0]
+            assert call_args[:3] == custom_cmd


### PR DESCRIPTION
## Summary
- Adds `scripts/check_test_counts.py` to validate README test count badges automatically by comparing documented floors (e.g. `3,500+ tests`, `137+ test files`) against actual pytest-collected counts
- Adds CI step in `.github/workflows/test.yml` to run the check on every unit test run with configurable tolerances (`--tolerance-tests 100 --tolerance-files 5`)
- Updates README badge counts to reflect the current test suite size (3,500+ tests, 137+ files) so the check passes immediately

## Test plan
- [x] `tests/unit/scripts/test_check_test_counts.py` passes (25 tests)
- [x] Pre-commit hooks pass (ruff, mypy, markdown lint, yaml lint, etc.)
- [x] `scripts/check_test_counts.py` runs successfully against current README
- [x] CI workflow includes the new check step after existing structure checks

Closes #1152