### PR TITLE
fix(tests): replace wall-clock timing assertions with mock-based

### DIFF
--- a/tests/unit/cli/test_progress.py
+++ b/tests/unit/cli/test_progress.py
@@ -3,6 +3,7 @@
 import sys
 from datetime import datetime, timedelta, timezone
 from io import StringIO
+from unittest.mock import patch
 
 from scylla.cli.progress import (
     EvalProgress,
@@ -30,13 +31,17 @@ class TestRunProgress:
         assert run.elapsed == timedelta(0)
 
     def test_elapsed_running(self) -> None:
-        """Test Elapsed running."""
+        """Test Elapsed running — uses mocked datetime.now to avoid wall-clock flakiness."""
+        fixed_now = datetime(2024, 1, 1, 12, 0, 10, tzinfo=timezone.utc)
+        fixed_start = datetime(2024, 1, 1, 12, 0, 0, tzinfo=timezone.utc)
         run = RunProgress(
             run_number=1,
             status=RunStatus.EXECUTING,
-            start_time=datetime.now(timezone.utc) - timedelta(seconds=10),
+            start_time=fixed_start,
         )
-        assert run.elapsed >= timedelta(seconds=10)
+        with patch("scylla.cli.progress.datetime") as mock_dt:
+            mock_dt.now.return_value = fixed_now
+            assert run.elapsed == timedelta(seconds=10)
 
     def test_elapsed_complete(self) -> None:
         """Test Elapsed complete."""


### PR DESCRIPTION
## Summary
- Replaces real wall-clock timing assertion in `TestRunProgress.test_elapsed_running` with a deterministic mock using `unittest.mock.patch`
- The test previously used `datetime.now(timezone.utc)` at construction time and called the `elapsed` property which internally also calls `datetime.now(timezone.utc)` — making the test non-deterministic under load
- Fixed timestamps (`2024-01-01T12:00:00Z` start, `2024-01-01T12:00:10Z` now) now give an exact `timedelta(seconds=10)` assertion

## Test plan
- [x] `tests/unit/cli/test_progress.py` — 31 tests pass, including the fixed `test_elapsed_running`
- [x] Full unit test suite — 3691 tests pass
- [x] Pre-commit hooks (ruff, mypy, black) all pass

Closes #1125

🤖 Generated with [Claude Code](https://claude.com/claude-code)