### PR TITLE
feat(analysis): add fig_strategic_drift_by_tier figure

### DIFF
--- a/scripts/generate_figures.py
+++ b/scripts/generate_figures.py
@@ -44,6 +44,7 @@ from scylla.analysis.figures.process_metrics import (
     fig_cfp_by_tier,
     fig_pr_revert_by_tier,
     fig_r_prog_by_tier,
+    fig_strategic_drift_by_tier,
 )
 from scylla.analysis.figures.spec_builder import apply_publication_theme
 from scylla.analysis.figures.subtest_detail import (
@@ -101,6 +102,7 @@ FIGURES: dict[str, tuple[str, Any]] = {
     "fig_r_prog_by_tier": ("tier", fig_r_prog_by_tier),
     "fig_cfp_by_tier": ("tier", fig_cfp_by_tier),
     "fig_pr_revert_by_tier": ("tier", fig_pr_revert_by_tier),
+    "fig_strategic_drift_by_tier": ("tier", fig_strategic_drift_by_tier),
 }
 
 

--- a/scylla/analysis/figures/process_metrics.py
+++ b/scylla/analysis/figures/process_metrics.py
@@ -1,7 +1,7 @@
 """Process metrics figures.
 
 Generates Fig_RProg (R_Prog by tier), Fig_CFP (CFP by tier),
-and Fig_PRRevert (PR Revert Rate by tier).
+Fig_PRRevert (PR Revert Rate by tier), and Fig_StrategicDrift (Strategic Drift by tier).
 """
 
 from __future__ import annotations
@@ -219,3 +219,55 @@ def fig_pr_revert_by_tier(runs_df: pd.DataFrame, output_dir: Path, render: bool 
     )
 
     save_figure(chart, "fig_pr_revert_by_tier", output_dir, render)
+
+
+def fig_strategic_drift_by_tier(
+    runs_df: pd.DataFrame, output_dir: Path, render: bool = True
+) -> None:
+    """Generate Fig_StrategicDrift: Strategic Drift by Tier.
+
+    Box plot showing strategic_drift distribution per tier, faceted by agent_model.
+    Skips gracefully if strategic_drift column is missing or all-null.
+
+    Args:
+        runs_df: Runs DataFrame (must contain 'strategic_drift', 'tier', 'agent_model' columns)
+        output_dir: Output directory for figure files
+        render: Whether to render to PNG/PDF (default: True)
+
+    """
+    if "strategic_drift" not in runs_df.columns:
+        logger.warning(
+            "strategic_drift column not found in runs_df; skipping fig_strategic_drift_by_tier"
+        )
+        return
+
+    data = _filter_process_data(
+        runs_df[["tier", "agent_model", "strategic_drift"]], "strategic_drift"
+    )
+    if data.empty:
+        logger.warning("No strategic_drift data available; skipping fig_strategic_drift_by_tier")
+        return
+
+    tier_order = derive_tier_order(data)
+    models = sorted(data["agent_model"].unique())
+    domain, range_ = get_color_scale("models", models)
+
+    chart = (
+        alt.Chart(data)
+        .mark_boxplot()
+        .encode(
+            x=alt.X("tier:N", sort=tier_order, title="Tier"),
+            y=alt.Y("strategic_drift:Q", scale=alt.Scale(domain=[0, 1]), title="Strategic Drift"),
+            color=alt.Color(
+                "agent_model:N",
+                scale=alt.Scale(domain=domain, range=range_),
+                title="Model",
+            ),
+        )
+        .facet(
+            column=alt.Column("agent_model:N", title="Model"),
+        )
+        .properties(title="Strategic Drift by Tier")
+    )
+
+    save_figure(chart, "fig_strategic_drift_by_tier", output_dir, render)

--- a/tests/unit/analysis/test_figures.py
+++ b/tests/unit/analysis/test_figures.py
@@ -632,12 +632,13 @@ def test_compute_dynamic_domain():
 
 
 def test_generate_figures_registry_includes_process_metrics() -> None:
-    """FIGURES registry contains the three process-metrics figures."""
+    """FIGURES registry contains all four process-metrics figures."""
     from scripts.generate_figures import FIGURES
 
     assert "fig_r_prog_by_tier" in FIGURES
     assert "fig_cfp_by_tier" in FIGURES
     assert "fig_pr_revert_by_tier" in FIGURES
+    assert "fig_strategic_drift_by_tier" in FIGURES
 
 
 def test_generate_figures_process_metrics_use_tier_category() -> None:
@@ -647,6 +648,7 @@ def test_generate_figures_process_metrics_use_tier_category() -> None:
     assert FIGURES["fig_r_prog_by_tier"][0] == "tier"
     assert FIGURES["fig_cfp_by_tier"][0] == "tier"
     assert FIGURES["fig_pr_revert_by_tier"][0] == "tier"
+    assert FIGURES["fig_strategic_drift_by_tier"][0] == "tier"
 
 
 def test_compute_dynamic_domain_padding():
@@ -720,3 +722,39 @@ def test_process_metrics_figures_handle_missing_columns(tmp_path):
     assert not (tmp_path / "fig_r_prog_by_tier.vl.json").exists()
     assert not (tmp_path / "fig_cfp_by_tier.vl.json").exists()
     assert not (tmp_path / "fig_pr_revert_by_tier.vl.json").exists()
+
+
+def test_fig_strategic_drift_by_tier(sample_runs_df, tmp_path):
+    """Smoke test: fig_strategic_drift_by_tier generates output file without error."""
+    from scylla.analysis.figures.process_metrics import fig_strategic_drift_by_tier
+
+    fig_strategic_drift_by_tier(sample_runs_df, tmp_path, render=False)
+    assert (tmp_path / "fig_strategic_drift_by_tier.vl.json").exists()
+
+
+def test_fig_strategic_drift_by_tier_missing_column(tmp_path):
+    """fig_strategic_drift_by_tier skips gracefully when column absent."""
+    import pandas as pd
+
+    from scylla.analysis.figures.process_metrics import fig_strategic_drift_by_tier
+
+    df = pd.DataFrame({"tier": ["T0"], "agent_model": ["Sonnet 4.5"], "score": [0.8]})
+    fig_strategic_drift_by_tier(df, tmp_path, render=False)
+    assert not (tmp_path / "fig_strategic_drift_by_tier.vl.json").exists()
+
+
+def test_fig_strategic_drift_by_tier_all_null(tmp_path):
+    """fig_strategic_drift_by_tier skips gracefully when column all-null."""
+    import pandas as pd
+
+    from scylla.analysis.figures.process_metrics import fig_strategic_drift_by_tier
+
+    df = pd.DataFrame(
+        {
+            "tier": ["T0", "T1"],
+            "agent_model": ["Sonnet 4.5", "Sonnet 4.5"],
+            "strategic_drift": [None, None],
+        }
+    )
+    fig_strategic_drift_by_tier(df, tmp_path, render=False)
+    assert not (tmp_path / "fig_strategic_drift_by_tier.vl.json").exists()


### PR DESCRIPTION
## Summary

- Added `fig_strategic_drift_by_tier` to `scylla/analysis/figures/process_metrics.py` following the exact box-plot pattern of `fig_r_prog_by_tier`
- Added import and registry entry in `scripts/generate_figures.py` under the `tier` category
- Added 3 tests to `tests/unit/analysis/test_figures.py`: smoke test (output created), missing column skip, all-null skip
- Updated `test_generate_figures_registry_includes_process_metrics` and `test_generate_figures_process_metrics_use_tier_category` to include the new figure

## Test plan

- [x] `test_fig_strategic_drift_by_tier` — output file created
- [x] `test_fig_strategic_drift_by_tier_missing_column` — skips gracefully when column absent
- [x] `test_fig_strategic_drift_by_tier_all_null` — skips gracefully when column all-null
- [x] All 388 analysis unit tests pass
- [x] Pre-commit (ruff, mypy) passes clean

Closes #1198

🤖 Generated with [Claude Code](https://claude.com/claude-code)