### PR TITLE
[Fix] Fix Dockerfile heredoc RUN syntax after PYEOF terminator

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -75,7 +75,7 @@ for g in extras:
     deps.extend(opt.get(g, []))
 print(' '.join(deps))
 PYEOF
-    && pip install --user --no-cache-dir $(cat /tmp/deps.txt) \
+RUN pip install --user --no-cache-dir $(cat /tmp/deps.txt) \
     && rm -f /tmp/deps.txt
 
 # Layer 3: Package install (invalidated when scylla/ source changes)


### PR DESCRIPTION
## Summary

- Fixes Dockerfile parse error: `unknown instruction: &&` on line 78
- The `PYEOF` heredoc terminator ends the shell heredoc input, so subsequent `&&` chained commands after `PYEOF` are parsed as new Docker instructions rather than shell continuations
- Split into a separate `RUN` step to fix the syntax

## Root Cause

PR #1313 merged with a broken `docker/Dockerfile`:
```dockerfile
PYEOF
    && pip install --user --no-cache-dir $(cat /tmp/deps.txt) \  ← Docker parse error
    && rm -f /tmp/deps.txt
```

## Fix

```dockerfile
PYEOF
RUN pip install --user --no-cache-dir $(cat /tmp/deps.txt) \    ← valid new RUN step
    && rm -f /tmp/deps.txt
```

## Test plan
- [x] `docker build --check docker/` — no errors, no warnings
- [x] All 11 Dockerfile unit tests pass (test_dockerfile.py + test_dockerfile_extras_validation.py)