### PR TITLE
fix(tests): prefix unused variable with underscore (RUF059)

### DIFF
--- a/scripts/check_docstring_fragments.py
+++ b/scripts/check_docstring_fragments.py
@@ -252,6 +252,7 @@ def scan_file(file_path: Path, repo_root: Path) -> list[FragmentFinding]:
 
 EXCLUDED_PREFIXES = (
     ".pixi/",
+    ".worktrees/",
     "build/",
     "node_modules/",
     "tests/claude-code/",

--- a/tests/unit/scripts/test_validation.py
+++ b/tests/unit/scripts/test_validation.py
@@ -107,7 +107,7 @@ class TestCheckRequiredSections:
     def test_matches_heading_at_any_level(self) -> None:
         """Matches headings at ## and ### levels."""
         content = "### Deep Section\n"
-        ok, missing = check_required_sections(content, ["Deep Section"])
+        ok, _missing = check_required_sections(content, ["Deep Section"])
         assert ok is True
 
 


### PR DESCRIPTION
## Summary
- Fixes RUF059 lint error in `tests/unit/scripts/test_validation.py:110` — unused unpacked variable `missing` prefixed with `_`
- Also adds `.worktrees/` to docstring fragment scanner exclusions to prevent false positives from third-party packages installed in worktree pixi environments

## Impact
This unblocks PRs #1401, #1397, and #1392 which all fail CI due to this RUF059 error on main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)