### PR TITLE
[Feat] Add JSON schemas for defaults.yaml, tier configs, and model configs

### DIFF
--- a/schemas/defaults.schema.json
+++ b/schemas/defaults.schema.json
@@ -1,0 +1,173 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://github.com/mvillmow/ProjectScylla/schemas/defaults.schema.json",
+  "title": "ProjectScylla Defaults Schema",
+  "description": "Schema for config/defaults.yaml — global evaluation framework defaults",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "evaluation": {
+      "type": "object",
+      "description": "Evaluation execution settings",
+      "additionalProperties": false,
+      "properties": {
+        "runs_per_eval": {
+          "type": "integer",
+          "description": "Number of runs per evaluation",
+          "minimum": 1,
+          "maximum": 100,
+          "examples": [10]
+        },
+        "timeout": {
+          "type": "integer",
+          "description": "Default timeout per run in seconds",
+          "minimum": 60,
+          "maximum": 86400,
+          "examples": [300, 3600]
+        },
+        "seed": {
+          "description": "Random seed for reproducibility (null for random)",
+          "oneOf": [
+            {"type": "integer"},
+            {"type": "null"}
+          ],
+          "examples": [42, null]
+        }
+      }
+    },
+    "metrics": {
+      "type": "object",
+      "description": "Metrics calculation settings",
+      "additionalProperties": false,
+      "properties": {
+        "quality": {
+          "type": "array",
+          "description": "Quality metrics to calculate",
+          "items": {"type": "string"},
+          "examples": [["pass_rate", "impl_rate", "progress_rate", "consistency"]]
+        },
+        "economic": {
+          "type": "array",
+          "description": "Economic metrics to calculate",
+          "items": {"type": "string"},
+          "examples": [["cost_of_pass", "token_distribution", "change_fail_percentage"]]
+        }
+      }
+    },
+    "output": {
+      "type": "object",
+      "description": "Output directory configuration",
+      "additionalProperties": false,
+      "properties": {
+        "runs_dir": {
+          "type": "string",
+          "description": "Directory for run artifacts",
+          "examples": ["runs"]
+        },
+        "summaries_dir": {
+          "type": "string",
+          "description": "Directory for summary reports",
+          "examples": ["summaries"]
+        },
+        "reports_dir": {
+          "type": "string",
+          "description": "Directory for full reports",
+          "examples": ["reports"]
+        }
+      }
+    },
+    "logging": {
+      "type": "object",
+      "description": "Logging configuration",
+      "additionalProperties": false,
+      "properties": {
+        "level": {
+          "type": "string",
+          "description": "Python logging level",
+          "enum": ["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"],
+          "examples": ["INFO"]
+        },
+        "format": {
+          "type": "string",
+          "description": "Python logging format string",
+          "examples": ["%(asctime)s - %(name)s - %(levelname)s - %(message)s"]
+        }
+      }
+    },
+    "default_model": {
+      "type": "string",
+      "description": "Default model ID when no --model flag is provided",
+      "minLength": 1,
+      "examples": ["claude-sonnet-4-5-20250929"]
+    },
+    "runs_per_tier": {
+      "type": "integer",
+      "description": "Number of runs per tier (executor-level override)",
+      "minimum": 1,
+      "maximum": 100,
+      "examples": [10]
+    },
+    "timeout_seconds": {
+      "type": "integer",
+      "description": "Timeout per run in seconds (executor-level override)",
+      "minimum": 60,
+      "maximum": 86400,
+      "examples": [3600]
+    },
+    "max_cost_usd": {
+      "type": "number",
+      "description": "Maximum cost per run in USD",
+      "minimum": 0.0,
+      "examples": [10.0]
+    },
+    "judge": {
+      "type": "object",
+      "description": "Judge model configuration",
+      "additionalProperties": false,
+      "properties": {
+        "model": {
+          "type": "string",
+          "description": "Judge model identifier",
+          "minLength": 1
+        },
+        "adapter": {
+          "type": "string",
+          "description": "Adapter to use for judge",
+          "minLength": 1
+        }
+      }
+    },
+    "adapters": {
+      "type": "object",
+      "description": "Adapter configuration",
+      "additionalProperties": false,
+      "properties": {
+        "default": {
+          "type": "string",
+          "description": "Default adapter name",
+          "minLength": 1
+        },
+        "available": {
+          "type": "array",
+          "description": "List of available adapter names",
+          "items": {"type": "string", "minLength": 1}
+        }
+      }
+    },
+    "cleanup": {
+      "type": "object",
+      "description": "Workspace cleanup settings",
+      "additionalProperties": false,
+      "properties": {
+        "delete_workspace": {
+          "type": "boolean",
+          "description": "Whether to delete workspace after run"
+        },
+        "keep_logs": {
+          "type": "boolean",
+          "description": "Whether to keep logs after run"
+        }
+      }
+    }
+  }
+}

