### PR TITLE
feat(automation): Add --review mode to implement_issues.py

### DIFF
--- a/scripts/implement_issues.py
+++ b/scripts/implement_issues.py
@@ -1,13 +1,15 @@
 #!/usr/bin/env python3
-"""Bulk GitHub issue implementation script.
+"""Bulk GitHub issue implementation and PR review script.
 
 Implements GitHub issues in parallel using Claude Code in isolated
-git worktrees with dependency resolution.
+git worktrees with dependency resolution. Also supports reviewing
+and fixing open PRs linked to specified issues.
 
 Usage:
     python scripts/implement_issues.py --epic 123
     python scripts/implement_issues.py --epic 123 --analyze
     python scripts/implement_issues.py --health-check
+    python scripts/implement_issues.py --review --issues 595 596
 """
 
 import argparse
@@ -79,7 +81,19 @@ Examples:
 
   # Don't auto-merge PRs
   %(prog)s --issues 595 --no-auto-merge
+
+  # Review and fix open PRs for specific issues
+  %(prog)s --review --issues 595 596
+
+  # Review with dry run
+  %(prog)s --review --issues 595 --dry-run
         """,
+    )
+
+    parser.add_argument(
+        "--review",
+        action="store_true",
+        help="Review and fix open PRs linked to specified issues (requires --issues)",
     )
 
     parser.add_argument(
@@ -174,6 +188,12 @@ Examples:
     if args.epic and args.issues:
         parser.error("Cannot specify both --epic and --issues")
 
+    if args.review and not args.issues:
+        parser.error("--review requires --issues (not supported with --epic)")
+
+    if args.review and args.epic:
+        parser.error("--review cannot be used with --epic")
+
     return args
 
 
@@ -205,7 +225,9 @@ def main() -> int:
         enable_ui=not args.no_ui,
     )
 
-    if args.health_check:
+    if args.review:
+        logger.info(f"Starting PR review for issues: {args.issues}")
+    elif args.health_check:
         logger.info("Running health check")
     elif args.issues:
         logger.info(f"Starting implementation of issues: {args.issues}")
@@ -214,6 +236,28 @@ def main() -> int:
 
     with terminal_guard():
         try:
+            if args.review:
+                from scylla.automation.models import ReviewerOptions
+                from scylla.automation.reviewer import PRReviewer
+
+                reviewer_options = ReviewerOptions(
+                    issues=args.issues or [],
+                    max_workers=args.max_workers,
+                    dry_run=args.dry_run,
+                    enable_retrospective=not args.no_retrospective,
+                    enable_ui=not args.no_ui,
+                )
+                reviewer = PRReviewer(reviewer_options)
+                results = reviewer.run()
+
+                failed = [num for num, result in results.items() if not result.success]
+                if failed:
+                    logger.error(f"Failed to review {len(failed)} PR(s) for issue(s): {failed}")
+                    return 1
+
+                logger.info("PR review complete")
+                return 0
+
             # Run implementer
             implementer = IssueImplementer(options)
             results = implementer.run()

--- a/scylla/automation/__init__.py
+++ b/scylla/automation/__init__.py
@@ -18,10 +18,14 @@ from scylla.automation.models import (
     IssueState,
     PlannerOptions,
     PlanResult,
+    ReviewerOptions,
+    ReviewPhase,
+    ReviewState,
     WorkerResult,
 )
 from scylla.automation.planner import Planner
 from scylla.automation.retry import retry_on_network_error, retry_with_backoff
+from scylla.automation.reviewer import PRReviewer
 from scylla.automation.status_tracker import StatusTracker
 from scylla.automation.worktree_manager import WorktreeManager
 
