### PR TITLE
refactor(resume): make handle_zombie follow immutable pattern

### DIFF
--- a/scylla/e2e/resume_manager.py
+++ b/scylla/e2e/resume_manager.py
@@ -89,7 +89,8 @@ class ResumeManager:
 
         if is_zombie(self.checkpoint, experiment_dir, heartbeat_timeout_seconds):
             logger.warning("Zombie experiment detected — resetting to 'interrupted'")
-            self.checkpoint = reset_zombie_checkpoint(self.checkpoint, checkpoint_path)
+            reset_checkpoint = reset_zombie_checkpoint(self.checkpoint, checkpoint_path)
+            return self.config, reset_checkpoint
 
         return self.config, self.checkpoint
 

--- a/tests/unit/e2e/test_resume_manager.py
+++ b/tests/unit/e2e/test_resume_manager.py
@@ -87,6 +87,7 @@ class TestHandleZombie:
         reset_checkpoint = base_checkpoint.model_copy(update={"status": "interrupted"})
 
         rm = _make_manager(base_checkpoint, base_config, mock_tier_manager)
+        original_checkpoint = rm.checkpoint
 
         with (
             patch("scylla.e2e.resume_manager.is_zombie", return_value=True) as mock_is_zombie,
@@ -101,6 +102,8 @@ class TestHandleZombie:
         mock_reset.assert_called_once_with(base_checkpoint, checkpoint_path)
         assert checkpoint.status == "interrupted"
         assert config is base_config
+        # handle_zombie must NOT mutate self.checkpoint — purely functional
+        assert rm.checkpoint is original_checkpoint
 
     def test_no_zombie_checkpoint_unchanged(
         self,


### PR DESCRIPTION
## Summary
- Remove `self.checkpoint = reset_zombie_checkpoint(...)` mutation from `handle_zombie()` in `scylla/e2e/resume_manager.py`
- Assign result to local `reset_checkpoint` variable and return early, consistent with `restore_cli_args` and `reset_failed_states`
- Add `assert rm.checkpoint is original_checkpoint` to `test_zombie_detected_resets_checkpoint` to enforce the immutable contract

## Test plan
- [x] All 30 unit tests in `tests/unit/e2e/test_resume_manager.py` pass
- [x] New assertion verifies `rm.checkpoint` is not mutated after `handle_zombie()` returns

Closes #1223