### PR TITLE
[Docs] Bump test count floor to 3,600+ / 143+ files in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Python](https://img.shields.io/badge/python-3.10+-blue.svg)](https://python.org)
 [![License](https://img.shields.io/badge/license-BSD--3--Clause-blue.svg)](LICENSE)
-[![Tests](https://img.shields.io/badge/tests-3500%2B-brightgreen.svg)](#)
+[![Tests](https://img.shields.io/badge/tests-3600%2B-brightgreen.svg)](#)
 [![Status](https://img.shields.io/badge/status-stable-brightgreen.svg)](#)
 
 ## 📑 Table of Contents
@@ -339,11 +339,11 @@ Schema: `scylla/analysis/schemas/run_result_schema.json`
 
 ### 🧪 Testing
 
-ProjectScylla has a comprehensive test suite with **137+ test files** covering all functionality.
+ProjectScylla has a comprehensive test suite with **143+ test files** covering all functionality.
 
 #### Test Categories
 
-- **Unit Tests** (137+ files): Analysis (incl. integration-style tests), adapters, config, executors, judges, metrics, reporting
+- **Unit Tests** (143+ files): Analysis (incl. integration-style tests), adapters, config, executors, judges, metrics, reporting
 - **E2E Tests** (1 file): Full pipeline validation
 - **Test Fixtures** (47+ scenarios): Complete test cases with expected outputs
 
@@ -489,7 +489,7 @@ TypeError: unsupported operand type(s) for +: 'float' and 'str'
 
 ✅ **Reproducible configuration** (all parameters in config.yaml)
 
-✅ **Comprehensive test suite** (3,500+ tests, all passing)
+✅ **Comprehensive test suite** (3,600+ tests, all passing)
 
 ✅ **Documented methodology** with citations
 


### PR DESCRIPTION
## Summary

- Updates README.md badge and documentation to reflect actual test counts (3,600+ tests, 143+ test files)
- Fixes the `check_test_counts.py` CI failure affecting 16 open PRs
- Tolerance window is 100 tests / 5 files; current counts (3,600 / 143) are now documented correctly

## Impact

Unblocks rebasing of PRs: #1321, #1315, #1313, #1312, #1310, #1309, #1308, #1307, #1300, #1299, #1296, #1295, #1293, #1291, #1305, #1290

## Test plan

- [x] All 4 occurrences updated (badge line 5, line 342, line 346, line 492)
- [x] CI passes with 3599 tests (1 skipped template test)
- [x] No logic changes, README-only update