### PR TITLE
[Refactor] Add ruff rule sets B, SIM, C4, RUF

### DIFF
--- a/pixi.lock
+++ b/pixi.lock
@@ -3786,7 +3786,7 @@ packages:
 - pypi: ./
   name: scylla
   version: 0.1.0
-  sha256: 38ade6242617ec7acc6a2cba3dcce584ecb288dae69a02bc9d3f6aafcdf25250
+  sha256: 55c909bee68416a8157d065d3f0584f632afcaa12c6e8d3e747e32ea92ef42c7
   requires_dist:
   - click>=8.0
   - pydantic>=2.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,13 +71,21 @@ target-version = "py310"
 # S101 is selected explicitly (not via the full "S"/bandit group) so that
 # assert statements are flagged as errors in production code.  Tests are
 # exempted below via per-file-ignores, where assert is the pytest idiom.
-select = ["E", "F", "W", "I", "N", "D", "UP", "S101"]
+select = ["E", "F", "W", "I", "N", "D", "UP", "S101", "B", "SIM", "C4", "RUF"]
 ignore = [
     "D100",  # Missing docstring in public module
     "D104",  # Missing docstring in public package
     "D203",  # 1 blank line before class (conflicts with D211)
     "D213",  # Multi-line summary second line (conflicts with D212)
     "D417",  # Missing argument descriptions in docstring
+    # B — flake8-bugbear
+    "B017",  # Do not assert blind exception — inline comments name the actual type
+    # SIM — flake8-simplify
+    "SIM117",  # pytest.raises() must be the innermost context manager; cannot merge
+    # RUF — ruff-specific
+    "RUF001",  # Intentional Unicode (Greek letters, math notation) in strings/docstrings
+    "RUF002",  # Intentional Unicode (en-dash, multiplication sign) in docstrings
+    "RUF003",  # Intentional Unicode (en-dash, multiplication sign) in comments
 ]
 
 [tool.ruff.lint.per-file-ignores]

--- a/scripts/agents/agent_stats.py
+++ b/scripts/agents/agent_stats.py
@@ -160,7 +160,7 @@ class AgentAnalyzer:
                     {"target": target, "description": link_text}
                 )
 
-    def format_text(self) -> str:  # noqa: C901  # text report formatting with many conditional branches
+    def format_text(self) -> str:  # text report formatting with many conditional branches
         """Format statistics as plain text report.
 
         Returns:

--- a/scripts/agents/check_frontmatter.py
+++ b/scripts/agents/check_frontmatter.py
@@ -77,7 +77,7 @@ def validate_field_type(field_name: str, value: Any, expected_type: type) -> str
 
 def validate_frontmatter(
     frontmatter: dict[str, Any], file_path: Path, verbose: bool = False
-) -> list[str]:  # noqa: C901  # field validation with many rules
+) -> list[str]:  # field validation with many rules
     """Validate the frontmatter data.
 
     Args:

--- a/scripts/agents/validate_agents.py
+++ b/scripts/agents/validate_agents.py
@@ -358,7 +358,7 @@ def validate_file(file_path: Path, verbose: bool = False) -> ValidationResult:
     return result
 
 
