### PR TITLE
fix(deps): Reconcile duplicate pytest version specs in pixi.toml

### DIFF
--- a/pixi.toml
+++ b/pixi.toml
@@ -37,8 +37,6 @@ jsonschema = ">=4.0,<5"
 defusedxml = ">=0.7,<1"
 
 [feature.dev.dependencies]
-pytest = ">=7.0"
-pytest-cov = ">=4.0"
 pre-commit = ">=3.0"
 ruff = ">=0.1.0"
 mypy = ">=1.8.0"


### PR DESCRIPTION
## Summary
- Removed duplicate `pytest` and `pytest-cov` entries from `[feature.dev.dependencies]`
- The conflicting lower-bound constraints (`>=7.0` / `>=4.0`) could allow pytest 10.x in dev environments
- The stricter `[dependencies]` specs (`pytest >=9.0.2,<10`, `pytest-cov >=7.0.0,<8`) are now the sole constraints

## Test plan
- [x] `pixi install` succeeds without conflicts
- [x] `pixi run pytest --version` resolves to pytest 9.0.2

Closes #1354