### PR TITLE
feat(docker): add tomllib/tomli fallback to support Python 3.10 builder stage

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -35,10 +35,9 @@ RUN pip install --no-cache-dir "hatchling==1.29.0"
 # Layer 2: Dependencies (invalidated only when pyproject.toml changes or EXTRAS changes)
 # Copy only pyproject.toml first so dependency installs are cached separately
 # from source changes.
-# NOTE: Uses tomllib (Python stdlib since 3.11; see issue #1138). The base image
-# MUST remain Python 3.11+. If downgrading to 3.10, replace with:
-#   pip install tomli && python3 -c "import tomli as tomllib; ..."
-# or add: try: import tomllib \n except ImportError: import tomli as tomllib
+# NOTE: Uses tomllib with a tomli fallback (see issues #1138, #1200). The builder stage
+# supports Python 3.10+ — tomllib is stdlib since 3.11; tomli is pre-installed as a
+# fallback for 3.10 environments (e.g. minimal/musl variants).
 #
 # Optional-dependency groups from [project.optional-dependencies] that are built
 # into this layer when EXTRAS is set at build time:
@@ -51,7 +50,24 @@ RUN pip install --no-cache-dir "hatchling==1.29.0"
 #   docker build --build-arg EXTRAS=analysis,dev .  # + both groups
 ARG EXTRAS=""
 COPY pyproject.toml /opt/scylla/
-RUN python3 -c "import tomllib, os; data = tomllib.load(open('/opt/scylla/pyproject.toml', 'rb')); project = data.get('project', {}); deps = list(project.get('dependencies', [])); opt = project.get('optional-dependencies', {}); [deps.extend(opt.get(g.strip(), [])) for g in os.environ.get('EXTRAS', '').split(',') if g.strip()]; open('/tmp/deps.txt', 'w').write(' '.join(deps))" EXTRAS="$EXTRAS" \
+RUN pip install --no-cache-dir "tomli==2.0.2" \
+    && EXTRAS="$EXTRAS" python3 - <<'PYEOF' > /tmp/deps.txt
+import os
+try:
+    import tomllib
+except ImportError:
+    import tomli as tomllib  # type: ignore[no-redef]  # Python 3.10 fallback (#1200)
+with open('/opt/scylla/pyproject.toml', 'rb') as f:
+    data = tomllib.load(f)
+project = data.get('project', {})
+deps = list(project.get('dependencies', []))
+opt = project.get('optional-dependencies', {})
+for g in os.environ.get('EXTRAS', '').split(','):
+    g = g.strip()
+    if g:
+        deps.extend(opt.get(g, []))
+print(' '.join(deps))
+PYEOF
     && pip install --user --no-cache-dir $(cat /tmp/deps.txt) \
     && rm -f /tmp/deps.txt
 

--- a/tests/unit/scripts/test_dockerfile_constraints.py
+++ b/tests/unit/scripts/test_dockerfile_constraints.py
@@ -1,8 +1,8 @@
 """Tests for Dockerfile Python version constraints.
 
-Ensures the base image satisfies the Python 3.11+ requirement imposed by
-the use of tomllib (stdlib since Python 3.11) in the dependency-extraction
-RUN layer. See issue #1138.
+Ensures the base image satisfies the Python 3.10+ minimum and that the
+dependency-extraction RUN layer uses a tomllib/tomli fallback so it works
+on both Python 3.10 and 3.11+. See issues #1138 and #1200.
 """
 
 import re
@@ -12,8 +12,8 @@ import pytest
 
 DOCKERFILE_PATH = Path(__file__).parents[3] / "docker" / "Dockerfile"
 
-# Minimum Python version required for tomllib (stdlib since 3.11)
-MIN_PYTHON_VERSION = (3, 11)
+# Minimum Python version supported by the builder stage (tomli fallback added in #1200)
+MIN_PYTHON_VERSION = (3, 10)
 
 
 def _parse_python_base_versions(dockerfile_content: str) -> list[tuple[int, int]]:
@@ -42,7 +42,7 @@ def _parse_python_base_versions(dockerfile_content: str) -> list[tuple[int, int]
 
 
 class TestDockerfileBaseImageVersion:
-    """Assert Dockerfile base image meets Python 3.11+ requirement."""
+    """Assert Dockerfile base image meets Python 3.10+ minimum requirement."""
 
     def test_dockerfile_exists(self) -> None:
         """Dockerfile must exist at docker/Dockerfile."""
@@ -52,12 +52,11 @@ class TestDockerfileBaseImageVersion:
         )
 
     def test_base_image_python_version_meets_tomllib_requirement(self) -> None:
-        """Every Python base image in the Dockerfile must be >= 3.11.
+        """Every Python base image in the Dockerfile must be >= 3.10.
 
