### PR TITLE
[feat] Add pre-commit hook to validate config files against schemas

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -130,6 +130,17 @@ repos:
         language: system
         files: ^(CLAUDE\.md|README\.md|pyproject\.toml)$
         pass_filenames: false
+      - id: validate-config-schemas
+        name: Validate Config Files Against JSON Schemas
+        description: >-
+          Validates config/defaults.yaml, config/models/*.yaml, and
+          tests/fixtures/config/tiers/*.yaml against their JSON schemas in schemas/
+        entry: pixi run python scripts/validate_config_schemas.py
+        language: system
+        files: >-
+          ^(config/defaults\.yaml|config/models/.+\.yaml|
+          tests/fixtures/config/tiers/.+\.yaml)$
+        pass_filenames: true
 
   # Markdown linting
   - repo: https://github.com/DavidAnson/markdownlint-cli2

--- a/scripts/validate_config_schemas.py
+++ b/scripts/validate_config_schemas.py
@@ -1,0 +1,180 @@
+#!/usr/bin/env python3
+"""Validate config files against their JSON schemas as a pre-commit gate.
+
+Receives file paths as positional arguments (via ``pass_filenames: true``) and
+dispatches each file to the correct JSON schema based on path pattern.  Exits 1
+if any validation error is found, blocking the commit.
+
+Supported file patterns:
+- ``config/defaults.yaml`` → ``schemas/defaults.schema.json``
+- ``config/models/*.yaml`` → ``schemas/model.schema.json``
+- ``tests/fixtures/config/tiers/*.yaml`` → ``schemas/tier.schema.json``
+
+Usage:
+    python scripts/validate_config_schemas.py config/defaults.yaml
+    python scripts/validate_config_schemas.py config/models/claude-sonnet.yaml
+    python scripts/validate_config_schemas.py --verbose config/defaults.yaml
+
+Exit codes:
+    0: All files valid (or no matching schema found — warned, not failed)
+    1: One or more schema violations found
+"""
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+
+import jsonschema
+import yaml
+
+_REPO_ROOT = Path(__file__).parent.parent
+
+# Ordered list of (regex_pattern, schema_relative_path) pairs.
+# The relative path is resolved against the repo root at runtime.
+_SCHEMA_MAP: list[tuple[re.Pattern[str], Path]] = [
+    (re.compile(r"^config/defaults\.yaml$"), Path("schemas/defaults.schema.json")),
+    (re.compile(r"^config/models/.+\.yaml$"), Path("schemas/model.schema.json")),
+    (
+        re.compile(r"^tests/fixtures/config/tiers/.+\.yaml$"),
+        Path("schemas/tier.schema.json"),
+    ),
+]
+
+
+def resolve_schema(file_path: Path, repo_root: Path) -> Path | None:
+    """Return the schema path for *file_path*, or ``None`` if no match.
+
+    Args:
+        file_path: Absolute or relative path to the config file.
+        repo_root: Root of the repository (used to compute the relative path).
+
+    Returns:
+        Absolute path to the matching JSON schema file, or ``None``.
+
+    """
+    try:
+        rel = file_path.resolve().relative_to(repo_root.resolve())
+    except ValueError:
+        # file_path is not under repo_root — try treating it as already relative
+        rel = Path(str(file_path))
+
+    rel_str = rel.as_posix()
+    for pattern, schema_rel in _SCHEMA_MAP:
+        if pattern.match(rel_str):
+            return repo_root / schema_rel
+    return None
+
+
+def validate_file(file_path: Path, schema: dict[str, object]) -> list[str]:
+    """Validate a YAML config file against *schema*.
+
+    Args:
+        file_path: Path to the YAML config file to validate.
+        schema: Parsed JSON schema dict.
+
+    Returns:
+        List of human-readable error strings (empty list means valid).
+
+    """
+    try:
+        with open(file_path) as fh:
+            content = yaml.safe_load(fh)
+    except (OSError, yaml.YAMLError) as exc:
+        return [f"Could not read/parse YAML: {exc}"]
+
+    errors: list[str] = []
+    validator = jsonschema.Draft7Validator(schema)
+    for error in sorted(validator.iter_errors(content), key=lambda e: list(e.path)):
+        path = ".".join(str(p) for p in error.absolute_path) or "<root>"
+        errors.append(f"  [{path}] {error.message}")
+    return errors
+
+
+def check_files(files: list[Path], repo_root: Path, verbose: bool = False) -> int:
+    """Validate each file against its matching schema.
+
+    Args:
+        files: List of file paths to check.
+        repo_root: Repository root used for schema resolution.
+        verbose: If True, print ``PASS:`` lines for valid files.
+
+    Returns:
+        0 if all files are valid, 1 if any violations are found.
+
+    """
+    if not files:
+        return 0
+
+    schema_cache: dict[Path, dict[str, object]] = {}
+    any_failure = False
+
+    for file_path in files:
+        schema_path = resolve_schema(file_path, repo_root)
+        if schema_path is None:
+            print(
+                f"WARNING: No schema mapping for {file_path} — skipping",
+                file=sys.stderr,
+            )
+            continue
+
+        if schema_path not in schema_cache:
+            try:
+                schema_cache[schema_path] = json.loads(schema_path.read_text())
+            except (OSError, json.JSONDecodeError) as exc:
+                print(
+                    f"ERROR: Could not load schema {schema_path}: {exc}",
+                    file=sys.stderr,
+                )
+                any_failure = True
+                continue
+
+        errors = validate_file(file_path, schema_cache[schema_path])
+        if errors:
+            print(f"FAIL: {file_path}", file=sys.stderr)
+            for error in errors:
+                print(error, file=sys.stderr)
+            any_failure = True
+        elif verbose:
+            print(f"PASS: {file_path}")
+
+    return 1 if any_failure else 0
+
+
+def main() -> int:
+    """CLI entry point for config schema validation.
+
+    Returns:
+        Exit code (0 if clean, 1 if violations found).
+
+    """
+    parser = argparse.ArgumentParser(
+        description="Validate config files against their JSON schemas",
+        epilog="Example: %(prog)s config/defaults.yaml config/models/*.yaml",
+    )
+    parser.add_argument(
+        "files",
+        nargs="*",
+        type=Path,
+        help="Config files to validate (passed by pre-commit via pass_filenames: true)",
+    )
+    parser.add_argument(
+        "--verbose",
+        "-v",
+        action="store_true",
+        help="Print passing file names as well",
+    )
+    parser.add_argument(
+        "--repo-root",
+        type=Path,
+        default=_REPO_ROOT,
+        help="Repository root for resolving schema paths (default: parent of this script)",
+    )
+
+    args = parser.parse_args()
+    return check_files(args.files, args.repo_root, verbose=args.verbose)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/unit/scripts/test_validate_config_schemas.py
+++ b/tests/unit/scripts/test_validate_config_schemas.py
@@ -1,0 +1,315 @@
+"""Tests for scripts/validate_config_schemas.py."""
+
+import json
+import textwrap
+from pathlib import Path
+
+import pytest
+
+from scripts.validate_config_schemas import check_files, resolve_schema, validate_file
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_REPO_ROOT = Path(__file__).parent.parent.parent.parent
+
+
+def _write_yaml(directory: Path, filename: str, content: str) -> Path:
+    """Write a YAML file into *directory* and return its path."""
+    path = directory / filename
+    path.write_text(textwrap.dedent(content))
+    return path
+
+
+def _write_schema(directory: Path, filename: str, schema: dict[str, object]) -> Path:
+    """Write a JSON schema file into *directory* and return its path."""
+    path = directory / filename
+    path.write_text(json.dumps(schema))
+    return path
+
+
+# Minimal valid schema for test use
+_SIMPLE_SCHEMA: dict[str, object] = {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "type": "object",
+    "required": ["name"],
+    "additionalProperties": False,
+    "properties": {
+        "name": {"type": "string"},
+        "count": {"type": "integer"},
+    },
+}
+
+# ---------------------------------------------------------------------------
+# TestResolveSchema
+# ---------------------------------------------------------------------------
+
+
+class TestResolveSchema:
+    """Tests for resolve_schema()."""
+
+    def test_defaults_yaml_matches(self) -> None:
+        """config/defaults.yaml should match defaults.schema.json."""
+        path = _REPO_ROOT / "config" / "defaults.yaml"
+        result = resolve_schema(path, _REPO_ROOT)
+        assert result is not None
+        assert result.name == "defaults.schema.json"
+
+    def test_model_yaml_matches(self) -> None:
+        """config/models/*.yaml should match model.schema.json."""
+        path = _REPO_ROOT / "config" / "models" / "some-model.yaml"
+        result = resolve_schema(path, _REPO_ROOT)
+        assert result is not None
+        assert result.name == "model.schema.json"
+
+    def test_tier_fixture_yaml_matches(self) -> None:
+        """tests/fixtures/config/tiers/*.yaml should match tier.schema.json."""
+        path = _REPO_ROOT / "tests" / "fixtures" / "config" / "tiers" / "t0.yaml"
+        result = resolve_schema(path, _REPO_ROOT)
+        assert result is not None
+        assert result.name == "tier.schema.json"
+
+    def test_unknown_path_returns_none(self) -> None:
+        """A path not matching any pattern should return None."""
+        path = _REPO_ROOT / "config" / "unknown.yaml"
+        assert resolve_schema(path, _REPO_ROOT) is None
+
+    def test_non_yaml_model_file_returns_none(self) -> None:
+        """A non-yaml file in config/models/ should not match."""
+        path = _REPO_ROOT / "config" / "models" / "README.md"
+        assert resolve_schema(path, _REPO_ROOT) is None
+
+    @pytest.mark.parametrize(
+        "rel_path",
+        [
+            "config/defaults.yaml",
+            "config/models/claude-sonnet.yaml",
+            "tests/fixtures/config/tiers/t1.yaml",
+        ],
+    )
+    def test_all_supported_patterns_match(self, rel_path: str) -> None:
+        """All documented path patterns should resolve to a schema."""
+        path = _REPO_ROOT / rel_path
+        assert resolve_schema(path, _REPO_ROOT) is not None
+
+
+# ---------------------------------------------------------------------------
+# TestValidateFile
+# ---------------------------------------------------------------------------
+
+
+class TestValidateFile:
+    """Tests for validate_file()."""
+
+    def test_valid_yaml_returns_no_errors(self, tmp_path: Path) -> None:
+        """A YAML file conforming to the schema should produce no errors."""
+        cfg = _write_yaml(tmp_path, "good.yaml", 'name: "hello"\n')
+        errors = validate_file(cfg, _SIMPLE_SCHEMA)
+        assert errors == []
+
+    def test_missing_required_field_returns_error(self, tmp_path: Path) -> None:
+        """Missing required field should be reported."""
+        cfg = _write_yaml(tmp_path, "bad.yaml", "count: 5\n")
+        errors = validate_file(cfg, _SIMPLE_SCHEMA)
+        assert len(errors) >= 1
+        assert any("name" in e for e in errors)
+
+    def test_wrong_field_type_returns_error(self, tmp_path: Path) -> None:
+        """Field with wrong type should produce an error containing the path."""
+        cfg = _write_yaml(tmp_path, "bad_type.yaml", 'name: "ok"\ncount: "not-an-int"\n')
+        errors = validate_file(cfg, _SIMPLE_SCHEMA)
+        assert len(errors) >= 1
+        assert any("count" in e for e in errors)
+
+    def test_additional_property_returns_error(self, tmp_path: Path) -> None:
+        """Extra field rejected by additionalProperties: false should be reported."""
+        cfg = _write_yaml(tmp_path, "extra.yaml", 'name: "ok"\nextra_field: true\n')
+        errors = validate_file(cfg, _SIMPLE_SCHEMA)
+        assert len(errors) >= 1
+        assert any("extra_field" in e for e in errors)
+
+    def test_malformed_yaml_returns_error(self, tmp_path: Path) -> None:
+        """Malformed YAML should return an error string without raising."""
+        cfg = tmp_path / "bad.yaml"
+        cfg.write_text("key: [unclosed\n")
+        errors = validate_file(cfg, _SIMPLE_SCHEMA)
+        assert len(errors) == 1
+        assert "parse" in errors[0].lower() or "read" in errors[0].lower()
+
+    def test_missing_file_returns_error(self, tmp_path: Path) -> None:
+        """Non-existent file should return an error string."""
+        cfg = tmp_path / "nonexistent.yaml"
+        errors = validate_file(cfg, _SIMPLE_SCHEMA)
+        assert len(errors) == 1
+
+    def test_multiple_errors_all_returned(self, tmp_path: Path) -> None:
+        """Multiple schema violations should all appear in the result."""
+        cfg = _write_yaml(
+            tmp_path,
+            "multi.yaml",
+            "count: 'bad'\nextra: true\n",  # missing 'name', wrong type, extra field
+        )
+        errors = validate_file(cfg, _SIMPLE_SCHEMA)
+        assert len(errors) >= 2
+
+
+# ---------------------------------------------------------------------------
+# TestCheckFiles
+# ---------------------------------------------------------------------------
+
+
+class TestCheckFiles:
+    """Tests for check_files()."""
+
+    def _make_schema_root(self, tmp_path: Path) -> Path:
+        """Create a fake repo root with schemas/ directory."""
+        schemas_dir = tmp_path / "schemas"
+        schemas_dir.mkdir()
+        _write_schema(schemas_dir, "defaults.schema.json", _SIMPLE_SCHEMA)
+        _write_schema(schemas_dir, "model.schema.json", _SIMPLE_SCHEMA)
+        _write_schema(schemas_dir, "tier.schema.json", _SIMPLE_SCHEMA)
+        return tmp_path
+
+    def test_empty_file_list_returns_zero(self, tmp_path: Path) -> None:
+        """No files should return exit code 0."""
+        repo_root = self._make_schema_root(tmp_path)
+        assert check_files([], repo_root) == 0
+
+    def test_valid_file_returns_zero(self, tmp_path: Path) -> None:
+        """A valid config file should return exit code 0."""
+        repo_root = self._make_schema_root(tmp_path)
+        cfg_dir = tmp_path / "config" / "models"
+        cfg_dir.mkdir(parents=True)
+        cfg = _write_yaml(cfg_dir, "model.yaml", 'name: "test-model"\n')
+        assert check_files([cfg], repo_root) == 0
+
+    def test_invalid_file_returns_one(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """An invalid config should return exit code 1."""
+        repo_root = self._make_schema_root(tmp_path)
+        cfg_dir = tmp_path / "config" / "models"
+        cfg_dir.mkdir(parents=True)
+        cfg = _write_yaml(cfg_dir, "bad.yaml", "extra_field: true\n")
+        assert check_files([cfg], repo_root) == 1
+        captured = capsys.readouterr()
+        assert "FAIL" in captured.err
+
+    def test_all_errors_reported_not_just_first(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """Both invalid files should appear in stderr, not just the first."""
+        repo_root = self._make_schema_root(tmp_path)
+        cfg_dir = tmp_path / "config" / "models"
+        cfg_dir.mkdir(parents=True)
+        bad_a = _write_yaml(cfg_dir, "bad_a.yaml", "extra_a: 1\n")
+        bad_b = _write_yaml(cfg_dir, "bad_b.yaml", "extra_b: 2\n")
+        result = check_files([bad_a, bad_b], repo_root)
+        assert result == 1
+        captured = capsys.readouterr()
+        assert "bad_a.yaml" in captured.err
+        assert "bad_b.yaml" in captured.err
+
+    def test_unknown_schema_path_warns_and_skips(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """A file with no matching schema should warn but not fail."""
+        repo_root = self._make_schema_root(tmp_path)
+        unknown = tmp_path / "some" / "other" / "file.yaml"
+        unknown.parent.mkdir(parents=True)
+        unknown.write_text('name: "ok"\n')
+        result = check_files([unknown], repo_root)
+        assert result == 0
+        captured = capsys.readouterr()
+        assert "WARNING" in captured.err
+
+    def test_verbose_prints_pass_lines(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """With verbose=True, valid files should print PASS: lines to stdout."""
+        repo_root = self._make_schema_root(tmp_path)
+        cfg_dir = tmp_path / "config" / "models"
+        cfg_dir.mkdir(parents=True)
+        cfg = _write_yaml(cfg_dir, "good.yaml", 'name: "valid"\n')
+        result = check_files([cfg], repo_root, verbose=True)
+        assert result == 0
+        captured = capsys.readouterr()
+        assert "PASS" in captured.out
+        assert "good.yaml" in captured.out
+
+    def test_verbose_false_no_pass_output(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """Without verbose, valid files should not produce stdout output."""
+        repo_root = self._make_schema_root(tmp_path)
+        cfg_dir = tmp_path / "config" / "models"
+        cfg_dir.mkdir(parents=True)
+        cfg = _write_yaml(cfg_dir, "good.yaml", 'name: "valid"\n')
+        check_files([cfg], repo_root, verbose=False)
+        captured = capsys.readouterr()
+        assert captured.out == ""
+
+    def test_one_valid_one_invalid_returns_one(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """Mix of valid and invalid should return exit code 1."""
+        repo_root = self._make_schema_root(tmp_path)
+        cfg_dir = tmp_path / "config" / "models"
+        cfg_dir.mkdir(parents=True)
+        good = _write_yaml(cfg_dir, "good.yaml", 'name: "ok"\n')
+        bad = _write_yaml(cfg_dir, "bad.yaml", "extra: true\n")
+        assert check_files([good, bad], repo_root) == 1
+
+
+# ---------------------------------------------------------------------------
+# TestMainIntegration — real schema files
+# ---------------------------------------------------------------------------
+
+
+class TestMainIntegration:
+    """Integration tests using actual schema and config files from the repo."""
+
+    def test_defaults_yaml_validates(self) -> None:
+        """The real config/defaults.yaml should pass schema validation."""
+        defaults = _REPO_ROOT / "config" / "defaults.yaml"
+        if not defaults.exists():
+            pytest.skip("config/defaults.yaml not present")
+        schema_path = _REPO_ROOT / "schemas" / "defaults.schema.json"
+        schema = json.loads(schema_path.read_text())
+        errors = validate_file(defaults, schema)
+        assert errors == [], f"defaults.yaml failed: {errors}"
+
+    def test_model_configs_validate(self) -> None:
+        """All real config/models/*.yaml files should pass schema validation."""
+        models_dir = _REPO_ROOT / "config" / "models"
+        if not models_dir.exists():
+            pytest.skip("config/models/ directory not present")
+        schema_path = _REPO_ROOT / "schemas" / "model.schema.json"
+        schema = json.loads(schema_path.read_text())
+        model_files = [f for f in models_dir.glob("*.yaml") if not f.name.startswith("_")]
+        if not model_files:
+            pytest.skip("No model config files found")
+        failures: list[str] = []
+        for model_file in model_files:
+            errors = validate_file(model_file, schema)
+            if errors:
+                failures.append(f"{model_file}: {errors}")
+        assert not failures, "\n".join(failures)
+
+    def test_tier_fixture_configs_validate(self) -> None:
+        """All tier fixture YAML files should pass schema validation."""
+        tiers_dir = _REPO_ROOT / "tests" / "fixtures" / "config" / "tiers"
+        if not tiers_dir.exists():
+            pytest.skip("tests/fixtures/config/tiers/ directory not present")
+        schema_path = _REPO_ROOT / "schemas" / "tier.schema.json"
+        schema = json.loads(schema_path.read_text())
+        tier_files = list(tiers_dir.glob("*.yaml"))
+        if not tier_files:
+            pytest.skip("No tier fixture files found")
+        failures: list[str] = []
+        for tier_file in tier_files:
+            errors = validate_file(tier_file, schema)
+            if errors:
+                failures.append(f"{tier_file}: {errors}")
+        assert not failures, "\n".join(failures)


### PR DESCRIPTION
## Summary

- Adds `scripts/validate_config_schemas.py` to validate config YAML files against their JSON schemas at commit time
- Registers the new `validate-config-schemas` hook in `.pre-commit-config.yaml` (triggers on `config/defaults.yaml`, `config/models/*.yaml`, and `tests/fixtures/config/tiers/*.yaml`)
- Adds 26 unit tests in `tests/unit/scripts/test_validate_config_schemas.py`

## Implementation Details

The script follows the existing pattern of `check_model_config_consistency.py`:
- Positional `files` args via `pass_filenames: true`
- Schema dispatch via path-pattern → schema mapping
- `[ERROR]`/`PASS:` output style with `--verbose` flag
- Exits 0 if all files valid (or no matching schema), exits 1 on violations

Schema mappings:
| File pattern | Schema |
|---|---|
| `config/defaults.yaml` | `schemas/defaults.schema.json` |
| `config/models/*.yaml` | `schemas/model.schema.json` |
| `tests/fixtures/config/tiers/*.yaml` | `schemas/tier.schema.json` |

## Test Plan

- [x] 26 unit tests covering `resolve_schema`, `validate_file`, `check_files`, and integration tests against real config files
- [x] All 4460 existing tests still pass
- [x] `mypy` clean on new files
- [x] `ruff` check and format clean
- [x] Real config files all pass: `pixi run python scripts/validate_config_schemas.py config/defaults.yaml config/models/*.yaml tests/fixtures/config/tiers/*.yaml --verbose`

Closes #1382

🤖 Generated with [Claude Code](https://claude.com/claude-code)