### PR TITLE
[Testing] Annotate test functions in tests/unit/adapters/ for mypy compliance

### DIFF
--- a/tests/unit/adapters/test_base.py
+++ b/tests/unit/adapters/test_base.py
@@ -19,7 +19,7 @@ from scylla.adapters.base import (
 class ConcreteAdapter(BaseAdapter):
     """Concrete implementation for testing."""
 
-    def run(self, config, tier_config=None):
+    def run(self, config: AdapterConfig, tier_config: object = None) -> AdapterResult:
         """Return success result."""
         return AdapterResult(exit_code=0, stdout="success", stderr="")
 


### PR DESCRIPTION
## Summary
- Add explicit type annotations to `ConcreteAdapter.run()` override in `tests/unit/adapters/test_base.py` (parameter types and `-> AdapterResult` return type)
- All 160 test functions across the 7 adapter test files already had `-> None` annotations; this completes the explicit annotation of the one remaining unannotated helper method

## Test plan
- [x] All 160 adapter unit tests pass (`tests/unit/adapters/`)
- [x] Pre-commit hooks pass (ruff, mypy, black all clean)
- [x] `pixi run mypy tests/unit/adapters/` reports "Success: no issues found in 9 source files"

Closes #1289

🤖 Generated with [Claude Code](https://claude.com/claude-code)