--- a/schemas/model.schema.json
+++ b/schemas/model.schema.json
@@ -1,0 +1,81 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://github.com/mvillmow/ProjectScylla/schemas/model.schema.json",
+  "title": "ProjectScylla Model Configuration Schema",
+  "description": "Schema for config/models/*.yaml files that define model-level settings",
+  "type": "object",
+  "required": ["model_id"],
+  "additionalProperties": false,
+  "properties": {
+    "model_id": {
+      "type": "string",
+      "description": "Unique model identifier",
+      "minLength": 1,
+      "examples": ["claude-sonnet-4-5-20250929", "claude-opus-4-5-20251101", "goose"]
+    },
+    "name": {
+      "type": "string",
+      "description": "Human-readable model name",
+      "default": "",
+      "examples": ["Claude Sonnet 4.5", "Claude Opus 4.5", "Goose"]
+    },
+    "provider": {
+      "type": "string",
+      "description": "Model provider (e.g., anthropic, openai, block)",
+      "default": "",
+      "examples": ["anthropic", "openai", "block"]
+    },
+    "adapter": {
+      "type": "string",
+      "description": "Adapter to use for this model",
+      "default": "claude_code",
+      "examples": ["claude_code", "openai_codex", "cline", "goose"]
+    },
+    "temperature": {
+      "type": "number",
+      "description": "Sampling temperature (0.0 = deterministic)",
+      "default": 0.0,
+      "minimum": 0.0,
+      "maximum": 2.0,
+      "examples": [0.0, 0.7, 1.0]
+    },
+    "max_tokens": {
+      "type": "integer",
+      "description": "Maximum tokens per response",
+      "default": 8192,
+      "minimum": 1,
+      "maximum": 200000,
+      "examples": [8192, 16384, 100000]
+    },
+    "cost_per_1k_input": {
+      "type": "number",
+      "description": "Cost per 1K input tokens in USD",
+      "default": 0.0,
+      "minimum": 0.0,
+      "examples": [0.003, 0.015]
+    },
+    "cost_per_1k_output": {
+      "type": "number",
+      "description": "Cost per 1K output tokens in USD",
+      "default": 0.0,
+      "minimum": 0.0,
+      "examples": [0.015, 0.075]
+    },
+    "timeout_seconds": {
+      "description": "Per-run timeout override in seconds (null uses framework default)",
+      "oneOf": [
+        {"type": "integer", "minimum": 60, "maximum": 86400},
+        {"type": "null"}
+      ],
+      "examples": [3600, null]
+    },
+    "max_cost_usd": {
+      "description": "Maximum cost per run in USD (null uses framework default)",
+      "oneOf": [
+        {"type": "number", "minimum": 0.0},
+        {"type": "null"}
+      ],
+      "examples": [5.0, null]
+    }
+  }
+}

