### PR TITLE
fix(pre-commit): add check-docstring-fragments hook for orphaned fragment detection

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -116,8 +116,8 @@ repos:
         types: [markdown]
         pass_filenames: false
       - id: check-docstring-fragments
-        name: Check Docstring Fragment False Positives
-        description: Validates Python docstrings as complete semantic units to prevent false positive fragment detection during audits
+        name: Check Orphaned Docstring Fragments
+        description: Detects orphaned lowercase continuation lines in module-level and function docstrings (e.g., lines starting with connector words like 'across', 'and', 'or') and fails the commit
         entry: pixi run python scripts/check_docstring_fragments.py
         language: system
         files: \.py$


### PR DESCRIPTION
## Summary

- Clarifies the `check-docstring-fragments` pre-commit hook name and description to accurately reflect its purpose: catching orphaned lowercase continuation lines in docstrings at commit time
- The hook was introduced in #1363 but the name/description incorrectly framed it as handling "false positives" rather than detecting genuine orphaned fragments
- All underlying infrastructure (`scripts/check_docstring_fragments.py`, tests, hook wiring) was already in place from prior work

## Implementation

The `check-docstring-fragments` hook in `.pre-commit-config.yaml`:
- Uses AST-based detection (not line-by-line) to find docstrings whose first line starts with a lowercase connector word (`across`, `and`, `or`, `but`, etc.)
- Exits 1 on any violation, failing the commit
- Scoped to `*.py` files via `files: \.py$`
- Supports `--verbose` and `--json` output flags

## Test plan

- [x] 68 unit tests in `tests/unit/scripts/test_check_docstring_fragments.py` — all pass
- [x] Hook fires correctly on clean files (exit 0) and files with violations (exit 1)
- [x] Pre-commit hook configuration is valid YAML

Closes #1398

🤖 Generated with [Claude Code](https://claude.com/claude-code)