### PR TITLE
ci: update pixi-version from v0.62.2 to v0.63.2 in all workflows

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Install pixi
         uses: prefix-dev/setup-pixi@v0.9.4
         with:
-          pixi-version: v0.62.2
+          pixi-version: v0.63.2
           environments: lint
 
       - name: Cache pixi environments

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Install pixi
         uses: prefix-dev/setup-pixi@v0.9.4
         with:
-          pixi-version: v0.62.2
+          pixi-version: v0.63.2
           environments: lint
 
       - name: Cache pixi environments

--- a/.github/workflows/shell-test.yml
+++ b/.github/workflows/shell-test.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Install pixi
         uses: prefix-dev/setup-pixi@v0.9.4
         with:
-          pixi-version: v0.62.2
+          pixi-version: v0.63.2
           cache: true
 
       - name: Cache pixi environments

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -67,7 +67,7 @@ jobs:
       - name: Install pixi
         uses: prefix-dev/setup-pixi@v0.9.4
         with:
-          pixi-version: v0.62.2
+          pixi-version: v0.63.2
 
       - name: Cache pixi environments
         uses: actions/cache@v5


### PR DESCRIPTION
## Summary
- Updates pixi version from `v0.62.2` to `v0.63.2` in all 4 CI workflows (`pre-commit.yml`, `test.yml`, `security.yml`, `shell-test.yml`)

## Root Cause
`pixi.lock` is generated locally with pixi `0.63.2`, but CI workflows were pinned to `v0.62.2`. When the pixi environment cache expires (or misses), pixi `0.62.2` fails to install from a `0.63.2`-format lock file with error: `lock-file not up-to-date with the workspace`.

This caused PR #1417 CI to fail intermittently when the cache was not warm.

## Test plan
- [ ] All CI checks pass after updating pixi version
- [ ] No other workflow changes