-def main() -> int:  # noqa: C901  # CLI main with multiple command paths
+def main() -> int:  # CLI main with multiple command paths
     """Run the agent validation script."""
     parser = argparse.ArgumentParser(
         description="Comprehensive validation of agent configuration files",

--- a/scripts/check_model_config_consistency.py
+++ b/scripts/check_model_config_consistency.py
@@ -44,7 +44,7 @@ def find_model_configs(config_dir: Path) -> list[Path]:
     return sorted(f for f in config_dir.glob("*.yaml") if not f.name.startswith("_"))
 
 
-def check_configs(config_dir: Path, verbose: bool = False) -> int:  # noqa: C901  # config validation with many checks
+def check_configs(config_dir: Path, verbose: bool = False) -> int:
     """Check all model configs in *config_dir* for filename/model_id consistency.
 
     For each YAML file the function:

--- a/scripts/check_type_alias_shadowing.py
+++ b/scripts/check_type_alias_shadowing.py
@@ -70,7 +70,7 @@ def is_shadowing_pattern(alias: str, target: str) -> bool:
     return target_lower.endswith(alias_lower)
 
 
-def detect_shadowing(file_path: Path) -> list[tuple[int, str, str, str]]:  # noqa: C901  # AST traversal with multiple node types
+def detect_shadowing(file_path: Path) -> list[tuple[int, str, str, str]]:
     """Find type alias shadowing violations in a Python file.
 
     Args:

--- a/scripts/filter_audit.py
+++ b/scripts/filter_audit.py
@@ -20,6 +20,7 @@ but do not cause a non-zero exit (printed as warnings).
 
 from __future__ import annotations
 
+import contextlib
 import json
 import re
 import sys
@@ -74,10 +75,8 @@ def extract_cvss_score(severity_list: list[dict[str, Any]]) -> float | None:
         # Check for a direct numeric "score" alongside the vector
         numeric = entry.get("base_score") or entry.get("cvss_score")
         if numeric is not None:
-            try:
+            with contextlib.suppress(TypeError, ValueError):
                 scores.append(float(numeric))
-            except (TypeError, ValueError):
-                pass
     return max(scores) if scores else None
 
 

--- a/scripts/fix_markdown.py
+++ b/scripts/fix_markdown.py
@@ -148,7 +148,7 @@ class MarkdownFixer:
 
         return "\n".join(fixed_lines), fixes
 
-    def _fix_structural_issues(self, content: str) -> tuple[str, int]:  # noqa: C901  # markdown repair with many fix categories
+    def _fix_structural_issues(self, content: str) -> tuple[str, int]:
         """Fix structural markdown issues (MD022, MD031, MD032, MD029, MD036).
 
         - MD022: Headings surrounded by blank lines

--- a/scripts/generate_figures.py
+++ b/scripts/generate_figures.py
@@ -106,7 +106,7 @@ FIGURES: dict[str, tuple[str, Any]] = {
 }
 
 
-def main() -> None:  # noqa: C901  # figure generation with many conditional paths
+def main() -> None:  # figure generation with many conditional paths
     """Run the figure generation script."""
     parser = argparse.ArgumentParser(
         description="Generate figures for the paper",

--- a/scripts/manage_experiment.py
+++ b/scripts/manage_experiment.py
@@ -649,7 +649,7 @@ def _run_batch(test_dirs: list[Path], args: argparse.Namespace) -> int:
     return 0 if failed_count == 0 else 1
 
 
-def cmd_run(args: argparse.Namespace) -> int:  # noqa: C901 — unified run command
+def cmd_run(args: argparse.Namespace) -> int:
     """Execute the 'run' subcommand (single test or batch mode)."""
     import yaml
 

--- a/scripts/migrate_skills_to_mnemosyne.py
+++ b/scripts/migrate_skills_to_mnemosyne.py
@@ -416,7 +416,7 @@ def cleanup_flat_skills(mnemosyne_dir: Path, dry_run: bool = False) -> None:
                 print(f"Removed flat skills/{skill_name}/")
 
 
-def main() -> int:  # noqa: C901  # CLI main with multiple phases
+def main() -> int:  # CLI main with multiple phases
     """Execute the migration workflow."""
     args = parse_args()
 

--- a/scylla/analysis/loader.py
+++ b/scylla/analysis/loader.py
@@ -638,7 +638,7 @@ def load_run(run_dir: Path, experiment: str, tier: str, subtest: str, agent_mode
         progress_tracking = result.get("progress_tracking")
         changes = result.get("changes")
         if progress_tracking or changes:
-            from scylla.metrics.process import (  # noqa: PLC0415
+            from scylla.metrics.process import (
                 ChangeResult,
                 ProgressStep,
                 ProgressTracker,

--- a/scylla/analysis/tables/__init__.py
+++ b/scylla/analysis/tables/__init__.py
@@ -42,9 +42,9 @@ __all__ = [
     "table04_criteria_performance",
     "table05_cost_analysis",
     "table06_model_comparison",
-    "table_cfp_comparison",
     "table07_subtest_detail",
     "table08_summary_statistics",
     "table09_experiment_config",
     "table10_normality_tests",
+    "table_cfp_comparison",
 ]

--- a/scylla/analysis/tables/comparison.py
+++ b/scylla/analysis/tables/comparison.py
@@ -38,7 +38,7 @@ _FMT_RATE = f".{config.precision_rates}f"
 _FMT_COST = f".{config.precision_costs}f"
 
 
-def _generate_pairwise_comparison(  # noqa: C901  # pairwise comparison with many metric types
+def _generate_pairwise_comparison(  # pairwise comparison with many metric types
     runs_df: pd.DataFrame,
     metric_column: str,
     metric_name: str,
@@ -141,10 +141,7 @@ def _generate_pairwise_comparison(  # noqa: C901  # pairwise comparison with man
             )
 
             # Post-hoc power (Mann-Whitney) — skip for small samples
-            if n1 >= 5 and n2 >= 5:
-                power = mann_whitney_power(n1, n2, abs(delta))
-            else:
-                power = float("nan")
+            power = mann_whitney_power(n1, n2, abs(delta)) if n1 >= 5 and n2 >= 5 else float("nan")
 
             pairwise_data.append(
                 {
@@ -182,10 +179,7 @@ def _generate_pairwise_comparison(  # noqa: C901  # pairwise comparison with man
             )
 
             # Post-hoc power (Mann-Whitney) — skip for small samples
-            if n1 >= 5 and n2 >= 5:
-                power = mann_whitney_power(n1, n2, abs(delta))
-            else:
-                power = float("nan")
+            power = mann_whitney_power(n1, n2, abs(delta)) if n1 >= 5 and n2 >= 5 else float("nan")
 
             pairwise_data.append(
                 {
@@ -392,7 +386,7 @@ def table02b_impl_rate_comparison(runs_df: pd.DataFrame) -> tuple[str, str]:
     )
 
 
-def table04_criteria_performance(  # noqa: C901  # table generation with many criteria branches
+def table04_criteria_performance(  # table generation with many criteria branches
     criteria_df: pd.DataFrame,
     runs_df: pd.DataFrame,
     criteria_weights: dict[str, float] | None = None,
@@ -416,7 +410,7 @@ def table04_criteria_performance(  # noqa: C901  # table generation with many cr
         # Derive criteria and uniform weights from the actual data
         unique_criteria = sorted(criteria_df["criterion"].unique())
         n = len(unique_criteria)
-        criteria_weights = {c: 1.0 / n for c in unique_criteria} if n > 0 else {}
+        criteria_weights = dict.fromkeys(unique_criteria, 1.0 / n) if n > 0 else {}
 
     # Aggregate by (agent_model, criterion)
     criterion_stats = []

--- a/scylla/automation/curses_ui.py
+++ b/scylla/automation/curses_ui.py
@@ -196,7 +196,7 @@ class CursesUI:
             except KeyboardInterrupt:
                 break
 
-    def _refresh_display(self) -> None:  # noqa: C901  # TUI rendering with many display states
+    def _refresh_display(self) -> None:  # TUI rendering with many display states
         """Refresh the curses display."""
         if not self.stdscr:
             return

--- a/scylla/automation/implementer.py
+++ b/scylla/automation/implementer.py
@@ -251,7 +251,7 @@ class IssueImplementer:
 
         return {}
 
-    def _implement_all(self) -> dict[int, WorkerResult]:  # noqa: C901  # orchestrator with many issue states
+    def _implement_all(self) -> dict[int, WorkerResult]:  # orchestrator with many issue states
         """Implement all issues with dependency awareness.
 
         Returns:
@@ -336,7 +336,7 @@ class IssueImplementer:
         self._print_summary(results)
         return results
 
-    def _implement_issue(self, issue_number: int) -> WorkerResult:  # noqa: C901  # issue implementation with many phase transitions
+    def _implement_issue(self, issue_number: int) -> WorkerResult:
         """Implement a single issue.
 
         Args:

--- a/scylla/automation/planner.py
+++ b/scylla/automation/planner.py
@@ -401,9 +401,8 @@ class Planner:
             repo_root = get_repo_root()
             mnemosyne_root = repo_root / "build" / "ProjectMnemosyne"
 
-            if not mnemosyne_root.exists():
-                if not self._ensure_mnemosyne(mnemosyne_root):
-                    return ""
+            if not mnemosyne_root.exists() and not self._ensure_mnemosyne(mnemosyne_root):
+                return ""
 
             marketplace_path = mnemosyne_root / ".claude-plugin" / "marketplace.json"
             if not marketplace_path.exists():

--- a/scylla/automation/reviewer.py
+++ b/scylla/automation/reviewer.py
@@ -629,7 +629,7 @@ class PRReviewer:
                 )
             return self.states[issue_number]
 
-    def _review_pr(self, issue_number: int, pr_number: int) -> WorkerResult:  # noqa: C901
+    def _review_pr(self, issue_number: int, pr_number: int) -> WorkerResult:
         """Review and fix a single PR.
 
         Args:

--- a/scylla/config/loader.py
+++ b/scylla/config/loader.py
@@ -402,7 +402,7 @@ class ConfigLoader:
     # Merged Configuration Loading
     # -------------------------------------------------------------------------
 
-    def load(self, test_id: str, model_id: str) -> ScyllaConfig:  # noqa: C901  # config loading with many format/type branches
+    def load(self, test_id: str, model_id: str) -> ScyllaConfig:
         """Load and merge configuration for a test run.
 
         Applies three-level priority hierarchy:

--- a/scylla/e2e/__init__.py
+++ b/scylla/e2e/__init__.py
@@ -43,8 +43,6 @@ from scylla.e2e.rate_limit import (
 from scylla.e2e.subtest_state_machine import SubtestStateMachine
 
 __all__ = [
-    # State machines
-    "SubtestStateMachine",
     # Checkpoint
     "CheckpointError",
     "ConfigMismatchError",
@@ -59,6 +57,8 @@ __all__ = [
     "RateLimitInfo",
     "SubTestConfig",
     "SubTestResult",
+    # State machines
+    "SubtestStateMachine",
     "TierConfig",
     "TierID",
     "TierResult",

--- a/scylla/e2e/llm_judge.py
+++ b/scylla/e2e/llm_judge.py
@@ -191,7 +191,7 @@ def _is_modular_repo(workspace: Path) -> bool:
     return (workspace / "bazelw").exists() and (workspace / "mojo").is_dir()
 
 
-def _run_mojo_pipeline(workspace: Path) -> BuildPipelineResult:  # noqa: C901  # Mojo pipeline with many repo-type and command branches
+def _run_mojo_pipeline(workspace: Path) -> BuildPipelineResult:
     """Run Mojo build/lint pipeline and capture results.
 
     Detects if workspace is the modular/mojo monorepo and uses appropriate commands:
@@ -373,7 +373,7 @@ def _get_pipeline_env() -> dict[str, str]:
     return env
 
 
-def _run_python_pipeline(workspace: Path) -> BuildPipelineResult:  # noqa: C901  # Python pipeline with many lint/build outcome branches
+def _run_python_pipeline(workspace: Path) -> BuildPipelineResult:
     """Run Python build/lint pipeline and capture results.
 
     Args:
@@ -559,7 +559,7 @@ def _run_build_pipeline(workspace: Path, language: str = "python") -> BuildPipel
 # This module now imports and uses that consolidated implementation.
 
 
-def _get_workspace_state(workspace: Path) -> str:  # noqa: C901  # workspace state detection with many file patterns
+def _get_workspace_state(workspace: Path) -> str:
     """Get a description of modified/created files in the workspace.
 
     Only lists files that were modified or created by the agent (using git status),
@@ -763,7 +763,7 @@ def _load_reference_patch(reference_path: Path) -> str | None:
         return None
 
 
-def run_llm_judge(  # noqa: C901  # judge execution with many retry/error paths
+def run_llm_judge(  # judge execution with many retry/error paths
     workspace: Path,
     task_prompt: str,
     agent_output: str,

--- a/scylla/e2e/parallel_executor.py
+++ b/scylla/e2e/parallel_executor.py
@@ -160,7 +160,7 @@ class RateLimitCoordinator:
         return self._shutdown_event.is_set()
 
 
-def run_tier_subtests_parallel(  # noqa: C901  # parallel execution with many concurrency cases
+def run_tier_subtests_parallel(  # parallel execution with many concurrency cases
     config: ExperimentConfig,
     tier_id: TierID,
     tier_config: TierConfig,

--- a/scylla/e2e/regenerate.py
+++ b/scylla/e2e/regenerate.py
@@ -233,7 +233,7 @@ def scan_run_results(
     return results
 
 
-def rejudge_missing_runs(  # noqa: C901  # workspace state detection with many file patterns
+def rejudge_missing_runs(  # workspace state detection with many file patterns
     experiment_dir: Path,
     config: ExperimentConfig,
     run_results: dict[str, dict[str, list[E2ERunResult]]],

--- a/scylla/e2e/rerun.py
+++ b/scylla/e2e/rerun.py
@@ -150,7 +150,7 @@ def _classify_run_status(run_dir: Path) -> RunStatus:
     return RunStatus.MISSING
 
 
-def scan_runs_needing_rerun(  # noqa: C901  # experiment rerun with many retry/skip conditions
+def scan_runs_needing_rerun(  # experiment rerun with many retry/skip conditions
     experiment_dir: Path,
     config: ExperimentConfig,
     tier_manager: TierManager,
@@ -428,7 +428,7 @@ def rerun_single_run(
         return None
 
 
-def rerun_experiment(  # noqa: C901  # run scanning with many filter conditions
+def rerun_experiment(  # run scanning with many filter conditions
     experiment_dir: Path,
     dry_run: bool = False,
     verbose: bool = False,

--- a/scylla/e2e/rerun_judges.py
+++ b/scylla/e2e/rerun_judges.py
@@ -182,7 +182,7 @@ def _classify_judge_slots(
     return results
 
 
-def scan_judges_needing_rerun(  # noqa: C901  # judge scan with many filter conditions
+def scan_judges_needing_rerun(  # judge scan with many filter conditions
     experiment_dir: Path,
     config: ExperimentConfig,
     tier_manager: TierManager,
@@ -616,7 +616,7 @@ def _regenerate_consensus(run_dir: Path, judge_models: list[str]) -> bool:
     return True
 
 
-def rerun_judges_experiment(  # noqa: C901  # judge rerun with many retry/skip paths
+def rerun_judges_experiment(  # judge rerun with many retry/skip paths
     experiment_dir: Path,
     dry_run: bool = False,
     verbose: bool = False,

--- a/scylla/e2e/resume_manager.py
+++ b/scylla/e2e/resume_manager.py
@@ -246,11 +246,13 @@ class ResumeManager:
                             for sub_id, sub_state in self.checkpoint.subtest_states.get(
                                 tier_id_str, {}
                             ).items():
-                                if sub_state in ("aggregated", "runs_complete"):
-                                    if self._subtest_has_incomplete_runs(tier_id_str, sub_id):
-                                        self.checkpoint.subtest_states[tier_id_str][sub_id] = (
-                                            "runs_in_progress"
-                                        )
+                                has_incomplete = self._subtest_has_incomplete_runs(
+                                    tier_id_str, sub_id
+                                )
+                                if sub_state in ("aggregated", "runs_complete") and has_incomplete:
+                                    self.checkpoint.subtest_states[tier_id_str][sub_id] = (
+                                        "runs_in_progress"
+                                    )
                         else:
                             self.checkpoint.tier_states[tier_id_str] = "subtests_running"
 

--- a/scylla/e2e/run_report.py
+++ b/scylla/e2e/run_report.py
@@ -675,7 +675,7 @@ def _generate_criteria_comparison_table(
     return lines
 
 
-def _get_workspace_files(workspace_path: Path) -> list[tuple[str, str]]:  # noqa: C901  # single run execution with many outcome/retry branches
+def _get_workspace_files(workspace_path: Path) -> list[tuple[str, str]]:
     """Get files created/modified by agent, with their status.
 
     Returns both committed and uncommitted files created by the agent.

--- a/scylla/e2e/runner.py
+++ b/scylla/e2e/runner.py
@@ -22,6 +22,8 @@ if TYPE_CHECKING:
     from scylla.e2e.models import SubTestResult, TierConfig
     from scylla.e2e.scheduler import ParallelismScheduler
 
+import contextlib
+
 from scylla.e2e.checkpoint import (
     E2ECheckpoint,
     compute_config_hash,
@@ -744,10 +746,8 @@ class E2ERunner:
 
         _current_exp_state = ExperimentState.INITIALIZING
         if self.checkpoint:
-            try:
+            with contextlib.suppress(ValueError):
                 _current_exp_state = ExperimentState(self.checkpoint.experiment_state)
-            except ValueError:
-                pass
 
         _resume_states = {
             ExperimentState.TIERS_RUNNING,
@@ -802,13 +802,11 @@ class E2ERunner:
 
         # Handle early stop (--until-experiment)
         final_state = esm.get_state()
-        if final_state not in (ExperimentState.COMPLETE, ExperimentState.FAILED):
-            if (
-                self.config.until_experiment_state
-                and final_state == self.config.until_experiment_state
-            ):
-                logger.info(f"Stopped at --until-experiment {final_state.value}")
-                return self._aggregate_results(tier_results, start_time)
+        if final_state not in (ExperimentState.COMPLETE, ExperimentState.FAILED) and (
+            self.config.until_experiment_state and final_state == self.config.until_experiment_state
+        ):
+            logger.info(f"Stopped at --until-experiment {final_state.value}")
+            return self._aggregate_results(tier_results, start_time)
 
         # Return result (populated by action_tiers_complete)
         if self._last_experiment_result is not None:

--- a/scylla/e2e/stages.py
+++ b/scylla/e2e/stages.py
@@ -812,7 +812,7 @@ def _build_progress_steps(
     total_delta = sum(file_deltas)
 
     steps: list[ProgressStep] = []
-    for (filepath, status), delta in zip(entries, file_deltas):
+    for (filepath, status), delta in zip(entries, file_deltas, strict=False):
         weight = delta / total_delta if total_delta > 0 else 1.0
         steps.append(
             ProgressStep(

--- a/scylla/e2e/subtest_executor.py
+++ b/scylla/e2e/subtest_executor.py
@@ -72,30 +72,30 @@ logger = logging.getLogger(__name__)
 #   from scylla.e2e.subtest_executor import run_tier_subtests_parallel
 # continue to work without modification
 __all__ = [
+    # Parallel executor exports (imported lazily to avoid circular imports)
+    "RateLimitCoordinator",
     "SubTestExecutor",
-    "aggregate_run_results",
-    # Agent runner exports
-    "_save_agent_result",
-    "_load_agent_result",
-    "_create_agent_model_md",
-    "_has_valid_agent_result",
-    # Judge runner exports
-    "_save_judge_result",
-    "_load_judge_result",
-    "_has_valid_judge_result",
+    "_commit_test_config",
     "_compute_judge_consensus",
-    "_run_judge",
+    "_create_agent_model_md",
+    "_detect_rate_limit_from_results",  # noqa: F822
+    "_has_valid_agent_result",
+    "_has_valid_judge_result",
+    "_load_agent_result",
+    "_load_judge_result",
     # Workspace setup exports
     "_move_to_failed",
-    "_commit_test_config",
-    "_setup_workspace",
-    # Parallel executor exports (imported lazily to avoid circular imports)
-    "RateLimitCoordinator",  # noqa: F822
-    "run_tier_subtests_parallel",  # noqa: F822
-    "_detect_rate_limit_from_results",  # noqa: F822
     "_retry_with_new_pool",  # noqa: F822
-    "_run_subtest_in_process_safe",  # noqa: F822
+    "_run_judge",
     "_run_subtest_in_process",  # noqa: F822
+    "_run_subtest_in_process_safe",  # noqa: F822
+    # Agent runner exports
+    "_save_agent_result",
+    # Judge runner exports
+    "_save_judge_result",
+    "_setup_workspace",
+    "aggregate_run_results",
+    "run_tier_subtests_parallel",  # noqa: F822
 ]
 
 

--- a/scylla/e2e/tier_manager.py
+++ b/scylla/e2e/tier_manager.py
@@ -108,7 +108,7 @@ class TierManager:
             delegation_enabled=global_tier_config.delegation_enabled,
         )
 
-    def prepare_workspace(  # noqa: C901  # workspace setup with many config scenarios
+    def prepare_workspace(  # workspace setup with many config scenarios
         self,
         workspace: Path,
         tier_id: TierID,
@@ -316,7 +316,7 @@ class TierManager:
 
         return cast(dict[str, Any], config.get("resources", {}))
 
-    def _create_symlinks(  # noqa: C901  # symlink creation with many source/target patterns
+    def _create_symlinks(  # symlink creation with many source/target patterns
         self,
         workspace: Path,
         resources: dict[str, Any],
@@ -507,7 +507,7 @@ class TierManager:
         with open(settings_path, "w") as f:
             json.dump(settings, f, indent=2)
 
-    def build_resource_suffix(self, subtest: SubTestConfig) -> str:  # noqa: C901  # resource suffix building with many combinations
+    def build_resource_suffix(self, subtest: SubTestConfig) -> str:
         """Build prompt suffix based on configured resources.
 
         Uses bullet list format for resources:
@@ -750,7 +750,7 @@ class TierManager:
 
         return merged_resources
 
-    def _merge_tier_resources(  # noqa: C901  # file discovery with many path patterns
+    def _merge_tier_resources(  # file discovery with many path patterns
         self,
         merged_resources: dict[str, Any],
         new_resources: dict[str, Any],
@@ -833,7 +833,7 @@ class TierManager:
             if "levels" in new_agents:
                 merged_levels = merged_resources["agents"].get("levels", [])
                 merged_levels.extend(new_agents["levels"])
-                merged_resources["agents"]["levels"] = sorted(list(set(merged_levels)))
+                merged_resources["agents"]["levels"] = sorted(set(merged_levels))
 
             # Merge names
             if "names" in new_agents:

--- a/scylla/judge/cleanup_evaluator.py
+++ b/scylla/judge/cleanup_evaluator.py
@@ -103,9 +103,9 @@ class CleanupEvaluator:
             Set of relative file paths in the workspace.
 
         """
-        return set(
+        return {
             str(p.relative_to(self.workspace)) for p in self.workspace.rglob("*") if p.is_file()
-        )
+        }
 
     def find_cleanup_script(self) -> Path | None:
         """Find cleanup script in workspace.

--- a/scylla/reporting/scorecard.py
+++ b/scylla/reporting/scorecard.py
@@ -86,7 +86,7 @@ def _grade_to_points(grade: str) -> float:
     return max(0.0, min(5.0, points))
 
 
-def _points_to_grade(points: float) -> str:  # noqa: C901  # grade mapping with many score thresholds
+def _points_to_grade(points: float) -> str:  # grade mapping with many score thresholds
     """Convert point value back to letter grade.
 
     Uses industry-aligned scale where S is the highest grade.

--- a/tests/claude-code/shared/compose/compose_skills.py
+++ b/tests/claude-code/shared/compose/compose_skills.py
@@ -123,7 +123,7 @@ def get_skill_by_name(skill_name: str) -> Path | None:
     return None
 
 
-def compose(  # noqa: C901  # skill composition with many conditional branches
+def compose(  # skill composition with many conditional branches
     categories: list[str] | None,
     skills: list[str] | None,
     output: Path,

--- a/tests/claude-code/shared/compose/generate_subtiers.py
+++ b/tests/claude-code/shared/compose/generate_subtiers.py
@@ -456,7 +456,7 @@ def list_configurations() -> None:
     print(f"Total test cases: {total * len(MODELS)}")
 
 
-def main() -> None:  # noqa: C901  # CLI main with multiple tier generation modes
+def main() -> None:  # CLI main with multiple tier generation modes
     """Generate sub-tier configurations from command line arguments."""
     parser = argparse.ArgumentParser(
         description="Generate sub-tier configurations for testing",

--- a/tests/integration/e2e/test_additive_resume.py
+++ b/tests/integration/e2e/test_additive_resume.py
@@ -137,13 +137,13 @@ def _simulate_tier_subtests_at_state(
         # Advance subtest to RUNS_IN_PROGRESS (the PENDING action fires runs)
         ssm = SubtestStateMachine(checkpoint=cp, checkpoint_path=cp_path)
 
-        def _pending_runs() -> None:
+        def _pending_runs(_sid: str = subtest_id) -> None:
             """Simulate executing run_count runs up to until_run_state."""
             run_sm = StateMachine(checkpoint=cp, checkpoint_path=cp_path)
             for run_num in range(1, run_count + 1):
                 run_sm.advance_to_completion(
                     tier_id,
-                    subtest_id,
+                    _sid,
                     run_num,
                     make_noop_run_actions(),
                     until_state=until_run_state,

--- a/tests/integration/e2e/test_until_from_stepping.py
+++ b/tests/integration/e2e/test_until_from_stepping.py
@@ -350,7 +350,7 @@ class TestSubtestLevelStepping:
             )
 
         # Validate: all subtests in RUNS_IN_PROGRESS, none FAILED
-        expected_substates = {sid: "runs_in_progress" for sid in subtest_ids}
+        expected_substates = dict.fromkeys(subtest_ids, "runs_in_progress")
         validate_checkpoint_states(
             cp_path,
             expected_subtest_states={"T0": expected_substates},
@@ -748,7 +748,7 @@ class TestCrossLevelPropagation:
             assert final == SubtestState.RUNS_IN_PROGRESS
 
         # All subtests should be in RUNS_IN_PROGRESS, none FAILED
-        expected_subtest_states = {sid: "runs_in_progress" for sid in subtest_ids}
+        expected_subtest_states = dict.fromkeys(subtest_ids, "runs_in_progress")
         expected_run_states = {sid: {"1": "replay_generated"} for sid in subtest_ids}
         validate_checkpoint_states(
             cp_path,

--- a/tests/unit/analysis/test_export_data.py
+++ b/tests/unit/analysis/test_export_data.py
@@ -899,7 +899,7 @@ def test_sparse_process_metrics_graceful_degradation():
     rng = np.random.RandomState(0)
     rows = []
     for tier in ["T0", "T1"]:
-        for i in range(5):
+        for _i in range(5):
             rows.append(
                 {
                     "agent_model": "model1",

--- a/tests/unit/automation/test_planner.py
+++ b/tests/unit/automation/test_planner.py
@@ -157,11 +157,9 @@ class TestRunAdvise:
 
         def patched_exists(p: Path) -> bool:
             call_count[0] += 1
-            if call_count[0] == 1:
-                # First call: mnemosyne_root.exists() -> False (triggers _ensure_mnemosyne)
-                return False
+            # First call: mnemosyne_root.exists() -> False (triggers _ensure_mnemosyne)
             # Subsequent calls (marketplace check): True
-            return True
+            return call_count[0] != 1
 
         with (
             patch("scylla.automation.planner.get_repo_root") as mock_get_repo,
@@ -212,9 +210,7 @@ class TestRunAdvise:
             # mnemosyne_root exists but marketplace.json is always absent
             if p.name == "ProjectMnemosyne":
                 return True
-            if p.name == "marketplace.json":
-                return False
-            return True
+            return p.name != "marketplace.json"
 
         with (
             patch("scylla.automation.planner.get_repo_root") as mock_get_repo,

--- a/tests/unit/e2e/test_checkpoint.py
+++ b/tests/unit/e2e/test_checkpoint.py
@@ -805,7 +805,7 @@ class TestSaveCheckpointThreadSafety:
         def save_worker() -> None:
             try:
                 save_checkpoint(checkpoint, checkpoint_path)
-            except Exception as exc:  # noqa: BLE001
+            except Exception as exc:
                 errors.append(exc)
 
         threads = [threading.Thread(target=save_worker) for _ in range(20)]

--- a/tests/unit/e2e/test_experiment_result_writer.py
+++ b/tests/unit/e2e/test_experiment_result_writer.py
@@ -365,7 +365,7 @@ class TestFindFrontier:
         t0_result = _make_tier_result(TierID.T0, pass_rate=0.5, total_cost=2.0)
         t1_result = _make_tier_result(TierID.T1, pass_rate=0.5, total_cost=0.5)
 
-        tier_id, cop = writer.find_frontier({TierID.T0: t0_result, TierID.T1: t1_result})
+        tier_id, _cop = writer.find_frontier({TierID.T0: t0_result, TierID.T1: t1_result})
 
         # T1 has CoP = mean_cost / pass_rate = 0.5 / 0.5 = 1.0
         # T0 has CoP = 2.0 / 0.5 = 4.0

--- a/tests/unit/e2e/test_llm_judge.py
+++ b/tests/unit/e2e/test_llm_judge.py
@@ -7,7 +7,7 @@ import os
 import subprocess
 import tempfile
 from pathlib import Path
-from typing import Any
+from typing import Any, ClassVar
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -1276,7 +1276,7 @@ class TestRunLlmJudgeRetry:
     """
 
     # Minimal patch context shared by most tests
-    _COMMON_PATCHES = [
+    _COMMON_PATCHES: ClassVar[list[tuple[str, Any]]] = [
         ("scylla.e2e.llm_judge._get_workspace_state", "(no changes)"),
         ("scylla.e2e.llm_judge._get_patchfile", "(no changes)"),
         ("scylla.e2e.llm_judge._get_deleted_files", []),

--- a/tests/unit/e2e/test_model_validation.py
+++ b/tests/unit/e2e/test_model_validation.py
@@ -18,12 +18,12 @@ class TestIsRateLimitError:
 
     def test_hit_your_limit_detected(self) -> None:
         """'hit your limit' triggers rate limit detection."""
-        result, wait = is_rate_limit_error("You've hit your limit for the day.")
+        result, _wait = is_rate_limit_error("You've hit your limit for the day.")
         assert result is True
 
     def test_rate_limit_phrase_detected(self) -> None:
         """'rate limit' phrase triggers detection."""
-        result, wait = is_rate_limit_error("API rate limit exceeded.")
+        result, _wait = is_rate_limit_error("API rate limit exceeded.")
         assert result is True
 
     def test_parse_minutes(self) -> None:

--- a/tests/unit/e2e/test_parallel_executor.py
+++ b/tests/unit/e2e/test_parallel_executor.py
@@ -429,23 +429,23 @@ class TestRunSubtestInProcessSafe:
         config = MagicMock()
         tier_config = MagicMock()
 
-        return dict(
-            config=config,
-            tier_id=TierID.T0,
-            tier_config=tier_config,
-            subtest=subtest,
-            baseline=None,
-            results_dir=tmp_path / "results",
-            tiers_dir=tmp_path / "tiers",
-            base_repo=tmp_path / "repo",
-            repo_url="https://github.com/example/repo.git",
-            commit=None,
-            checkpoint=None,
-            checkpoint_path=None,
-            coordinator=None,
-            scheduler=None,
-            experiment_dir=None,
-        )
+        return {
+            "config": config,
+            "tier_id": TierID.T0,
+            "tier_config": tier_config,
+            "subtest": subtest,
+            "baseline": None,
+            "results_dir": tmp_path / "results",
+            "tiers_dir": tmp_path / "tiers",
+            "base_repo": tmp_path / "repo",
+            "repo_url": "https://github.com/example/repo.git",
+            "commit": None,
+            "checkpoint": None,
+            "checkpoint_path": None,
+            "coordinator": None,
+            "scheduler": None,
+            "experiment_dir": None,
+        }
 
     def test_success_passthrough(self, tmp_path) -> None:
         """When _run_subtest_in_process succeeds, result is passed through unchanged."""
@@ -553,7 +553,7 @@ class TestRunSubtestInProcessSafe:
             ):
                 try:
                     _run_subtest_in_process_safe(**call_args)
-                except Exception as raised:  # noqa: BLE001
+                except Exception as raised:
                     raise AssertionError(
                         f"_run_subtest_in_process_safe raised {type(raised).__name__} "
                         f"when it should never raise"

--- a/tests/unit/e2e/test_runner.py
+++ b/tests/unit/e2e/test_runner.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import contextlib
 from pathlib import Path
 from typing import Any
 from unittest.mock import MagicMock, call, patch
@@ -612,10 +613,9 @@ class TestResumeTierConfigPreload:
             with patch(
                 "scylla.e2e.tier_action_builder.run_tier_subtests_parallel", return_value={}
             ):
-                try:
+                with contextlib.suppress(Exception):
                     runner._run_tier(TierID.T0, baseline=None, scheduler=None)
-                except Exception:  # noqa: BLE001
-                    pass  # We only care that tier_manager.load_tier_config was called
+                    # We only care that tier_manager.load_tier_config was called
 
         # load_tier_config must be called once for the pre-load (resume path)
         mock_tm.load_tier_config.assert_called_once_with(TierID.T0, mock_config.skip_agent_teams)
@@ -656,10 +656,8 @@ class TestResumeTierConfigPreload:
             with patch(
                 "scylla.e2e.tier_action_builder.run_tier_subtests_parallel", return_value={}
             ):
-                try:
+                with contextlib.suppress(Exception):
                     runner._run_tier(TierID.T0, baseline=None, scheduler=None)
-                except Exception:  # noqa: BLE001
-                    pass
 
         # load_tier_config should NOT have been called (pre-load skipped for PENDING)
         mock_tm.load_tier_config.assert_not_called()
@@ -699,10 +697,8 @@ class TestResumeTierConfigPreload:
             with patch(
                 "scylla.e2e.tier_action_builder.run_tier_subtests_parallel", return_value={}
             ):
-                try:
+                with contextlib.suppress(Exception):
                     runner._run_tier(TierID.T0, baseline=None, scheduler=None)
-                except Exception:  # noqa: BLE001
-                    pass
 
         mock_tm.load_tier_config.assert_not_called()
 

--- a/tests/unit/e2e/test_runner_state_machine.py
+++ b/tests/unit/e2e/test_runner_state_machine.py
@@ -10,6 +10,7 @@ Covers:
 
 from __future__ import annotations
 
+import contextlib
 from pathlib import Path
 from typing import Any
 from unittest.mock import MagicMock, patch
@@ -314,11 +315,9 @@ class TestRunTierUsesTierStateMachine:
             mock_build_actions.return_value = {}
             mock_advance.return_value = TierState.SUBTESTS_RUNNING
 
-            # Capture the call
-            try:
+            # Capture the call — may fail due to missing TierResult; we just check the call
+            with contextlib.suppress(Exception):
                 runner._run_tier(TierID.T0, None, None)
-            except Exception:
-                pass  # May fail due to missing TierResult — we just check the call
 
             if mock_advance.called:
                 call_kwargs = mock_advance.call_args

--- a/tests/unit/scripts/agents/test_agent_utils.py
+++ b/tests/unit/scripts/agents/test_agent_utils.py
@@ -118,7 +118,7 @@ class TestExtractFrontmatterParsed:
         """Returns (text, dict) tuple with parsed YAML."""
         result = extract_frontmatter_parsed(VALID_FRONTMATTER_CONTENT)
         assert result is not None
-        text, data = result
+        _text, data = result
         assert data["name"] == "test-agent"
         assert data["model"] == "sonnet"
 

--- a/tests/unit/scripts/test_check_readmes.py
+++ b/tests/unit/scripts/test_check_readmes.py
@@ -103,7 +103,7 @@ class TestCheckRequiredSections:
         docs.mkdir()
         readme = docs / "README.md"
         sections = ["Overview", "Structure"]
-        ok, missing = check_required_sections(readme, sections)
+        ok, _missing = check_required_sections(readme, sections)
         assert ok is True
 
     def test_case_insensitive_section_matching(self, tmp_path: Path) -> None:
@@ -111,7 +111,7 @@ class TestCheckRequiredSections:
         readme = tmp_path / "README.md"
         # "overview" lowercase should match "Overview" requirement
         sections = ["overview", "installation", "usage"]
-        ok, missing = check_required_sections(readme, sections)
+        ok, _missing = check_required_sections(readme, sections)
         assert ok is True
 
 

--- a/tests/unit/scripts/test_check_type_alias_shadowing.py
+++ b/tests/unit/scripts/test_check_type_alias_shadowing.py
@@ -83,7 +83,7 @@ class TestDetectShadowing:
         f.write_text("Result = DomainResult\n")
         violations = detect_shadowing(f)
         assert len(violations) == 1
-        line_num, line, alias, target = violations[0]
+        line_num, _line, alias, target = violations[0]
         assert alias == "Result"
         assert target == "DomainResult"
         assert line_num == 1

--- a/tests/unit/scripts/test_fix_markdown.py
+++ b/tests/unit/scripts/test_fix_markdown.py
@@ -97,7 +97,7 @@ class TestFixMd026:
     def test_removes_trailing_period(self) -> None:
         """Trailing period is removed from heading."""
         f = fixer()
-        result, fixes = f._fix_md026_heading_punctuation("# Title.\n")
+        result, _fixes = f._fix_md026_heading_punctuation("# Title.\n")
         assert "Title." not in result
 
     def test_leaves_clean_heading_unchanged(self) -> None:
@@ -186,7 +186,7 @@ class TestFixFile:
         original = "# Heading:\n\n\ncontent\n"
         md.write_text(original)
         f = fixer(dry_run=True)
-        modified, fixes = f.fix_file(md)
+        _modified, _fixes = f.fix_file(md)
         # File should not have changed on disk
         assert md.read_text() == original
 
@@ -220,7 +220,7 @@ class TestProcessPath:
         (tmp_path / "a.md").write_text("# OK\n\ncontent\n")
         (tmp_path / "b.md").write_text("# OK\n\ncontent\n")
         f = fixer()
-        files_modified, total_fixes = f.process_path(tmp_path)
+        files_modified, _total_fixes = f.process_path(tmp_path)
         # Should have found 2 files (modified or not)
         assert isinstance(files_modified, int)
 

--- a/tests/unit/scripts/test_generate_changelog.py
+++ b/tests/unit/scripts/test_generate_changelog.py
@@ -41,14 +41,14 @@ class TestParseCommit:
 
     def test_non_conventional_commit(self) -> None:
         """Non-conventional commits default to 'other' type."""
-        h, t, s, m = parse_commit("abc1234|Some free-form message|Author")
+        _h, t, s, m = parse_commit("abc1234|Some free-form message|Author")
         assert t == "other"
         assert s == ""
         assert m == "Some free-form message"
 
     def test_malformed_line_returns_other(self) -> None:
         """Lines without proper format return empty hash and 'other' type."""
-        h, t, s, m = parse_commit("malformed-no-pipes")
+        h, t, _s, _m = parse_commit("malformed-no-pipes")
         assert h == ""
         assert t == "other"
 

--- a/tests/unit/scripts/test_validate_links.py
+++ b/tests/unit/scripts/test_validate_links.py
@@ -148,19 +148,19 @@ class TestValidateInternalLink:
         target.parent.mkdir()
         target.write_text("# Guide")
         source = tmp_path / "README.md"
-        is_valid, err = validate_internal_link("/docs/guide.md", source, tmp_path)
+        is_valid, _err = validate_internal_link("/docs/guide.md", source, tmp_path)
         assert is_valid is True
 
     def test_broken_absolute_link(self, tmp_path: Path) -> None:
         """Absolute link to missing file is invalid."""
         source = tmp_path / "README.md"
-        is_valid, err = validate_internal_link("/missing.md", source, tmp_path)
+        is_valid, _err = validate_internal_link("/missing.md", source, tmp_path)
         assert is_valid is False
 
     def test_pure_anchor_link_is_valid(self, tmp_path: Path) -> None:
         """Pure anchor links (no path) are considered valid (skipped)."""
         source = tmp_path / "README.md"
-        is_valid, err = validate_internal_link("#section", source, tmp_path)
+        is_valid, _err = validate_internal_link("#section", source, tmp_path)
         assert is_valid is True
 
 


### PR DESCRIPTION
## Summary
- Adds B (flake8-bugbear), SIM (flake8-simplify), C4 (flake8-comprehensions), and RUF (ruff-specific) rule sets to the ruff `select` list in `pyproject.toml`
- Added `ignore` entries with explanatory comments for B017, SIM117, RUF001/002/003 (legitimate exceptions)
- Fixed all 233 violations: 44 safe auto-fixes, 36 unsafe auto-fixes, remaining manual fixes

## Test plan
- [x] `ruff check scylla/ scripts/ tests/` passes clean (0 violations)
- [x] `pre-commit run --all-files` passes
- [x] 3999 unit tests pass, 72% coverage (above 9% floor and 75% scylla/ threshold)

Closes #1356

🤖 Generated with [Claude Code](https://claude.com/claude-code)