### PR TITLE
[Test] Add tests for 12 untested scripts

### DIFF
--- a/tests/unit/scripts/test_check_defaults_filename.py
+++ b/tests/unit/scripts/test_check_defaults_filename.py
@@ -1,0 +1,69 @@
+"""Tests for scripts/check_defaults_filename.py."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+from check_defaults_filename import main
+
+
+class TestMain:
+    """Tests for main()."""
+
+    def test_returns_zero_when_validation_passes(self, tmp_path: Path) -> None:
+        """Returns 0 when defaults file exists and validation passes."""
+        config_dir = tmp_path / "config"
+        config_dir.mkdir()
+        defaults_file = config_dir / "defaults.yaml"
+        defaults_file.write_text("key: value\n")
+
+        with (
+            patch("check_defaults_filename._REPO_ROOT", tmp_path),
+            patch("check_defaults_filename.validate_defaults_filename", return_value=[]),
+        ):
+            result = main()
+
+        assert result == 0
+
+    def test_returns_one_when_file_missing(self, tmp_path: Path) -> None:
+        """Returns 1 when defaults config file does not exist."""
+        with patch("check_defaults_filename._REPO_ROOT", tmp_path):
+            # No defaults.yaml in tmp_path/config/
+            result = main()
+
+        assert result == 1
+
+    def test_returns_one_when_validation_fails(self, tmp_path: Path) -> None:
+        """Returns 1 when validate_defaults_filename returns warnings."""
+        config_dir = tmp_path / "config"
+        config_dir.mkdir()
+        defaults_file = config_dir / "defaults.yaml"
+        defaults_file.write_text("key: value\n")
+
+        with (
+            patch("check_defaults_filename._REPO_ROOT", tmp_path),
+            patch(
+                "check_defaults_filename.validate_defaults_filename",
+                return_value=["filename mismatch"],
+            ),
+        ):
+            result = main()
+
+        assert result == 1
+
+    def test_prints_errors_when_validation_fails(self, tmp_path: Path, capsys: object) -> None:
+        """Prints each warning to stderr when validation fails."""
+        config_dir = tmp_path / "config"
+        config_dir.mkdir()
+        defaults_file = config_dir / "defaults.yaml"
+        defaults_file.write_text("key: value\n")
+
+        with (
+            patch("check_defaults_filename._REPO_ROOT", tmp_path),
+            patch(
+                "check_defaults_filename.validate_defaults_filename",
+                return_value=["bad name"],
+            ),
+        ):
+            main()

--- a/tests/unit/scripts/test_docker_build_timing.py
+++ b/tests/unit/scripts/test_docker_build_timing.py
@@ -1,0 +1,98 @@
+"""Tests for scripts/docker_build_timing.py."""
+
+from __future__ import annotations
+
+from docker_build_timing import build_summary_table, compute_reduction, count_cached_layers
+
+
+class TestCountCachedLayers:
+    """Tests for count_cached_layers()."""
+
+    def test_counts_single_cached_line(self) -> None:
+        """Counts one CACHED line correctly."""
+        log = "#1 CACHED\n#2 [1/3] FROM ubuntu\n"
+        assert count_cached_layers(log) == 1
+
+    def test_counts_multiple_cached_lines(self) -> None:
+        """Counts multiple CACHED lines."""
+        log = "#1 CACHED\n#2 CACHED\n#3 [3/4] RUN apt-get install\n#4 CACHED\n"
+        assert count_cached_layers(log) == 3
+
+    def test_returns_zero_for_no_cache(self) -> None:
+        """Returns 0 when no CACHED lines are present."""
+        log = "#1 [1/3] FROM ubuntu\n#2 [2/3] COPY . .\n"
+        assert count_cached_layers(log) == 0
+
+    def test_case_insensitive(self) -> None:
+        """Counts lowercase 'cached' as well."""
+        log = "cached step 1\nCACHED step 2\n"
+        assert count_cached_layers(log) == 2
+
+    def test_empty_log(self) -> None:
+        """Returns 0 for empty build log."""
+        assert count_cached_layers("") == 0
+
+
+class TestComputeReduction:
+    """Tests for compute_reduction()."""
+
+    def test_computes_percentage_reduction(self) -> None:
+        """Computes percentage reduction correctly."""
+        result = compute_reduction(cold_seconds=100, warm_seconds=40)
+        assert result == 60.0
+
+    def test_rounds_to_one_decimal(self) -> None:
+        """Result is rounded to one decimal place."""
+        result = compute_reduction(cold_seconds=300, warm_seconds=200)
+        assert result == 33.3
+
+    def test_returns_zero_for_zero_cold(self) -> None:
+        """Returns 0.0 when cold_seconds is zero to avoid division by zero."""
+        result = compute_reduction(cold_seconds=0, warm_seconds=50)
+        assert result == 0.0
+
+    def test_negative_cold_returns_zero(self) -> None:
+        """Returns 0.0 when cold_seconds is negative."""
+        result = compute_reduction(cold_seconds=-10, warm_seconds=5)
+        assert result == 0.0
+
+    def test_full_cache_hit(self) -> None:
+        """Returns 100.0 when warm build takes 0 seconds."""
+        result = compute_reduction(cold_seconds=120, warm_seconds=0)
+        assert result == 100.0
+
+
+class TestBuildSummaryTable:
+    """Tests for build_summary_table()."""
+
+    def test_contains_required_metrics(self) -> None:
+        """Table includes cold/warm build times, reduction, and cached layers."""
+        table = build_summary_table(
+            cold_seconds=120, warm_seconds=30, cached_layers=5, reduction=75.0
+        )
+        assert "120s" in table
+        assert "30s" in table
+        assert "75.0%" in table
+        assert "5" in table
+
+    def test_pass_verdict_when_reduction_meets_threshold(self) -> None:
+        """Shows PASS when reduction is >= 30%."""
+        table = build_summary_table(
+            cold_seconds=100, warm_seconds=50, cached_layers=3, reduction=50.0
+        )
+        assert "PASS" in table
+
+    def test_fail_verdict_when_reduction_below_threshold(self) -> None:
+        """Shows FAIL when reduction is < 30%."""
+        table = build_summary_table(
+            cold_seconds=100, warm_seconds=80, cached_layers=1, reduction=20.0
+        )
+        assert "FAIL" in table
+
+    def test_returns_markdown_table(self) -> None:
+        """Output is a Markdown table with header row."""
+        table = build_summary_table(
+            cold_seconds=60, warm_seconds=20, cached_layers=4, reduction=66.7
+        )
+        assert "| Metric | Value |" in table
+        assert "|" in table

--- a/tests/unit/scripts/test_export_data.py
+++ b/tests/unit/scripts/test_export_data.py
@@ -1,0 +1,93 @@
+"""Tests for scripts/export_data.py."""
+
+from __future__ import annotations
+
+import math
+from unittest.mock import patch
+
+from export_data import json_nan_handler
+
+
+class TestJsonNanHandler:
+    """Tests for json_nan_handler()."""
+
+    def test_converts_nan_to_none(self) -> None:
+        """Converts float NaN to None."""
+        assert json_nan_handler(math.nan) is None
+
+    def test_converts_inf_to_none(self) -> None:
+        """Converts positive infinity to None."""
+        assert json_nan_handler(math.inf) is None
+
+    def test_converts_neg_inf_to_none(self) -> None:
+        """Converts negative infinity to None."""
+        assert json_nan_handler(-math.inf) is None
+
+    def test_passes_through_normal_float(self) -> None:
+        """Returns normal float values unchanged."""
+        assert json_nan_handler(3.14) == 3.14
+
+    def test_passes_through_zero(self) -> None:
+        """Returns 0.0 unchanged."""
+        assert json_nan_handler(0.0) == 0.0
+
+    def test_passes_through_non_float(self) -> None:
+        """Returns non-float objects unchanged."""
+        obj = {"key": "value"}
+        assert json_nan_handler(obj) is obj
+
+    def test_passes_through_string(self) -> None:
+        """Returns strings unchanged."""
+        assert json_nan_handler("hello") == "hello"
+
+    def test_passes_through_none(self) -> None:
+        """Returns None input unchanged."""
+        assert json_nan_handler(None) is None
+
+
+class TestComputeNormalityTests:
+    """Tests for _compute_normality_tests()."""
+
+    def test_skips_tier_with_fewer_than_three_rows(self) -> None:
+        """Skips tiers with less than 3 data points."""
+        import pandas as pd
+        from export_data import _compute_normality_tests
+
+        runs_df = pd.DataFrame(
+            {
+                "agent_model": ["m1", "m1"],
+                "tier": ["T0", "T0"],
+                "score": [0.5, 0.6],
+            }
+        )
+        result = _compute_normality_tests(runs_df, ["m1"], ["T0"])
+        assert result == []
+
+    def test_returns_empty_list_for_empty_dataframe(self) -> None:
+        """Returns empty list when dataframe has no rows."""
+        import pandas as pd
+        from export_data import _compute_normality_tests
+
+        runs_df = pd.DataFrame(columns=["agent_model", "tier", "score"])
+        result = _compute_normality_tests(runs_df, ["m1"], ["T0"])
+        assert result == []
+
+    def test_calls_shapiro_wilk_for_valid_data(self) -> None:
+        """Calls shapiro_wilk for each metric with >= 3 data points."""
+        import pandas as pd
+        from export_data import _compute_normality_tests
+
+        runs_df = pd.DataFrame(
+            {
+                "agent_model": ["m1"] * 5,
+                "tier": ["T0"] * 5,
+                "score": [0.1, 0.5, 0.9, 0.3, 0.7],
+            }
+        )
+        with patch("export_data.shapiro_wilk", return_value=(0.95, 0.4)) as mock_sw:
+            result = _compute_normality_tests(runs_df, ["m1"], ["T0"])
+
+        assert mock_sw.called
+        assert len(result) > 0
+        assert result[0]["model"] == "m1"
+        assert result[0]["tier"] == "T0"

--- a/tests/unit/scripts/test_generate_all_results.py
+++ b/tests/unit/scripts/test_generate_all_results.py
@@ -1,0 +1,94 @@
+"""Tests for scripts/generate_all_results.py."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+from generate_all_results import run_script
+
+
+class TestRunScript:
+    """Tests for run_script()."""
+
+    def test_returns_true_on_success(self) -> None:
+        """Returns True when subprocess exits with code 0."""
+        mock_result = MagicMock()
+        mock_result.returncode = 0
+
+        with patch("generate_all_results.subprocess.run", return_value=mock_result):
+            result = run_script("scripts/export_data.py", [], "Exporting data")
+
+        assert result is True
+
+    def test_returns_false_on_failure(self) -> None:
+        """Returns False when subprocess exits with non-zero code."""
+        mock_result = MagicMock()
+        mock_result.returncode = 1
+
+        with patch("generate_all_results.subprocess.run", return_value=mock_result):
+            result = run_script("scripts/export_data.py", [], "Exporting data")
+
+        assert result is False
+
+    def test_returns_false_on_exception(self) -> None:
+        """Returns False when subprocess raises an exception."""
+        with patch("generate_all_results.subprocess.run", side_effect=OSError("not found")):
+            result = run_script("scripts/export_data.py", [], "Exporting data")
+
+        assert result is False
+
+    def test_passes_args_to_subprocess(self) -> None:
+        """Forwards extra args to the subprocess command."""
+        mock_result = MagicMock()
+        mock_result.returncode = 0
+
+        with patch("generate_all_results.subprocess.run", return_value=mock_result) as mock_run:
+            run_script("scripts/export_data.py", ["--data-dir", "/tmp"], "desc")
+
+        call_cmd = mock_run.call_args[0][0]
+        assert "--data-dir" in call_cmd
+        assert "/tmp" in call_cmd
+
+    def test_command_includes_pixi_run(self) -> None:
+        """Command starts with 'pixi run python'."""
+        mock_result = MagicMock()
+        mock_result.returncode = 0
+
+        with patch("generate_all_results.subprocess.run", return_value=mock_result) as mock_run:
+            run_script("scripts/export_data.py", [], "desc")
+
+        call_cmd = mock_run.call_args[0][0]
+        assert call_cmd[:3] == ["pixi", "run", "python"]
+
+
+class TestMain:
+    """Tests for main() orchestration logic."""
+
+    def test_runs_all_three_steps_by_default(self) -> None:
+        """Calls run_script three times when no skip flags are set."""
+        with patch("generate_all_results.run_script", return_value=True) as mock_run:
+            with patch("generate_all_results.terminal_guard"):
+                from generate_all_results import main
+
+                with patch(
+                    "sys.argv",
+                    ["generate_all_results.py"],
+                ):
+                    main()
+
+        assert mock_run.call_count == 3
+
+    def test_skips_figures_when_flag_set(self) -> None:
+        """Skips figure generation step when --skip-figures is passed."""
+        with patch("generate_all_results.run_script", return_value=True) as mock_run:
+            with patch("generate_all_results.terminal_guard"):
+                from generate_all_results import main
+
+                with patch(
+                    "sys.argv",
+                    ["generate_all_results.py", "--skip-figures"],
+                ):
+                    main()
+
+        # Should only run export_data and generate_tables (2 calls)
+        assert mock_run.call_count == 2

