### PR TITLE
docs: apply March 2026 quality audit documentation fixes

### DIFF
--- a/.claude/shared/metrics-definitions.md
+++ b/.claude/shared/metrics-definitions.md
@@ -236,7 +236,7 @@ Ablation_Score = performance_with_component - performance_without_component
 
 ## Tier-Specific Metrics
 
-### T3 (Tooling)
+### T2 (Tooling)
 
 **Tool Call Success Rate**:
 
@@ -250,7 +250,7 @@ Tool_Success_Rate = successful_tool_calls / total_tool_calls
 Tool_Utilization = tasks_using_tools / total_tasks
 ```
 
-### T4 (Delegation)
+### T3 (Delegation)
 
 **Delegation Overhead**:
 
@@ -264,7 +264,7 @@ Delegation_Overhead = multi_agent_cost / single_agent_equivalent_cost
 Task_Distribution_Efficiency = 1 - (idle_time / total_time)
 ```
 
-### T5 (Hierarchy)
+### T4 (Hierarchy)
 
 **Correction Frequency**:
 
@@ -854,6 +854,6 @@ schema_pct = distribution.get_type_percentage(ComponentType.TOOL_SCHEMA)
 
 ## Related Documentation
 
-- [Judge Protocol](./judge-protocol.md) - How judgments produce weighted_score
-- [Evaluation Categories](./judge-protocol.md#evaluation-categories) - 10 quality categories
+- [Judge Protocol](../../docs/design/judge-protocol.md) - How judgments produce weighted_score
+- [Evaluation Categories](../../docs/design/judge-protocol.md#evaluation-categories) - 10 quality categories
 - [Research Methodology](../research.md) - Original metrics definitions

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -274,9 +274,9 @@ Is the task well-defined with predictable steps?
 **DO**: Use absolute file paths with line numbers when referencing code:
 
 ```markdown
-GOOD: Updated /home/user/ProjectScylla/scylla/metrics/cop.py:45-52
+GOOD: Updated /home/user/ProjectScylla/scylla/metrics/grading.py:45-52
 
-BAD: Updated cop.py (ambiguous - which file?)
+BAD: Updated grading.py (ambiguous - which file?)
 ```
 
 #### Benchmark Results
@@ -410,6 +410,7 @@ ProjectScylla/
 |   +-- judge/                   # LLM judge system (.py)
 |   +-- metrics/                 # Metrics calculation (.py)
 |   +-- reporting/               # Report generation (.py)
+|   +-- utils/                   # Utility functions (.py)
 +-- scripts/                     # Python automation scripts
 +-- tests/                       # Python test suite (pytest)
 +-- .claude/                     # Operational configurations

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -444,7 +444,7 @@ pixi run pytest tests/unit/analysis/test_stats.py -v -k "test_bootstrap"
 export SCYLLA_LOG_LEVEL=DEBUG
 
 # Run with pdb
-pixi run python -m pdb scripts/run_experiment.py
+pixi run python -m pdb scripts/manage_experiment.py
 
 # Pytest debugging
 pixi run pytest tests/ -v --pdb  # Drop into debugger on failure
@@ -464,7 +464,8 @@ ProjectScylla/
 │   ├── executor/        # Execution engine
 │   ├── judge/           # LLM judge system
 │   ├── metrics/         # Metrics calculation
-│   └── reporting/       # Report generation
+│   ├── reporting/       # Report generation
+│   └── utils/           # Utility functions
 ├── tests/               # Test suite
 │   ├── unit/            # Unit tests
 │   ├── integration/     # Integration tests

--- a/README.md
+++ b/README.md
@@ -331,7 +331,7 @@ fullruns/{experiment_name}/{timestamp}/
 - `exit_code` (0 = success)
 - `judges` (list with grades & criteria)
 
-Schema: `scylla/analysis/schemas/run_result_schema.json`
+Schema: `scylla/analysis/schemas/run_result.schema.json`
 
 ---
 

--- a/scylla/analysis/__init__.py
+++ b/scylla/analysis/__init__.py
@@ -1,8 +1,8 @@
 """Analysis pipeline for experiment results.
 
 This module provides data loading, statistical analysis, figure generation,
-and table generation for the ProjectScylla experiment results.
-numpy, scipy, matplotlib, altair) which have no Mojo equivalents.
+and table generation for the ProjectScylla experiment results using Python
+libraries (numpy, scipy, matplotlib, altair).
 """
 
 from scylla.analysis.dataframes import (

--- a/scylla/executor/runner.py
+++ b/scylla/executor/runner.py
@@ -1,8 +1,8 @@
 """Test runner orchestration for agent evaluations.
 
 This module provides the EvalRunner class that orchestrates test execution
-across multiple tiers, models, and runs in Docker containers.
-parallel execution, and file I/O operations.
+across multiple tiers, models, and runs in Docker containers, with support for
+parallel execution and file I/O operations.
 """
 
 from __future__ import annotations


### PR DESCRIPTION
## Summary

- Fix tier labels in `metrics-definitions.md` (T3/T4/T5 → T2/T3/T4 per canonical CLAUDE.md definitions)
- Fix broken relative link to `judge-protocol.md` (`./judge-protocol.md` → `../../docs/design/judge-protocol.md`)
- Fix `CONTRIBUTING.md`: stale `run_experiment.py` → `manage_experiment.py`; add missing `scylla/utils/` to project structure
- Fix `CLAUDE.md`: stale `cop.py` example → `grading.py`; add `scylla/utils/` to project structure tree
- Fix `README.md` schema filename: `run_result_schema.json` → `run_result.schema.json`
- Fix garbled docstrings in `scylla/executor/runner.py:1-6` and `scylla/analysis/__init__.py:1-6`

## Test plan
- [ ] Verify tier labels T2/T3/T4 match CLAUDE.md table (T2=Tooling, T3=Delegation, T4=Hierarchy)
- [ ] Verify `docs/design/judge-protocol.md` exists at referenced path
- [ ] Verify `scripts/manage_experiment.py` exists
- [ ] Verify `scylla/utils/` exists in codebase
- [ ] Verify `scylla/metrics/grading.py` exists (CoP metric location)
- [ ] Verify `scylla/analysis/schemas/run_result.schema.json` exists

🤖 Generated with [Claude Code](https://claude.com/claude-code)