### PR TITLE
fix(automation): delete .mnemosyne.lock after successful clone

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -88,6 +88,7 @@ worktrees
 # Automation runtime directories
 .worktrees/
 .issue_implementer/
+.mnemosyne.lock
 
 # Root-level log files (automation scripts, debugging)
 /*.log

--- a/scylla/automation/planner.py
+++ b/scylla/automation/planner.py
@@ -359,6 +359,7 @@ class Planner:
                         text=True,
                     )
                     logger.info("ProjectMnemosyne cloned successfully")
+                    lock_path.unlink(missing_ok=True)
                     return True
 
                 except subprocess.CalledProcessError as e:

--- a/tests/unit/automation/test_planner.py
+++ b/tests/unit/automation/test_planner.py
@@ -271,6 +271,19 @@ class TestEnsureMnemosyne:
         assert result is True
         mock_run.assert_not_called()
 
+    def test_lock_file_removed_after_successful_clone(self, planner, tmp_path):
+        """Test that the lock file is removed after a successful clone."""
+        mnemosyne_root = tmp_path / "ProjectMnemosyne"
+        lock_path = tmp_path / ".mnemosyne.lock"
+
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0)
+
+            result = planner._ensure_mnemosyne(mnemosyne_root)
+
+        assert result is True
+        assert not lock_path.exists(), "Lock file should be removed after successful clone"
+
     def test_concurrent_clone_only_once(self, mock_options, tmp_path):
         """Test concurrent calls only clone once (lock prevents double-clone)."""
         mnemosyne_root = tmp_path / "ProjectMnemosyne"


### PR DESCRIPTION
## Summary

- Adds `lock_path.unlink(missing_ok=True)` after a successful `gh repo clone` in `_ensure_mnemosyne()` so the fcntl lock file does not linger in `build/` after each clone
- Adds `.mnemosyne.lock` to `.gitignore` as a belt-and-suspenders guard
- Adds `test_lock_file_removed_after_successful_clone` unit test in `TestEnsureMnemosyne` to verify the lock file is absent after a successful clone

## Test plan

- [ ] `pixi run python -m pytest tests/unit/automation/test_planner.py -v` — all 16 tests pass, including the new lock-file cleanup assertion
- [ ] `pre-commit run --all-files` — all hooks pass

Closes #1327