### PR TITLE
fix(hooks): exclude .worktrees/ and .claude/worktrees/ from pre-commit scanners

### DIFF
--- a/scripts/audit_doc_examples.py
+++ b/scripts/audit_doc_examples.py
@@ -143,6 +143,8 @@ EXCLUDED_PREFIXES = (
     "docs/arxiv/",
     "tests/claude-code/",
     ".pixi/",
+    ".worktrees/",
+    ".claude/worktrees/",
     "build/",
     "node_modules/",
 )

--- a/scripts/check_docstring_fragments.py
+++ b/scripts/check_docstring_fragments.py
@@ -253,6 +253,7 @@ def scan_file(file_path: Path, repo_root: Path) -> list[FragmentFinding]:
 EXCLUDED_PREFIXES = (
     ".pixi/",
     ".worktrees/",
+    ".claude/worktrees/",
     "build/",
     "node_modules/",
     "tests/claude-code/",


### PR DESCRIPTION
## Summary
- Adds `.worktrees/` and `.claude/worktrees/` to `EXCLUDED_PREFIXES` in both `scripts/audit_doc_examples.py` and `scripts/check_docstring_fragments.py`
- Prevents false positives from git worktree directories (third-party packages, test fixtures, benchmark artifacts) being flagged as policy violations

## Root Cause
The `audit-doc-policy` and `check-docstring-fragments` pre-commit hooks scan all matching files in the repo via `rglob`, including files inside `.worktrees/` and `.claude/worktrees/` git worktree directories. These contain copies of the full repo (including `docs/arxiv/` benchmark data and test skill files) that legitimately contain patterns like `--squash` or fragment docstrings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)