-        tomllib is only available in the Python stdlib from 3.11 onwards. If
-        the base image is downgraded to 3.10 the dependency-extraction RUN
-        layer will fail with ModuleNotFoundError. This test acts as a
-        regression guard. See issue #1138.
+        The dependency-extraction RUN layer uses a tomllib/tomli fallback
+        (tomllib stdlib since 3.11, tomli pre-installed for 3.10). This test
+        acts as a regression guard. See issues #1138 and #1200.
         """
         content = DOCKERFILE_PATH.read_text()
         versions = _parse_python_base_versions(content)
@@ -71,27 +70,45 @@ class TestDockerfileBaseImageVersion:
             assert (major, minor) >= MIN_PYTHON_VERSION, (
                 f"Dockerfile base image python:{major}.{minor} is below the "
                 f"minimum required version {MIN_PYTHON_VERSION[0]}.{MIN_PYTHON_VERSION[1]}. "
-                "tomllib is only available in the Python stdlib from 3.11+. "
-                "Either keep the base image at 3.11+ or add a tomli fallback "
-                "(see issue #1138 and the comment in docker/Dockerfile)."
+                "The builder stage requires Python 3.10+ (tomli fallback added in #1200). "
+                "See issues #1138 and #1200 and the comment in docker/Dockerfile."
             )
 
     def test_tomllib_constraint_comment_present(self) -> None:
-        """Dockerfile must contain the tomllib constraint comment.
+        """Dockerfile must reference both tomllib and the fallback mechanism.
 
-        This is a regression guard ensuring the constraint documentation
-        added in issue #1138 is not accidentally removed.
+        This is a regression guard ensuring the tomllib/tomli fallback
+        added in issues #1138 and #1200 is not accidentally removed.
         """
         content = DOCKERFILE_PATH.read_text()
         assert "tomllib" in content, (
             "The word 'tomllib' was not found in docker/Dockerfile. "
-            "The constraint comment documenting the Python 3.11+ requirement "
-            "appears to have been removed. See issue #1138."
+            "The tomllib/tomli fallback appears to have been removed. "
+            "See issues #1138 and #1200."
         )
-        assert "#1138" in content, (
-            "Issue #1138 reference not found in docker/Dockerfile. "
-            "The constraint comment linking to issue #1138 appears to have "
-            "been removed."
+        assert "tomli" in content, (
+            "The word 'tomli' was not found in docker/Dockerfile. "
+            "The tomli fallback package for Python 3.10 appears to have been removed. "
+            "See issue #1200."
+        )
+
+    def test_tomli_fallback_present(self) -> None:
+        """Dockerfile must contain the try/except ImportError tomli fallback.
+
+        Verifies that the dependency-extraction RUN layer includes the
+        try/except pattern so Python 3.10 environments can fall back to tomli.
+        See issue #1200.
+        """
+        content = DOCKERFILE_PATH.read_text()
+        assert "except ImportError:" in content, (
+            "No 'except ImportError:' found in docker/Dockerfile. "
+            "The tomllib->tomli fallback pattern appears to have been removed. "
+            "See issue #1200."
+        )
+        assert "import tomli as tomllib" in content, (
+            "The 'import tomli as tomllib' fallback was not found in docker/Dockerfile. "
+            "The Python 3.10 fallback for tomllib appears to have been removed. "
+            "See issue #1200."
         )
 
 


### PR DESCRIPTION
## Summary

- Replace bare `import tomllib` one-liner in Layer 2 with a heredoc-based `try/except ImportError` fallback (`tomllib` → `tomli as tomllib`)
- Pre-install `tomli==2.0.2` (pinned per #1209) so the fallback is always available for Python 3.10 environments
- Use a heredoc Python script in the RUN layer for clarity and correctness (avoids shell quoting issues with `\n` in `-c` strings)
- Update `tests/unit/scripts/test_dockerfile_constraints.py`:
  - Lower `MIN_PYTHON_VERSION` from `(3, 11)` to `(3, 10)`
  - Update docstrings and error messages to reference both `#1138` and `#1200`
  - Add `test_tomli_fallback_present` regression guard asserting `except ImportError:` and `import tomli as tomllib` are present
  - Broaden `test_tomllib_constraint_comment_present` to also check for `tomli`

## Test plan

- [x] `tests/unit/scripts/test_dockerfile_constraints.py` — all 15 tests pass (including new `test_tomli_fallback_present`)
- [x] `tests/unit/e2e/test_dockerfile.py` — all 3 tests pass (pinned `tomli==2.0.2` satisfies `#1209` pinning check)
- [x] Full unit suite: 3511 passed, 0 failed
- [x] Pre-commit hooks: all passed (ruff, mypy, trim-whitespace, etc.)

Closes #1200

🤖 Generated with [Claude Code](https://claude.com/claude-code)