--- a/tests/unit/scripts/test_generate_figures.py
+++ b/tests/unit/scripts/test_generate_figures.py
@@ -1,0 +1,49 @@
+"""Tests for scripts/generate_figures.py."""
+
+from __future__ import annotations
+
+from generate_figures import FIGURES
+
+
+class TestFiguresRegistry:
+    """Tests for the FIGURES module-level registry."""
+
+    def test_figures_dict_is_not_empty(self) -> None:
+        """FIGURES registry contains at least one entry."""
+        assert len(FIGURES) > 0
+
+    def test_figures_keys_are_strings(self) -> None:
+        """All keys in FIGURES are strings."""
+        for key in FIGURES:
+            assert isinstance(key, str)
+
+    def test_figures_values_are_tuples(self) -> None:
+        """All values in FIGURES are (category_str, callable) tuples."""
+        for name, value in FIGURES.items():
+            assert isinstance(value, tuple), f"{name} value is not a tuple"
+            assert len(value) == 2, f"{name} tuple has unexpected length"
+
+    def test_figures_categories_are_strings(self) -> None:
+        """First element of each tuple (category) is a string."""
+        for name, (category, _fn) in FIGURES.items():
+            assert isinstance(category, str), f"{name} category is not a string"
+
+    def test_figures_functions_are_callable(self) -> None:
+        """Second element of each tuple (generator fn) is callable."""
+        for name, (_category, fn) in FIGURES.items():
+            assert callable(fn), f"{name} generator function is not callable"
+
+    def test_known_figures_present(self) -> None:
+        """Spot-check that key figures are registered."""
+        expected = [
+            "fig01_score_variance_by_tier",
+            "fig04_pass_rate_by_tier",
+            "fig06_cop_by_tier",
+        ]
+        for fig in expected:
+            assert fig in FIGURES, f"{fig} not found in FIGURES registry"
+
+    def test_no_duplicate_figure_names(self) -> None:
+        """All figure names are unique (dict keys are inherently unique)."""
+        # This is trivially true for a dict but documents the intent.
+        assert len(FIGURES) == len(set(FIGURES.keys()))

