### PR TITLE
fix(codeowners): Remove stale /agents/ entry

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -29,7 +29,6 @@
 
 # Agent configurations and hierarchy
 /.claude/ @HomericIntelligence/projectscylla-maintainers
-/agents/ @HomericIntelligence/projectscylla-maintainers
 
 # Model configurations
 /config/models/ @HomericIntelligence/projectscylla-maintainers


### PR DESCRIPTION
## Summary
- Removes the stale `/agents/` entry from `.github/CODEOWNERS` (line 32)
- The top-level `/agents/` directory does not exist in the repository
- Agent configurations are at `/.claude/agents/`, already covered by the `/.claude/` entry

## Verification
- `/.claude/` entry on line 31 continues to cover all agent configurations
- No top-level `/agents/` directory exists

Closes #1353