### PR TITLE
fix(docs): Fix garbled module docstring in executor/runner.py

### DIFF
--- a/scylla/executor/runner.py
+++ b/scylla/executor/runner.py
@@ -1,7 +1,7 @@
 """Test runner orchestration for agent evaluations.
 
-This module provides the EvalRunner class that orchestrates test execution
-across multiple tiers, models, and runs in Docker containers, with support for
+This module provides the EvalRunner class, which orchestrates test execution
+across multiple tiers, models, and Docker container runs with support for
 parallel execution and file I/O operations.
 """
 


### PR DESCRIPTION
## Summary

- Rewrites the module docstring in `scylla/executor/runner.py` (lines 1-6) to eliminate visual ambiguity at the line break
- Changes `"that orchestrates"` to `"which orchestrates"` and restructures the wrapped sentence for cleaner readability
- Pure documentation change — zero behavioral impact

## Test plan

- [x] `pre-commit run --files scylla/executor/runner.py` passes (black, ruff, mypy all green)
- [x] No tests required — documentation-only change

Closes #1346

🤖 Generated with [Claude Code](https://claude.com/claude-code)