### PR TITLE
[Feat] Add CI step to measure Docker build cache efficiency (issue #1173)

### DIFF
--- a/.github/workflows/docker-test.yml
+++ b/.github/workflows/docker-test.yml
@@ -4,12 +4,14 @@ on:
   pull_request:
     paths:
       - 'docker/**'
+      - 'scylla/**'
       - 'tests/shell/**'
       - '.github/workflows/docker-test.yml'
   push:
     branches: [main]
     paths:
       - 'docker/**'
+      - 'scylla/**'
       - 'tests/shell/**'
       - '.github/workflows/docker-test.yml'
 
@@ -34,3 +36,79 @@ jobs:
 
       # Docker integration tests are deferred — see docs/dev/adr/docker-testing-deferred.md
       # Entrypoint script testing is tracked in GitHub issue #1113
+
+  docker-build-timing:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    env:
+      DOCKER_BUILDKIT: "1"
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Build cold (no cache)
+        id: cold_build
+        run: |
+          START=$SECONDS
+          docker build -f docker/Dockerfile . --progress=plain --no-cache \
+            2>&1 | tee /tmp/build_cold.log
+          echo "duration=$((SECONDS - START))" >> "$GITHUB_OUTPUT"
+
+      - name: Apply trivial source-only change
+        run: echo '# timing-probe' >> scylla/__init__.py
+
+      - name: Build warm (source-only change, Layer 1+2 should be cached)
+        id: warm_build
+        run: |
+          START=$SECONDS
+          docker build -f docker/Dockerfile . --progress=plain \
+            2>&1 | tee /tmp/build_warm.log
+          echo "duration=$((SECONDS - START))" >> "$GITHUB_OUTPUT"
+
+      - name: Revert source change
+        if: always()
+        run: git checkout scylla/__init__.py
+
+      - name: Report timing results
+        env:
+          COLD_DURATION: ${{ steps.cold_build.outputs.duration }}
+          WARM_DURATION: ${{ steps.warm_build.outputs.duration }}
+        run: |
+          python3 - <<'PYEOF'
+          import os
+          import sys
+
+          sys.path.insert(0, ".")
+          from scripts.docker_build_timing import (
+              build_summary_table,
+              compute_reduction,
+              count_cached_layers,
+          )
+
+          cold = int(os.environ["COLD_DURATION"])
+          warm = int(os.environ["WARM_DURATION"])
+
+          with open("/tmp/build_warm.log") as f:
+              warm_log = f.read()
+
+          cached_count = count_cached_layers(warm_log)
+          reduction = compute_reduction(cold, warm)
+          table = build_summary_table(cold, warm, cached_count, reduction)
+
+          summary_path = os.environ.get("GITHUB_STEP_SUMMARY", "/dev/stdout")
+          with open(summary_path, "a") as f:
+              f.write(table)
+          print(table)
+
+          if reduction < 30:
+              print(
+                  f"::warning::Docker source-only rebuild reduced build time by "
+                  f"{reduction}% -- below the >=30% target. "
+                  "Review layer ordering in docker/Dockerfile."
+              )
+          else:
+              print(
+                  f"::notice::Docker source-only rebuild achieved {reduction}% "
+                  "reduction -- meets >=30% acceptance criterion."
+              )
+          PYEOF

--- a/scripts/docker_build_timing.py
+++ b/scripts/docker_build_timing.py
@@ -1,0 +1,79 @@
+"""Docker build timing utilities.
+
+Shared helper functions used by both the CI script in docker-test.yml and the
+unit tests in tests/unit/docker/test_docker_build_timing.py.
+
+No Docker daemon required to import this module — all functions operate on
+plain text (build log strings) or pure arithmetic.
+"""
+
+from __future__ import annotations
+
+
+def count_cached_layers(build_log: str) -> int:
+    """Count the number of CACHED layer lines in a docker build --progress=plain log.
+
+    BuildKit emits ``#N CACHED`` lines for each layer that was restored from
+    the local layer cache.  This count indicates how effective the cache was
+    for a particular build.
+
+    Args:
+        build_log: Full stdout+stderr from ``docker build --progress=plain``.
+
+    Returns:
+        Number of lines that contain the word ``CACHED`` (case-insensitive).
+
+    """
+    return build_log.upper().count("CACHED")
+
+
+def compute_reduction(cold_seconds: int, warm_seconds: int) -> float:
+    """Compute the percentage reduction in build time from cold to warm build.
+
+    Args:
+        cold_seconds: Wall-clock seconds for the cold (no-cache) build.
+        warm_seconds: Wall-clock seconds for the warm (source-change) rebuild.
+
+    Returns:
+        Percentage reduction, rounded to one decimal place.
+        Returns 0.0 if *cold_seconds* is zero to avoid division by zero.
+
+    """
+    if cold_seconds <= 0:
+        return 0.0
+    reduction = (cold_seconds - warm_seconds) / cold_seconds * 100
+    return round(reduction, 1)
+
+
+def build_summary_table(
+    cold_seconds: int,
+    warm_seconds: int,
+    cached_layers: int,
+    reduction: float,
+) -> str:
+    """Render a Markdown table summarising the before/after build timing.
+
+    The table is written to ``$GITHUB_STEP_SUMMARY`` by the CI report step so
+    it appears as a structured summary in the GitHub Actions UI.
+
+    Args:
+        cold_seconds: Wall-clock seconds for the cold build.
+        warm_seconds: Wall-clock seconds for the warm rebuild.
+        cached_layers: Number of ``CACHED`` layers in the warm build log.
+        reduction: Percentage time reduction (from :func:`compute_reduction`).
+
+    Returns:
+        Markdown string containing the full summary table.
+
+    """
+    verdict = "PASS" if reduction >= 30 else "FAIL"
+    return (
+        "## Docker Build Timing: Source-Only Change Cache Efficiency\n\n"
+        "| Metric | Value |\n"
+        "|--------|-------|\n"
+        f"| Cold build (no cache) | {cold_seconds}s |\n"
+        f"| Warm rebuild (source change only) | {warm_seconds}s |\n"
+        f"| Reduction | {reduction}% |\n"
+        f"| Cached layers (warm build) | {cached_layers} |\n"
+        f"| Acceptance criterion (≥30%) | {verdict} |\n"
+    )

--- a/tests/unit/docker/test_docker_build_timing.py
+++ b/tests/unit/docker/test_docker_build_timing.py
@@ -1,0 +1,181 @@
+"""Unit tests for Docker build timing utilities.
+
+Tests the helper functions in scripts/docker_build_timing.py without
+requiring a Docker daemon — purely static logic tests.
+
+See GitHub issue #1173.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from scripts.docker_build_timing import (
+    build_summary_table,
+    compute_reduction,
+    count_cached_layers,
+)
+
+
+class TestCachedLayerExtraction:
+    """Tests for count_cached_layers()."""
+
+    def test_counts_cached_lines_in_sample_log(self) -> None:
+        """Typical BuildKit --progress=plain output with several CACHED lines."""
+        log = (
+            "#1 [internal] load build definition from Dockerfile\n"
+            "#1 DONE 0.1s\n"
+            "#2 [internal] load .dockerignore\n"
+            "#2 DONE 0.0s\n"
+            "#3 [builder 1/5] FROM python:3.12-slim\n"
+            "#3 CACHED\n"
+            "#4 [builder 2/5] RUN apt-get update\n"
+            "#4 CACHED\n"
+            "#5 [builder 3/5] RUN pip install hatchling\n"
+            "#5 CACHED\n"
+            "#6 [builder 4/5] COPY pyproject.toml\n"
+            "#6 CACHED\n"
+            "#7 [builder 5/5] RUN pip install deps\n"
+            "#7 CACHED\n"
+            "#8 [builder 6/5] COPY scylla/\n"
+            "#8 DONE 0.5s\n"
+        )
+        assert count_cached_layers(log) == 5
+
+    def test_case_insensitive_cached_match(self) -> None:
+        """Matches regardless of CACHED capitalisation."""
+        log = "cached\nCACHED\nCached\n"
+        assert count_cached_layers(log) == 3
+
+    def test_zero_cached_in_cold_build_log(self) -> None:
+        """A cold (no-cache) build log contains no CACHED markers."""
+        log = (
+            "#1 [internal] load build definition\n"
+            "#1 DONE 0.1s\n"
+            "#2 [builder 1/3] FROM python:3.12-slim\n"
+            "#2 DONE 12.3s\n"
+        )
+        assert count_cached_layers(log) == 0
+
+    def test_empty_log(self) -> None:
+        """Empty log returns zero."""
+        assert count_cached_layers("") == 0
+
+
+class TestReductionFormula:
+    """Tests for compute_reduction()."""
+
+    def test_50_percent_reduction(self) -> None:
+        """100s cold, 50s warm → 50% reduction."""
+        assert compute_reduction(100, 50) == 50.0
+
+    def test_30_percent_boundary_pass(self) -> None:
+        """Exactly 30% reduction."""
+        assert compute_reduction(100, 70) == 30.0
+
+    def test_29_percent_below_threshold(self) -> None:
+        """29% reduction is below the ≥30% acceptance criterion."""
+        assert compute_reduction(100, 71) == 29.0
+
+    def test_zero_cold_duration_does_not_divide_by_zero(self) -> None:
+        """cold_seconds=0 must return 0.0 without raising ZeroDivisionError."""
+        assert compute_reduction(0, 50) == 0.0
+
+    def test_reduction_rounds_to_one_decimal(self) -> None:
+        """Result is rounded to exactly one decimal place."""
+        # 100s → 33s: (67/100)*100 = 67.0%
+        result = compute_reduction(100, 33)
+        assert result == 67.0
+        # 120s → 85s: 35/120 * 100 = 29.166... → 29.2
+        result2 = compute_reduction(120, 85)
+        assert result2 == 29.2
+
+    def test_warm_longer_than_cold_gives_negative_reduction(self) -> None:
+        """If warm build is somehow slower, reduction is negative (no divide-by-zero)."""
+        result = compute_reduction(50, 100)
+        assert result == -100.0
+
+    def test_identical_durations_give_zero_reduction(self) -> None:
+        """Same cold and warm time → 0% reduction."""
+        assert compute_reduction(60, 60) == 0.0
+
+
+class TestMarkdownTableFormat:
+    """Tests for build_summary_table()."""
+
+    def test_table_contains_required_columns(self) -> None:
+        """Table must include the four required metric rows."""
+        table = build_summary_table(
+            cold_seconds=120,
+            warm_seconds=80,
+            cached_layers=5,
+            reduction=33.3,
+        )
+        assert "Cold build (no cache)" in table
+        assert "Warm rebuild (source change only)" in table
+        assert "Reduction" in table
+        assert "Cached layers (warm build)" in table
+        assert "Acceptance criterion" in table
+
+    def test_pass_when_reduction_gte_30(self) -> None:
+        """Verdict is PASS when reduction >= 30%."""
+        table = build_summary_table(
+            cold_seconds=100,
+            warm_seconds=60,
+            cached_layers=3,
+            reduction=40.0,
+        )
+        assert "PASS" in table
+        assert "FAIL" not in table
+
+    def test_fail_when_reduction_lt_30(self) -> None:
+        """Verdict is FAIL when reduction < 30%."""
+        table = build_summary_table(
+            cold_seconds=100,
+            warm_seconds=80,
+            cached_layers=1,
+            reduction=20.0,
+        )
+        assert "FAIL" in table
+
+    def test_values_appear_in_table(self) -> None:
+        """Cold, warm, reduction, and cached-layer values are present."""
+        table = build_summary_table(
+            cold_seconds=200,
+            warm_seconds=50,
+            cached_layers=7,
+            reduction=75.0,
+        )
+        assert "200s" in table
+        assert "50s" in table
+        assert "75.0%" in table
+        assert "7" in table
+
+    def test_table_has_markdown_header(self) -> None:
+        """Table output begins with a level-2 Markdown heading."""
+        table = build_summary_table(
+            cold_seconds=90,
+            warm_seconds=45,
+            cached_layers=4,
+            reduction=50.0,
+        )
+        assert table.startswith("## Docker Build Timing")
+
+    @pytest.mark.parametrize(
+        ("reduction", "expected_verdict"),
+        [
+            (0.0, "FAIL"),
+            (29.9, "FAIL"),
+            (30.0, "PASS"),
+            (100.0, "PASS"),
+        ],
+    )
+    def test_verdict_boundary_values(self, reduction: float, expected_verdict: str) -> None:
+        """Verdict is PASS at exactly 30% and above, FAIL below."""
+        table = build_summary_table(
+            cold_seconds=100,
+            warm_seconds=int(100 - reduction),
+            cached_layers=0,
+            reduction=reduction,
+        )
+        assert expected_verdict in table


### PR DESCRIPTION
## Summary

- Adds a new `docker-build-timing` job to `.github/workflows/docker-test.yml` that runs two consecutive Docker builds (cold + warm with a trivial `scylla/__init__.py` comment) and reports the ≥30% Layer-3 cache reduction claim with actual measured data
- Adds `scylla/**` to the workflow's trigger paths so source-only PRs also run the timing job
- Extracts the timing logic into `scripts/docker_build_timing.py` (shared between CI and tests)
- Adds 20 unit tests in `tests/unit/docker/test_docker_build_timing.py` (no Docker daemon required)

## Test plan

- [x] 20 new unit tests all pass (`pytest tests/unit/docker/test_docker_build_timing.py`)
- [x] Full test suite passes (3605 tests, coverage ≥ 9%)
- [x] Pre-commit hooks pass (ruff, mypy, yaml-lint, check-unit-test-structure)
- [ ] CI `docker-build-timing` job runs on the PR and shows the timing table in the Job Summary

Closes #1173

🤖 Generated with [Claude Code](https://claude.com/claude-code)