--- a/schemas/tier.schema.json
+++ b/schemas/tier.schema.json
@@ -1,0 +1,66 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://github.com/mvillmow/ProjectScylla/schemas/tier.schema.json",
+  "title": "ProjectScylla Tier Configuration Schema",
+  "description": "Schema for config/tiers/*.yaml files that define testing tier configurations",
+  "type": "object",
+  "required": ["tier", "name"],
+  "additionalProperties": false,
+  "properties": {
+    "tier": {
+      "type": "string",
+      "description": "Tier identifier in format t0-t6",
+      "pattern": "^t[0-6]$",
+      "examples": ["t0", "t1", "t2", "t3", "t4", "t5", "t6"]
+    },
+    "name": {
+      "type": "string",
+      "description": "Human-readable tier name",
+      "minLength": 1,
+      "examples": ["Vanilla", "Prompted", "Tooling", "Delegation"]
+    },
+    "description": {
+      "type": "string",
+      "description": "Description of what this tier tests",
+      "default": "",
+      "examples": ["Base LLM with zero-shot prompting"]
+    },
+    "system_prompt": {
+      "description": "System prompt text for this tier (null to use default)",
+      "oneOf": [
+        {"type": "string"},
+        {"type": "null"}
+      ],
+      "examples": ["You are a helpful assistant.", null]
+    },
+    "skills": {
+      "type": "array",
+      "description": "Skills enabled for this tier",
+      "default": [],
+      "items": {"type": "string", "minLength": 1},
+      "examples": [["commit", "review-pr"]]
+    },
+    "tools": {
+      "type": "array",
+      "description": "Tools enabled for this tier",
+      "default": [],
+      "items": {"type": "string", "minLength": 1},
+      "examples": [["bash", "read", "write"]]
+    },
+    "uses_tools": {
+      "type": "boolean",
+      "description": "Whether this tier uses external tools",
+      "default": false
+    },
+    "uses_delegation": {
+      "type": "boolean",
+      "description": "Whether this tier uses agent delegation",
+      "default": false
+    },
+    "uses_hierarchy": {
+      "type": "boolean",
+      "description": "Whether this tier uses hierarchical orchestration",
+      "default": false
+    }
+  }
+}

