### PR TITLE
test(scripts): add tests for get_commits_stats

### DIFF
--- a/tests/unit/scripts/test_get_stats.py
+++ b/tests/unit/scripts/test_get_stats.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from unittest.mock import MagicMock, patch
 
-from get_stats import get_issues_stats, get_prs_stats
+from get_stats import get_commits_stats, get_issues_stats, get_prs_stats
 
 
 class TestGetIssuesStats:
@@ -116,3 +116,88 @@ class TestGetPrsStats:
 
         first_call_args = mock_run.call_args_list[0][0][0]
         assert not any("author:" in str(a) for a in first_call_args)
+
+
+class TestGetCommitsStats:
+    """Tests for get_commits_stats()."""
+
+    def test_returns_total_on_success(self) -> None:
+        """Returns dict with total commit count when gh CLI succeeds."""
+        mock_result = MagicMock()
+        mock_result.returncode = 0
+        mock_result.stdout = "42\n"
+
+        with patch("get_stats.subprocess.run", return_value=mock_result):
+            result = get_commits_stats("2026-01-01", "2026-01-31", None, "owner/repo")
+
+        assert result == {"total": 42}
+
+    def test_returns_zero_on_gh_failure(self) -> None:
+        """Returns all-zero dict when gh CLI fails."""
+        mock_result = MagicMock()
+        mock_result.returncode = 1
+
+        with patch("get_stats.subprocess.run", return_value=mock_result):
+            result = get_commits_stats("2026-01-01", "2026-01-31", None, "owner/repo")
+
+        assert result == {"total": 0}
+
+    def test_includes_author_param_when_specified(self) -> None:
+        """Adds author filter parameter to gh CLI call when author is provided."""
+        mock_result = MagicMock()
+        mock_result.returncode = 0
+        mock_result.stdout = "5\n"
+
+        with patch("get_stats.subprocess.run", return_value=mock_result) as mock_run:
+            get_commits_stats("2026-01-01", "2026-01-31", "alice", "owner/repo")
+
+        call_args = mock_run.call_args[0][0]
+        assert any("author=alice" in str(a) for a in call_args)
+
+    def test_no_author_param_when_none(self) -> None:
+        """Does not add author parameter when author is None."""
+        mock_result = MagicMock()
+        mock_result.returncode = 0
+        mock_result.stdout = "0\n"
+
+        with patch("get_stats.subprocess.run", return_value=mock_result) as mock_run:
+            get_commits_stats("2026-01-01", "2026-01-31", None, "owner/repo")
+
+        call_args = mock_run.call_args[0][0]
+        assert not any("author=" in str(a) for a in call_args)
+
+    def test_sums_multiple_paginated_pages(self) -> None:
+        """Sums counts across multiple paginated pages returned by gh CLI."""
+        mock_result = MagicMock()
+        mock_result.returncode = 0
+        mock_result.stdout = "30\n30\n10\n"
+
+        with patch("get_stats.subprocess.run", return_value=mock_result):
+            result = get_commits_stats("2026-01-01", "2026-01-31", None, "owner/repo")
+
+        assert result == {"total": 70}
+
+    def test_uses_since_and_until_date_params(self) -> None:
+        """Passes since and until timestamps derived from start/end dates."""
+        mock_result = MagicMock()
+        mock_result.returncode = 0
+        mock_result.stdout = "1\n"
+
+        with patch("get_stats.subprocess.run", return_value=mock_result) as mock_run:
+            get_commits_stats("2026-01-01", "2026-01-31", None, "owner/repo")
+
+        call_args = mock_run.call_args[0][0]
+        assert any("2026-01-01T00:00:00Z" in str(a) for a in call_args)
+        assert any("2026-01-31T23:59:59Z" in str(a) for a in call_args)
+
+    def test_uses_correct_repo_owner_and_name(self) -> None:
+        """Constructs the API path using the owner and repo name from the repo argument."""
+        mock_result = MagicMock()
+        mock_result.returncode = 0
+        mock_result.stdout = "3\n"
+
+        with patch("get_stats.subprocess.run", return_value=mock_result) as mock_run:
+            get_commits_stats("2026-01-01", "2026-01-31", None, "myorg/myrepo")
+
+        call_args = mock_run.call_args[0][0]
+        assert any("repos/myorg/myrepo/commits" in str(a) for a in call_args)


### PR DESCRIPTION
Add `TestGetCommitsStats` class to `tests/unit/scripts/test_get_stats.py` covering all key behaviors and branches of `get_commits_stats`:

- Returns correct total on success
- Returns zero dict when gh CLI fails (non-zero returncode)
- Includes `author=<name>` parameter when author is specified
- Omits author parameter when author is None
- Sums counts across multiple paginated pages
- Passes correct `since` and `until` timestamps derived from start/end dates
- Constructs the correct `repos/{owner}/{repo}/commits` API path

Closes #1385