--- a/tests/unit/scripts/test_generate_tables.py
+++ b/tests/unit/scripts/test_generate_tables.py
@@ -1,0 +1,107 @@
+"""Tests for scripts/generate_tables.py."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+class TestMain:
+    """Tests for main() table generation logic."""
+
+    def _make_mock_experiments(self) -> list[MagicMock]:
+        """Return a non-empty list of mock experiments."""
+        return [MagicMock()]
+
+    def test_exits_early_when_no_experiments_found(
+        self, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """Prints error and returns when no experiments are found."""
+        with (
+            patch("generate_tables.load_all_experiments", return_value=[]),
+            patch("generate_tables.load_rubric_weights", return_value={}),
+            patch("sys.argv", ["generate_tables.py", "--data-dir", "/tmp/nonexistent"]),
+        ):
+            from generate_tables import main
+
+            main()
+
+        captured = capsys.readouterr()
+        assert "ERROR" in captured.out
+
+    def test_creates_output_directory(self, tmp_path: Path) -> None:
+        """Creates the output directory before writing tables."""
+        output_dir = tmp_path / "tables"
+        experiments = self._make_mock_experiments()
+
+        mock_df = MagicMock()
+        mock_df.__len__ = lambda self: 5
+
+        with (
+            patch("generate_tables.load_all_experiments", return_value=experiments),
+            patch("generate_tables.load_rubric_weights", return_value={}),
+            patch("generate_tables.build_runs_df", return_value=mock_df),
+            patch("generate_tables.build_judges_df", return_value=mock_df),
+            patch("generate_tables.build_criteria_df", return_value=mock_df),
+            patch("generate_tables.build_subtests_df", return_value=mock_df),
+            patch("generate_tables.table01_tier_summary", return_value=("md", "tex")),
+            patch("generate_tables.table02_tier_comparison", return_value=("md", "tex")),
+            patch("generate_tables.table02b_impl_rate_comparison", return_value=("md", "tex")),
+            patch("generate_tables.table03_judge_agreement", return_value=("md", "tex")),
+            patch("generate_tables.table04_criteria_performance", return_value=("md", "tex")),
+            patch("generate_tables.table05_cost_analysis", return_value=("md", "tex")),
+            patch("generate_tables.table06_model_comparison", return_value=("md", "tex")),
+            patch("generate_tables.table07_subtest_detail", return_value=("md", "tex")),
+            patch("generate_tables.table08_summary_statistics", return_value=("md", "tex")),
+            patch("generate_tables.table09_experiment_config", return_value=("md", "tex")),
+            patch("generate_tables.table10_normality_tests", return_value=("md", "tex")),
+            patch(
+                "sys.argv",
+                ["generate_tables.py", "--output-dir", str(output_dir)],
+            ),
+        ):
+            from generate_tables import main
+
+            main()
+
+        assert output_dir.exists()
+
+    def test_writes_md_and_tex_files(self, tmp_path: Path) -> None:
+        """Writes .md and .tex files for each table."""
+        output_dir = tmp_path / "tables"
+        experiments = self._make_mock_experiments()
+
+        mock_df = MagicMock()
+        mock_df.__len__ = lambda self: 5
+
+        with (
+            patch("generate_tables.load_all_experiments", return_value=experiments),
+            patch("generate_tables.load_rubric_weights", return_value={}),
+            patch("generate_tables.build_runs_df", return_value=mock_df),
+            patch("generate_tables.build_judges_df", return_value=mock_df),
+            patch("generate_tables.build_criteria_df", return_value=mock_df),
+            patch("generate_tables.build_subtests_df", return_value=mock_df),
+            patch("generate_tables.table01_tier_summary", return_value=("# T1 md", "t1 tex")),
+            patch("generate_tables.table02_tier_comparison", return_value=("md", "tex")),
+            patch("generate_tables.table02b_impl_rate_comparison", return_value=("md", "tex")),
+            patch("generate_tables.table03_judge_agreement", return_value=("md", "tex")),
+            patch("generate_tables.table04_criteria_performance", return_value=("md", "tex")),
+            patch("generate_tables.table05_cost_analysis", return_value=("md", "tex")),
+            patch("generate_tables.table06_model_comparison", return_value=("md", "tex")),
+            patch("generate_tables.table07_subtest_detail", return_value=("md", "tex")),
+            patch("generate_tables.table08_summary_statistics", return_value=("md", "tex")),
+            patch("generate_tables.table09_experiment_config", return_value=("md", "tex")),
+            patch("generate_tables.table10_normality_tests", return_value=("md", "tex")),
+            patch(
+                "sys.argv",
+                ["generate_tables.py", "--output-dir", str(output_dir)],
+            ),
+        ):
+            from generate_tables import main
+
+            main()
+
+        assert (output_dir / "tab01_tier_summary.md").exists()
+        assert (output_dir / "tab01_tier_summary.tex").exists()

--- a/tests/unit/scripts/test_get_stats.py
+++ b/tests/unit/scripts/test_get_stats.py
@@ -1,0 +1,118 @@
+"""Tests for scripts/get_stats.py."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+from get_stats import get_issues_stats, get_prs_stats
+
+
+class TestGetIssuesStats:
+    """Tests for get_issues_stats()."""
+
+    def test_returns_counts_on_success(self) -> None:
+        """Returns dict with total/open/closed when gh CLI succeeds."""
+        mock_total = MagicMock()
+        mock_total.returncode = 0
+        mock_total.stdout = "10\n"
+
+        mock_open = MagicMock()
+        mock_open.returncode = 0
+        mock_open.stdout = "3\n"
+
+        with patch("get_stats.subprocess.run", side_effect=[mock_total, mock_open]):
+            result = get_issues_stats("2026-01-01", "2026-01-31", None, "owner/repo")
+
+        assert result["total"] == 10
+        assert result["open"] == 3
+        assert result["closed"] == 7
+
+    def test_returns_zeros_on_gh_failure(self) -> None:
+        """Returns all-zero dict when gh CLI fails."""
+        mock_result = MagicMock()
+        mock_result.returncode = 1
+
+        with patch("get_stats.subprocess.run", return_value=mock_result):
+            result = get_issues_stats("2026-01-01", "2026-01-31", None, "owner/repo")
+
+        assert result == {"total": 0, "open": 0, "closed": 0}
+
+    def test_includes_author_filter_in_query(self) -> None:
+        """Adds author filter to gh CLI query when author is specified."""
+        mock_total = MagicMock()
+        mock_total.returncode = 0
+        mock_total.stdout = "5\n"
+
+        mock_open = MagicMock()
+        mock_open.returncode = 0
+        mock_open.stdout = "2\n"
+
+        with patch("get_stats.subprocess.run", side_effect=[mock_total, mock_open]) as mock_run:
+            get_issues_stats("2026-01-01", "2026-01-31", "alice", "owner/repo")
+
+        # Check that the query passed to gh includes author filter
+        first_call_args = mock_run.call_args_list[0][0][0]
+        query_arg = next((a for a in first_call_args if "author:alice" in str(a)), None)
+        assert query_arg is not None
+
+
+class TestGetPrsStats:
+    """Tests for get_prs_stats()."""
+
+    def test_returns_counts_on_success(self) -> None:
+        """Returns dict with total/merged/open/closed when gh CLI succeeds."""
+        mock_total = MagicMock()
+        mock_total.returncode = 0
+        mock_total.stdout = "20\n"
+
+        mock_merged = MagicMock()
+        mock_merged.returncode = 0
+        mock_merged.stdout = "15\n"
+
+        mock_open = MagicMock()
+        mock_open.returncode = 0
+        mock_open.stdout = "3\n"
+
+        with patch(
+            "get_stats.subprocess.run",
+            side_effect=[mock_total, mock_merged, mock_open],
+        ):
+            result = get_prs_stats("2026-01-01", "2026-01-31", None, "owner/repo")
+
+        assert result["total"] == 20
+        assert result["merged"] == 15
+        assert result["open"] == 3
+        assert result["closed"] == 2
+
+    def test_returns_zeros_on_gh_failure(self) -> None:
+        """Returns all-zero dict when gh CLI fails."""
+        mock_result = MagicMock()
+        mock_result.returncode = 1
+
+        with patch("get_stats.subprocess.run", return_value=mock_result):
+            result = get_prs_stats("2026-01-01", "2026-01-31", None, "owner/repo")
+
+        assert result == {"total": 0, "merged": 0, "open": 0, "closed": 0}
+
+    def test_no_author_filter_by_default(self) -> None:
+        """Does not add author filter when author is None."""
+        mock_total = MagicMock()
+        mock_total.returncode = 0
+        mock_total.stdout = "0\n"
+
+        mock_merged = MagicMock()
+        mock_merged.returncode = 0
+        mock_merged.stdout = "0\n"
+
+        mock_open = MagicMock()
+        mock_open.returncode = 0
+        mock_open.stdout = "0\n"
+
+        with patch(
+            "get_stats.subprocess.run",
+            side_effect=[mock_total, mock_merged, mock_open],
+        ) as mock_run:
+            get_prs_stats("2026-01-01", "2026-01-31", None, "owner/repo")
+
+        first_call_args = mock_run.call_args_list[0][0][0]
+        assert not any("author:" in str(a) for a in first_call_args)

