### PR TITLE
feat(hooks): Add pre-commit hook to detect Mojo migration artifacts

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,6 +13,15 @@ repos:
         language: pygrep
         files: \.py$
         types: [python]
+      - id: check-mojo-artifacts
+        name: Check for Mojo Migration Artifacts
+        description: >-
+          Fail if scylla/ contains Mojo migration artifact phrases
+          ('Mojo equivalents' or 'no Mojo') left over from a prior migration attempt.
+        entry: '(Mojo equivalents|no Mojo)'
+        language: pygrep
+        files: ^scylla/.*\.py$
+        types: [python]
       - id: pip-audit
         name: pip-audit CVE Scan
         entry: pixi run audit

--- a/tests/unit/scripts/test_check_mojo_artifacts.py
+++ b/tests/unit/scripts/test_check_mojo_artifacts.py
@@ -1,0 +1,46 @@
+r"""Tests for the check-mojo-artifacts pre-commit hook regex pattern.
+
+The hook uses pygrep with pattern ``(Mojo equivalents|no Mojo)`` against
+files matching ``^scylla/.*\.py$``.  These tests unit-test that regex
+directly, without invoking pre-commit itself.
+"""
+
+from __future__ import annotations
+
+import re
+
+import pytest
+
+PATTERN = re.compile(r"(Mojo equivalents|no Mojo)")
+
+
+@pytest.mark.parametrize(
+    "line",
+    [
+        "# Mojo equivalents",
+        "generate Mojo equivalents for all public functions",
+        "# no Mojo",
+        "has no Mojo support",
+        "This function has no Mojo equivalent.",
+        "# TODO: add Mojo equivalents later",
+    ],
+)
+def test_pattern_matches_artifact_phrases(line: str) -> None:
+    """Pattern must match lines containing the banned artifact phrases."""
+    assert PATTERN.search(line) is not None, f"Expected match in: {line!r}"
+
+
+@pytest.mark.parametrize(
+    "line",
+    [
+        "# Mojo stdlib limitation",
+        "mojo-format",
+        "Python only",
+        "# No mojo (lowercase)",
+        "equivalent in Python",
+        "# mojo equivalents (all lowercase)",
+    ],
+)
+def test_pattern_does_not_match_legitimate_lines(line: str) -> None:
+    """Pattern must not match legitimate lines that don't contain the banned phrases."""
+    assert PATTERN.search(line) is None, f"Unexpected match in: {line!r}"


### PR DESCRIPTION
## Summary

- Adds `check-mojo-artifacts` pygrep hook in `.pre-commit-config.yaml` that fails if any `scylla/*.py` file contains `'Mojo equivalents'` or `'no Mojo'`
- Adds 12 unit tests in `tests/unit/scripts/test_check_mojo_artifacts.py` validating the regex against positive and negative cases
- Zero-dependency implementation using the existing `pygrep` pattern (same approach as `check-shell-injection`)

## Test plan

- [x] 12 new unit tests pass (`test_pattern_matches_artifact_phrases` × 6, `test_pattern_does_not_match_legitimate_lines` × 6)
- [x] Full unit test suite passes (4011 existing + 12 new = 4023 total, 1 skipped)
- [x] All pre-commit hooks pass on commit
- [x] `grep -r 'Mojo equivalents\|no Mojo' scylla/` returns zero matches (clean baseline confirmed)

Closes #1366

🤖 Generated with [Claude Code](https://claude.com/claude-code)