### PR TITLE
feat(ci): add Python version drift detection across pyproject.toml and Dockerfile

### DIFF
--- a/tests/unit/scripts/test_check_python_version_consistency.py
+++ b/tests/unit/scripts/test_check_python_version_consistency.py
@@ -296,7 +296,7 @@ class TestCheckVersionConsistency:
 
     def test_digest_pinned_dockerfile_matches(self, tmp_path: Path) -> None:
         """Should correctly match when Dockerfile uses digest-pinned FROM."""
-        digest = "sha256:f3fa41d74a768c2fce8016b98c191ae8c1bacd8f1152870a3f9f87d350920b7c"
         write_pyproject(tmp_path, ["Programming Language :: Python :: 3.12"])
+        digest = "sha256:f3fa41d74a768c2fce8016b98c191ae8c1bacd8f1152870a3f9f87d350920b7c"
         write_dockerfile(tmp_path, f"FROM python:3.12-slim@{digest} AS builder")
         assert check_version_consistency(tmp_path) == 0


### PR DESCRIPTION
## Summary

- Adds `scripts/check_python_version_consistency.py` — standalone stdlib-only script (`tomllib`/`tomli` fallback + `re`). Parses highest `Programming Language :: Python :: X.Y` classifier from `pyproject.toml` and compares it to the `FROM python:X.Y` line in `docker/Dockerfile`.
- Adds 31 unit tests in `tests/unit/scripts/test_check_python_version_consistency.py` covering all edge cases: missing files, malformed TOML, digest-pinned FROM lines (`FROM python:3.12-slim@sha256:...`), multi-stage builds, numeric version comparison (3.9 < 3.10).
- Adds pre-commit hook (`check-python-version-consistency`) triggered on changes to `pyproject.toml` or `docker/Dockerfile`.
- Adds CI step in `.github/workflows/test.yml` using `python3` (stdlib-only, no pixi install required) placed after the BaseRunMetrics tracking step.

## Test plan

- [x] 31 new unit tests pass
- [x] 3615 total tests pass (coverage 9%+ combined, 79.57% unit-only)
- [x] Script correctly detects existing drift in repo (pyproject.toml has 3.13 classifier, Dockerfile uses 3.12) — expected behavior per issue intent

Closes #1168