--- a/tests/unit/scripts/test_implement_issues.py
+++ b/tests/unit/scripts/test_implement_issues.py
@@ -1,0 +1,103 @@
+"""Tests for scripts/implement_issues.py."""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from unittest.mock import patch
+
+from implement_issues import parse_args, setup_logging
+
+
+class TestSetupLogging:
+    """Tests for setup_logging()."""
+
+    def test_sets_debug_level_when_verbose(self) -> None:
+        """Configures DEBUG level when verbose=True."""
+        with patch("implement_issues.logging.basicConfig") as mock_config:
+            setup_logging(verbose=True)
+
+        mock_config.assert_called_once()
+        call_kwargs = mock_config.call_args[1]
+        assert call_kwargs["level"] == logging.DEBUG
+
+    def test_sets_info_level_by_default(self) -> None:
+        """Configures INFO level when verbose=False."""
+        with patch("implement_issues.logging.basicConfig") as mock_config:
+            setup_logging(verbose=False)
+
+        mock_config.assert_called_once()
+        call_kwargs = mock_config.call_args[1]
+        assert call_kwargs["level"] == logging.INFO
+
+    def test_creates_log_file_when_log_dir_given(self, tmp_path: Path) -> None:
+        """Creates a FileHandler when log_dir is specified."""
+        log_dir = tmp_path / "logs"
+
+        with patch("implement_issues.logging.basicConfig"):
+            with patch("implement_issues.logging.FileHandler"):
+                with patch("implement_issues.logging.getLogger"):
+                    setup_logging(log_dir=log_dir)
+
+        assert log_dir.exists()
+
+    def test_no_file_handler_without_log_dir(self) -> None:
+        """Does not create a FileHandler when log_dir is None."""
+        with patch("implement_issues.logging.basicConfig"):
+            with patch("implement_issues.logging.FileHandler") as mock_fh:
+                setup_logging(log_dir=None)
+
+        mock_fh.assert_not_called()
+
+
+class TestParseArgs:
+    """Tests for parse_args()."""
+
+    def test_parses_epic_number(self) -> None:
+        """Parses --epic argument as an integer."""
+        with patch("sys.argv", ["implement_issues.py", "--epic", "123"]):
+            args = parse_args()
+
+        assert args.epic == 123
+
+    def test_parses_issues_list(self) -> None:
+        """Parses multiple --issues as a list of ints."""
+        with patch("sys.argv", ["implement_issues.py", "--issues", "595", "596", "597"]):
+            args = parse_args()
+
+        assert args.issues == [595, 596, 597]
+
+    def test_dry_run_defaults_false(self) -> None:
+        """dry_run is False when --dry-run is not passed."""
+        with patch("sys.argv", ["implement_issues.py", "--issues", "1"]):
+            args = parse_args()
+
+        assert args.dry_run is False
+
+    def test_dry_run_set_true(self) -> None:
+        """dry_run is True when --dry-run is passed."""
+        with patch("sys.argv", ["implement_issues.py", "--issues", "1", "--dry-run"]):
+            args = parse_args()
+
+        assert args.dry_run is True
+
+    def test_max_workers_default(self) -> None:
+        """max_workers defaults to 3."""
+        with patch("sys.argv", ["implement_issues.py", "--issues", "1"]):
+            args = parse_args()
+
+        assert args.max_workers == 3
+
+    def test_analyze_flag(self) -> None:
+        """--analyze flag is captured."""
+        with patch("sys.argv", ["implement_issues.py", "--epic", "1", "--analyze"]):
+            args = parse_args()
+
+        assert args.analyze is True
+
+    def test_health_check_flag(self) -> None:
+        """--health-check flag is captured."""
+        with patch("sys.argv", ["implement_issues.py", "--health-check"]):
+            args = parse_args()
+
+        assert args.health_check is True

