### PR TITLE
fix(batch): re-queue completed tests when --max-subtests expands subtest count

### DIFF
--- a/scripts/manage_experiment.py
+++ b/scripts/manage_experiment.py
@@ -605,8 +605,28 @@ def _run_batch(test_dirs: list[Path], args: argparse.Namespace) -> int:
                 with open(summary_path) as f:
                     summary = json.load(f)
                 for r in summary.get("results", []):
-                    if r.get("status") != "error" or not args.retry_errors:
-                        completed_ids.add(r["test_id"])
+                    if r.get("status") == "error" and args.retry_errors:
+                        continue
+                    # If --max-subtests was specified, check whether the checkpoint
+                    # has fewer subtests than requested. If so, re-run to expand.
+                    if args.max_subtests is not None:
+                        result_dir = r.get("result_dir")
+                        if result_dir:
+                            cp_path = Path(result_dir) / "checkpoint.json"
+                            try:
+                                with open(cp_path) as cp_f:
+                                    cp = json.load(cp_f)
+                                subtest_states = cp.get("subtest_states", {})
+                                needs_expansion = False
+                                for tier_subtests in subtest_states.values():
+                                    if len(tier_subtests) < args.max_subtests:
+                                        needs_expansion = True
+                                        break
+                                if needs_expansion:
+                                    continue
+                            except Exception:
+                                pass
+                    completed_ids.add(r["test_id"])
             except Exception:
                 pass
 


### PR DESCRIPTION
## Summary

- Batch mode previously skipped all non-error tests based solely on `batch_summary.json` status, ignoring whether `--max-subtests` requested more subtests than the checkpoint contained
- When `--max-subtests` is specified, each completed test's checkpoint is now inspected; if any tier has fewer subtests than requested, the test is re-queued
- The resume manager already handles running only the new subtests correctly — this fix ensures batch mode doesn't short-circuit before reaching it

## Test plan

- [ ] Run with `--max-subtests 3` against a results dir with `max-subtests 1` runs — should detect and re-queue tests needing expansion
- [ ] Run with `--retry-errors` and no `--max-subtests` — behavior unchanged (only error tests re-queued)
- [ ] Run against already-complete runs with matching `--max-subtests` — "All tests already completed" message still fires