### PR TITLE
[Feat] Add table_cfp_comparison to tables.py

### DIFF
--- a/scylla/analysis/tables/__init__.py
+++ b/scylla/analysis/tables/__init__.py
@@ -16,6 +16,7 @@ from scylla.analysis.tables.comparison import (
     table02b_impl_rate_comparison,
     table04_criteria_performance,
     table06_model_comparison,
+    table_cfp_comparison,
 )
 from scylla.analysis.tables.detail import (
     table03_judge_agreement,
@@ -41,6 +42,7 @@ __all__ = [
     "table04_criteria_performance",
     "table05_cost_analysis",
     "table06_model_comparison",
+    "table_cfp_comparison",
     "table07_subtest_detail",
     "table08_summary_statistics",
     "table09_experiment_config",

--- a/scylla/analysis/tables/comparison.py
+++ b/scylla/analysis/tables/comparison.py
@@ -892,9 +892,47 @@ def table06_model_comparison(runs_df: pd.DataFrame) -> tuple[str, str]:
     return markdown, latex
 
 
+def table_cfp_comparison(runs_df: pd.DataFrame) -> tuple[str, str]:
+    """Compare Change Fail Percentage (CFP) and R_Prog across tiers.
+
+    Uses the same Kruskal-Wallis → pairwise Mann-Whitney U → Holm-Bonferroni
+    pipeline as table02_tier_comparison. Reports results for both CFP
+    and R_Prog (Fine-Grained Progress Rate) to support research.md §6.3.
+
+    Args:
+        runs_df: Runs DataFrame (requires 'cfp' and 'r_prog' columns).
+
+    Returns:
+        Tuple of (markdown_table, latex_table).
+
+    """
+    if "cfp" not in runs_df.columns:
+        return (
+            "*(CFP data not yet collected)*",
+            "% CFP data not yet collected",
+        )
+
+    cfp_md, cfp_latex = _generate_pairwise_comparison(
+        runs_df,
+        metric_column="cfp",
+        metric_name="CFP",
+        table_title="Change Fail Percentage by Tier",
+        table_label="cfp_comparison",
+    )
+    r_prog_md, r_prog_latex = _generate_pairwise_comparison(
+        runs_df,
+        metric_column="r_prog",
+        metric_name="R\\_Prog",
+        table_title="Fine-Grained Progress Rate by Tier",
+        table_label="r_prog_comparison",
+    )
+    return (cfp_md + "\n\n" + r_prog_md, cfp_latex + "\n\n" + r_prog_latex)
+
+
 __all__ = [
     "table02_tier_comparison",
     "table02b_impl_rate_comparison",
     "table04_criteria_performance",
     "table06_model_comparison",
+    "table_cfp_comparison",
 ]

--- a/tests/unit/analysis/test_tables.py
+++ b/tests/unit/analysis/test_tables.py
@@ -50,6 +50,7 @@ def test_table_function_signatures():
         "table08_summary_statistics",
         "table09_experiment_config",
         "table10_normality_tests",
+        "table_cfp_comparison",
     ]
 
     for func_name in table_functions:
@@ -834,3 +835,82 @@ def test_table10_calculation_verification():
     # Verify latex has same structure
     assert "NormalModel" in latex
     assert "UniformModel" in latex
+
+
+# ============================================================================
+# Tests for table_cfp_comparison
+# ============================================================================
+
+
+def test_table_cfp_comparison_format(sample_runs_df):
+    """Test table_cfp_comparison returns valid dual-format output."""
+    from scylla.analysis.tables import table_cfp_comparison
+
+    markdown, latex = table_cfp_comparison(sample_runs_df)
+
+    assert isinstance(markdown, str)
+    assert isinstance(latex, str)
+    assert len(markdown) > 0
+    assert len(latex) > 0
+
+    # Both CFP and R_Prog sections should be present
+    assert "CFP" in markdown
+    assert "tabular" in latex or "table" in latex.lower()
+
+
+def test_table_cfp_comparison_missing_column():
+    """Test table_cfp_comparison returns placeholder when cfp column is absent."""
+    import pandas as pd
+
+    from scylla.analysis.tables import table_cfp_comparison
+
+    df = pd.DataFrame(
+        {
+            "agent_model": ["Sonnet 4.5"] * 5,
+            "tier": ["T0"] * 5,
+            "score": [0.5, 0.6, 0.7, 0.8, 0.9],
+            "passed": [True] * 5,
+        }
+    )
+
+    markdown, latex = table_cfp_comparison(df)
+
+    # Should return placeholder strings without raising
+    assert isinstance(markdown, str)
+    assert isinstance(latex, str)
+    assert len(markdown) > 0
+    assert len(latex) > 0
+
+
+def test_table_cfp_comparison_all_nan(sample_runs_df):
+    """Test table_cfp_comparison handles all-NaN cfp column without error."""
+    from scylla.analysis.tables import table_cfp_comparison
+
+    df = sample_runs_df.copy()
+    df["cfp"] = float("nan")
+    df["r_prog"] = float("nan")
+
+    markdown, latex = table_cfp_comparison(df)
+
+    # Should complete without exception and return valid strings
+    assert isinstance(markdown, str)
+    assert isinstance(latex, str)
+
+
+def test_table_cfp_comparison_statistical_workflow(sample_runs_df):
+    """Test table_cfp_comparison uses correct statistical workflow."""
+    from scylla.analysis.tables import table_cfp_comparison
+
+    markdown, latex = table_cfp_comparison(sample_runs_df)
+
+    # Verify statistical workflow documented in CFP section
+    assert "Kruskal-Wallis" in markdown
+    assert "Mann-Whitney" in markdown
+    assert "Holm-Bonferroni" in markdown
+
+    # Verify both sections present
+    assert "Change Fail Percentage" in markdown
+    assert "Fine-Grained Progress" in markdown
+
+    # LaTeX should have two table environments
+    assert latex.count(r"\begin{table}") >= 2


### PR DESCRIPTION
## Summary

- Implements `table_cfp_comparison()` in `scylla/analysis/tables/comparison.py` as a thin wrapper around the existing `_generate_pairwise_comparison()` helper
- Runs the full Kruskal-Wallis → pairwise Mann-Whitney U → Holm-Bonferroni pipeline for both CFP and R_Prog metrics to support research.md §6.3
- Includes column-existence guard: returns a placeholder string when `cfp` column is absent
- Exports `table_cfp_comparison` from `scylla/analysis/tables/__init__.py`

## Test plan

- [x] `test_table_cfp_comparison_format` — smoke test: returns `(str, str)`, non-empty, CFP appears in markdown, `tabular` in latex
- [x] `test_table_cfp_comparison_missing_column` — returns graceful placeholder when `cfp` column is absent
- [x] `test_table_cfp_comparison_all_nan` — completes without error when all `cfp`/`r_prog` values are NaN
- [x] `test_table_cfp_comparison_statistical_workflow` — verifies Kruskal-Wallis, Mann-Whitney, Holm-Bonferroni present; both sections in output
- [x] `test_table_function_signatures` — updated to include `table_cfp_comparison`
- [x] All 39 tables tests pass; 3588 tests pass overall

Closes #1187

🤖 Generated with [Claude Code](https://claude.com/claude-code)