### PR TITLE
refactor(e2e): remove empty TYPE_CHECKING block from run_report.py

### DIFF
--- a/scylla/e2e/run_report.py
+++ b/scylla/e2e/run_report.py
@@ -17,7 +17,7 @@ from __future__ import annotations
 
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import Any
 
 from scylla.e2e.run_report_hierarchy import (
     generate_experiment_summary_table as generate_experiment_summary_table,
@@ -76,9 +76,6 @@ from scylla.e2e.run_report_sections import (
 from scylla.e2e.run_report_sections import (
     _get_workspace_files as _get_workspace_files,
 )
-
-if TYPE_CHECKING:
-    pass
 
 
 def generate_run_report(


### PR DESCRIPTION
Closes #1396

## Summary

- Removes unused `if TYPE_CHECKING: pass` block (was lines 80-81 in `scylla/e2e/run_report.py`)
- Removes `TYPE_CHECKING` from the `from typing import` statement since it is no longer referenced

## Test plan

- [x] `pre-commit run --files scylla/e2e/run_report.py` — all hooks pass
- [x] `pixi run pytest tests/unit/e2e/ --override-ini="addopts=" -q` — 1405 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)