### PR TITLE
feat(e2e): expose process_metrics in per-run report.json and report.md

### DIFF
--- a/scylla/e2e/run_report.py
+++ b/scylla/e2e/run_report.py
@@ -12,6 +12,7 @@ Each level has both JSON and markdown reports with relative links.
 from __future__ import annotations
 
 import json
+import math
 from collections.abc import Callable
 from datetime import datetime, timezone
 from pathlib import Path
@@ -369,6 +370,57 @@ def _generate_judge_section(
     return lines
 
 
+def _format_process_metric_value(val: Any) -> str:
+    """Format a process metric value for display.
+
+    Args:
+        val: Metric value (float, int, or None)
+
+    Returns:
+        Formatted string: 4 decimal places for floats, 'N/A' for None/NaN.
+
+    """
+    if val is None:
+        return "N/A"
+    try:
+        f = float(val)
+        if math.isnan(f):
+            return "N/A"
+        return f"{f:.4f}"
+    except (TypeError, ValueError):
+        return "N/A"
+
+
+def _generate_process_metrics_section(process_metrics: dict[str, Any]) -> list[str]:
+    """Generate process metrics section markdown.
+
+    Args:
+        process_metrics: Dict with keys r_prog, strategic_drift, cfp, pr_revert_rate
+
+    Returns:
+        List of markdown lines for process metrics section.
+
+    """
+    r_prog = _format_process_metric_value(process_metrics.get("r_prog"))
+    strategic_drift = _format_process_metric_value(process_metrics.get("strategic_drift"))
+    cfp = _format_process_metric_value(process_metrics.get("cfp"))
+    pr_revert_rate = _format_process_metric_value(process_metrics.get("pr_revert_rate"))
+
+    return [
+        "---",
+        "",
+        "## Process Metrics",
+        "",
+        "| Metric | Value |",
+        "|--------|-------|",
+        f"| R_Prog (Fine-Grained Progress) | {r_prog} |",
+        f"| Strategic Drift | {strategic_drift} |",
+        f"| CFP (Change Fail %) | {cfp} |",
+        f"| PR Revert Rate | {pr_revert_rate} |",
+        "",
+    ]
+
+
 def generate_run_report(
     tier_id: str,
     subtest_id: str,
@@ -390,6 +442,7 @@ def generate_run_report(
     token_stats: dict[str, int] | None = None,
     agent_duration_seconds: float | None = None,
     judge_duration_seconds: float | None = None,
+    process_metrics: dict[str, Any] | None = None,
 ) -> str:
     """Generate markdown report content for a single run.
 
@@ -414,6 +467,8 @@ def generate_run_report(
             input_tokens, output_tokens, cache_creation_tokens, cache_read_tokens
         agent_duration_seconds: Agent execution time (optional)
         judge_duration_seconds: Judge evaluation time (optional)
+        process_metrics: Optional process metrics dict with keys:
+            r_prog, strategic_drift, cfp, pr_revert_rate
 
     Returns:
         Formatted markdown report string.
@@ -486,6 +541,10 @@ def generate_run_report(
 
     # Add workspace state
     lines.extend(_generate_workspace_state_section(workspace_path))
+
+    # Add process metrics section if available
+    if process_metrics and isinstance(process_metrics, dict):
+        lines.extend(_generate_process_metrics_section(process_metrics))
 
     # Add agent output link
     lines.extend(
@@ -714,6 +773,7 @@ def save_run_report(
     token_stats: dict[str, int] | None = None,
     agent_duration_seconds: float | None = None,
     judge_duration_seconds: float | None = None,
+    process_metrics: dict[str, Any] | None = None,
 ) -> None:
     """Generate and save markdown report for a single run.
 
@@ -743,6 +803,7 @@ def save_run_report(
         token_stats=token_stats,
         agent_duration_seconds=agent_duration_seconds,
         judge_duration_seconds=judge_duration_seconds,
+        process_metrics=process_metrics,
     )
 
     output_path.parent.mkdir(parents=True, exist_ok=True)
@@ -762,6 +823,7 @@ def save_run_report_json(
     passed: bool,
     cost_usd: float,
     duration_seconds: float,
+    process_metrics: dict[str, Any] | None = None,
 ) -> None:
     """Save JSON report for a single run.
 
@@ -773,9 +835,11 @@ def save_run_report_json(
         passed: Whether passed
         cost_usd: Cost in USD
         duration_seconds: Duration
+        process_metrics: Optional process metrics dict with keys:
+            r_prog, strategic_drift, cfp, pr_revert_rate
 
     """
-    report = {
+    report: dict[str, Any] = {
         "run_number": run_number,
         "score": score,
         "grade": grade,
@@ -784,6 +848,20 @@ def save_run_report_json(
         "duration_seconds": duration_seconds,
         "generated_at": datetime.now(timezone.utc).isoformat(),
     }
+
+    if process_metrics and isinstance(process_metrics, dict):
+        guarded: dict[str, float | None] = {}
+        for key in ("r_prog", "strategic_drift", "cfp", "pr_revert_rate"):
+            val = process_metrics.get(key)
+            if val is None:
+                guarded[key] = None
+            else:
+                try:
+                    f = float(val)
+                    guarded[key] = None if math.isnan(f) else f
+                except (TypeError, ValueError):
+                    guarded[key] = None
+        report["process_metrics"] = guarded
 
     (run_dir / "report.json").write_text(json.dumps(report, indent=2))
 

--- a/scylla/e2e/stages.py
+++ b/scylla/e2e/stages.py
@@ -1303,6 +1303,15 @@ def stage_write_report(ctx: RunContext) -> None:
 
     token_stats = ctx.run_result.token_stats
 
+    # Read process_metrics from run_result.json written by stage_finalize_run
+    process_metrics: dict[str, Any] | None = None
+    try:
+        with open(ctx.run_dir / "run_result.json") as f:
+            run_result_data = json.load(f)
+        process_metrics = run_result_data.get("process_metrics")
+    except (OSError, json.JSONDecodeError, KeyError):
+        pass
+
     save_run_report(
         output_path=ctx.run_dir / "report.md",
         tier_id=ctx.tier_id.value,
@@ -1325,6 +1334,7 @@ def stage_write_report(ctx: RunContext) -> None:
         token_stats=token_stats.to_dict(),
         agent_duration_seconds=ctx.agent_duration,
         judge_duration_seconds=ctx.judge_duration,
+        process_metrics=process_metrics,
     )
 
     save_run_report_json(
@@ -1335,6 +1345,7 @@ def stage_write_report(ctx: RunContext) -> None:
         passed=ctx.judgment["passed"],
         cost_usd=ctx.agent_result.cost_usd,
         duration_seconds=ctx.agent_duration + ctx.judge_duration,
+        process_metrics=process_metrics,
     )
 
 

--- a/tests/unit/e2e/test_run_report.py
+++ b/tests/unit/e2e/test_run_report.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 from datetime import datetime, timezone
 from pathlib import Path
+from typing import Any
 from unittest.mock import MagicMock, patch
 
 from scylla.e2e.models import (
@@ -334,6 +335,138 @@ class TestSaveRunReportJson:
         assert data["cost_usd"] == 0.0042
         assert data["duration_seconds"] == 12.5
         assert "generated_at" in data
+
+
+class TestGenerateRunReportProcessMetrics:
+    """Tests for process_metrics integration in generate_run_report."""
+
+    def _base_kwargs(self, tmp_path: Path) -> dict[str, Any]:
+        workspace = tmp_path / "workspace"
+        workspace.mkdir()
+        return {
+            "tier_id": "T0",
+            "subtest_id": "baseline",
+            "run_number": 1,
+            "score": 0.75,
+            "grade": "B",
+            "passed": True,
+            "reasoning": "Good",
+            "cost_usd": 0.001,
+            "duration_seconds": 5.0,
+            "tokens_input": 100,
+            "tokens_output": 50,
+            "exit_code": 0,
+            "task_prompt": "Test task",
+            "workspace_path": workspace,
+        }
+
+    def test_process_metrics_present(self, tmp_path: Path) -> None:
+        """All four process metrics render in the markdown table."""
+        pm = {"r_prog": 0.8, "strategic_drift": 0.1, "cfp": 0.05, "pr_revert_rate": 0.0}
+        report = generate_run_report(**self._base_kwargs(tmp_path), process_metrics=pm)
+        assert "## Process Metrics" in report
+        assert "R_Prog (Fine-Grained Progress)" in report
+        assert "Strategic Drift" in report
+        assert "CFP (Change Fail %)" in report
+        assert "PR Revert Rate" in report
+        assert "0.8000" in report
+        assert "0.1000" in report
+        assert "0.0500" in report
+        assert "0.0000" in report
+
+    def test_process_metrics_absent(self, tmp_path: Path) -> None:
+        """No crash and no section when process_metrics is None."""
+        report = generate_run_report(**self._base_kwargs(tmp_path), process_metrics=None)
+        assert "## Process Metrics" not in report
+
+    def test_process_metrics_empty_dict(self, tmp_path: Path) -> None:
+        """Empty dict does not render the section (falsy guard)."""
+        report = generate_run_report(**self._base_kwargs(tmp_path), process_metrics={})
+        assert "## Process Metrics" not in report
+
+    def test_process_metrics_partial_none_values(self, tmp_path: Path) -> None:
+        """Fields with None value render as N/A."""
+        pm = {"r_prog": 0.5, "strategic_drift": None, "cfp": None, "pr_revert_rate": 0.2}
+        report = generate_run_report(**self._base_kwargs(tmp_path), process_metrics=pm)
+        assert "## Process Metrics" in report
+        assert "0.5000" in report
+        assert "0.2000" in report
+        # N/A for None fields
+        assert report.count("N/A") >= 2
+
+
+class TestSaveRunReportJsonProcessMetrics:
+    """Tests for process_metrics in save_run_report_json."""
+
+    def test_json_includes_process_metrics(self, tmp_path: Path) -> None:
+        """JSON report includes process_metrics key when provided."""
+        run_dir = tmp_path / "run_01"
+        run_dir.mkdir()
+        pm = {"r_prog": 0.9, "strategic_drift": 0.05, "cfp": 0.0, "pr_revert_rate": 0.0}
+
+        save_run_report_json(
+            run_dir=run_dir,
+            run_number=1,
+            score=0.9,
+            grade="S",
+            passed=True,
+            cost_usd=0.001,
+            duration_seconds=3.0,
+            process_metrics=pm,
+        )
+
+        data = json.loads((run_dir / "report.json").read_text())
+        assert "process_metrics" in data
+        assert data["process_metrics"]["r_prog"] == 0.9
+        assert data["process_metrics"]["strategic_drift"] == 0.05
+        assert data["process_metrics"]["cfp"] == 0.0
+        assert data["process_metrics"]["pr_revert_rate"] == 0.0
+
+    def test_json_process_metrics_absent(self, tmp_path: Path) -> None:
+        """JSON report has no process_metrics key when not provided."""
+        run_dir = tmp_path / "run_01"
+        run_dir.mkdir()
+
+        save_run_report_json(
+            run_dir=run_dir,
+            run_number=1,
+            score=0.5,
+            grade="C",
+            passed=False,
+            cost_usd=0.002,
+            duration_seconds=6.0,
+        )
+
+        data = json.loads((run_dir / "report.json").read_text())
+        assert "process_metrics" not in data
+
+    def test_json_process_metrics_nan_guarded(self, tmp_path: Path) -> None:
+        """NaN values in process_metrics are serialized as null."""
+        run_dir = tmp_path / "run_01"
+        run_dir.mkdir()
+        pm = {
+            "r_prog": float("nan"),
+            "strategic_drift": 0.1,
+            "cfp": None,
+            "pr_revert_rate": 0.0,
+        }
+
+        save_run_report_json(
+            run_dir=run_dir,
+            run_number=1,
+            score=0.6,
+            grade="B",
+            passed=True,
+            cost_usd=0.001,
+            duration_seconds=4.0,
+            process_metrics=pm,
+        )
+
+        data = json.loads((run_dir / "report.json").read_text())
+        assert data["process_metrics"]["r_prog"] is None
+        assert data["process_metrics"]["cfp"] is None
+        assert data["process_metrics"]["strategic_drift"] == 0.1
+        assert data["process_metrics"]["pr_revert_rate"] == 0.0
 
 
 class TestGetWorkspaceFiles:


### PR DESCRIPTION
## Summary

- Added `process_metrics` parameter to `generate_run_report()`, `save_run_report()`, and `save_run_report_json()` in `scylla/e2e/run_report.py`
- `generate_run_report()` renders a `## Process Metrics` table showing R_Prog, Strategic Drift, CFP, and PR Revert Rate
- `save_run_report_json()` writes a `process_metrics` key with NaN-guarded float values (NaN → null)
- `stage_write_report()` in `scylla/e2e/stages.py` reads `process_metrics` from the already-written `run_result.json` and passes it to both save functions
- Added 7 new unit tests covering: metrics present, absent, empty dict, partial None, JSON inclusion, JSON absent, and NaN guarding

## Test plan

- [x] `tests/unit/e2e/test_run_report.py` — 27 tests pass (new: `TestGenerateRunReportProcessMetrics` + `TestSaveRunReportJsonProcessMetrics`)
- [x] `tests/unit/e2e/` — 1319 tests pass
- [x] Full test suite — 3591 passed, 1 skipped
- [x] Pre-commit hooks (ruff, mypy, all checks) pass

Closes #1181

🤖 Generated with [Claude Code](https://claude.com/claude-code)