### PR TITLE
docs(contributing): add scylla/discovery/ to project structure listing

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -460,6 +460,7 @@ ProjectScylla/
 │   ├── automation/      # Automation utilities
 │   ├── config/          # Configuration
 │   ├── core/            # Core types
+│   ├── discovery/       # Resource discovery
 │   ├── e2e/             # E2E testing framework
 │   ├── executor/        # Execution engine
 │   ├── judge/           # LLM judge system


### PR DESCRIPTION
## Summary
- Added `scylla/discovery/` to the project structure listing in `CONTRIBUTING.md`
- Placed in correct alphabetical position between `core/` and `e2e/`
- `scylla/utils/` was already present

## Test plan
- [x] Verified `scylla/discovery/` exists: contains `__init__.py`, `agents.py`, `blocks.py`, `skills.py`
- [x] Verified `scylla/utils/` already listed (no change needed)
- [x] Confirmed alphabetical ordering is correct

Closes #1352

🤖 Generated with [Claude Code](https://claude.com/claude-code)