### PR TITLE
[Fix] Clone ProjectMnemosyne when missing instead of skipping advise step

### DIFF
--- a/scylla/automation/planner.py
+++ b/scylla/automation/planner.py
@@ -9,12 +9,14 @@ Provides:
 
 from __future__ import annotations
 
+import fcntl
 import json
 import logging
 import os
 import subprocess
 import threading
 from concurrent.futures import Future, ThreadPoolExecutor, as_completed
+from pathlib import Path
 from typing import Any
 
 from .git_utils import get_repo_root
@@ -38,6 +40,8 @@ class Planner:
     Supports parallel planning with rate limit handling and
     duplicate detection.
     """
+
+    _mnemosyne_lock: threading.Lock = threading.Lock()
 
     def __init__(self, options: PlannerOptions):
         """Initialize planner.
@@ -313,6 +317,57 @@ class Planner:
         except subprocess.TimeoutExpired as e:
             raise RuntimeError(f"Claude timed out after {timeout}s") from e
 
+    def _ensure_mnemosyne(self, mnemosyne_root: Path) -> bool:
+        """Clone ProjectMnemosyne if it does not exist locally.
+
+        Uses a class-level threading lock and an fcntl file lock to prevent
+        race conditions when multiple parallel workers call this simultaneously.
+
+        Args:
+            mnemosyne_root: Expected local path for ProjectMnemosyne
+
+        Returns:
+            True if the directory exists (or was cloned successfully), False otherwise
+
+        """
+        with Planner._mnemosyne_lock:
+            # TOCTOU guard: re-check inside the lock
+            if mnemosyne_root.exists():
+                return True
+
+            lock_path = mnemosyne_root.parent / ".mnemosyne.lock"
+            lock_path.parent.mkdir(parents=True, exist_ok=True)
+
+            with open(lock_path, "w") as lock_file:
+                fcntl.flock(lock_file, fcntl.LOCK_EX)
+                try:
+                    # Re-check after acquiring file lock
+                    if mnemosyne_root.exists():
+                        return True
+
+                    logger.info(f"Cloning ProjectMnemosyne to {mnemosyne_root}...")
+                    subprocess.run(
+                        [
+                            "gh",
+                            "repo",
+                            "clone",
+                            "HomericIntelligence/ProjectMnemosyne",
+                            str(mnemosyne_root),
+                        ],
+                        check=True,
+                        capture_output=True,
+                        text=True,
+                    )
+                    logger.info("ProjectMnemosyne cloned successfully")
+                    return True
+
+                except subprocess.CalledProcessError as e:
+                    logger.warning(f"Failed to clone ProjectMnemosyne: {e.stderr or e}")
+                    return False
+
+                finally:
+                    fcntl.flock(lock_file, fcntl.LOCK_UN)
+
     def _run_advise(self, issue_number: int, issue_title: str, issue_body: str) -> str:
         """Search team knowledge base for relevant prior learnings.
 
@@ -331,10 +386,8 @@ class Planner:
             mnemosyne_root = repo_root / "build" / "ProjectMnemosyne"
 
             if not mnemosyne_root.exists():
-                logger.warning(
-                    "ProjectMnemosyne not found at build/ProjectMnemosyne, skipping advise step"
-                )
-                return ""
+                if not self._ensure_mnemosyne(mnemosyne_root):
+                    return ""
 
             marketplace_path = mnemosyne_root / ".claude-plugin" / "marketplace.json"
             if not marketplace_path.exists():

--- a/tests/unit/automation/test_planner.py
+++ b/tests/unit/automation/test_planner.py
@@ -1,5 +1,7 @@
 """Tests for the Planner automation."""
 
+import subprocess
+import threading
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -135,17 +137,42 @@ class TestRunAdvise:
 
             assert result == ""
 
-    def test_skips_when_mnemosyne_missing(self, planner):
-        """Test skips advise when ProjectMnemosyne is missing."""
+    def test_skips_when_mnemosyne_missing_and_clone_fails(self, planner):
+        """Test returns empty string when ProjectMnemosyne is missing and clone fails."""
         with (
             patch("scylla.automation.planner.get_repo_root") as mock_get_repo,
-            patch.object(Path, "exists", return_value=False),
+            patch.object(planner, "_ensure_mnemosyne", return_value=False) as mock_ensure,
         ):
             mock_get_repo.return_value = Path("/repo")
 
-            result = planner._run_advise(123, "Test Issue", "Issue body")
+            with patch.object(Path, "exists", return_value=False):
+                result = planner._run_advise(123, "Test Issue", "Issue body")
 
             assert result == ""
+            mock_ensure.assert_called_once()
+
+    def test_clones_mnemosyne_when_missing(self, planner):
+        """Test proceeds with advise after cloning ProjectMnemosyne."""
+        call_count = [0]
+
+        def patched_exists(p: Path) -> bool:
+            call_count[0] += 1
+            if call_count[0] == 1:
+                # First call: mnemosyne_root.exists() -> False (triggers _ensure_mnemosyne)
+                return False
+            # Subsequent calls (marketplace check): True
+            return True
+
+        with (
+            patch("scylla.automation.planner.get_repo_root") as mock_get_repo,
+            patch.object(planner, "_ensure_mnemosyne", return_value=True),
+            patch.object(Path, "exists", patched_exists),
+            patch.object(planner, "_call_claude", return_value="## Related Skills\nFound 2 skills"),
+        ):
+            mock_get_repo.return_value = Path("/repo")
+            result = planner._run_advise(123, "Test Issue", "Issue body")
+
+        assert "Related Skills" in result
 
 
 class TestGeneratePlan:
@@ -197,3 +224,84 @@ class TestGeneratePlan:
 
             # Plan should still be generated
             assert "Implementation Plan" in plan
+
+
+class TestEnsureMnemosyne:
+    """Tests for _ensure_mnemosyne method."""
+
+    def test_clone_success(self, planner, tmp_path):
+        """Test successful clone returns True and runs correct command."""
+        mnemosyne_root = tmp_path / "ProjectMnemosyne"
+
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0)
+
+            result = planner._ensure_mnemosyne(mnemosyne_root)
+
+        assert result is True
+        mock_run.assert_called_once()
+        cmd = mock_run.call_args[0][0]
+        assert "gh" in cmd
+        assert "repo" in cmd
+        assert "clone" in cmd
+        assert "HomericIntelligence/ProjectMnemosyne" in cmd
+        assert str(mnemosyne_root) in cmd
+
+    def test_clone_failure(self, planner, tmp_path):
+        """Test clone failure returns False and logs warning."""
+        mnemosyne_root = tmp_path / "ProjectMnemosyne"
+
+        with patch("subprocess.run") as mock_run:
+            mock_run.side_effect = subprocess.CalledProcessError(
+                1, "gh", stderr="authentication failed"
+            )
+
+            result = planner._ensure_mnemosyne(mnemosyne_root)
+
+        assert result is False
+
+    def test_no_clone_if_exists(self, planner, tmp_path):
+        """Test does not clone when directory already exists."""
+        mnemosyne_root = tmp_path / "ProjectMnemosyne"
+        mnemosyne_root.mkdir()
+
+        with patch("subprocess.run") as mock_run:
+            result = planner._ensure_mnemosyne(mnemosyne_root)
+
+        assert result is True
+        mock_run.assert_not_called()
+
+    def test_concurrent_clone_only_once(self, mock_options, tmp_path):
+        """Test concurrent calls only clone once (lock prevents double-clone)."""
+        mnemosyne_root = tmp_path / "ProjectMnemosyne"
+
+        clone_calls = []
+        start_event = threading.Event()
+
+        def fake_clone(cmd: list[str], **kwargs: object) -> MagicMock:
+            clone_calls.append(1)
+            # Create the directory so subsequent checks see it
+            mnemosyne_root.mkdir(exist_ok=True)
+            return MagicMock(returncode=0)
+
+        planner1 = Planner(mock_options)
+        planner2 = Planner(mock_options)
+
+        results: list[bool] = []
+
+        def worker(p: Planner) -> None:
+            start_event.wait()
+            results.append(p._ensure_mnemosyne(mnemosyne_root))
+
+        t1 = threading.Thread(target=worker, args=(planner1,))
+        t2 = threading.Thread(target=worker, args=(planner2,))
+
+        with patch("subprocess.run", side_effect=fake_clone):
+            t1.start()
+            t2.start()
+            start_event.set()
+            t1.join()
+            t2.join()
+
+        assert all(results), "Both threads should return True"
+        assert len(clone_calls) == 1, "Clone should only happen once"


### PR DESCRIPTION
## Summary
- Adds `_ensure_mnemosyne(mnemosyne_root)` helper to `Planner` that clones `HomericIntelligence/ProjectMnemosyne` via `gh repo clone` when the directory is absent
- Updates `_run_advise()` to call `_ensure_mnemosyne()` instead of immediately warning and returning `""` when the directory is missing
- Clone failures (network/auth issues) are gracefully handled — logs a warning and returns `False` so advise is skipped (same contract as before)
- Uses a class-level `threading.Lock` and `fcntl` file lock to prevent double-cloning when multiple parallel workers race

## Test plan
- [x] `test_skips_when_mnemosyne_missing_and_clone_fails` — clone fails → returns `""`
- [x] `test_clones_mnemosyne_when_missing` — clone succeeds → advise proceeds
- [x] `test_clone_success` — subprocess called with correct `gh repo clone` args
- [x] `test_clone_failure` — `CalledProcessError` returns `False`
- [x] `test_no_clone_if_exists` — directory already exists → subprocess not called
- [x] `test_concurrent_clone_only_once` — two threads race; clone called exactly once
- [x] All 15 planner tests pass; full unit suite (3119 tests) pass

Closes #1324

🤖 Generated with [Claude Code](https://claude.com/claude-code)