### PR TITLE
[Refactor] Standardize process-metrics figure naming to fig28/fig29/fig30

### DIFF
--- a/scripts/generate_figures.py
+++ b/scripts/generate_figures.py
@@ -41,9 +41,9 @@ from scylla.analysis.figures.judge_analysis import (
 )
 from scylla.analysis.figures.model_comparison import fig11_tier_uplift, fig12_consistency
 from scylla.analysis.figures.process_metrics import (
-    fig_cfp_by_tier,
-    fig_pr_revert_by_tier,
-    fig_r_prog_by_tier,
+    fig28_r_prog_by_tier,
+    fig29_cfp_by_tier,
+    fig30_pr_revert_by_tier,
     fig_strategic_drift_by_tier,
 )
 from scylla.analysis.figures.spec_builder import apply_publication_theme
@@ -99,9 +99,9 @@ FIGURES: dict[str, tuple[str, Any]] = {
     "fig25_impl_rate_by_tier": ("impl_rate", fig25_impl_rate_by_tier),
     "fig26_impl_rate_vs_pass_rate": ("impl_rate", fig26_impl_rate_vs_pass_rate),
     "fig27_impl_rate_distribution": ("impl_rate", fig27_impl_rate_distribution),
-    "fig_r_prog_by_tier": ("tier", fig_r_prog_by_tier),
-    "fig_cfp_by_tier": ("tier", fig_cfp_by_tier),
-    "fig_pr_revert_by_tier": ("tier", fig_pr_revert_by_tier),
+    "fig28_r_prog_by_tier": ("tier", fig28_r_prog_by_tier),
+    "fig29_cfp_by_tier": ("tier", fig29_cfp_by_tier),
+    "fig30_pr_revert_by_tier": ("tier", fig30_pr_revert_by_tier),
     "fig_strategic_drift_by_tier": ("tier", fig_strategic_drift_by_tier),
 }
 

--- a/scylla/analysis/figures/process_metrics.py
+++ b/scylla/analysis/figures/process_metrics.py
@@ -1,7 +1,7 @@
 """Process metrics figures.
 
-Generates Fig_RProg (R_Prog by tier), Fig_CFP (CFP by tier),
-Fig_PRRevert (PR Revert Rate by tier), and Fig_StrategicDrift (Strategic Drift by tier).
+Generates Fig 28 (R_Prog by tier), Fig 29 (CFP by tier),
+Fig 30 (PR Revert Rate by tier), and Fig_StrategicDrift (Strategic Drift by tier).
 """
 
 from __future__ import annotations
@@ -43,8 +43,8 @@ def _filter_process_data(runs_df: pd.DataFrame, column: str) -> pd.DataFrame:
     return filtered
 
 
-def fig_r_prog_by_tier(runs_df: pd.DataFrame, output_dir: Path, render: bool = True) -> None:
-    """Generate Fig_RProg: Fine-Grained Progress Rate by Tier.
+def fig28_r_prog_by_tier(runs_df: pd.DataFrame, output_dir: Path, render: bool = True) -> None:
+    """Generate Fig 28: Fine-Grained Progress Rate by Tier.
 
     Box plot showing r_prog distribution per tier, faceted by agent_model.
     Skips gracefully if r_prog column is missing or all-null.
