### PR TITLE
[feat] Add semantic docstring fragment validator pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -106,6 +106,14 @@ repos:
         files: \.md$
         types: [markdown]
         pass_filenames: false
+      - id: check-docstring-fragments
+        name: Check Docstring Fragment False Positives
+        description: Validates Python docstrings as complete semantic units to prevent false positive fragment detection during audits
+        entry: pixi run python scripts/check_docstring_fragments.py
+        language: system
+        files: \.py$
+        types: [python]
+        pass_filenames: false
       - id: check-doc-config-consistency
         name: Check Doc/Config Metric Consistency
         description: Fails if coverage threshold in CLAUDE.md or README.md --cov path diverges from pyproject.toml

--- a/scripts/check_docstring_fragments.py
+++ b/scripts/check_docstring_fragments.py
@@ -1,0 +1,311 @@
+#!/usr/bin/env python3
+"""Check Python docstrings for genuine sentence fragments.
+
+Parses Python source files using the ``ast`` module to extract docstrings as
+complete strings (not line-by-line), then validates that the first sentence of
+each docstring is not a genuine fragment.
+
+This prevents the false-positive class of errors where a correctly wrapped
+multi-line docstring is flagged as a fragment because the continuation line
+is evaluated in isolation — the triggering case from the March 2026 audit of
+``scylla/executor/runner.py`` lines 4-5.
+
+A **genuine fragment** is a docstring whose first line, when taken alone, is
+clearly a partial sentence continuation (e.g., starts with a lowercase
+connector word like ``"across"``, ``"and"``, ``"or"``, ``"but"``).  Normal
+noun-phrase summaries and complete sentences are always allowed.
+
+Excluded paths (archived / test-fixture content that is not authoritative):
+  - ``.pixi/``
+  - ``build/``
+  - ``node_modules/``
+  - ``tests/claude-code/``
+
+Usage::
+
+    python scripts/check_docstring_fragments.py
+    python scripts/check_docstring_fragments.py --verbose
+
+Exit codes:
+    0: No violations found
+    1: One or more violations found
+"""
+
+from __future__ import annotations
+
+import ast
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+from scylla.automation.git_utils import get_repo_root
+
+# ---------------------------------------------------------------------------
+# Data model
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class FragmentFinding:
+    """A genuine docstring fragment found in a Python source file."""
+
+    file: str
+    line: int
+    docstring_first_line: str
+    context: str
+
+    def format(self) -> str:
+        """Return a human-readable description of this finding."""
+        return (
+            f"  {self.file}:{self.line}\n"
+            f"    Context: {self.context}\n"
+            f"    First line: {self.docstring_first_line!r}\n"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Fragment detection logic
+# ---------------------------------------------------------------------------
+
+# Lowercase connector words that indicate a line is a mid-sentence continuation
+# rather than the start of a valid docstring.
+_CONTINUATION_STARTERS = frozenset(
+    {
+        "across",
+        "after",
+        "against",
+        "along",
+        "also",
+        "although",
+        "among",
+        "and",
+        "around",
+        "as",
+        "at",
+        "because",
+        "before",
+        "beneath",
+        "beside",
+        "between",
+        "beyond",
+        "but",
+        "by",
+        "despite",
+        "during",
+        "except",
+        "for",
+        "from",
+        "hence",
+        "however",
+        "if",
+        "in",
+        "including",
+        "instead",
+        "into",
+        "nor",
+        "of",
+        "on",
+        "or",
+        "over",
+        "plus",
+        "since",
+        "so",
+        "than",
+        "that",
+        "the",
+        "then",
+        "thereby",
+        "therefore",
+        "though",
+        "through",
+        "throughout",
+        "thus",
+        "to",
+        "toward",
+        "under",
+        "unless",
+        "until",
+        "upon",
+        "via",
+        "when",
+        "where",
+        "whereas",
+        "whether",
+        "which",
+        "while",
+        "with",
+        "within",
+        "without",
+        "yet",
+    }
+)
+
+
+def _is_genuine_fragment(docstring: str) -> bool:
+    """Return True if the docstring's first line is a genuine sentence fragment.
+
+    A genuine fragment is detected when the very first non-empty line of the
+    docstring starts with a lowercase continuation word (e.g. ``"across"``,
+    ``"and"``, ``"or"``).  This catches cases where an auditor's line-by-line
+    tool would flag the second line of a wrapped sentence as a standalone
+    docstring.
+
+    Normal noun-phrase titles, imperative sentences, and complete sentences all
+    start with a capitalised word or a recognised technical prefix and are
+    therefore not flagged.
+    """
+    lines = docstring.splitlines()
+    # Find the first non-empty line
+    first_line = ""
+    for line in lines:
+        stripped = line.strip()
+        if stripped:
+            first_line = stripped
+            break
+
+    if not first_line:
+        return False
+
+    # Extract the first word
+    first_word = first_line.split()[0].rstrip(".,;:!?")
+
+    # A genuine fragment starts with a pure lowercase continuation word
+    # (not a capitalised word, not a technical token, not an abbreviation).
+    if first_word and first_word == first_word.lower() and first_word.isalpha():
+        return first_word in _CONTINUATION_STARTERS
+
+    return False
+
+
+# ---------------------------------------------------------------------------
+# AST-based docstring extraction
+# ---------------------------------------------------------------------------
+
+
+def _context_label(node: ast.AST) -> str:
+    """Return a human-readable label for the AST node containing a docstring."""
+    if isinstance(node, ast.Module):
+        return "module"
+    if isinstance(node, ast.ClassDef):
+        return f"class {node.name}"
+    if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+        return f"def {node.name}"
+    return "unknown"
+
+
+def _docstring_nodes(
+    tree: ast.Module,
+) -> list[tuple[ast.AST, str, int]]:
+    """Yield (node, docstring_text, line_number) for all docstring-bearing nodes."""
+    results: list[tuple[ast.AST, str, int]] = []
+
+    for node in ast.walk(tree):
+        if not isinstance(node, (ast.Module, ast.ClassDef, ast.FunctionDef, ast.AsyncFunctionDef)):
+            continue
+        body = getattr(node, "body", [])
+        if not body:
+            continue
+        first_stmt = body[0]
+        if not isinstance(first_stmt, ast.Expr):
+            continue
+        value = first_stmt.value
+        if not isinstance(value, ast.Constant) or not isinstance(value.value, str):
+            continue
+        results.append((node, value.value, first_stmt.lineno))
+
+    return results
+
+
+def scan_file(file_path: Path, repo_root: Path) -> list[FragmentFinding]:
+    """Scan a single Python file and return genuine fragment findings."""
+    findings: list[FragmentFinding] = []
+    try:
+        source = file_path.read_text(encoding="utf-8", errors="replace")
+    except OSError:
+        return findings
+
+    try:
+        tree = ast.parse(source, filename=str(file_path))
+    except SyntaxError:
+        return findings
+
+    relative_path = str(file_path.relative_to(repo_root))
+
+    for node, docstring, lineno in _docstring_nodes(tree):
+        if _is_genuine_fragment(docstring):
+            first_line = next((ln.strip() for ln in docstring.splitlines() if ln.strip()), "")
+            findings.append(
+                FragmentFinding(
+                    file=relative_path,
+                    line=lineno,
+                    docstring_first_line=first_line,
+                    context=_context_label(node),
+                )
+            )
+
+    return findings
+
+
+# ---------------------------------------------------------------------------
+# Paths to exclude from scanning
+# ---------------------------------------------------------------------------
+
+EXCLUDED_PREFIXES = (
+    ".pixi/",
+    "build/",
+    "node_modules/",
+    "tests/claude-code/",
+)
+
+
+def scan_repository(repo_root: Path) -> list[FragmentFinding]:
+    """Scan all non-excluded Python files in the repository."""
+    all_findings: list[FragmentFinding] = []
+
+    for py_file in sorted(repo_root.rglob("*.py")):
+        relative = py_file.relative_to(repo_root)
+        relative_str = str(relative).replace("\\", "/")
+        if any(relative_str.startswith(prefix) for prefix in EXCLUDED_PREFIXES):
+            continue
+        all_findings.extend(scan_file(py_file, repo_root))
+
+    return all_findings
+
+
+# ---------------------------------------------------------------------------
+# Reporting
+# ---------------------------------------------------------------------------
+
+
+def format_report(findings: list[FragmentFinding]) -> str:
+    """Format findings as a human-readable text report."""
+    if not findings:
+        return "No docstring fragment violations found.\n"
+
+    lines: list[str] = [
+        f"Found {len(findings)} genuine docstring fragment(s):",
+        "",
+    ]
+    for f in findings:
+        lines.append(f.format())
+
+    return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# Entry point
+# ---------------------------------------------------------------------------
+
+
+def main() -> int:
+    """Run the docstring fragment check."""
+    repo_root = get_repo_root()
+    findings = scan_repository(repo_root)
+
+    print(format_report(findings))
+
+    return 0 if not findings else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/unit/scripts/test_check_docstring_fragments.py
+++ b/tests/unit/scripts/test_check_docstring_fragments.py
@@ -1,0 +1,345 @@
+"""Tests for scripts/check_docstring_fragments.py."""
+
+from __future__ import annotations
+
+import textwrap
+from pathlib import Path
+
+import pytest
+
+from scripts.check_docstring_fragments import (
+    FragmentFinding,
+    _is_genuine_fragment,
+    format_report,
+    scan_file,
+    scan_repository,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def make_py(tmp_path: Path, name: str, content: str) -> Path:
+    """Write a Python file and return its path."""
+    path = tmp_path / name
+    path.write_text(textwrap.dedent(content))
+    return path
+
+
+# ---------------------------------------------------------------------------
+# _is_genuine_fragment — unit tests
+# ---------------------------------------------------------------------------
+
+
+class TestIsGenuineFragment:
+    """Unit tests for _is_genuine_fragment."""
+
+    def test_wrapped_sentence_not_flagged(self) -> None:
+        """Multi-line wrapped docstring starting with capital word is not a fragment."""
+        docstring = (
+            "This module provides the EvalRunner class that orchestrates test execution\n"
+            "across multiple tiers, models, and runs in Docker containers."
+        )
+        assert not _is_genuine_fragment(docstring)
+
+    def test_single_line_complete_sentence_not_flagged(self) -> None:
+        """Single-line docstring with complete sentence is not a fragment."""
+        assert not _is_genuine_fragment("Run the evaluation harness.")
+
+    def test_noun_phrase_summary_not_flagged(self) -> None:
+        """Short noun-phrase title (no terminal punctuation) is not a fragment."""
+        assert not _is_genuine_fragment("Audit Doc Policy Violations")
+
+    def test_imperative_sentence_not_flagged(self) -> None:
+        """Imperative sentence starting with capitalised verb is not a fragment."""
+        assert not _is_genuine_fragment("Return the repo root path.")
+
+    def test_continuation_word_across_flagged(self) -> None:
+        """Docstring starting with 'across' is a genuine fragment."""
+        assert _is_genuine_fragment("across multiple tiers and runs.")
+
+    def test_continuation_word_and_flagged(self) -> None:
+        """Docstring starting with 'and' is a genuine fragment."""
+        assert _is_genuine_fragment("and reports violations with file:line references.")
+
+    def test_continuation_word_or_flagged(self) -> None:
+        """Docstring starting with 'or' is a genuine fragment."""
+        assert _is_genuine_fragment("or raises RuntimeError on failure.")
+
+    def test_continuation_word_but_flagged(self) -> None:
+        """Docstring starting with 'but' is a genuine fragment."""
+        assert _is_genuine_fragment("but skips excluded directories.")
+
+    def test_continuation_word_with_flagged(self) -> None:
+        """Docstring starting with 'with' is a genuine fragment."""
+        assert _is_genuine_fragment("with support for parallel execution.")
+
+    def test_continuation_word_in_flagged(self) -> None:
+        """Docstring starting with 'in' is a genuine fragment."""
+        assert _is_genuine_fragment("in parallel using thread pools.")
+
+    def test_empty_docstring_not_flagged(self) -> None:
+        """Empty docstring produces no fragment detection."""
+        assert not _is_genuine_fragment("")
+
+    def test_whitespace_only_docstring_not_flagged(self) -> None:
+        """Whitespace-only docstring is not a fragment."""
+        assert not _is_genuine_fragment("   \n  \n  ")
+
+    def test_technical_token_not_flagged(self) -> None:
+        """Docstring starting with a technical token (e.g. ``path``) is not flagged."""
+        # 'path' is not in _CONTINUATION_STARTERS
+        assert not _is_genuine_fragment("path to the configuration file.")
+
+    def test_lowercase_non_continuation_word_not_flagged(self) -> None:
+        """Lowercase word not in the continuation set is not flagged."""
+        assert not _is_genuine_fragment("validate the input schema.")
+
+    def test_multiline_fragment_detected_on_first_line(self) -> None:
+        """Only the first non-empty line is checked for fragments."""
+        docstring = "across multiple tiers\nand more details follow."
+        assert _is_genuine_fragment(docstring)
+
+    def test_leading_blank_lines_skipped(self) -> None:
+        """Leading blank lines are skipped; check applies to first non-empty line."""
+        docstring = "\n\nacross multiple tiers."
+        assert _is_genuine_fragment(docstring)
+
+    def test_leading_blank_lines_before_valid_start(self) -> None:
+        """Leading blank lines before a valid sentence are not flagged."""
+        docstring = "\n\nRun the evaluation harness."
+        assert not _is_genuine_fragment(docstring)
+
+
+# ---------------------------------------------------------------------------
+# scan_file — genuine fragment in module docstring
+# ---------------------------------------------------------------------------
+
+
+class TestScanFileDetectsFragments:
+    """scan_file correctly detects genuine docstring fragments."""
+
+    def test_detects_module_docstring_fragment(self, tmp_path: Path) -> None:
+        """Should flag a module docstring that is a genuine fragment."""
+        py = make_py(
+            tmp_path,
+            "bad_module.py",
+            '''\
+            """across multiple tiers and environments."""
+
+            x = 1
+            ''',
+        )
+        findings = scan_file(py, tmp_path)
+        assert len(findings) == 1
+        assert findings[0].context == "module"
+
+    def test_detects_function_docstring_fragment(self, tmp_path: Path) -> None:
+        """Should flag a function docstring that is a genuine fragment."""
+        py = make_py(
+            tmp_path,
+            "bad_func.py",
+            '''\
+            def my_func():
+                """and returns the computed result."""
+                pass
+            ''',
+        )
+        findings = scan_file(py, tmp_path)
+        assert len(findings) == 1
+        assert "my_func" in findings[0].context
+
+    def test_detects_class_docstring_fragment(self, tmp_path: Path) -> None:
+        """Should flag a class docstring that is a genuine fragment."""
+        py = make_py(
+            tmp_path,
+            "bad_class.py",
+            '''\
+            class MyClass:
+                """or raises on invalid config."""
+                pass
+            ''',
+        )
+        findings = scan_file(py, tmp_path)
+        assert len(findings) == 1
+        assert "MyClass" in findings[0].context
+
+
+# ---------------------------------------------------------------------------
+# scan_file — valid docstrings pass
+# ---------------------------------------------------------------------------
+
+
+class TestScanFilePassesValidDocstrings:
+    """scan_file does not flag valid docstrings."""
+
+    def test_wrapped_sentence_not_flagged(self, tmp_path: Path) -> None:
+        """Wrapped multi-line sentence (the runner.py case) must not be flagged."""
+        py = make_py(
+            tmp_path,
+            "runner.py",
+            '''\
+            """Test runner orchestration for agent evaluations.
+
+            This module provides the EvalRunner class that orchestrates test execution
+            across multiple tiers, models, and runs in Docker containers, with support for
+            parallel execution and file I/O operations.
+            """
+
+            x = 1
+            ''',
+        )
+        findings = scan_file(py, tmp_path)
+        assert findings == []
+
+    def test_complete_single_line_docstring_passes(self, tmp_path: Path) -> None:
+        """Single-line complete sentence passes."""
+        py = make_py(
+            tmp_path,
+            "good.py",
+            '''\
+            """Scan all markdown files and report violations."""
+
+            x = 1
+            ''',
+        )
+        assert scan_file(py, tmp_path) == []
+
+    def test_noun_phrase_docstring_passes(self, tmp_path: Path) -> None:
+        """Short noun-phrase summary without punctuation passes."""
+        py = make_py(
+            tmp_path,
+            "good.py",
+            '''\
+            """Evaluation harness utilities."""
+
+            x = 1
+            ''',
+        )
+        assert scan_file(py, tmp_path) == []
+
+    def test_file_with_no_docstrings_passes(self, tmp_path: Path) -> None:
+        """File with no docstrings produces no findings."""
+        py = make_py(
+            tmp_path,
+            "no_docs.py",
+            """\
+            x = 1
+            y = 2
+            """,
+        )
+        assert scan_file(py, tmp_path) == []
+
+    def test_syntax_error_file_returns_no_findings(self, tmp_path: Path) -> None:
+        """File with syntax errors is skipped gracefully."""
+        py = tmp_path / "broken.py"
+        py.write_text("def (:\n  pass\n")
+        assert scan_file(py, tmp_path) == []
+
+    def test_multiple_valid_docstrings_all_pass(self, tmp_path: Path) -> None:
+        """Multiple valid docstrings in one file all pass."""
+        py = make_py(
+            tmp_path,
+            "multi.py",
+            '''\
+            """Module for evaluations."""
+
+            class Foo:
+                """Represents a foo object."""
+
+                def bar(self):
+                    """Return bar value."""
+                    pass
+            ''',
+        )
+        assert scan_file(py, tmp_path) == []
+
+
+# ---------------------------------------------------------------------------
+# scan_repository — exclusion paths
+# ---------------------------------------------------------------------------
+
+
+class TestScanRepositoryExclusions:
+    """scan_repository skips excluded directory prefixes."""
+
+    @pytest.mark.parametrize(
+        "excluded_dir",
+        [
+            ".pixi",
+            "build",
+            "node_modules",
+            "tests/claude-code",
+        ],
+    )
+    def test_excludes_path(self, tmp_path: Path, excluded_dir: str) -> None:
+        """Files under excluded paths should not be scanned."""
+        excluded_path = tmp_path / excluded_dir
+        excluded_path.mkdir(parents=True)
+        bad_py = excluded_path / "bad.py"
+        bad_py.write_text('"""across multiple tiers."""\nx = 1\n')
+        findings = scan_repository(tmp_path)
+        assert findings == []
+
+    def test_scans_non_excluded_path(self, tmp_path: Path) -> None:
+        """Files outside excluded paths should be scanned and violations reported."""
+        py = tmp_path / "my_module.py"
+        py.write_text('"""across multiple tiers."""\nx = 1\n')
+        findings = scan_repository(tmp_path)
+        assert len(findings) == 1
+
+
+# ---------------------------------------------------------------------------
+# Reporting
+# ---------------------------------------------------------------------------
+
+
+class TestFormatReport:
+    """format_report produces readable output."""
+
+    def test_no_findings_message(self) -> None:
+        """Should report no violations when findings list is empty."""
+        report = format_report([])
+        assert "No docstring fragment violations found" in report
+
+    def test_lists_finding_with_file_and_line(self) -> None:
+        """Report should include file path and line number."""
+        finding = FragmentFinding(
+            file="scylla/executor/runner.py",
+            line=1,
+            docstring_first_line="across multiple tiers.",
+            context="module",
+        )
+        report = format_report([finding])
+        assert "scylla/executor/runner.py:1" in report
+
+    def test_lists_finding_context(self) -> None:
+        """Report should include context label."""
+        finding = FragmentFinding(
+            file="scylla/foo.py",
+            line=5,
+            docstring_first_line="and returns the value.",
+            context="def compute",
+        )
+        report = format_report([finding])
+        assert "def compute" in report
+
+    def test_count_in_header(self) -> None:
+        """Report header should contain the number of findings."""
+        findings = [
+            FragmentFinding(
+                file="a.py",
+                line=1,
+                docstring_first_line="across x.",
+                context="module",
+            ),
+            FragmentFinding(
+                file="b.py",
+                line=2,
+                docstring_first_line="and y.",
+                context="def foo",
+            ),
+        ]
+        report = format_report(findings)
+        assert "2" in report


### PR DESCRIPTION
## Summary

- Adds `scripts/check_docstring_fragments.py`: AST-based validator that parses Python docstrings as complete semantic units (not line-by-line), detecting only genuine fragments (docstrings whose first non-empty line starts with a lowercase continuation word like `across`, `and`, `or`, `but`)
- Adds 35 unit tests in `tests/unit/scripts/test_check_docstring_fragments.py` covering fragment detection, valid wrapped multi-line docstring pass-through, path exclusions, and report formatting
- Registers `check-docstring-fragments` hook in `.pre-commit-config.yaml` after `audit-doc-policy`, runs on all `*.py` files

The key correctness test: `scylla/executor/runner.py`'s wrapped docstring (`"This module provides the EvalRunner class... / across multiple tiers..."`) passes cleanly — confirming the false positive that triggered the March 2026 audit issue is permanently prevented.

## Test plan

- [x] All 35 new unit tests pass
- [x] Full 4034-test suite passes with 72.11% coverage (above 9% floor)
- [x] `pre-commit run check-docstring-fragments --all-files` runs clean on entire repo
- [x] All pre-commit hooks pass on changed files

Closes #1363