--- a/tests/unit/scripts/test_lint_configs.py
+++ b/tests/unit/scripts/test_lint_configs.py
@@ -1,0 +1,116 @@
+"""Tests for scripts/lint_configs.py."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from lint_configs import ConfigLinter
+
+
+class TestConfigLinterLintFile:
+    """Tests for ConfigLinter.lint_file()."""
+
+    def test_returns_false_for_missing_file(self, tmp_path: Path) -> None:
+        """Returns False when file does not exist."""
+        linter = ConfigLinter()
+        result = linter.lint_file(tmp_path / "nonexistent.yaml")
+        assert result is False
+        assert any("not found" in e for e in linter.errors)
+
+    def test_returns_true_for_valid_yaml(self, tmp_path: Path) -> None:
+        """Returns True for a simple valid YAML file."""
+        config_file = tmp_path / "valid.yaml"
+        config_file.write_text("key: value\nother: 123\n")
+        linter = ConfigLinter()
+        result = linter.lint_file(config_file)
+        assert result is True
+        assert linter.errors == []
+
+    def test_detects_tab_indentation(self, tmp_path: Path) -> None:
+        """Reports an error when tabs are used instead of spaces."""
+        config_file = tmp_path / "tabbed.yaml"
+        config_file.write_text("parent:\n\tchild: value\n")
+        linter = ConfigLinter()
+        linter.lint_file(config_file)
+        assert any("Tab" in e for e in linter.errors)
+
+    def test_detects_trailing_whitespace(self, tmp_path: Path) -> None:
+        """Records a warning for trailing whitespace."""
+        config_file = tmp_path / "trailing.yaml"
+        config_file.write_text("key: value   \n")
+        linter = ConfigLinter()
+        linter.lint_file(config_file)
+        assert any("Trailing whitespace" in w for w in linter.warnings)
+
+    def test_unmatched_brace_causes_error(self, tmp_path: Path) -> None:
+        """Reports error when braces are unbalanced."""
+        config_file = tmp_path / "unmatched.yaml"
+        config_file.write_text("key: {value\n")
+        linter = ConfigLinter()
+        result = linter.lint_file(config_file)
+        assert result is False
+        assert any("brace" in e.lower() for e in linter.errors)
+
+
+class TestConfigLinterParseValue:
+    """Tests for ConfigLinter._parse_value()."""
+
+    def test_parses_true(self) -> None:
+        """Parses 'true' as Python True."""
+        linter = ConfigLinter()
+        assert linter._parse_value("true") is True
+
+    def test_parses_false(self) -> None:
+        """Parses 'false' as Python False."""
+        linter = ConfigLinter()
+        assert linter._parse_value("false") is False
+
+    def test_parses_integer(self) -> None:
+        """Parses integer strings as int."""
+        linter = ConfigLinter()
+        assert linter._parse_value("42") == 42
+
+    def test_parses_float(self) -> None:
+        """Parses float strings as float."""
+        linter = ConfigLinter()
+        assert linter._parse_value("3.14") == 3.14
+
+    def test_parses_quoted_string(self) -> None:
+        """Strips surrounding quotes from string values."""
+        linter = ConfigLinter()
+        assert linter._parse_value('"hello"') == "hello"
+
+    def test_parses_list(self) -> None:
+        """Parses bracketed comma-separated values as a list."""
+        linter = ConfigLinter()
+        result = linter._parse_value("[a, b, c]")
+        assert isinstance(result, list)
+        assert len(result) == 3
+
+
+class TestConfigLinterHelpers:
+    """Tests for ConfigLinter helper methods."""
+
+    def test_has_nested_key_found(self) -> None:
+        """Returns True when nested key path exists."""
+        linter = ConfigLinter()
+        config = {"a": {"b": {"c": 1}}}
+        assert linter._has_nested_key(config, "a.b.c") is True
+
+    def test_has_nested_key_missing(self) -> None:
+        """Returns False when nested key path is absent."""
+        linter = ConfigLinter()
+        config = {"a": {"b": 1}}
+        assert linter._has_nested_key(config, "a.b.c") is False
+
+    def test_get_nested_value_returns_value(self) -> None:
+        """Returns value at nested key path."""
+        linter = ConfigLinter()
+        config = {"x": {"y": 42}}
+        assert linter._get_nested_value(config, "x.y") == 42
+
+    def test_get_nested_value_returns_none_for_missing(self) -> None:
+        """Returns None when path does not exist."""
+        linter = ConfigLinter()
+        config: dict[str, object] = {"x": {}}
+        assert linter._get_nested_value(config, "x.y") is None

--- a/tests/unit/scripts/test_migrate_skills_to_mnemosyne.py
+++ b/tests/unit/scripts/test_migrate_skills_to_mnemosyne.py
@@ -1,0 +1,129 @@
+"""Tests for scripts/migrate_skills_to_mnemosyne.py."""
+
+from __future__ import annotations
+
+from migrate_skills_to_mnemosyne import (
+    inject_yaml_frontmatter,
+    normalize_author,
+    normalize_date,
+    resolve_category,
+    restructure_plugin_json,
+)
+
+
+class TestResolveCategory:
+    """Tests for resolve_category()."""
+
+    def test_returns_hardcoded_assignment(self) -> None:
+        """Returns hardcoded category for known skill names."""
+        result = resolve_category("add-analysis-metric", {})
+        assert result == "evaluation"
+
+    def test_uses_json_category_field(self) -> None:
+        """Uses category from plugin JSON when no hardcoded assignment."""
+        result = resolve_category("unknown-skill", {"category": "architecture"})
+        assert result == "architecture"
+
+    def test_normalizes_json_category(self) -> None:
+        """Normalizes 'metrics' category to 'evaluation'."""
+        result = resolve_category("unknown-skill", {"category": "metrics"})
+        assert result == "evaluation"
+
+    def test_uses_heuristic_for_fix_prefix(self) -> None:
+        """Assigns 'debugging' for skills with 'fix-' prefix."""
+        result = resolve_category("fix-some-bug", {})
+        assert result == "debugging"
+
+    def test_uses_heuristic_for_test_prefix(self) -> None:
+        """Assigns 'testing' for skills starting with 'test'."""
+        result = resolve_category("test-my-feature", {})
+        assert result == "testing"
+
+    def test_defaults_to_tooling(self) -> None:
+        """Returns 'tooling' as fallback for unrecognized skills."""
+        result = resolve_category("completely-unknown-skill", {})
+        assert result == "tooling"
+
+
+class TestNormalizeAuthor:
+    """Tests for normalize_author()."""
+
+    def test_converts_string_to_dict(self) -> None:
+        """Converts string author to dict with 'name' key."""
+        result = normalize_author("Alice")
+        assert result == {"name": "Alice"}
+
+    def test_returns_dict_unchanged(self) -> None:
+        """Returns dict author unchanged."""
+        author = {"name": "Bob", "email": "bob@example.com"}
+        result = normalize_author(author)
+        assert result == author
+
+
+class TestNormalizeDate:
+    """Tests for normalize_date()."""
+
+    def test_returns_date_field_when_present(self) -> None:
+        """Returns 'date' field if present."""
+        result = normalize_date({"date": "2025-01-15"})
+        assert result == "2025-01-15"
+
+    def test_falls_back_to_created_field(self) -> None:
+        """Returns 'created' field when 'date' is absent."""
+        result = normalize_date({"created": "2025-03-01"})
+        assert result == "2025-03-01"
+
+    def test_returns_none_when_neither_present(self) -> None:
+        """Returns None when neither 'date' nor 'created' is present."""
+        result = normalize_date({})
+        assert result is None
+
+
+class TestInjectYamlFrontmatter:
+    """Tests for inject_yaml_frontmatter()."""
+
+    def test_leaves_existing_frontmatter_intact(self) -> None:
+        """Does not modify content that already has YAML frontmatter."""
+        content = "---\nname: test\n---\n# Body\n"
+        result = inject_yaml_frontmatter(content, "test-skill", {})
+        assert result == content
+
+    def test_injects_frontmatter_when_missing(self) -> None:
+        """Prepends frontmatter when content has no leading '---'."""
+        content = "# My Skill\n\nThis is the skill body.\n"
+        result = inject_yaml_frontmatter(content, "my-skill", {})
+        assert result.startswith("---")
+        assert "user-invocable: false" in result
+
+    def test_includes_description_when_provided(self) -> None:
+        """Includes description field in injected frontmatter."""
+        content = "# My Skill\n"
+        result = inject_yaml_frontmatter(content, "my-skill", {"description": "Does things"})
+        assert "Does things" in result
+
+    def test_injected_frontmatter_ends_with_separator(self) -> None:
+        """Injected frontmatter ends with '---' before the body."""
+        content = "# Skill body\n"
+        result = inject_yaml_frontmatter(content, "test", {})
+        # The frontmatter block should end before the original content
+        parts = result.split("---")
+        assert len(parts) >= 3  # opening ---, frontmatter, closing ---
+
+
+class TestRestructurePluginJson:
+    """Tests for restructure_plugin_json()."""
+
+    def test_always_sets_version(self) -> None:
+        """Output always contains 'version' field."""
+        result = restructure_plugin_json({}, "my-skill")
+        assert "version" in result
+
+    def test_preserves_name_from_plugin_data(self) -> None:
+        """Copies name from plugin_data if present."""
+        result = restructure_plugin_json({"name": "My Skill"}, "my-skill")
+        assert result.get("name") == "My Skill"
+
+    def test_falls_back_to_skill_name(self) -> None:
+        """Uses skill_name as name when plugin_data has no 'name' field."""
+        result = restructure_plugin_json({}, "fallback-skill")
+        assert result.get("name") == "fallback-skill"

--- a/tests/unit/scripts/test_plan_issues.py
+++ b/tests/unit/scripts/test_plan_issues.py
@@ -1,0 +1,127 @@
+"""Tests for scripts/plan_issues.py."""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from plan_issues import parse_args, setup_logging
+
+
+class TestSetupLogging:
+    """Tests for setup_logging()."""
+
+    def test_sets_debug_level_when_verbose(self) -> None:
+        """Configures DEBUG level when verbose=True."""
+        with patch("plan_issues.logging.basicConfig") as mock_config:
+            setup_logging(verbose=True)
+
+        mock_config.assert_called_once()
+        assert mock_config.call_args[1]["level"] == logging.DEBUG
+
+    def test_sets_info_level_by_default(self) -> None:
+        """Configures INFO level when verbose=False."""
+        with patch("plan_issues.logging.basicConfig") as mock_config:
+            setup_logging(verbose=False)
+
+        mock_config.assert_called_once()
+        assert mock_config.call_args[1]["level"] == logging.INFO
+
+
+class TestParseArgs:
+    """Tests for parse_args()."""
+
+    def test_parses_issues_list(self) -> None:
+        """Parses --issues as a list of ints."""
+        with patch("sys.argv", ["plan_issues.py", "--issues", "123", "456"]):
+            args = parse_args()
+
+        assert args.issues == [123, 456]
+
+    def test_dry_run_defaults_false(self) -> None:
+        """dry_run is False by default."""
+        with patch("sys.argv", ["plan_issues.py", "--issues", "1"]):
+            args = parse_args()
+
+        assert args.dry_run is False
+
+    def test_dry_run_set_true(self) -> None:
+        """dry_run is True when --dry-run is passed."""
+        with patch("sys.argv", ["plan_issues.py", "--issues", "1", "--dry-run"]):
+            args = parse_args()
+
+        assert args.dry_run is True
+
+    def test_parallel_defaults_to_three(self) -> None:
+        """Parallel defaults to 3."""
+        with patch("sys.argv", ["plan_issues.py", "--issues", "1"]):
+            args = parse_args()
+
+        assert args.parallel == 3
+
+    def test_force_defaults_false(self) -> None:
+        """Force is False by default."""
+        with patch("sys.argv", ["plan_issues.py", "--issues", "1"]):
+            args = parse_args()
+
+        assert args.force is False
+
+    def test_system_prompt_path(self, tmp_path: Path) -> None:
+        """Parses --system-prompt as a Path."""
+        prompt_file = tmp_path / "prompt.md"
+        with patch(
+            "sys.argv", ["plan_issues.py", "--issues", "1", "--system-prompt", str(prompt_file)]
+        ):
+            args = parse_args()
+
+        assert args.system_prompt == prompt_file
+
+
+class TestMain:
+    """Tests for main()."""
+
+    def test_returns_one_on_planner_failure(self) -> None:
+        """Returns 1 when planner reports failures."""
+        mock_planner = MagicMock()
+        mock_planner.run.return_value = {123: MagicMock(success=False)}
+
+        with (
+            patch("plan_issues.Planner", return_value=mock_planner),
+            patch("sys.argv", ["plan_issues.py", "--issues", "123"]),
+        ):
+            from plan_issues import main
+
+            result = main()
+
+        assert result == 1
+
+    def test_returns_zero_on_success(self) -> None:
+        """Returns 0 when all issues are planned successfully."""
+        mock_planner = MagicMock()
+        mock_planner.run.return_value = {123: MagicMock(success=True)}
+
+        with (
+            patch("plan_issues.Planner", return_value=mock_planner),
+            patch("sys.argv", ["plan_issues.py", "--issues", "123"]),
+        ):
+            from plan_issues import main
+
+            result = main()
+
+        assert result == 0
+
+    def test_returns_130_on_keyboard_interrupt(self) -> None:
+        """Returns 130 on KeyboardInterrupt."""
+        mock_planner = MagicMock()
+        mock_planner.run.side_effect = KeyboardInterrupt
+
+        with (
+            patch("plan_issues.Planner", return_value=mock_planner),
+            patch("sys.argv", ["plan_issues.py", "--issues", "1"]),
+        ):
+            from plan_issues import main
+
+            result = main()
+
+        assert result == 130

--- a/tests/unit/scripts/test_validation.py
+++ b/tests/unit/scripts/test_validation.py
@@ -1,0 +1,185 @@
+"""Tests for scripts/validation.py."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from validation import (
+    check_required_sections,
+    count_markdown_issues,
+    extract_markdown_links,
+    find_markdown_files,
+    validate_directory_exists,
+    validate_file_exists,
+    validate_relative_link,
+)
+
+
+class TestFindMarkdownFiles:
+    """Tests for find_markdown_files()."""
+
+    def test_finds_md_files_recursively(self, tmp_path: Path) -> None:
+        """Discovers .md files in subdirectories."""
+        (tmp_path / "sub").mkdir()
+        (tmp_path / "README.md").write_text("# Root")
+        (tmp_path / "sub" / "guide.md").write_text("# Guide")
+        files = find_markdown_files(tmp_path)
+        names = {f.name for f in files}
+        assert "README.md" in names
+        assert "guide.md" in names
+
+    def test_excludes_default_dirs(self, tmp_path: Path) -> None:
+        """Skips files inside excluded directories (e.g., .git)."""
+        git_dir = tmp_path / ".git"
+        git_dir.mkdir()
+        (git_dir / "COMMIT_EDITMSG.md").write_text("msg")
+        (tmp_path / "docs.md").write_text("# Docs")
+        files = find_markdown_files(tmp_path)
+        names = {f.name for f in files}
+        assert "COMMIT_EDITMSG.md" not in names
+        assert "docs.md" in names
+
+    def test_returns_sorted_list(self, tmp_path: Path) -> None:
+        """Returns files in sorted order."""
+        (tmp_path / "z.md").write_text("")
+        (tmp_path / "a.md").write_text("")
+        files = find_markdown_files(tmp_path)
+        assert files == sorted(files)
+
+    def test_empty_directory(self, tmp_path: Path) -> None:
+        """Returns empty list for directory with no .md files."""
+        assert find_markdown_files(tmp_path) == []
+
+
+class TestValidateFileExists:
+    """Tests for validate_file_exists()."""
+
+    def test_returns_true_for_existing_file(self, tmp_path: Path) -> None:
+        """Returns True for a regular file that exists."""
+        f = tmp_path / "file.txt"
+        f.write_text("content")
+        assert validate_file_exists(f) is True
+
+    def test_returns_false_for_missing_file(self, tmp_path: Path) -> None:
+        """Returns False for a file that does not exist."""
+        assert validate_file_exists(tmp_path / "missing.txt") is False
+
+    def test_returns_false_for_directory(self, tmp_path: Path) -> None:
+        """Returns False when path points to a directory."""
+        assert validate_file_exists(tmp_path) is False
+
+
+class TestValidateDirectoryExists:
+    """Tests for validate_directory_exists()."""
+
+    def test_returns_true_for_existing_dir(self, tmp_path: Path) -> None:
+        """Returns True for a directory that exists."""
+        assert validate_directory_exists(tmp_path) is True
+
+    def test_returns_false_for_missing_dir(self, tmp_path: Path) -> None:
+        """Returns False for a directory that does not exist."""
+        assert validate_directory_exists(tmp_path / "nonexistent") is False
+
+    def test_returns_false_for_file(self, tmp_path: Path) -> None:
+        """Returns False when path points to a file."""
+        f = tmp_path / "file.txt"
+        f.write_text("x")
+        assert validate_directory_exists(f) is False
+
+
+class TestCheckRequiredSections:
+    """Tests for check_required_sections()."""
+
+    def test_finds_all_required_sections(self) -> None:
+        """Returns True and empty missing list when all sections present."""
+        content = "# Doc\n\n## Overview\n\n## Usage\n"
+        ok, missing = check_required_sections(content, ["Overview", "Usage"])
+        assert ok is True
+        assert missing == []
+
+    def test_reports_missing_section(self) -> None:
+        """Returns False and lists missing sections."""
+        content = "# Doc\n\n## Overview\n"
+        ok, missing = check_required_sections(content, ["Overview", "Usage"])
+        assert ok is False
+        assert "Usage" in missing
+
+    def test_matches_heading_at_any_level(self) -> None:
+        """Matches headings at ## and ### levels."""
+        content = "### Deep Section\n"
+        ok, missing = check_required_sections(content, ["Deep Section"])
+        assert ok is True
+
+
+class TestExtractMarkdownLinks:
+    """Tests for extract_markdown_links()."""
+
+    def test_extracts_links(self) -> None:
+        """Extracts link targets from [text](url) syntax."""
+        content = "See [this](https://example.com) and [that](local.md).\n"
+        links = extract_markdown_links(content)
+        targets = [link for link, _lineno in links]
+        assert "https://example.com" in targets
+        assert "local.md" in targets
+
+    def test_returns_line_numbers(self) -> None:
+        """Returns correct line numbers for each link."""
+        content = "line 1\n[link](url) on line 2\nline 3\n"
+        links = extract_markdown_links(content)
+        assert any(lineno == 2 for _target, lineno in links)
+
+    def test_empty_content_returns_empty(self) -> None:
+        """Returns empty list for content with no links."""
+        assert extract_markdown_links("No links here.\n") == []
+
+
+class TestValidateRelativeLink:
+    """Tests for validate_relative_link()."""
+
+    def test_external_links_are_valid(self, tmp_path: Path) -> None:
+        """External http/https links are always valid."""
+        ok, _ = validate_relative_link("https://example.com", tmp_path / "file.md", tmp_path)
+        assert ok is True
+
+    def test_anchor_only_links_are_valid(self, tmp_path: Path) -> None:
+        """Anchor-only links (#section) are always valid."""
+        ok, _ = validate_relative_link("#section", tmp_path / "file.md", tmp_path)
+        assert ok is True
+
+    def test_existing_relative_file_is_valid(self, tmp_path: Path) -> None:
+        """Returns True for a relative link whose target file exists."""
+        target = tmp_path / "target.md"
+        target.write_text("# Target")
+        source = tmp_path / "source.md"
+        ok, _ = validate_relative_link("target.md", source, tmp_path)
+        assert ok is True
+
+    def test_missing_relative_file_is_invalid(self, tmp_path: Path) -> None:
+        """Returns False for a relative link whose target file is missing."""
+        source = tmp_path / "source.md"
+        ok, err = validate_relative_link("missing.md", source, tmp_path)
+        assert ok is False
+        assert err is not None
+
+
+class TestCountMarkdownIssues:
+    """Tests for count_markdown_issues()."""
+
+    def test_counts_trailing_whitespace(self) -> None:
+        """Counts lines with trailing whitespace."""
+        content = "line one   \nline two\nline three  \n"
+        issues = count_markdown_issues(content)
+        assert issues["trailing_whitespace"] == 2
+
+    def test_counts_code_blocks_without_language(self) -> None:
+        """Counts fenced code blocks missing language tags."""
+        content = "Text\n```\ncode here\n```\n"
+        issues = count_markdown_issues(content)
+        assert issues["missing_language_tags"] == 1
+
+    def test_no_issues_for_clean_content(self) -> None:
+        """Returns zero for all counts on clean content."""
+        content = "# Heading\n\nClean paragraph.\n\n```python\ncode\n```\n"
+        issues = count_markdown_issues(content)
+        assert issues["trailing_whitespace"] == 0
+        assert issues["missing_language_tags"] == 0