--- a/tests/unit/config/test_json_schemas.py
+++ b/tests/unit/config/test_json_schemas.py
@@ -1,0 +1,262 @@
+"""Tests for JSON schema files in schemas/.
+
+Validates that each schema:
+- Is well-formed JSON
+- Passes against real config files
+- Rejects invalid data (additionalProperties enforcement)
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import jsonschema
+import pytest
+import yaml
+
+# Paths
+REPO_ROOT = Path(__file__).parents[3]
+SCHEMAS_DIR = REPO_ROOT / "schemas"
+CONFIG_DIR = REPO_ROOT / "config"
+TIER_FIXTURES_DIR = REPO_ROOT / "tests" / "fixtures" / "config" / "tiers"
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def load_schema(name: str) -> dict[str, Any]:
+    """Load a JSON schema by filename."""
+    path = SCHEMAS_DIR / name
+    with path.open() as f:
+        return json.load(f)  # type: ignore[no-any-return]
+
+
+def load_yaml(path: Path) -> dict[str, Any]:
+    """Load a YAML file as a dict."""
+    with path.open() as f:
+        return yaml.safe_load(f)  # type: ignore[no-any-return]
+
+
+def check_schema(instance: dict[str, Any], schema: dict[str, Any]) -> None:
+    """Check instance against schema using jsonschema draft-07."""
+    validator_cls = jsonschema.validators.validator_for(schema)
+    validator = validator_cls(schema)
+    validator.validate(instance)
+
+
+# ---------------------------------------------------------------------------
+# Schema loading tests
+# ---------------------------------------------------------------------------
+
+
+class TestSchemaFiles:
+    """Verify schema files exist and are valid JSON."""
+
+    @pytest.mark.parametrize(
+        "schema_name",
+        ["defaults.schema.json", "tier.schema.json", "model.schema.json"],
+    )
+    def test_schema_file_exists(self, schema_name: str) -> None:
+        """Schema file must exist."""
+        assert (SCHEMAS_DIR / schema_name).exists()
+
+    @pytest.mark.parametrize(
+        "schema_name",
+        ["defaults.schema.json", "tier.schema.json", "model.schema.json"],
+    )
+    def test_schema_is_valid_json(self, schema_name: str) -> None:
+        """Schema file must be valid JSON."""
+        schema = load_schema(schema_name)
+        assert isinstance(schema, dict)
+
+    @pytest.mark.parametrize(
+        "schema_name",
+        ["defaults.schema.json", "tier.schema.json", "model.schema.json"],
+    )
+    def test_schema_has_required_keys(self, schema_name: str) -> None:
+        """Each schema must have $schema, title, type, and additionalProperties."""
+        schema = load_schema(schema_name)
+        assert "$schema" in schema
+        assert "title" in schema
+        assert schema.get("type") == "object"
+        assert schema.get("additionalProperties") is False
+
+
+# ---------------------------------------------------------------------------
+# defaults.schema.json
+# ---------------------------------------------------------------------------
+
+
+class TestDefaultsSchema:
+    """Tests for defaults.schema.json against config/defaults.yaml."""
+
+    @pytest.fixture
+    def schema(self) -> dict[str, Any]:
+        """Load defaults schema."""
+        return load_schema("defaults.schema.json")
+
+    @pytest.fixture
+    def defaults_data(self) -> dict[str, Any]:
+        """Load config/defaults.yaml."""
+        return load_yaml(CONFIG_DIR / "defaults.yaml")
+
+    def test_real_defaults_yaml_is_valid(
+        self, schema: dict[str, Any], defaults_data: dict[str, Any]
+    ) -> None:
+        """config/defaults.yaml must conform to defaults.schema.json."""
+        check_schema(defaults_data, schema)
+
+    def test_rejects_additional_property(self, schema: dict[str, Any]) -> None:
+        """Schema must reject unknown top-level keys."""
+        with pytest.raises(jsonschema.ValidationError):
+            check_schema({"unknown_key": "value"}, schema)
+
+    def test_accepts_empty_object(self, schema: dict[str, Any]) -> None:
+        """All fields are optional — empty dict must conform."""
+        check_schema({}, schema)
+
+    def test_rejects_invalid_logging_level(self, schema: dict[str, Any]) -> None:
+        """logging.level must be one of the valid log levels."""
+        with pytest.raises(jsonschema.ValidationError):
+            check_schema({"logging": {"level": "VERBOSE"}}, schema)
+
+    def test_rejects_out_of_range_runs_per_eval(self, schema: dict[str, Any]) -> None:
+        """evaluation.runs_per_eval must be in [1, 100]."""
+        with pytest.raises(jsonschema.ValidationError):
+            check_schema({"evaluation": {"runs_per_eval": 0}}, schema)
+
+    def test_seed_allows_null(self, schema: dict[str, Any]) -> None:
+        """evaluation.seed can be null."""
+        check_schema({"evaluation": {"seed": None}}, schema)
+
+    def test_seed_allows_integer(self, schema: dict[str, Any]) -> None:
+        """evaluation.seed can be an integer."""
+        check_schema({"evaluation": {"seed": 42}}, schema)
+
+
+# ---------------------------------------------------------------------------
+# tier.schema.json
+# ---------------------------------------------------------------------------
+
+
+class TestTierSchema:
+    """Tests for tier.schema.json against fixture tier configs."""
+
+    @pytest.fixture
+    def schema(self) -> dict[str, Any]:
+        """Load tier schema."""
+        return load_schema("tier.schema.json")
+
+    @pytest.mark.parametrize("fixture_file", ["t0.yaml", "t1.yaml"])
+    def test_real_tier_fixture_is_valid(self, schema: dict[str, Any], fixture_file: str) -> None:
+        """Tier fixture files must conform to tier.schema.json."""
+        data = load_yaml(TIER_FIXTURES_DIR / fixture_file)
+        check_schema(data, schema)
+
+    def test_rejects_missing_tier(self, schema: dict[str, Any]) -> None:
+        """Tier is required."""
+        with pytest.raises(jsonschema.ValidationError):
+            check_schema({"name": "Vanilla"}, schema)
+
+    def test_rejects_missing_name(self, schema: dict[str, Any]) -> None:
+        """Name is required."""
+        with pytest.raises(jsonschema.ValidationError):
+            check_schema({"tier": "t0"}, schema)
+
+    def test_rejects_invalid_tier_format(self, schema: dict[str, Any]) -> None:
+        """Tier must match pattern t0-t6."""
+        with pytest.raises(jsonschema.ValidationError):
+            check_schema({"tier": "T0", "name": "Vanilla"}, schema)
+
+    def test_rejects_out_of_range_tier(self, schema: dict[str, Any]) -> None:
+        """Tier t7 is out of range."""
+        with pytest.raises(jsonschema.ValidationError):
+            check_schema({"tier": "t7", "name": "Beyond"}, schema)
+
+    def test_rejects_additional_property(self, schema: dict[str, Any]) -> None:
+        """Schema must reject unknown keys."""
+        with pytest.raises(jsonschema.ValidationError):
+            check_schema({"tier": "t0", "name": "Vanilla", "unknown": True}, schema)
+
+    def test_system_prompt_allows_null(self, schema: dict[str, Any]) -> None:
+        """system_prompt can be null."""
+        check_schema({"tier": "t0", "name": "Vanilla", "system_prompt": None}, schema)
+
+    def test_system_prompt_allows_string(self, schema: dict[str, Any]) -> None:
+        """system_prompt can be a string."""
+        check_schema(
+            {"tier": "t1", "name": "Prompted", "system_prompt": "You are helpful."},
+            schema,
+        )
+
+    def test_minimal_valid_tier(self, schema: dict[str, Any]) -> None:
+        """Only tier and name are required."""
+        check_schema({"tier": "t3", "name": "Delegation"}, schema)
+
+
+# ---------------------------------------------------------------------------
+# model.schema.json
+# ---------------------------------------------------------------------------
+
+
+class TestModelSchema:
+    """Tests for model.schema.json against config/models/*.yaml."""
+
+    @pytest.fixture
+    def schema(self) -> dict[str, Any]:
+        """Load model schema."""
+        return load_schema("model.schema.json")
+
+    @pytest.mark.parametrize(
+        "model_file",
+        [
+            "claude-sonnet-4-5-20250929.yaml",
+            "claude-haiku-4-5-20250929.yaml",
+            "claude-opus-4-5-20251101.yaml",
+            "goose.yaml",
+        ],
+    )
+    def test_real_model_yaml_is_valid(self, schema: dict[str, Any], model_file: str) -> None:
+        """Real model config files must conform to model.schema.json."""
+        data = load_yaml(CONFIG_DIR / "models" / model_file)
+        check_schema(data, schema)
+
+    def test_rejects_missing_model_id(self, schema: dict[str, Any]) -> None:
+        """model_id is required."""
+        with pytest.raises(jsonschema.ValidationError):
+            check_schema({"name": "Claude"}, schema)
+
+    def test_rejects_additional_property(self, schema: dict[str, Any]) -> None:
+        """Schema must reject unknown keys."""
+        with pytest.raises(jsonschema.ValidationError):
+            check_schema({"model_id": "test-model", "unknown_field": "value"}, schema)
+
+    def test_rejects_out_of_range_temperature(self, schema: dict[str, Any]) -> None:
+        """Temperature must be in [0.0, 2.0]."""
+        with pytest.raises(jsonschema.ValidationError):
+            check_schema({"model_id": "test", "temperature": 3.0}, schema)
+
+    def test_rejects_zero_max_tokens(self, schema: dict[str, Any]) -> None:
+        """max_tokens must be >= 1."""
+        with pytest.raises(jsonschema.ValidationError):
+            check_schema({"model_id": "test", "max_tokens": 0}, schema)
+
+    def test_timeout_allows_null(self, schema: dict[str, Any]) -> None:
+        """timeout_seconds can be null."""
+        check_schema({"model_id": "test", "timeout_seconds": None}, schema)
+
+    def test_timeout_allows_integer(self, schema: dict[str, Any]) -> None:
+        """timeout_seconds can be a valid integer."""
+        check_schema({"model_id": "test", "timeout_seconds": 3600}, schema)
+
+    def test_max_cost_allows_null(self, schema: dict[str, Any]) -> None:
+        """max_cost_usd can be null."""
+        check_schema({"model_id": "test", "max_cost_usd": None}, schema)
+
+    def test_minimal_valid_model(self, schema: dict[str, Any]) -> None:
+        """Only model_id is required."""
+        check_schema({"model_id": "minimal-model"}, schema)


### PR DESCRIPTION
## Summary
- Add `schemas/defaults.schema.json` covering `DefaultsConfig` fields (evaluation, metrics, output, logging, default_model, and optional executor fields)
- Add `schemas/tier.schema.json` covering `TierConfig` fields with `t0-t6` pattern constraint
- Add `schemas/model.schema.json` covering `ModelConfig` fields with nullable timeout/max_cost fields
- All schemas use `additionalProperties: false` for strict validation, derived directly from Pydantic models in `scylla/config/models.py`
- Add `tests/unit/config/test_json_schemas.py` with 38 parametrized tests validating each schema against real config files and rejecting invalid data

## Test plan
- [x] All 38 new schema tests pass
- [x] Full unit test suite passes (4037 passed, 1 skipped)
- [x] Coverage at 72.02% (above 9% combined floor)
- [x] All pre-commit hooks pass (ruff, mypy, etc.)

Closes #1357