@@ -56,12 +56,12 @@ def fig_r_prog_by_tier(runs_df: pd.DataFrame, output_dir: Path, render: bool = T
 
     """
     if "r_prog" not in runs_df.columns:
-        logger.warning("r_prog column not found in runs_df; skipping fig_r_prog_by_tier")
+        logger.warning("r_prog column not found in runs_df; skipping fig28_r_prog_by_tier")
         return
 
     data = _filter_process_data(runs_df[["tier", "agent_model", "r_prog"]], "r_prog")
     if data.empty:
-        logger.warning("No r_prog data available; skipping fig_r_prog_by_tier")
+        logger.warning("No r_prog data available; skipping fig28_r_prog_by_tier")
         return
 
     tier_order = derive_tier_order(data)
@@ -86,11 +86,11 @@ def fig_r_prog_by_tier(runs_df: pd.DataFrame, output_dir: Path, render: bool = T
         .properties(title="Fine-Grained Progress Rate (R_Prog) by Tier")
     )
 
-    save_figure(chart, "fig_r_prog_by_tier", output_dir, render)
+    save_figure(chart, "fig28_r_prog_by_tier", output_dir, render)
 
 
-def fig_cfp_by_tier(runs_df: pd.DataFrame, output_dir: Path, render: bool = True) -> None:
-    """Generate Fig_CFP: Change Fail Percentage by Tier.
+def fig29_cfp_by_tier(runs_df: pd.DataFrame, output_dir: Path, render: bool = True) -> None:
+    """Generate Fig 29: Change Fail Percentage by Tier.
 
     Bar chart of mean CFP per tier with error bars, faceted by agent_model.
     Skips gracefully if cfp column is missing or all-null.
@@ -102,12 +102,12 @@ def fig_cfp_by_tier(runs_df: pd.DataFrame, output_dir: Path, render: bool = True
 
     """
     if "cfp" not in runs_df.columns:
-        logger.warning("cfp column not found in runs_df; skipping fig_cfp_by_tier")
+        logger.warning("cfp column not found in runs_df; skipping fig29_cfp_by_tier")
         return
 
     data = _filter_process_data(runs_df[["tier", "agent_model", "cfp"]], "cfp")
     if data.empty:
-        logger.warning("No cfp data available; skipping fig_cfp_by_tier")
+        logger.warning("No cfp data available; skipping fig29_cfp_by_tier")
         return
 
     tier_order = derive_tier_order(data)
@@ -149,11 +149,11 @@ def fig_cfp_by_tier(runs_df: pd.DataFrame, output_dir: Path, render: bool = True
         .properties(title="Change Fail Percentage (CFP) by Tier")
     )
 
-    save_figure(chart, "fig_cfp_by_tier", output_dir, render)
+    save_figure(chart, "fig29_cfp_by_tier", output_dir, render)
 
 
-def fig_pr_revert_by_tier(runs_df: pd.DataFrame, output_dir: Path, render: bool = True) -> None:
-    """Generate Fig_PRRevert: PR Revert Rate by Tier.
+def fig30_pr_revert_by_tier(runs_df: pd.DataFrame, output_dir: Path, render: bool = True) -> None:
+    """Generate Fig 30: PR Revert Rate by Tier.
 
     Bar chart of mean PR revert rate per tier with error bars, faceted by agent_model.
     Skips gracefully if pr_revert_rate column is missing or all-null.
@@ -165,14 +165,16 @@ def fig_pr_revert_by_tier(runs_df: pd.DataFrame, output_dir: Path, render: bool 
 
     """
     if "pr_revert_rate" not in runs_df.columns:
-        logger.warning("pr_revert_rate column not found in runs_df; skipping fig_pr_revert_by_tier")
+        logger.warning(
+            "pr_revert_rate column not found in runs_df; skipping fig30_pr_revert_by_tier"
+        )
         return
 
     data = _filter_process_data(
         runs_df[["tier", "agent_model", "pr_revert_rate"]], "pr_revert_rate"
     )
     if data.empty:
-        logger.warning("No pr_revert_rate data available; skipping fig_pr_revert_by_tier")
+        logger.warning("No pr_revert_rate data available; skipping fig30_pr_revert_by_tier")
         return
 
     tier_order = derive_tier_order(data)
@@ -218,7 +220,7 @@ def fig_pr_revert_by_tier(runs_df: pd.DataFrame, output_dir: Path, render: bool 
         .properties(title="PR Revert Rate by Tier")
     )
 
-    save_figure(chart, "fig_pr_revert_by_tier", output_dir, render)
+    save_figure(chart, "fig30_pr_revert_by_tier", output_dir, render)
 
 
 def fig_strategic_drift_by_tier(

--- a/tests/unit/analysis/test_figures.py
+++ b/tests/unit/analysis/test_figures.py
@@ -635,9 +635,9 @@ def test_generate_figures_registry_includes_process_metrics() -> None:
     """FIGURES registry contains all four process-metrics figures."""
     from scripts.generate_figures import FIGURES
 
-    assert "fig_r_prog_by_tier" in FIGURES
-    assert "fig_cfp_by_tier" in FIGURES
-    assert "fig_pr_revert_by_tier" in FIGURES
+    assert "fig28_r_prog_by_tier" in FIGURES
+    assert "fig29_cfp_by_tier" in FIGURES
+    assert "fig30_pr_revert_by_tier" in FIGURES
     assert "fig_strategic_drift_by_tier" in FIGURES
 
 
@@ -645,9 +645,9 @@ def test_generate_figures_process_metrics_use_tier_category() -> None:
     """Process-metrics figures are registered under the 'tier' category."""
     from scripts.generate_figures import FIGURES
 
-    assert FIGURES["fig_r_prog_by_tier"][0] == "tier"
-    assert FIGURES["fig_cfp_by_tier"][0] == "tier"
-    assert FIGURES["fig_pr_revert_by_tier"][0] == "tier"
+    assert FIGURES["fig28_r_prog_by_tier"][0] == "tier"
+    assert FIGURES["fig29_cfp_by_tier"][0] == "tier"
+    assert FIGURES["fig30_pr_revert_by_tier"][0] == "tier"
     assert FIGURES["fig_strategic_drift_by_tier"][0] == "tier"
 
 
@@ -669,28 +669,28 @@ def test_compute_dynamic_domain_padding():
     assert domain_pad[1] - domain_pad[0] >= domain_no_pad[1] - domain_no_pad[0]
 
 
-def test_fig_r_prog_by_tier(sample_runs_df, tmp_path):
-    """Smoke test: fig_r_prog_by_tier generates output file without error."""
-    from scylla.analysis.figures.process_metrics import fig_r_prog_by_tier
+def test_fig28_r_prog_by_tier(sample_runs_df, tmp_path):
+    """Smoke test: fig28_r_prog_by_tier generates output file without error."""
+    from scylla.analysis.figures.process_metrics import fig28_r_prog_by_tier
 
-    fig_r_prog_by_tier(sample_runs_df, tmp_path, render=False)
-    assert (tmp_path / "fig_r_prog_by_tier.vl.json").exists()
-
-
-def test_fig_cfp_by_tier(sample_runs_df, tmp_path):
-    """Smoke test: fig_cfp_by_tier generates output file without error."""
-    from scylla.analysis.figures.process_metrics import fig_cfp_by_tier
-
-    fig_cfp_by_tier(sample_runs_df, tmp_path, render=False)
-    assert (tmp_path / "fig_cfp_by_tier.vl.json").exists()
+    fig28_r_prog_by_tier(sample_runs_df, tmp_path, render=False)
+    assert (tmp_path / "fig28_r_prog_by_tier.vl.json").exists()
 
 
-def test_fig_pr_revert_by_tier(sample_runs_df, tmp_path):
-    """Smoke test: fig_pr_revert_by_tier generates output file without error."""
-    from scylla.analysis.figures.process_metrics import fig_pr_revert_by_tier
+def test_fig29_cfp_by_tier(sample_runs_df, tmp_path):
+    """Smoke test: fig29_cfp_by_tier generates output file without error."""
+    from scylla.analysis.figures.process_metrics import fig29_cfp_by_tier
 
-    fig_pr_revert_by_tier(sample_runs_df, tmp_path, render=False)
-    assert (tmp_path / "fig_pr_revert_by_tier.vl.json").exists()
+    fig29_cfp_by_tier(sample_runs_df, tmp_path, render=False)
+    assert (tmp_path / "fig29_cfp_by_tier.vl.json").exists()
+
+
+def test_fig30_pr_revert_by_tier(sample_runs_df, tmp_path):
+    """Smoke test: fig30_pr_revert_by_tier generates output file without error."""
+    from scylla.analysis.figures.process_metrics import fig30_pr_revert_by_tier
+
+    fig30_pr_revert_by_tier(sample_runs_df, tmp_path, render=False)
+    assert (tmp_path / "fig30_pr_revert_by_tier.vl.json").exists()
 
 
 def test_process_metrics_figures_handle_missing_columns(tmp_path):
@@ -698,9 +698,9 @@ def test_process_metrics_figures_handle_missing_columns(tmp_path):
     import pandas as pd
 
     from scylla.analysis.figures.process_metrics import (
-        fig_cfp_by_tier,
-        fig_pr_revert_by_tier,
-        fig_r_prog_by_tier,
+        fig28_r_prog_by_tier,
+        fig29_cfp_by_tier,
+        fig30_pr_revert_by_tier,
     )
 
     # DataFrame without any process-metrics columns
@@ -714,14 +714,14 @@ def test_process_metrics_figures_handle_missing_columns(tmp_path):
     )
 
     # Should not raise, just skip generation
-    fig_r_prog_by_tier(df, tmp_path, render=False)
-    fig_cfp_by_tier(df, tmp_path, render=False)
-    fig_pr_revert_by_tier(df, tmp_path, render=False)
+    fig28_r_prog_by_tier(df, tmp_path, render=False)
+    fig29_cfp_by_tier(df, tmp_path, render=False)
+    fig30_pr_revert_by_tier(df, tmp_path, render=False)
 
     # No files should be created since columns are missing
-    assert not (tmp_path / "fig_r_prog_by_tier.vl.json").exists()
-    assert not (tmp_path / "fig_cfp_by_tier.vl.json").exists()
-    assert not (tmp_path / "fig_pr_revert_by_tier.vl.json").exists()
+    assert not (tmp_path / "fig28_r_prog_by_tier.vl.json").exists()
+    assert not (tmp_path / "fig29_cfp_by_tier.vl.json").exists()
+    assert not (tmp_path / "fig30_pr_revert_by_tier.vl.json").exists()
 
 
 def test_fig_strategic_drift_by_tier(sample_runs_df, tmp_path):

--- a/tests/unit/analysis/test_process_metrics_integration.py
+++ b/tests/unit/analysis/test_process_metrics_integration.py
@@ -399,47 +399,47 @@ def sample_runs_df_with_process_metrics() -> pd.DataFrame:
     return pd.DataFrame(data)
 
 
-def test_fig_r_prog_by_tier_smoke(sample_runs_df_with_process_metrics, tmp_path) -> None:
-    """fig_r_prog_by_tier executes without error and produces output file."""
-    from scylla.analysis.figures.process_metrics import fig_r_prog_by_tier
+def test_fig28_r_prog_by_tier_smoke(sample_runs_df_with_process_metrics, tmp_path) -> None:
+    """fig28_r_prog_by_tier executes without error and produces output file."""
+    from scylla.analysis.figures.process_metrics import fig28_r_prog_by_tier
 
-    fig_r_prog_by_tier(sample_runs_df_with_process_metrics, tmp_path, render=False)
+    fig28_r_prog_by_tier(sample_runs_df_with_process_metrics, tmp_path, render=False)
 
-    assert (tmp_path / "fig_r_prog_by_tier.vl.json").exists()
-
-
-def test_fig_cfp_by_tier_smoke(sample_runs_df_with_process_metrics, tmp_path) -> None:
-    """fig_cfp_by_tier executes without error and produces output file."""
-    from scylla.analysis.figures.process_metrics import fig_cfp_by_tier
-
-    fig_cfp_by_tier(sample_runs_df_with_process_metrics, tmp_path, render=False)
-
-    assert (tmp_path / "fig_cfp_by_tier.vl.json").exists()
+    assert (tmp_path / "fig28_r_prog_by_tier.vl.json").exists()
 
 
-def test_fig_pr_revert_by_tier_smoke(sample_runs_df_with_process_metrics, tmp_path) -> None:
-    """fig_pr_revert_by_tier executes without error and produces output file."""
-    from scylla.analysis.figures.process_metrics import fig_pr_revert_by_tier
+def test_fig29_cfp_by_tier_smoke(sample_runs_df_with_process_metrics, tmp_path) -> None:
+    """fig29_cfp_by_tier executes without error and produces output file."""
+    from scylla.analysis.figures.process_metrics import fig29_cfp_by_tier
 
-    fig_pr_revert_by_tier(sample_runs_df_with_process_metrics, tmp_path, render=False)
+    fig29_cfp_by_tier(sample_runs_df_with_process_metrics, tmp_path, render=False)
 
-    assert (tmp_path / "fig_pr_revert_by_tier.vl.json").exists()
+    assert (tmp_path / "fig29_cfp_by_tier.vl.json").exists()
 
 
-def test_fig_r_prog_by_tier_skips_missing_column(tmp_path) -> None:
-    """fig_r_prog_by_tier skips gracefully when r_prog column is absent."""
-    from scylla.analysis.figures.process_metrics import fig_r_prog_by_tier
+def test_fig30_pr_revert_by_tier_smoke(sample_runs_df_with_process_metrics, tmp_path) -> None:
+    """fig30_pr_revert_by_tier executes without error and produces output file."""
+    from scylla.analysis.figures.process_metrics import fig30_pr_revert_by_tier
+
+    fig30_pr_revert_by_tier(sample_runs_df_with_process_metrics, tmp_path, render=False)
+
+    assert (tmp_path / "fig30_pr_revert_by_tier.vl.json").exists()
+
+
+def test_fig28_r_prog_by_tier_skips_missing_column(tmp_path) -> None:
+    """fig28_r_prog_by_tier skips gracefully when r_prog column is absent."""
+    from scylla.analysis.figures.process_metrics import fig28_r_prog_by_tier
 
     df = pd.DataFrame({"tier": ["T0"], "agent_model": ["Sonnet 4.5"], "score": [0.8]})
     # Should not raise
-    fig_r_prog_by_tier(df, tmp_path, render=False)
+    fig28_r_prog_by_tier(df, tmp_path, render=False)
     # No file should be produced
-    assert not (tmp_path / "fig_r_prog_by_tier.vl.json").exists()
+    assert not (tmp_path / "fig28_r_prog_by_tier.vl.json").exists()
 
 
-def test_fig_r_prog_by_tier_skips_all_null(tmp_path) -> None:
-    """fig_r_prog_by_tier skips gracefully when r_prog column is all-null."""
-    from scylla.analysis.figures.process_metrics import fig_r_prog_by_tier
+def test_fig28_r_prog_by_tier_skips_all_null(tmp_path) -> None:
+    """fig28_r_prog_by_tier skips gracefully when r_prog column is all-null."""
+    from scylla.analysis.figures.process_metrics import fig28_r_prog_by_tier
 
     df = pd.DataFrame(
         {
@@ -449,5 +449,5 @@ def test_fig_r_prog_by_tier_skips_all_null(tmp_path) -> None:
         }
     )
     # Should not raise
-    fig_r_prog_by_tier(df, tmp_path, render=False)
-    assert not (tmp_path / "fig_r_prog_by_tier.vl.json").exists()
+    fig28_r_prog_by_tier(df, tmp_path, render=False)
+    assert not (tmp_path / "fig28_r_prog_by_tier.vl.json").exists()


### PR DESCRIPTION
## Summary

- Renamed `fig_r_prog_by_tier` → `fig28_r_prog_by_tier`
- Renamed `fig_cfp_by_tier` → `fig29_cfp_by_tier`
- Renamed `fig_pr_revert_by_tier` → `fig30_pr_revert_by_tier`
- Updated `save_figure()` name arguments, logger warnings, and module docstring in `process_metrics.py`
- Updated imports and FIGURES registry keys in `generate_figures.py`
- Updated all test assertions, test function names, and import references in `test_figures.py` and `test_process_metrics_integration.py`

## Test plan

- [x] All 69 analysis unit tests pass (`tests/unit/analysis/`)
- [x] Pre-commit hooks pass (ruff, mypy, formatting)
- [x] No stale references to old names remain in codebase
- [x] `--list-figures` output now shows fig28/fig29/fig30 in sequential alphabetical order

Closes #1199

🤖 Generated with [Claude Code](https://claude.com/claude-code)