@@ -35,9 +39,13 @@ __all__ = [
     # Data models
     "IssueInfo",
     "IssueState",
+    "PRReviewer",
     "PlanResult",
     "Planner",
     "PlannerOptions",
+    "ReviewPhase",
+    "ReviewState",
+    "ReviewerOptions",
     "StatusTracker",
     "WorkerResult",
     "WorktreeManager",

--- a/scylla/automation/models.py
+++ b/scylla/automation/models.py
@@ -124,6 +124,42 @@ class ImplementerOptions(BaseModel):
     enable_ui: bool = True
 
 
+class ReviewPhase(str, Enum):
+    """Phase of PR review and fix workflow."""
+
+    ANALYZING = "analyzing"
+    FIXING = "fixing"
+    PUSHING = "pushing"
+    RETROSPECTIVE = "retrospective"
+    COMPLETED = "completed"
+    FAILED = "failed"
+
+
+class ReviewState(BaseModel):
+    """State tracking for PR review and fix workflow."""
+
+    issue_number: int
+    pr_number: int
+    phase: ReviewPhase = ReviewPhase.ANALYZING
+    worktree_path: str | None = None
+    branch_name: str | None = None
+    plan_path: str | None = None
+    session_id: str | None = None
+    started_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
+    completed_at: datetime | None = None
+    error: str | None = None
+
+
+class ReviewerOptions(BaseModel):
+    """Options for the PRReviewer."""
+
+    issues: list[int] = Field(default_factory=list)
+    max_workers: int = 3
+    dry_run: bool = False
+    enable_retrospective: bool = True
+    enable_ui: bool = True
+
+
 class DependencyGraph(BaseModel):
     """Dependency graph for issues."""
 

--- a/scylla/automation/prompts.py
+++ b/scylla/automation/prompts.py
@@ -247,6 +247,165 @@ def get_follow_up_prompt(issue_number: int) -> str:
     return FOLLOW_UP_PROMPT.format(issue_number=issue_number)
 
 
+REVIEW_ANALYSIS_PROMPT = """
+Analyze PR #{pr_number} (linked to issue #{issue_number}) and produce a structured fix plan.
+
+**Working Directory:** {worktree_path}
+
+**Issue Description:**
+{issue_body}
+
+**PR Description:**
+{pr_description}
+
+**CI Status:**
+{ci_status}
+
+**CI Failure Logs:**
+{ci_logs}
+
+**Review Comments:**
+{review_comments}
+
+**PR Diff (summary):**
+{pr_diff}
+
+---
+
+**Your task:**
+Read the code in the working directory, review the information above, and produce a structured
+fix plan.
+
+**Output format (required):**
+
+## Summary
+Brief description of the overall state of the PR and what needs to be fixed.
+
+## Problems Found
+For each problem:
+- **Problem:** Description of the issue
+  - **Source:** Where it comes from (CI failure / review comment / code issue)
+  - **Fix:** Specific steps to resolve it
+
+## Fix Order
+Numbered sequence of fixes to apply (in dependency order).
+
+## Verification
+How to verify each fix is correct (tests to run, commands to execute).
+
+**Guidelines:**
+- Be specific about file paths and line numbers
+- Reference the actual code in the worktree, not just the diff
+- If no problems are found, say so explicitly in Summary and leave Problems Found empty
+- Focus on actionable fixes, not general advice
+"""
+
+REVIEW_FIX_PROMPT = """
+Implement the fixes described in the plan below for PR #{pr_number} (issue #{issue_number}).
+
+**Working Directory:** {worktree_path}
+
+**Fix Plan:**
+{plan}
+
+---
+
+**Your task:**
+Implement all fixes from the plan above. After implementing:
+
+1. Run tests: `pixi run python -m pytest tests/ -v`
+2. Run pre-commit: `pre-commit run --all-files`
+3. Fix any issues found by tests or pre-commit
+4. Commit all changes (but do NOT push — the script will push)
+
+**Commit message format:**
+```
+fix: Address review feedback for PR #{pr_number}
+
+Closes #{issue_number}
+
+Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
+```
+
+**Critical requirements:**
+- Only commit actual implementation files (no .env, .secret, credentials, etc.)
+- Do NOT push to origin — the script handles pushing
+- Ensure all tests pass before committing
+- Follow existing code patterns in scylla/
+
+**File handling:**
+- DO NOT create backup files (.orig, .bak, .swp, etc.)
+- Clean up any temporary files before committing
+"""
+
+
+def get_review_analysis_prompt(
+    pr_number: int,
+    issue_number: int,
+    pr_diff: str = "",
+    issue_body: str = "",
+    ci_status: str = "",
+    ci_logs: str = "",
+    review_comments: str = "",
+    pr_description: str = "",
+    worktree_path: str = "",
+) -> str:
+    """Get the PR review analysis prompt.
+
+    Args:
+        pr_number: GitHub PR number
+        issue_number: Linked GitHub issue number
+        pr_diff: PR diff output
+        issue_body: Issue body/description
+        ci_status: CI check status summary
+        ci_logs: CI failure log output
+        review_comments: PR review and inline comments
+        pr_description: PR description body
+        worktree_path: Working directory path
+
+    Returns:
+        Formatted analysis prompt
+
+    """
+    return REVIEW_ANALYSIS_PROMPT.format(
+        pr_number=pr_number,
+        issue_number=issue_number,
+        pr_diff=pr_diff,
+        issue_body=issue_body,
+        ci_status=ci_status,
+        ci_logs=ci_logs,
+        review_comments=review_comments,
+        pr_description=pr_description,
+        worktree_path=worktree_path,
+    )
+
+
+def get_review_fix_prompt(
+    pr_number: int,
+    issue_number: int,
+    plan: str = "",
+    worktree_path: str = "",
+) -> str:
+    """Get the PR fix implementation prompt.
+
+    Args:
+        pr_number: GitHub PR number
+        issue_number: Linked GitHub issue number
+        plan: Fix plan from analysis session
+        worktree_path: Working directory path
+
+    Returns:
+        Formatted fix prompt
+
+    """
+    return REVIEW_FIX_PROMPT.format(
+        pr_number=pr_number,
+        issue_number=issue_number,
+        plan=plan,
+        worktree_path=worktree_path,
+    )
+
+
 def get_pr_description(
     issue_number: int,
     summary: str,

--- a/scylla/automation/reviewer.py
+++ b/scylla/automation/reviewer.py
@@ -1,0 +1,860 @@
+"""PR review and fix automation using Claude Code in parallel worktrees.
+
+Provides:
+- Parallel PR review across multiple issues
+- Two-phase workflow: analysis then fix
+- Git worktree isolation per PR
+- State persistence and UI monitoring
+"""
+
+from __future__ import annotations
+
+import contextlib
+import json
+import logging
+import subprocess
+import threading
+import time
+from concurrent.futures import FIRST_COMPLETED, Future, ThreadPoolExecutor, wait
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from .curses_ui import CursesUI, ThreadLogManager
+from .git_utils import get_repo_root, run
+from .github_api import _gh_call, fetch_issue_info, write_secure
+from .models import ReviewerOptions, ReviewPhase, ReviewState, WorkerResult
+from .prompts import get_review_analysis_prompt, get_review_fix_prompt
+from .status_tracker import StatusTracker
+from .worktree_manager import WorktreeManager
+
+logger = logging.getLogger(__name__)
+
+
+class PRReviewer:
+    """Reviews and fixes open PRs linked to specified issues.
+
+    Features:
+    - Parallel PR review in isolated git worktrees
+    - Two-phase workflow: analysis session then fix session
+    - State persistence for observability
+    - Real-time curses UI for status monitoring
+    """
+
+    def __init__(self, options: ReviewerOptions):
+        """Initialize PR reviewer.
+
+        Args:
+            options: Reviewer configuration options
+
+        """
+        self.options = options
+        self.repo_root = get_repo_root()
+        self.state_dir = self.repo_root / ".issue_implementer"
+        self.state_dir.mkdir(parents=True, exist_ok=True)
+
+        self.worktree_manager = WorktreeManager()
+        self.status_tracker = StatusTracker(options.max_workers)
+        self.log_manager = ThreadLogManager()
+
+        self.states: dict[int, ReviewState] = {}
+        self.state_lock = threading.Lock()
+
+        self.ui: CursesUI | None = None
+
+    def _log(self, level: str, msg: str, thread_id: int | None = None) -> None:
+        """Log to both standard logger and UI thread buffer.
+
+        Args:
+            level: Log level ("error", "warning", or "info")
+            msg: Message to log
+            thread_id: Thread ID (defaults to current thread)
+
+        """
+        getattr(logger, level)(msg)
+        tid = thread_id or threading.get_ident()
+        prefix = {"error": "ERROR", "warning": "WARN", "info": ""}.get(level, "")
+        ui_msg = f"{prefix}: {msg}" if prefix else msg
+        self.log_manager.log(tid, ui_msg)
+
+    def run(self) -> dict[int, WorkerResult]:
+        """Run the PR reviewer.
+
+        Returns:
+            Dictionary mapping issue number to WorkerResult
+
+        """
+        logger.info(f"Starting PR review for issues: {self.options.issues}")
+
+        # Discover PRs for all issues
+        pr_map = self._discover_prs(self.options.issues)
+
+        if not pr_map:
+            logger.warning("No open PRs found for the specified issues")
+            return {}
+
+        logger.info(f"Found {len(pr_map)} PR(s) to review: {pr_map}")
+
+        # Start UI if enabled
+        if not self.options.dry_run and self.options.enable_ui:
+            self.ui = CursesUI(self.status_tracker, self.log_manager)
+            self.ui.start()
+
+        try:
+            results = self._review_all(pr_map)
+            return results
+        finally:
+            if self.ui:
+                self.ui.stop()
+            if not self.options.dry_run:
+                self.worktree_manager.cleanup_all()
+
+    def _discover_prs(self, issue_numbers: list[int]) -> dict[int, int]:
+        """Find open PRs linked to the given issue numbers.
+
+        First tries branch name lookup ({issue}-auto-impl), then falls back
+        to searching the PR body for the issue reference.
+
+        Args:
+            issue_numbers: List of issue numbers to find PRs for
+
+        Returns:
+            Mapping of issue_number -> pr_number for found PRs
+
+        """
+        pr_map: dict[int, int] = {}
+
+        for issue_num in issue_numbers:
+            pr_number = self._find_pr_for_issue(issue_num)
+            if pr_number is not None:
+                pr_map[issue_num] = pr_number
+            else:
+                logger.warning(f"No open PR found for issue #{issue_num}")
+
+        return pr_map
+
+    def _find_pr_for_issue(self, issue_number: int) -> int | None:
+        """Find the open PR for a single issue.
+
+        Args:
+            issue_number: GitHub issue number
+
+        Returns:
+            PR number if found, None otherwise
+
+        """
+        # Strategy 1: Look for branch named {issue}-auto-impl
+        branch_name = f"{issue_number}-auto-impl"
+        try:
+            result = _gh_call(
+                [
+                    "pr",
+                    "list",
+                    "--head",
+                    branch_name,
+                    "--state",
+                    "open",
+                    "--json",
+                    "number",
+                    "--limit",
+                    "1",
+                ],
+                check=False,
+            )
+            pr_data = json.loads(result.stdout or "[]")
+            if pr_data:
+                pr_number = pr_data[0]["number"]
+                logger.info(f"Found PR #{pr_number} for issue #{issue_number} via branch name")
+                return int(pr_number)
+        except Exception as e:
+            logger.debug(f"Branch-name lookup failed for issue #{issue_number}: {e}")
+
+        # Strategy 2: Search PR body for issue reference
+        try:
+            result = _gh_call(
+                [
+                    "pr",
+                    "list",
+                    "--state",
+                    "open",
+                    "--search",
+                    f"#{issue_number} in:body",
+                    "--json",
+                    "number",
+                    "--limit",
+                    "5",
+                ],
+                check=False,
+            )
+            pr_data = json.loads(result.stdout or "[]")
+            if pr_data:
+                pr_number = pr_data[0]["number"]
+                logger.info(f"Found PR #{pr_number} for issue #{issue_number} via body search")
+                return int(pr_number)
+        except Exception as e:
+            logger.debug(f"Body search failed for issue #{issue_number}: {e}")
+
+        return None
+
+    def _gather_pr_context(
+        self,
+        pr_number: int,
+        issue_number: int,
+        worktree_path: Path,
+    ) -> dict[str, str]:
+        """Gather all context needed for PR analysis.
+
+        Fetches diff, CI status, CI failure logs, review comments, and issue body.
+
+        Args:
+            pr_number: GitHub PR number
+            issue_number: Linked GitHub issue number
+            worktree_path: Path to worktree (for cwd)
+
+        Returns:
+            Dictionary with keys: pr_diff, issue_body, ci_status, ci_logs,
+            review_comments, pr_description
+
+        """
+        context: dict[str, str] = {
+            "pr_diff": "",
+            "issue_body": "",
+            "ci_status": "",
+            "ci_logs": "",
+            "review_comments": "",
+            "pr_description": "",
+        }
+
+        # Fetch PR diff
+        with contextlib.suppress(Exception):
+            result = _gh_call(["pr", "diff", str(pr_number)], check=False)
+            context["pr_diff"] = (result.stdout or "")[:8000]  # Cap to avoid huge diffs
+
+        # Fetch PR description and reviews/comments
+        with contextlib.suppress(Exception):
+            result = _gh_call(
+                [
+                    "pr",
+                    "view",
+                    str(pr_number),
+                    "--json",
+                    "body,reviews,comments",
+                ],
+            )
+            pr_data = json.loads(result.stdout or "{}")
+            context["pr_description"] = pr_data.get("body", "")
+
+            # Aggregate review comments
+            review_parts: list[str] = []
+            for review in pr_data.get("reviews", []):
+                state = review.get("state", "")
+                author = review.get("author", {}).get("login", "unknown")
+                body = review.get("body", "")
+                if body:
+                    review_parts.append(f"[{state}] @{author}: {body}")
+            for comment in pr_data.get("comments", []):
+                author = comment.get("author", {}).get("login", "unknown")
+                body = comment.get("body", "")
+                if body:
+                    review_parts.append(f"@{author}: {body}")
+            context["review_comments"] = "\n".join(review_parts)
+
+        # Fetch CI check status
+        with contextlib.suppress(Exception):
+            result = _gh_call(
+                ["pr", "checks", str(pr_number), "--json", "name,state,conclusion"],
+                check=False,
+            )
+            checks = json.loads(result.stdout or "[]")
+            status_lines = [
+                f"{c.get('name', '?')}: {c.get('conclusion') or c.get('state', '?')}"
+                for c in checks
+            ]
+            context["ci_status"] = "\n".join(status_lines)
+
+        # Fetch failed CI run logs
+        with contextlib.suppress(Exception):
+            result = _gh_call(
+                [
+                    "run",
+                    "list",
+                    "--branch",
+                    f"--pr={pr_number}",
+                    "--status",
+                    "failure",
+                    "--json",
+                    "databaseId",
+                    "--limit",
+                    "1",
+                ],
+                check=False,
+            )
+            runs = json.loads(result.stdout or "[]")
+            if runs:
+                run_id = runs[0].get("databaseId")
+                if run_id:
+                    log_result = _gh_call(
+                        ["run", "view", str(run_id), "--log-failed"],
+                        check=False,
+                    )
+                    context["ci_logs"] = (log_result.stdout or "")[:5000]
+
+        # Fetch issue body
+        with contextlib.suppress(Exception):
+            issue = fetch_issue_info(issue_number)
+            context["issue_body"] = issue.body
+
+        return context
+
+    def _run_analysis_session(
+        self,
+        pr_number: int,
+        issue_number: int,
+        worktree_path: Path,
+        context: dict[str, str],
+        slot_id: int | None = None,
+    ) -> str | None:
+        """Run the analysis (read-only) Claude session to produce a fix plan.
+
+        Args:
+            pr_number: GitHub PR number
+            issue_number: Linked issue number
+            worktree_path: Path to worktree
+            context: PR context from _gather_pr_context
+            slot_id: Worker slot ID for status updates
+
+        Returns:
+            Path to the saved plan file as a string, or None on failure
+
+        """
+        if self.options.dry_run:
+            logger.info(f"[DRY RUN] Would run analysis session for PR #{pr_number}")
+            return None
+
+        plan_file = self.state_dir / f"review-plan-{issue_number}.md"
+        prompt = get_review_analysis_prompt(
+            pr_number=pr_number,
+            issue_number=issue_number,
+            pr_diff=context.get("pr_diff", ""),
+            issue_body=context.get("issue_body", ""),
+            ci_status=context.get("ci_status", ""),
+            ci_logs=context.get("ci_logs", ""),
+            review_comments=context.get("review_comments", ""),
+            pr_description=context.get("pr_description", ""),
+            worktree_path=str(worktree_path),
+        )
+
+        prompt_file = worktree_path / f".claude-review-analysis-{issue_number}.md"
+        prompt_file.write_text(prompt)
+
+        log_file = self.state_dir / f"review-analysis-{issue_number}.log"
+
+        try:
+            result = run(
+                [
+                    "claude",
+                    str(prompt_file),
+                    "--output-format",
+                    "json",
+                    "--permission-mode",
+                    "dontAsk",
+                    "--allowedTools",
+                    "Read,Glob,Grep,Bash",
+                ],
+                cwd=worktree_path,
+                timeout=1200,  # 20 minutes
+            )
+            log_file.write_text(result.stdout or "")
+
+            # Extract the plan text from JSON output
+            try:
+                data = json.loads(result.stdout or "{}")
+                plan_text = data.get("result", result.stdout or "")
+            except (json.JSONDecodeError, AttributeError):
+                plan_text = result.stdout or ""
+
+            # Save plan to disk
+            write_secure(plan_file, plan_text)
+            logger.info(f"Analysis complete for PR #{pr_number}, plan saved to {plan_file}")
+            return str(plan_file)
+
+        except subprocess.CalledProcessError as e:
+            stdout = e.stdout or ""
+            stderr = e.stderr or ""
+            error_output = f"EXIT CODE: {e.returncode}\n\nSTDOUT:\n{stdout}\n\nSTDERR:\n{stderr}"
+            log_file.write_text(error_output)
+            raise RuntimeError(
+                f"Analysis session failed for PR #{pr_number}: {e.stderr or e.stdout}"
+            ) from e
+        except subprocess.TimeoutExpired as e:
+            log_file.write_text(f"TIMEOUT after {e.timeout}s\n\nOutput:\n{e.output or ''}")
+            raise RuntimeError(f"Analysis session timed out for PR #{pr_number}") from e
+        finally:
+            with contextlib.suppress(Exception):
+                prompt_file.unlink()
+
+    def _run_fix_session(
+        self,
+        pr_number: int,
+        issue_number: int,
+        worktree_path: Path,
+        plan_path: str,
+        slot_id: int | None = None,
+    ) -> str | None:
+        """Run the fix (full tools) Claude session to implement fixes.
+
+        Args:
+            pr_number: GitHub PR number
+            issue_number: Linked issue number
+            worktree_path: Path to worktree
+            plan_path: Path to the analysis plan file
+            slot_id: Worker slot ID for status updates
+
+        Returns:
+            Claude session_id if captured, None otherwise
+
+        """
+        if self.options.dry_run:
+            logger.info(f"[DRY RUN] Would run fix session for PR #{pr_number}")
+            return None
+
+        # Read plan content
+        plan_content = ""
+        with contextlib.suppress(Exception):
+            plan_content = Path(plan_path).read_text()
+
+        prompt = get_review_fix_prompt(
+            pr_number=pr_number,
+            issue_number=issue_number,
+            plan=plan_content,
+            worktree_path=str(worktree_path),
+        )
+
+        prompt_file = worktree_path / f".claude-review-fix-{issue_number}.md"
+        prompt_file.write_text(prompt)
+
+        log_file = self.state_dir / f"review-fix-{issue_number}.log"
+
+        try:
+            result = run(
+                [
+                    "claude",
+                    str(prompt_file),
+                    "--output-format",
+                    "json",
+                    "--permission-mode",
+                    "dontAsk",
+                    "--allowedTools",
+                    "Read,Write,Edit,Glob,Grep,Bash",
+                ],
+                cwd=worktree_path,
+                timeout=1800,  # 30 minutes
+            )
+            log_file.write_text(result.stdout or "")
+
+            # Extract session_id
+            try:
+                data = json.loads(result.stdout or "{}")
+                session_id: str | None = data.get("session_id")
+                return session_id
+            except (json.JSONDecodeError, AttributeError):
+                logger.warning(f"Could not parse session_id for PR #{pr_number}")
+                return None
+
+        except subprocess.CalledProcessError as e:
+            stdout = e.stdout or ""
+            stderr = e.stderr or ""
+            error_output = f"EXIT CODE: {e.returncode}\n\nSTDOUT:\n{stdout}\n\nSTDERR:\n{stderr}"
+            log_file.write_text(error_output)
+            raise RuntimeError(
+                f"Fix session failed for PR #{pr_number}: {e.stderr or e.stdout}"
+            ) from e
+        except subprocess.TimeoutExpired as e:
+            log_file.write_text(f"TIMEOUT after {e.timeout}s\n\nOutput:\n{e.output or ''}")
+            raise RuntimeError(f"Fix session timed out for PR #{pr_number}") from e
+        finally:
+            with contextlib.suppress(Exception):
+                prompt_file.unlink()
+
+    def _push_fixes(
+        self,
+        pr_number: int,
+        issue_number: int,
+        branch_name: str,
+        worktree_path: Path,
+    ) -> None:
+        """Commit any uncommitted changes and push to the PR branch.
+
+        Args:
+            pr_number: GitHub PR number
+            issue_number: Linked issue number
+            branch_name: Git branch name for the PR
+            worktree_path: Path to worktree
+
+        """
+        if self.options.dry_run:
+            logger.info(f"[DRY RUN] Would push fixes for PR #{pr_number}")
+            return
+
+        # Check for uncommitted changes
+        result = run(
+            ["git", "status", "--porcelain"],
+            cwd=worktree_path,
+            capture_output=True,
+        )
+
+        if result.stdout.strip():
+            logger.info(f"Committing uncommitted changes for PR #{pr_number}")
+            # Stage all non-secret files
+            secret_files = {
+                ".env",
+                ".secret",
+                "credentials.json",
+                "id_rsa",
+                "id_dsa",
+                "id_ecdsa",
+                "id_ed25519",
+            }
+            secret_extensions = {".key", ".pem", ".pfx", ".p12"}
+
+            files_to_add: list[str] = []
+            for line in result.stdout.strip().split("\n"):
+                if not line:
+                    continue
+                filename_part = line[3:]
+                if filename_part.startswith('"') and filename_part.endswith('"'):
+                    filename_part = filename_part[1:-1]
+                filename = Path(filename_part).name
+                if filename in secret_files or any(
+                    filename.endswith(ext) for ext in secret_extensions
+                ):
+                    logger.warning(f"Skipping potential secret file: {filename_part}")
+                    continue
+                files_to_add.append(filename_part)
+
+            if files_to_add:
+                run(["git", "add", *files_to_add], cwd=worktree_path)
+                commit_msg = (
+                    f"fix: Address review feedback for PR #{pr_number}\n\n"
+                    f"Closes #{issue_number}\n\n"
+                    f"Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>"
+                )
+                run(["git", "commit", "-m", commit_msg], cwd=worktree_path)
+                logger.info(f"Committed changes for PR #{pr_number}")
+
+        # Check if branch needs to be pushed
+        result = run(
+            ["git", "log", "origin/" + branch_name + "..HEAD", "--oneline"],
+            cwd=worktree_path,
+            capture_output=True,
+            check=False,
+        )
+
+        if result.stdout.strip():
+            logger.info(
+                f"Pushing {len(result.stdout.strip().splitlines())} commit(s) to PR #{pr_number}"
+            )
+            run(["git", "push", "origin", branch_name], cwd=worktree_path)
+            logger.info(f"Pushed fixes to PR #{pr_number}")
+        else:
+            logger.info(f"No new commits to push for PR #{pr_number}")
+
+    def _run_retrospective(
+        self,
+        session_id: str,
+        worktree_path: Path,
+        issue_number: int,
+        slot_id: int | None = None,
+    ) -> bool:
+        """Resume Claude session to run /retrospective.
+
+        Args:
+            session_id: Claude session ID
+            worktree_path: Path to worktree
+            issue_number: Issue number
+            slot_id: Worker slot ID for status updates
+
+        Returns:
+            True if retrospective completed successfully, False otherwise
+
+        """
+        self.state_dir.mkdir(parents=True, exist_ok=True)
+        log_file = self.state_dir / f"review-retrospective-{issue_number}.log"
+        try:
+            result = run(
+                [
+                    "claude",
+                    "--resume",
+                    session_id,
+                    (
+                        "/skills-registry-commands:retrospective"
+                        " commit the results and create a PR."
+                        " IMPORTANT: Only push skills to ProjectMnemosyne."
+                        " Do NOT create files under .claude-plugin/ in this repo."
+                    ),
+                    "--print",
+                    "--permission-mode",
+                    "dontAsk",
+                    "--allowedTools",
+                    "Read,Write,Edit,Glob,Grep,Bash",
+                ],
+                cwd=worktree_path,
+                timeout=600,  # 10 minutes
+            )
+            log_file.write_text(result.stdout or "")
+            logger.info(f"Retrospective completed for issue #{issue_number}")
+            return True
+        except Exception as e:
+            logger.warning(f"Retrospective failed for issue #{issue_number}: {e}")
+            error_output = f"FAILED: {e}\n"
+            if hasattr(e, "stdout"):
+                error_output += f"\nSTDOUT:\n{getattr(e, 'stdout', '') or ''}"
+            if hasattr(e, "stderr"):
+                error_output += f"\nSTDERR:\n{getattr(e, 'stderr', '') or ''}"
+            log_file.write_text(error_output)
+            return False
+
+    def _save_state(self, state: ReviewState) -> None:
+        """Save review state to disk."""
+        state_file = self.state_dir / f"review-{state.issue_number}.json"
+        write_secure(state_file, state.model_dump_json(indent=2))
+
+    def _get_or_create_state(self, issue_number: int, pr_number: int) -> ReviewState:
+        """Get or create review state for an issue."""
+        with self.state_lock:
+            if issue_number not in self.states:
+                self.states[issue_number] = ReviewState(
+                    issue_number=issue_number,
+                    pr_number=pr_number,
+                )
+            return self.states[issue_number]
+
+    def _review_pr(self, issue_number: int, pr_number: int) -> WorkerResult:  # noqa: C901
+        """Review and fix a single PR.
+
+        Args:
+            issue_number: GitHub issue number
+            pr_number: GitHub PR number
+
+        Returns:
+            WorkerResult
+
+        """
+        slot_id = self.status_tracker.acquire_slot()
+        if slot_id is None:
+            return WorkerResult(
+                issue_number=issue_number,
+                success=False,
+                error="Failed to acquire worker slot",
+            )
+
+        thread_id = threading.get_ident()
+
+        try:
+            self.status_tracker.update_slot(
+                slot_id, f"#{issue_number}: PR #{pr_number} Creating worktree"
+            )
+            self._log(
+                "info", f"Starting review of PR #{pr_number} for issue #{issue_number}", thread_id
+            )
+
+            state = self._get_or_create_state(issue_number, pr_number)
+
+            # Create worktree on the PR branch
+            branch_name = f"{issue_number}-auto-impl"
+            worktree_path = self.worktree_manager.create_worktree(issue_number, branch_name)
+
+            with self.state_lock:
+                state.worktree_path = str(worktree_path)
+                state.branch_name = branch_name
+            self._save_state(state)
+
+            # Phase 1: Gather context
+            self.status_tracker.update_slot(
+                slot_id, f"#{issue_number}: PR #{pr_number} Gathering context"
+            )
+            context = self._gather_pr_context(pr_number, issue_number, worktree_path)
+
+            # Phase 2: Analysis session
+            self.status_tracker.update_slot(slot_id, f"#{issue_number}: PR #{pr_number} Analyzing")
+            with self.state_lock:
+                state.phase = ReviewPhase.ANALYZING
+            self._save_state(state)
+
+            plan_path = self._run_analysis_session(
+                pr_number, issue_number, worktree_path, context, slot_id
+            )
+
+            with self.state_lock:
+                state.plan_path = plan_path
+            self._save_state(state)
+
+            # Phase 3: Fix session (always runs, even if no problems found)
+            self.status_tracker.update_slot(slot_id, f"#{issue_number}: PR #{pr_number} Fixing")
+            with self.state_lock:
+                state.phase = ReviewPhase.FIXING
+            self._save_state(state)
+
+            session_id = self._run_fix_session(
+                pr_number, issue_number, worktree_path, plan_path or "", slot_id
+            )
+
+            with self.state_lock:
+                state.session_id = session_id
+            self._save_state(state)
+
+            # Phase 4: Push fixes
+            self.status_tracker.update_slot(slot_id, f"#{issue_number}: PR #{pr_number} Pushing")
+            with self.state_lock:
+                state.phase = ReviewPhase.PUSHING
+            self._save_state(state)
+
+            self._push_fixes(pr_number, issue_number, branch_name, worktree_path)
+
+            # Phase 5: Retrospective (optional)
+            if self.options.enable_retrospective and session_id:
+                self.status_tracker.update_slot(
+                    slot_id, f"#{issue_number}: PR #{pr_number} Retrospective"
+                )
+                with self.state_lock:
+                    state.phase = ReviewPhase.RETROSPECTIVE
+                self._save_state(state)
+                self._run_retrospective(session_id, worktree_path, issue_number, slot_id)
+
+            # Mark completed
+            with self.state_lock:
+                state.phase = ReviewPhase.COMPLETED
+                state.completed_at = datetime.now(timezone.utc)
+            self._save_state(state)
+
+            self._log(
+                "info", f"PR #{pr_number} review complete for issue #{issue_number}", thread_id
+            )
+
+            return WorkerResult(
+                issue_number=issue_number,
+                success=True,
+                pr_number=pr_number,
+                branch_name=branch_name,
+                worktree_path=str(worktree_path),
+            )
+
+        except subprocess.TimeoutExpired as e:
+            error_msg = f"Timeout: {' '.join(str(c) for c in e.cmd[:3])} exceeded {e.timeout}s"
+            self._log("error", error_msg, thread_id)
+            self.status_tracker.update_slot(slot_id, f"#{issue_number}: FAILED - {error_msg[:50]}")
+            err_state = self.states.get(issue_number)
+            if err_state:
+                with self.state_lock:
+                    err_state.phase = ReviewPhase.FAILED
+                    err_state.error = error_msg
+                self._save_state(err_state)
+            return WorkerResult(issue_number=issue_number, success=False, error=error_msg)
+
+        except subprocess.CalledProcessError as e:
+            error_msg = (
+                f"Command failed (exit {e.returncode}): {' '.join(str(c) for c in e.cmd[:3])}"
+            )
+            self._log("error", error_msg, thread_id)
+            self.status_tracker.update_slot(slot_id, f"#{issue_number}: FAILED - {error_msg[:50]}")
+            err_state = self.states.get(issue_number)
+            if err_state:
+                with self.state_lock:
+                    err_state.phase = ReviewPhase.FAILED
+                    err_state.error = str(e)
+                self._save_state(err_state)
+            return WorkerResult(issue_number=issue_number, success=False, error=str(e))
+
+        except RuntimeError as e:
+            self._log("error", f"Runtime error: {e}", thread_id)
+            error_msg = str(e)[:80]
+            self.status_tracker.update_slot(slot_id, f"#{issue_number}: FAILED - {error_msg[:50]}")
+            err_state = self.states.get(issue_number)
+            if err_state:
+                with self.state_lock:
+                    err_state.phase = ReviewPhase.FAILED
+                    err_state.error = str(e)
+                self._save_state(err_state)
+            return WorkerResult(issue_number=issue_number, success=False, error=str(e))
+
+        except Exception as e:
+            self._log("error", f"Unexpected {type(e).__name__}: {e}", thread_id)
+            error_msg = str(e)[:80]
+            self.status_tracker.update_slot(slot_id, f"#{issue_number}: FAILED - {error_msg[:50]}")
+            err_state = self.states.get(issue_number)
+            if err_state:
+                with self.state_lock:
+                    err_state.phase = ReviewPhase.FAILED
+                    err_state.error = str(e)
+                self._save_state(err_state)
+            return WorkerResult(issue_number=issue_number, success=False, error=str(e))
+
+        finally:
+            time.sleep(1)
+            self.status_tracker.release_slot(slot_id)
+
+    def _review_all(self, pr_map: dict[int, int]) -> dict[int, WorkerResult]:
+        """Review all PRs in parallel.
+
+        Args:
+            pr_map: Mapping of issue_number -> pr_number
+
+        Returns:
+            Dictionary mapping issue number to WorkerResult
+
+        """
+        results: dict[int, WorkerResult] = {}
+
+        with ThreadPoolExecutor(max_workers=self.options.max_workers) as executor:
+            futures: dict[Future[Any], int] = {}
+
+            # Submit all PRs upfront (no dependency ordering needed for review)
+            for issue_num, pr_num in pr_map.items():
+                future = executor.submit(self._review_pr, issue_num, pr_num)
+                futures[future] = issue_num
+
+            while futures:
+                try:
+                    done, _pending = wait(futures.keys(), timeout=1.0, return_when=FIRST_COMPLETED)
+                except Exception:
+                    time.sleep(0.1)
+                    continue
+
+                for future in done:
+                    issue_num = futures.pop(future)
+                    try:
+                        result = future.result()
+                        results[issue_num] = result
+                        if result.success:
+                            logger.info(f"Issue #{issue_num} PR review completed")
+                        else:
+                            logger.error(f"Issue #{issue_num} PR review failed: {result.error}")
+                    except Exception as e:
+                        logger.error(f"Issue #{issue_num} raised exception: {e}")
+                        results[issue_num] = WorkerResult(
+                            issue_number=issue_num,
+                            success=False,
+                            error=str(e),
+                        )
+
+        self._print_summary(results)
+        return results
+
+    def _print_summary(self, results: dict[int, WorkerResult]) -> None:
+        """Print review summary."""
+        total = len(results)
+        successful = sum(1 for r in results.values() if r.success)
+        failed = total - successful
+
+        logger.info("=" * 60)
+        logger.info("PR Review Summary")
+        logger.info("=" * 60)
+        logger.info(f"Total PRs: {total}")
+        logger.info(f"Successful: {successful}")
+        logger.info(f"Failed: {failed}")
+
+        if failed > 0:
+            logger.info("\nFailed issues:")
+            for issue_num, result in results.items():
+                if not result.success:
+                    logger.info(f"  #{issue_num}: {result.error}")

--- a/tests/unit/automation/test_reviewer.py
+++ b/tests/unit/automation/test_reviewer.py
@@ -1,0 +1,751 @@
+"""Tests for the PRReviewer automation."""
+
+import json
+import subprocess
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from scylla.automation.models import ReviewerOptions, ReviewPhase, ReviewState
+from scylla.automation.reviewer import PRReviewer
+
+
+@pytest.fixture
+def mock_options() -> ReviewerOptions:
+    """Create mock ReviewerOptions."""
+    return ReviewerOptions(
+        issues=[595, 596],
+        max_workers=1,
+        dry_run=False,
+        enable_retrospective=False,
+        enable_ui=False,
+    )
+
+
+@pytest.fixture
+def reviewer(mock_options: ReviewerOptions) -> PRReviewer:
+    """Create a PRReviewer instance with mocked filesystem."""
+    with (
+        patch("scylla.automation.reviewer.get_repo_root") as mock_repo,
+        patch.object(Path, "mkdir"),
+    ):
+        mock_repo.return_value = Path("/repo")
+        return PRReviewer(mock_options)
+
+
+class TestReviewerOptions:
+    """Tests for ReviewerOptions model."""
+
+    def test_default_values(self) -> None:
+        """Test ReviewerOptions defaults."""
+        opts = ReviewerOptions()
+        assert opts.issues == []
+        assert opts.max_workers == 3
+        assert opts.dry_run is False
+        assert opts.enable_retrospective is True
+        assert opts.enable_ui is True
+
+    def test_custom_values(self) -> None:
+        """Test ReviewerOptions with custom values."""
+        opts = ReviewerOptions(
+            issues=[1, 2, 3],
+            max_workers=5,
+            dry_run=True,
+            enable_retrospective=False,
+            enable_ui=False,
+        )
+        assert opts.issues == [1, 2, 3]
+        assert opts.max_workers == 5
+        assert opts.dry_run is True
+        assert opts.enable_retrospective is False
+        assert opts.enable_ui is False
+
+
+class TestReviewState:
+    """Tests for ReviewState model."""
+
+    def test_default_phase(self) -> None:
+        """Test ReviewState starts in ANALYZING phase."""
+        state = ReviewState(issue_number=1, pr_number=10)
+        assert state.phase == ReviewPhase.ANALYZING
+        assert state.worktree_path is None
+        assert state.branch_name is None
+        assert state.plan_path is None
+        assert state.session_id is None
+        assert state.error is None
+        assert state.completed_at is None
+
+    def test_all_phases_exist(self) -> None:
+        """Test all ReviewPhase enum values are defined."""
+        phases = {p.value for p in ReviewPhase}
+        assert "analyzing" in phases
+        assert "fixing" in phases
+        assert "pushing" in phases
+        assert "retrospective" in phases
+        assert "completed" in phases
+        assert "failed" in phases
+
+
+class TestPRDiscovery:
+    """Tests for _discover_prs and _find_pr_for_issue methods."""
+
+    def test_find_pr_via_branch_name(self, reviewer: PRReviewer) -> None:
+        """Test PR discovery via branch name lookup."""
+        with patch("scylla.automation.reviewer._gh_call") as mock_gh:
+            mock_result = MagicMock()
+            mock_result.stdout = json.dumps([{"number": 42}])
+            mock_gh.return_value = mock_result
+
+            pr_number = reviewer._find_pr_for_issue(595)
+
+            assert pr_number == 42
+            # Verify branch-name strategy was tried
+            call_args = mock_gh.call_args_list[0][0][0]
+            assert "595-auto-impl" in call_args
+
+    def test_find_pr_via_body_search_fallback(self, reviewer: PRReviewer) -> None:
+        """Test PR discovery falls back to body search when branch not found."""
+        with patch("scylla.automation.reviewer._gh_call") as mock_gh:
+            empty_result = MagicMock()
+            empty_result.stdout = "[]"
+
+            body_result = MagicMock()
+            body_result.stdout = json.dumps([{"number": 99}])
+
+            # First call (branch lookup) returns empty, second call (search) returns PR
+            mock_gh.side_effect = [empty_result, body_result]
+
+            pr_number = reviewer._find_pr_for_issue(595)
+
+            assert pr_number == 99
+            assert mock_gh.call_count == 2
+
+    def test_find_pr_returns_none_when_not_found(self, reviewer: PRReviewer) -> None:
+        """Test returns None when no PR is found by either strategy."""
+        with patch("scylla.automation.reviewer._gh_call") as mock_gh:
+            empty_result = MagicMock()
+            empty_result.stdout = "[]"
+            mock_gh.return_value = empty_result
+
+            pr_number = reviewer._find_pr_for_issue(595)
+
+            assert pr_number is None
+
+    def test_discover_prs_multiple_issues(self, reviewer: PRReviewer) -> None:
+        """Test _discover_prs returns mapping for all found PRs."""
+        with patch.object(reviewer, "_find_pr_for_issue") as mock_find:
+            mock_find.side_effect = [42, None]
+
+            result = reviewer._discover_prs([595, 596])
+
+            assert result == {595: 42}
+            assert 596 not in result
+
+    def test_discover_prs_handles_gh_call_exception(self, reviewer: PRReviewer) -> None:
+        """Test _find_pr_for_issue handles gh call exceptions gracefully."""
+        with patch("scylla.automation.reviewer._gh_call") as mock_gh:
+            mock_gh.side_effect = [
+                subprocess.CalledProcessError(1, ["gh"]),
+                subprocess.CalledProcessError(1, ["gh"]),
+            ]
+
+            pr_number = reviewer._find_pr_for_issue(595)
+
+            assert pr_number is None
+
+    def test_discover_prs_empty_issues_list(self, reviewer: PRReviewer) -> None:
+        """Test _discover_prs with empty issues list returns empty dict."""
+        result = reviewer._discover_prs([])
+        assert result == {}
+
+
+class TestGatherPRContext:
+    """Tests for _gather_pr_context method."""
+
+    def test_all_fields_populated(self, reviewer: PRReviewer, tmp_path: Path) -> None:
+        """Test that all context fields are populated on success."""
+        worktree_path = tmp_path / "worktree"
+        worktree_path.mkdir()
+
+        mock_issue = MagicMock()
+        mock_issue.body = "Issue description here"
+
+        with (
+            patch("scylla.automation.reviewer._gh_call") as mock_gh,
+            patch("scylla.automation.reviewer.fetch_issue_info") as mock_fetch,
+        ):
+            mock_fetch.return_value = mock_issue
+
+            diff_result = MagicMock()
+            diff_result.stdout = "diff content here"
+
+            pr_view_result = MagicMock()
+            pr_view_result.stdout = json.dumps(
+                {
+                    "body": "PR description",
+                    "reviews": [
+                        {
+                            "state": "CHANGES_REQUESTED",
+                            "author": {"login": "user1"},
+                            "body": "Please fix X",
+                        }
+                    ],
+                    "comments": [{"author": {"login": "user2"}, "body": "Also fix Y"}],
+                }
+            )
+
+            checks_result = MagicMock()
+            checks_result.stdout = json.dumps(
+                [
+                    {"name": "ci/test", "state": "completed", "conclusion": "failure"},
+                ]
+            )
+
+            run_list_result = MagicMock()
+            run_list_result.stdout = "[]"
+
+            mock_gh.side_effect = [diff_result, pr_view_result, checks_result, run_list_result]
+
+            context = reviewer._gather_pr_context(42, 595, worktree_path)
+
+        assert context["pr_diff"] == "diff content here"
+        assert context["pr_description"] == "PR description"
+        assert "CHANGES_REQUESTED" in context["review_comments"]
+        assert "Please fix X" in context["review_comments"]
+        assert "Also fix Y" in context["review_comments"]
+        assert "ci/test" in context["ci_status"]
+        assert "failure" in context["ci_status"]
+        assert context["issue_body"] == "Issue description here"
+
+    def test_graceful_partial_failure(self, reviewer: PRReviewer, tmp_path: Path) -> None:
+        """Test that context is still returned if some calls fail."""
+        worktree_path = tmp_path / "worktree"
+        worktree_path.mkdir()
+
+        with (
+            patch("scylla.automation.reviewer._gh_call") as mock_gh,
+            patch("scylla.automation.reviewer.fetch_issue_info") as mock_fetch,
+        ):
+            mock_fetch.side_effect = RuntimeError("API error")
+            mock_gh.side_effect = Exception("All calls fail")
+
+            # Should not raise — returns empty strings for failed fields
+            context = reviewer._gather_pr_context(42, 595, worktree_path)
+
+        assert isinstance(context, dict)
+        assert "pr_diff" in context
+        assert "issue_body" in context
+
+    def test_context_caps_long_diff(self, reviewer: PRReviewer, tmp_path: Path) -> None:
+        """Test that very long PR diffs are capped."""
+        worktree_path = tmp_path / "worktree"
+        worktree_path.mkdir()
+
+        long_diff = "x" * 20000
+
+        with (
+            patch("scylla.automation.reviewer._gh_call") as mock_gh,
+            patch("scylla.automation.reviewer.fetch_issue_info") as mock_fetch,
+        ):
+            mock_fetch.side_effect = RuntimeError("skip")
+
+            diff_result = MagicMock()
+            diff_result.stdout = long_diff
+
+            pr_view_result = MagicMock()
+            pr_view_result.stdout = json.dumps({"body": "", "reviews": [], "comments": []})
+
+            checks_result = MagicMock()
+            checks_result.stdout = "[]"
+
+            run_list_result = MagicMock()
+            run_list_result.stdout = "[]"
+
+            mock_gh.side_effect = [diff_result, pr_view_result, checks_result, run_list_result]
+
+            context = reviewer._gather_pr_context(42, 595, worktree_path)
+
+        # Diff should be capped at 8000 chars
+        assert len(context["pr_diff"]) <= 8000
+
+
+class TestRunAnalysisSession:
+    """Tests for _run_analysis_session method."""
+
+    def test_creates_plan_file(self, reviewer: PRReviewer, tmp_path: Path) -> None:
+        """Test that analysis session creates a plan file."""
+        reviewer.state_dir = tmp_path
+        worktree_path = tmp_path / "worktree"
+        worktree_path.mkdir()
+
+        mock_result = MagicMock()
+        mock_result.stdout = json.dumps(
+            {"result": "## Summary\nNo issues found.", "session_id": "s1"}
+        )
+
+        context = {
+            "pr_diff": "",
+            "issue_body": "",
+            "ci_status": "",
+            "ci_logs": "",
+            "review_comments": "",
+            "pr_description": "",
+        }
+
+        with (
+            patch("scylla.automation.reviewer.run") as mock_run,
+            patch("scylla.automation.reviewer.write_secure") as mock_write,
+        ):
+            mock_run.return_value = mock_result
+
+            plan_path = reviewer._run_analysis_session(42, 595, worktree_path, context)
+
+        assert plan_path is not None
+        assert "review-plan-595" in plan_path
+        mock_write.assert_called_once()
+
+    def test_uses_read_only_tools(self, reviewer: PRReviewer, tmp_path: Path) -> None:
+        """Test that analysis session uses only read-only tools."""
+        reviewer.state_dir = tmp_path
+        worktree_path = tmp_path / "worktree"
+        worktree_path.mkdir()
+
+        mock_result = MagicMock()
+        mock_result.stdout = json.dumps({"result": "plan content", "session_id": "s1"})
+
+        context = {
+            "pr_diff": "",
+            "issue_body": "",
+            "ci_status": "",
+            "ci_logs": "",
+            "review_comments": "",
+            "pr_description": "",
+        }
+
+        with (
+            patch("scylla.automation.reviewer.run") as mock_run,
+            patch("scylla.automation.reviewer.write_secure"),
+        ):
+            mock_run.return_value = mock_result
+            reviewer._run_analysis_session(42, 595, worktree_path, context)
+
+            call_args = mock_run.call_args[0][0]
+            assert "--allowedTools" in call_args
+            tools_idx = call_args.index("--allowedTools")
+            tools = call_args[tools_idx + 1]
+            # Analysis must not include Write or Edit
+            assert "Write" not in tools
+            assert "Edit" not in tools
+            assert "Read" in tools
+
+    def test_dry_run_returns_none(self, mock_options: ReviewerOptions) -> None:
+        """Test dry run mode skips analysis and returns None."""
+        mock_options.dry_run = True
+        with (
+            patch("scylla.automation.reviewer.get_repo_root") as mock_repo,
+            patch.object(Path, "mkdir"),
+        ):
+            mock_repo.return_value = Path("/repo")
+            reviewer = PRReviewer(mock_options)
+
+        context = {
+            "pr_diff": "",
+            "issue_body": "",
+            "ci_status": "",
+            "ci_logs": "",
+            "review_comments": "",
+            "pr_description": "",
+        }
+        plan_path = reviewer._run_analysis_session(42, 595, Path("/tmp"), context)
+
+        assert plan_path is None
+
+    def test_timeout_raises_runtime_error(self, reviewer: PRReviewer, tmp_path: Path) -> None:
+        """Test timeout handling raises RuntimeError."""
+        reviewer.state_dir = tmp_path
+        worktree_path = tmp_path / "worktree"
+        worktree_path.mkdir()
+
+        context = {
+            "pr_diff": "",
+            "issue_body": "",
+            "ci_status": "",
+            "ci_logs": "",
+            "review_comments": "",
+            "pr_description": "",
+        }
+
+        with patch("scylla.automation.reviewer.run") as mock_run:
+            mock_run.side_effect = subprocess.TimeoutExpired("claude", 1200)
+
+            with pytest.raises(RuntimeError, match="timed out"):
+                reviewer._run_analysis_session(42, 595, worktree_path, context)
+
+    def test_process_error_raises_runtime_error(self, reviewer: PRReviewer, tmp_path: Path) -> None:
+        """Test CalledProcessError raises RuntimeError."""
+        reviewer.state_dir = tmp_path
+        worktree_path = tmp_path / "worktree"
+        worktree_path.mkdir()
+
+        context = {
+            "pr_diff": "",
+            "issue_body": "",
+            "ci_status": "",
+            "ci_logs": "",
+            "review_comments": "",
+            "pr_description": "",
+        }
+
+        with patch("scylla.automation.reviewer.run") as mock_run:
+            error = subprocess.CalledProcessError(1, ["claude"], stderr="error output")
+            error.stdout = ""
+            error.stderr = "error output"
+            mock_run.side_effect = error
+
+            with pytest.raises(RuntimeError, match="Analysis session failed"):
+                reviewer._run_analysis_session(42, 595, worktree_path, context)
+
+
+class TestRunFixSession:
+    """Tests for _run_fix_session method."""
+
+    def test_captures_session_id(self, reviewer: PRReviewer, tmp_path: Path) -> None:
+        """Test that fix session captures session_id from JSON output."""
+        reviewer.state_dir = tmp_path
+        worktree_path = tmp_path / "worktree"
+        worktree_path.mkdir()
+
+        plan_file = tmp_path / "review-plan-595.md"
+        plan_file.write_text("## Summary\nFix these things.")
+
+        mock_result = MagicMock()
+        mock_result.stdout = json.dumps({"session_id": "fix-session-abc", "result": "Done"})
+
+        with patch("scylla.automation.reviewer.run") as mock_run:
+            mock_run.return_value = mock_result
+
+            session_id = reviewer._run_fix_session(42, 595, worktree_path, str(plan_file))
+
+        assert session_id == "fix-session-abc"
+
+    def test_uses_full_tools(self, reviewer: PRReviewer, tmp_path: Path) -> None:
+        """Test that fix session uses full tool set including Write and Edit."""
+        reviewer.state_dir = tmp_path
+        worktree_path = tmp_path / "worktree"
+        worktree_path.mkdir()
+
+        plan_file = tmp_path / "review-plan-595.md"
+        plan_file.write_text("plan content")
+
+        mock_result = MagicMock()
+        mock_result.stdout = json.dumps({"session_id": "s1", "result": "Done"})
+
+        with patch("scylla.automation.reviewer.run") as mock_run:
+            mock_run.return_value = mock_result
+            reviewer._run_fix_session(42, 595, worktree_path, str(plan_file))
+
+            call_args = mock_run.call_args[0][0]
+            assert "--allowedTools" in call_args
+            tools_idx = call_args.index("--allowedTools")
+            tools = call_args[tools_idx + 1]
+            assert "Write" in tools
+            assert "Edit" in tools
+            assert "Read" in tools
+
+    def test_dry_run_returns_none(self, mock_options: ReviewerOptions) -> None:
+        """Test dry run mode skips fix session and returns None."""
+        mock_options.dry_run = True
+        with (
+            patch("scylla.automation.reviewer.get_repo_root") as mock_repo,
+            patch.object(Path, "mkdir"),
+        ):
+            mock_repo.return_value = Path("/repo")
+            reviewer = PRReviewer(mock_options)
+
+        session_id = reviewer._run_fix_session(42, 595, Path("/tmp"), "/tmp/plan.md")
+        assert session_id is None
+
+    def test_timeout_raises_runtime_error(self, reviewer: PRReviewer, tmp_path: Path) -> None:
+        """Test timeout handling raises RuntimeError."""
+        reviewer.state_dir = tmp_path
+        worktree_path = tmp_path / "worktree"
+        worktree_path.mkdir()
+
+        plan_file = tmp_path / "plan.md"
+        plan_file.write_text("plan")
+
+        with patch("scylla.automation.reviewer.run") as mock_run:
+            mock_run.side_effect = subprocess.TimeoutExpired("claude", 1800)
+
+            with pytest.raises(RuntimeError, match="timed out"):
+                reviewer._run_fix_session(42, 595, worktree_path, str(plan_file))
+
+    def test_missing_plan_file_uses_empty_plan(self, reviewer: PRReviewer, tmp_path: Path) -> None:
+        """Test that missing plan file results in empty plan string (no crash)."""
+        reviewer.state_dir = tmp_path
+        worktree_path = tmp_path / "worktree"
+        worktree_path.mkdir()
+
+        mock_result = MagicMock()
+        mock_result.stdout = json.dumps({"session_id": "s1", "result": "Done"})
+
+        with patch("scylla.automation.reviewer.run") as mock_run:
+            mock_run.return_value = mock_result
+            # Pass a non-existent plan path
+            session_id = reviewer._run_fix_session(42, 595, worktree_path, "/nonexistent/plan.md")
+
+        assert session_id == "s1"
+
+
+class TestReviewPR:
+    """Tests for _review_pr end-to-end workflow."""
+
+    def test_successful_review_returns_worker_result(
+        self, reviewer: PRReviewer, tmp_path: Path
+    ) -> None:
+        """Test successful PR review returns WorkerResult with success=True."""
+        reviewer.state_dir = tmp_path
+
+        worktree_path = tmp_path / "worktree"
+        worktree_path.mkdir()
+
+        with (
+            patch.object(reviewer.worktree_manager, "create_worktree") as mock_create,
+            patch.object(reviewer, "_gather_pr_context") as mock_context,
+            patch.object(reviewer, "_run_analysis_session") as mock_analysis,
+            patch.object(reviewer, "_run_fix_session") as mock_fix,
+            patch.object(reviewer, "_push_fixes") as mock_push,
+            patch.object(reviewer, "_save_state"),
+        ):
+            mock_create.return_value = worktree_path
+            mock_context.return_value = {
+                "pr_diff": "",
+                "issue_body": "",
+                "ci_status": "",
+                "ci_logs": "",
+                "review_comments": "",
+                "pr_description": "",
+            }
+            mock_analysis.return_value = str(tmp_path / "plan.md")
+            mock_fix.return_value = "session-abc"
+            mock_push.return_value = None
+
+            result = reviewer._review_pr(595, 42)
+
+        assert result.success is True
+        assert result.issue_number == 595
+        assert result.pr_number == 42
+
+    def test_failed_slot_acquisition_returns_failure(self, reviewer: PRReviewer) -> None:
+        """Test failure when no worker slot is available."""
+        with patch.object(reviewer.status_tracker, "acquire_slot") as mock_acquire:
+            mock_acquire.return_value = None
+
+            result = reviewer._review_pr(595, 42)
+
+        assert result.success is False
+        assert "slot" in (result.error or "").lower()
+
+    def test_analysis_failure_propagates(self, reviewer: PRReviewer, tmp_path: Path) -> None:
+        """Test that analysis session failure is propagated as WorkerResult failure."""
+        reviewer.state_dir = tmp_path
+
+        worktree_path = tmp_path / "worktree"
+        worktree_path.mkdir()
+
+        with (
+            patch.object(reviewer.worktree_manager, "create_worktree") as mock_create,
+            patch.object(reviewer, "_gather_pr_context") as mock_context,
+            patch.object(reviewer, "_run_analysis_session") as mock_analysis,
+            patch.object(reviewer, "_save_state"),
+        ):
+            mock_create.return_value = worktree_path
+            mock_context.return_value = {
+                "pr_diff": "",
+                "issue_body": "",
+                "ci_status": "",
+                "ci_logs": "",
+                "review_comments": "",
+                "pr_description": "",
+            }
+            mock_analysis.side_effect = RuntimeError("Analysis failed catastrophically")
+
+            result = reviewer._review_pr(595, 42)
+
+        assert result.success is False
+        assert "Analysis failed catastrophically" in (result.error or "")
+
+    def test_fix_failure_propagates(self, reviewer: PRReviewer, tmp_path: Path) -> None:
+        """Test that fix session failure is propagated as WorkerResult failure."""
+        reviewer.state_dir = tmp_path
+
+        worktree_path = tmp_path / "worktree"
+        worktree_path.mkdir()
+
+        with (
+            patch.object(reviewer.worktree_manager, "create_worktree") as mock_create,
+            patch.object(reviewer, "_gather_pr_context") as mock_context,
+            patch.object(reviewer, "_run_analysis_session") as mock_analysis,
+            patch.object(reviewer, "_run_fix_session") as mock_fix,
+            patch.object(reviewer, "_save_state"),
+        ):
+            mock_create.return_value = worktree_path
+            mock_context.return_value = {
+                "pr_diff": "",
+                "issue_body": "",
+                "ci_status": "",
+                "ci_logs": "",
+                "review_comments": "",
+                "pr_description": "",
+            }
+            mock_analysis.return_value = str(tmp_path / "plan.md")
+            mock_fix.side_effect = RuntimeError("Fix session timed out")
+
+            result = reviewer._review_pr(595, 42)
+
+        assert result.success is False
+        assert "Fix session timed out" in (result.error or "")
+
+    def test_push_failure_propagates(self, reviewer: PRReviewer, tmp_path: Path) -> None:
+        """Test that push failure is propagated as WorkerResult failure."""
+        reviewer.state_dir = tmp_path
+
+        worktree_path = tmp_path / "worktree"
+        worktree_path.mkdir()
+
+        with (
+            patch.object(reviewer.worktree_manager, "create_worktree") as mock_create,
+            patch.object(reviewer, "_gather_pr_context") as mock_context,
+            patch.object(reviewer, "_run_analysis_session") as mock_analysis,
+            patch.object(reviewer, "_run_fix_session") as mock_fix,
+            patch.object(reviewer, "_push_fixes") as mock_push,
+            patch.object(reviewer, "_save_state"),
+        ):
+            mock_create.return_value = worktree_path
+            mock_context.return_value = {
+                "pr_diff": "",
+                "issue_body": "",
+                "ci_status": "",
+                "ci_logs": "",
+                "review_comments": "",
+                "pr_description": "",
+            }
+            mock_analysis.return_value = str(tmp_path / "plan.md")
+            mock_fix.return_value = "s1"
+            mock_push.side_effect = subprocess.CalledProcessError(1, ["git", "push"])
+
+            result = reviewer._review_pr(595, 42)
+
+        assert result.success is False
+
+    def test_state_saved_as_failed_on_error(self, reviewer: PRReviewer, tmp_path: Path) -> None:
+        """Test that state is saved as FAILED when an error occurs."""
+        reviewer.state_dir = tmp_path
+
+        worktree_path = tmp_path / "worktree"
+        worktree_path.mkdir()
+
+        saved_states: list[ReviewState] = []
+
+        def capture_save(state: ReviewState) -> None:
+            saved_states.append(ReviewState(**state.model_dump()))
+
+        with (
+            patch.object(reviewer.worktree_manager, "create_worktree") as mock_create,
+            patch.object(reviewer, "_gather_pr_context") as mock_context,
+            patch.object(reviewer, "_run_analysis_session") as mock_analysis,
+            patch.object(reviewer, "_save_state", side_effect=capture_save),
+        ):
+            mock_create.return_value = worktree_path
+            mock_context.return_value = {
+                "pr_diff": "",
+                "issue_body": "",
+                "ci_status": "",
+                "ci_logs": "",
+                "review_comments": "",
+                "pr_description": "",
+            }
+            mock_analysis.side_effect = RuntimeError("boom")
+
+            reviewer._review_pr(595, 42)
+
+        # At least one saved state should be FAILED
+        assert any(s.phase == ReviewPhase.FAILED for s in saved_states)
+
+    def test_retrospective_skipped_when_disabled(
+        self, reviewer: PRReviewer, tmp_path: Path
+    ) -> None:
+        """Test that retrospective is not called when enable_retrospective=False."""
+        reviewer.state_dir = tmp_path
+
+        worktree_path = tmp_path / "worktree"
+        worktree_path.mkdir()
+
+        with (
+            patch.object(reviewer.worktree_manager, "create_worktree") as mock_create,
+            patch.object(reviewer, "_gather_pr_context") as mock_context,
+            patch.object(reviewer, "_run_analysis_session") as mock_analysis,
+            patch.object(reviewer, "_run_fix_session") as mock_fix,
+            patch.object(reviewer, "_push_fixes"),
+            patch.object(reviewer, "_run_retrospective") as mock_retro,
+            patch.object(reviewer, "_save_state"),
+        ):
+            mock_create.return_value = worktree_path
+            mock_context.return_value = {
+                "pr_diff": "",
+                "issue_body": "",
+                "ci_status": "",
+                "ci_logs": "",
+                "review_comments": "",
+                "pr_description": "",
+            }
+            mock_analysis.return_value = None
+            mock_fix.return_value = "session-id"
+
+            reviewer._review_pr(595, 42)
+
+        mock_retro.assert_not_called()
+
+    def test_retrospective_called_when_enabled(
+        self, mock_options: ReviewerOptions, tmp_path: Path
+    ) -> None:
+        """Test retrospective is called when enable_retrospective=True and session_id exists."""
+        mock_options.enable_retrospective = True
+
+        with (
+            patch("scylla.automation.reviewer.get_repo_root") as mock_repo,
+            patch.object(Path, "mkdir"),
+        ):
+            mock_repo.return_value = Path("/repo")
+            reviewer = PRReviewer(mock_options)
+
+        reviewer.state_dir = tmp_path
+        worktree_path = tmp_path / "worktree"
+        worktree_path.mkdir()
+
+        with (
+            patch.object(reviewer.worktree_manager, "create_worktree") as mock_create,
+            patch.object(reviewer, "_gather_pr_context") as mock_context,
+            patch.object(reviewer, "_run_analysis_session") as mock_analysis,
+            patch.object(reviewer, "_run_fix_session") as mock_fix,
+            patch.object(reviewer, "_push_fixes"),
+            patch.object(reviewer, "_run_retrospective") as mock_retro,
+            patch.object(reviewer, "_save_state"),
+        ):
+            mock_create.return_value = worktree_path
+            mock_context.return_value = {
+                "pr_diff": "",
+                "issue_body": "",
+                "ci_status": "",
+                "ci_logs": "",
+                "review_comments": "",
+                "pr_description": "",
+            }
+            mock_analysis.return_value = None
+            mock_fix.return_value = "session-abc"
+            mock_retro.return_value = True
+
+            reviewer._review_pr(595, 42)
+
+        mock_retro.assert_called_once()


### PR DESCRIPTION
## Summary
- Adds `PRReviewer` class with two-phase Claude workflow (read-only analysis then full-tools fix) for automating PR fix cycles
- Adds `--review` flag to `implement_issues.py` that discovers and fixes open PRs linked to specified issues in parallel worktrees

## Changes
- `scylla/automation/models.py`: Add `ReviewPhase` enum, `ReviewState` model, `ReviewerOptions` model
- `scylla/automation/prompts.py`: Add `REVIEW_ANALYSIS_PROMPT`, `REVIEW_FIX_PROMPT`, and getter functions
- `scylla/automation/reviewer.py` (new): `PRReviewer` class with `_discover_prs`, `_gather_pr_context`, `_run_analysis_session`, `_run_fix_session`, `_push_fixes`, `_run_retrospective`, `run()`
- `scripts/implement_issues.py`: `--review` flag with validation (requires `--issues`, incompatible with `--epic`)
- `scylla/automation/__init__.py`: Export `PRReviewer`, `ReviewerOptions`, `ReviewPhase`, `ReviewState`
- `tests/unit/automation/test_reviewer.py` (new): 31 unit tests covering all methods and error paths

## Test plan
- [x] 31 unit tests pass: `pytest tests/unit/automation/test_reviewer.py`
- [x] Pre-commit passes (ruff, mypy, all hooks)
- [x] Dry-run test: `python scripts/implement_issues.py --review --issues 1234 --dry-run`

Closes #1320

🤖 Generated with [Claude Code](https://claude.com/claude-code)