### PR TITLE
[feat] Extend drift check to cover README.md test count mentions

### DIFF
--- a/scripts/check_doc_config_consistency.py
+++ b/scripts/check_doc_config_consistency.py
@@ -272,7 +272,8 @@ def collect_actual_test_count(repo_root: Path) -> int | None:
     # Match "N selected" or "N tests collected" or "N test collected"
     m = re.search(r"(\d+)\s+(?:tests?\s+)?(?:selected|collected)", output)
     if m:
-        return int(m.group(1))
+        count = int(m.group(1))
+        return count if count > 0 else None
     return None
 
 

--- a/tests/unit/scripts/test_check_doc_config_consistency.py
+++ b/tests/unit/scripts/test_check_doc_config_consistency.py
@@ -436,6 +436,28 @@ class TestCollectActualTestCount:
         ):
             assert collect_actual_test_count(tmp_path) == 1
 
+    def test_zero_collected_returns_none(self, tmp_path: Path) -> None:
+        """Should return None when pytest reports 0 tests (collection failure)."""
+        mock_result = MagicMock()
+        mock_result.stdout = "0 selected\n"
+        mock_result.stderr = ""
+        with patch(
+            "scripts.check_doc_config_consistency.subprocess.run",
+            return_value=mock_result,
+        ):
+            assert collect_actual_test_count(tmp_path) is None
+
+    def test_zero_tests_collected_returns_none(self, tmp_path: Path) -> None:
+        """Should return None when pytest reports '0 tests collected' (collection failure)."""
+        mock_result = MagicMock()
+        mock_result.stdout = "0 tests collected\n"
+        mock_result.stderr = ""
+        with patch(
+            "scripts.check_doc_config_consistency.subprocess.run",
+            return_value=mock_result,
+        ):
+            assert collect_actual_test_count(tmp_path) is None
+
 
 # ---------------------------------------------------------------------------
 # check_readme_test_count


### PR DESCRIPTION
## Summary
- Adds `collect_actual_test_count()` to run `pytest --collect-only -q` and parse the collected test count
- Adds `check_readme_test_count()` to extract test count claims from README.md (e.g. `3,500+ tests`) and validate them against the actual count with a 10% tolerance
- Updates `main()` with Check 4 that calls these functions; gracefully skips if pytest is unavailable
- Updates module docstring to list the new check

## Test plan
- [x] `TestCollectActualTestCount` (6 tests): subprocess failure, bad output, `N selected`, `N tests collected`, `N test collected` (singular)
- [x] `TestCheckReadmeTestCount` (8 tests): within tolerance, too low, too high, no mention, missing file, comma-stripping, multiple mentions all valid, one stale
- [x] `TestMainIntegration` updated: existing 5 tests mock `collect_actual_test_count`; 2 new integration tests (graceful skip when `None`, exit 1 on mismatch)
- [x] All 3600 tests pass; pre-commit (ruff, mypy) clean

Closes #1226

🤖 Generated with [Claude Code](https://claude.com/claude-code)