### PR TITLE
[Testing] Annotate test functions in tests/unit/e2e/ for mypy compliance

### DIFF
--- a/tests/unit/e2e/test_baseline_regression.py
+++ b/tests/unit/e2e/test_baseline_regression.py
@@ -13,7 +13,7 @@ from scylla.judge.prompts import build_task_prompt
 
 
 @pytest.fixture
-def mock_pipeline_result():
+def mock_pipeline_result() -> BuildPipelineResult:
     """Create a mock BuildPipelineResult."""
     return BuildPipelineResult(
         language="python",
@@ -28,7 +28,7 @@ def mock_pipeline_result():
 
 
 @pytest.fixture
-def mock_baseline_all_passed():
+def mock_baseline_all_passed() -> BuildPipelineResult:
     """Create a baseline where everything passed."""
     return BuildPipelineResult(
         language="python",
@@ -42,7 +42,9 @@ def mock_baseline_all_passed():
     )
 
 
-def test_build_task_prompt_with_baseline(mock_pipeline_result, mock_baseline_all_passed):
+def test_build_task_prompt_with_baseline(
+    mock_pipeline_result: BuildPipelineResult, mock_baseline_all_passed: BuildPipelineResult
+) -> None:
     """Test that baseline section is rendered when baseline_pipeline_str is provided."""
     baseline_str = "**Overall Status**: ALL PASSED ✓\n\nBuild: ✓\nLint: ✓\nTest: ✓"
     pipeline_str = "**Overall Status**: SOME FAILED ✗\n\nBuild: ✓\nLint: ✗\nTest: ✓"
@@ -70,7 +72,7 @@ def test_build_task_prompt_with_baseline(mock_pipeline_result, mock_baseline_all
     assert baseline_pos < post_agent_pos
 
 
-def test_build_task_prompt_without_baseline():
+def test_build_task_prompt_without_baseline() -> None:
     """Test that no baseline section is rendered when baseline_pipeline_str is None."""
     pipeline_str = "**Overall Status**: ALL PASSED ✓"
 
@@ -89,7 +91,7 @@ def test_build_task_prompt_without_baseline():
     assert "Build/Lint/Test Pipeline Results" in prompt
 
 
-def test_build_task_prompt_baseline_section_before_post_agent():
+def test_build_task_prompt_baseline_section_before_post_agent() -> None:
     """Test that baseline section appears before post-agent section in prompt."""
     baseline_str = "Baseline status"
     pipeline_str = "Post-agent status"
@@ -108,7 +110,9 @@ def test_build_task_prompt_baseline_section_before_post_agent():
     assert baseline_idx < post_agent_idx, "Baseline section must appear before post-agent section"
 
 
-def test_save_load_pipeline_baseline(tmp_path, mock_pipeline_result):
+def test_save_load_pipeline_baseline(
+    tmp_path: Path, mock_pipeline_result: BuildPipelineResult
+) -> None:
     """Test round-trip persistence of pipeline baseline to/from JSON."""
     results_dir = tmp_path / "results"
     results_dir.mkdir()
@@ -129,7 +133,7 @@ def test_save_load_pipeline_baseline(tmp_path, mock_pipeline_result):
     assert loaded.all_passed == mock_pipeline_result.all_passed
 
 
-def test_load_pipeline_baseline_missing_file(tmp_path):
+def test_load_pipeline_baseline_missing_file(tmp_path: Path) -> None:
     """Test loading baseline when file doesn't exist returns None."""
     results_dir = tmp_path / "results"
     results_dir.mkdir()
@@ -138,7 +142,7 @@ def test_load_pipeline_baseline_missing_file(tmp_path):
     assert loaded is None
 
 
-def test_load_pipeline_baseline_invalid_json(tmp_path):
+def test_load_pipeline_baseline_invalid_json(tmp_path: Path) -> None:
     """Test loading baseline with invalid JSON returns None and logs warning."""
     results_dir = tmp_path / "results"
     results_dir.mkdir()
@@ -150,7 +154,7 @@ def test_load_pipeline_baseline_invalid_json(tmp_path):
     assert loaded is None
 
 
-def test_run_result_baseline_field():
+def test_run_result_baseline_field() -> None:
     """Test that E2ERunResult includes baseline_pipeline_summary in to_dict()."""
     baseline_summary = {
         "all_passed": True,
@@ -187,7 +191,7 @@ def test_run_result_baseline_field():
     assert result_dict["baseline_pipeline_summary"] == baseline_summary
 
 
-def test_run_result_baseline_field_none():
+def test_run_result_baseline_field_none() -> None:
     """Test that baseline_pipeline_summary can be None."""
     run_result = E2ERunResult(
         run_number=1,
@@ -217,7 +221,7 @@ def test_run_result_baseline_field_none():
     assert result_dict["baseline_pipeline_summary"] is None
 
 
-def test_baseline_summary_conversion(mock_pipeline_result):
+def test_baseline_summary_conversion(mock_pipeline_result: BuildPipelineResult) -> None:
     """Test that BuildPipelineResult is correctly converted to summary dict."""
     summary = {
         "all_passed": mock_pipeline_result.all_passed,

--- a/tests/unit/e2e/test_orchestrator.py
+++ b/tests/unit/e2e/test_orchestrator.py
@@ -82,7 +82,7 @@ class TestEvalOrchestratorWithFixture:
     """Tests for orchestrator with proper test fixture."""
 
     @pytest.fixture
-    def test_env(self, tmp_path: Path):
+    def test_env(self, tmp_path: Path) -> Path:
         """Create a test environment with config files."""
         # Create directory structure
         tests_dir = tmp_path / "tests" / "001-test"

--- a/tests/unit/e2e/test_rerun_base.py
+++ b/tests/unit/e2e/test_rerun_base.py
@@ -7,6 +7,8 @@ from enum import Enum
 from pathlib import Path
 
 import pytest
+from _pytest.capture import CaptureFixture
+from _pytest.monkeypatch import MonkeyPatch
 
 from scylla.e2e.rerun_base import load_rerun_context, print_dry_run_summary
 
@@ -41,7 +43,7 @@ class _TestJudgeItem:
     reason: str
 
 
-def test_load_rerun_context_success(tmp_path: Path):
+def test_load_rerun_context_success(tmp_path: Path) -> None:
     """Test successful loading of rerun context."""
     # Create experiment directory structure
     experiment_dir = tmp_path / "experiment"
@@ -87,7 +89,7 @@ def test_load_rerun_context_success(tmp_path: Path):
     assert context.tier_manager is not None
 
 
-def test_load_rerun_context_missing_config(tmp_path: Path):
+def test_load_rerun_context_missing_config(tmp_path: Path) -> None:
     """Test error when config file is missing."""
     experiment_dir = tmp_path / "experiment"
     experiment_dir.mkdir()
@@ -96,7 +98,7 @@ def test_load_rerun_context_missing_config(tmp_path: Path):
         load_rerun_context(experiment_dir)
 
 
-def test_load_rerun_context_missing_tiers_dir(tmp_path: Path, monkeypatch):
+def test_load_rerun_context_missing_tiers_dir(tmp_path: Path, monkeypatch: MonkeyPatch) -> None:
     """Test error when tiers directory cannot be found."""
     # Create experiment directory with config but no tiers
     experiment_dir = tmp_path / "experiment"
@@ -125,7 +127,7 @@ def test_load_rerun_context_missing_tiers_dir(tmp_path: Path, monkeypatch):
         load_rerun_context(experiment_dir)
 
 
-def test_print_dry_run_summary_runs(capsys):
+def test_print_dry_run_summary_runs(capsys: CaptureFixture[str]) -> None:
     """Test dry-run summary for run items."""
     # Create test items
     failed_runs = [
@@ -159,7 +161,7 @@ def test_print_dry_run_summary_runs(capsys):
     assert "T0/01/run_01: Never started" in captured.out
 
 
-def test_print_dry_run_summary_judges(capsys):
+def test_print_dry_run_summary_judges(capsys: CaptureFixture[str]) -> None:
     """Test dry-run summary for judge items."""
     # Create test items
     failed_slots = [
@@ -193,7 +195,7 @@ def test_print_dry_run_summary_judges(capsys):
     assert "T0/00/run_02 judge_01 (claude-sonnet-4-5): Never ran" in captured.out
 
 
-def test_print_dry_run_summary_truncation(capsys):
+def test_print_dry_run_summary_truncation(capsys: CaptureFixture[str]) -> None:
     """Test that dry-run summary truncates long lists."""
     # Create 15 failed runs
     failed_runs = [_TestRunItem("T0", f"{i:02d}", 1, "Failed") for i in range(15)]
@@ -213,7 +215,7 @@ def test_print_dry_run_summary_truncation(capsys):
     assert "... and 5 more" in captured.out
 
 
-def test_print_dry_run_summary_empty(capsys):
+def test_print_dry_run_summary_empty(capsys: CaptureFixture[str]) -> None:
     """Test dry-run summary with no items."""
     items_by_status: dict[_TestStatus, list[_TestRunItem]] = {
         _TestStatus.FAILED: [],


### PR DESCRIPTION
## Summary
- Adds `-> None` return type annotations to all test functions in `tests/unit/e2e/`
- Adds fixture return type annotations (`BuildPipelineResult`, `Path`) to `@pytest.fixture` functions
- Adds parameter type hints (`Path`, `MonkeyPatch`, `CaptureFixture[str]`, `BuildPipelineResult`) where needed for mypy compliance

## Test plan
- [ ] `mypy tests/unit/e2e/` passes
- [ ] All tests in `tests/unit/e2e/` pass
- [ ] Pre-commit hooks pass

Closes #1120