### PR DESCRIPTION
## Summary

- Creates 12 new test files in `tests/unit/scripts/` covering all previously untested scripts
- 130 new tests across the 12 files, all passing
- All I/O, subprocess, and network calls are mocked with `unittest.mock`

## Scripts covered

| Script | Test file |
|--------|-----------|
| `check_defaults_filename.py` | `test_check_defaults_filename.py` |
| `docker_build_timing.py` | `test_docker_build_timing.py` |
| `export_data.py` | `test_export_data.py` |
| `generate_all_results.py` | `test_generate_all_results.py` |
| `generate_figures.py` | `test_generate_figures.py` |
| `generate_tables.py` | `test_generate_tables.py` |
| `get_stats.py` | `test_get_stats.py` |
| `implement_issues.py` | `test_implement_issues.py` |
| `lint_configs.py` | `test_lint_configs.py` |
| `migrate_skills_to_mnemosyne.py` | `test_migrate_skills_to_mnemosyne.py` |
| `plan_issues.py` | `test_plan_issues.py` |
| `validation.py` | `test_validation.py` |

## Test plan

- [x] Each test file has at least 3 test functions (most have 5–15)
- [x] All new tests pass: `pixi run python -m pytest tests/unit/scripts/ -v`
- [x] No real I/O or network calls (all mocked)
- [x] Pre-commit hooks pass (ruff, mypy, black)

Closes #1358

🤖 Generated with [Claude Code](https://claude.com/claude-code)