### PR TITLE
refactor(automation): decompose implementer.py into sub-modules

### DIFF
--- a/scylla/automation/follow_up.py
+++ b/scylla/automation/follow_up.py
@@ -1,0 +1,198 @@
+"""Follow-up issue creation functions for issue implementation.
+
+Provides:
+- Parsing follow-up items from Claude JSON responses
+- Creating follow-up GitHub issues after implementation
+"""
+
+from __future__ import annotations
+
+import contextlib
+import json
+import logging
+import re
+import time
+from pathlib import Path
+from typing import Any
+
+from .git_utils import run
+from .github_api import gh_issue_comment, gh_issue_create
+from .prompts import get_follow_up_prompt
+
+logger = logging.getLogger(__name__)
+
+
+def parse_follow_up_items(text: str) -> list[dict[str, Any]]:
+    """Parse follow-up items from Claude's JSON response.
+
+    Args:
+        text: Claude's response text (may contain JSON in code blocks)
+
+    Returns:
+        List of follow-up item dictionaries with title, body, labels
+
+    """
+    # Try to extract JSON from code blocks or bare JSON
+    json_match = re.search(r"```(?:json)?\s*(\[.*?\])\s*```", text, re.DOTALL)
+    if json_match:
+        json_str = json_match.group(1)
+    else:
+        # Try to find bare JSON array
+        json_match = re.search(r"(\[.*\])", text, re.DOTALL)
+        if json_match:
+            json_str = json_match.group(1)
+        else:
+            logger.warning("No JSON array found in follow-up response")
+            return []
+
+    try:
+        items = json.loads(json_str)
+        if not isinstance(items, list):
+            logger.warning("Follow-up response is not a JSON array")
+            return []
+
+        # Validate and filter items
+        valid_items = []
+        for item in items[:5]:  # Cap at 5
+            if not isinstance(item, dict):
+                continue
+            if "title" not in item or "body" not in item:
+                logger.warning(f"Skipping follow-up item missing required fields: {item}")
+                continue
+
+            # Ensure labels is a list
+            if "labels" not in item or not isinstance(item["labels"], list):
+                item["labels"] = []
+
+            valid_items.append(item)
+
+        return valid_items
+
+    except json.JSONDecodeError as e:
+        logger.warning(f"Failed to parse follow-up JSON: {e}")
+        return []
+
+
+def run_follow_up_issues(
+    session_id: str,
+    worktree_path: Path,
+    issue_number: int,
+    state_dir: Path,
+    status_tracker: Any | None = None,
+    slot_id: int | None = None,
+) -> None:
+    """Resume Claude session to identify and file follow-up issues.
+
+    Args:
+        session_id: Claude session ID to resume
+        worktree_path: Path to git worktree
+        issue_number: Parent issue number
+        state_dir: Directory for state/log files
+        status_tracker: StatusTracker instance for slot updates (optional)
+        slot_id: Worker slot ID for status updates
+
+    """
+    state_dir.mkdir(parents=True, exist_ok=True)
+
+    # Write follow-up prompt to temp file in worktree
+    prompt_file = worktree_path / f".claude-followup-{issue_number}.md"
+    prompt_file.write_text(get_follow_up_prompt(issue_number))
+
+    try:
+        # Resume session and get follow-up items
+        result = run(
+            [
+                "claude",
+                "--resume",
+                session_id,
+                str(prompt_file),
+                "--output-format",
+                "json",
+            ],
+            cwd=worktree_path,
+            timeout=600,  # 10 minutes
+        )
+
+        # Save successful output to log file
+        follow_up_log = state_dir / f"follow-up-{issue_number}.log"
+        follow_up_log.write_text(result.stdout or "")
+
+        # Parse JSON output
+        try:
+            data = json.loads(result.stdout)
+            response_text = data.get("result", "")
+        except (json.JSONDecodeError, AttributeError) as e:
+            logger.warning(f"Could not parse follow-up response for issue #{issue_number}: {e}")
+            return
+
+        # Extract follow-up items
+        items = parse_follow_up_items(response_text)
+
+        if not items:
+            logger.info(f"No follow-up items identified for issue #{issue_number}")
+            return
+
+        # Create follow-up issues
+        created_issues = []
+        for i, item in enumerate(items, 1):
+            try:
+                # Update status
+                if slot_id is not None and status_tracker is not None:
+                    status_tracker.update_slot(
+                        slot_id, f"#{issue_number}: Creating follow-up {i}/{len(items)}"
+                    )
+
+                # Append reference to parent issue
+                body_with_ref = f"{item['body']}\n\n_Follow-up from #{issue_number}_"
+
+                # Create issue with labels
+                new_issue_num = gh_issue_create(
+                    title=item["title"],
+                    body=body_with_ref,
+                    labels=item.get("labels"),
+                )
+                created_issues.append(new_issue_num)
+
+                # Rate limit: sleep between creates
+                time.sleep(1)
+
+            except (
+                Exception
+            ) as e:  # broad catch: GitHub API can fail in many ways; continue with others
+                logger.warning(f"Failed to create follow-up issue '{item['title']}': {e}")
+                # Continue with remaining items
+
+        # Post summary comment on parent issue
+        if created_issues:
+            summary = f"Created {len(created_issues)} follow-up issue(s): " + ", ".join(
+                f"#{num}" for num in created_issues
+            )
+            try:
+                gh_issue_comment(issue_number, summary)
+                logger.info(f"Posted follow-up summary to issue #{issue_number}")
+            except Exception as e:  # broad catch: GitHub API call; non-critical summary post
+                logger.warning(f"Failed to post follow-up summary: {e}")
+
+        logger.info(
+            f"Follow-up issues completed for #{issue_number}: created {len(created_issues)}"
+        )
+
+    except (
+        Exception
+    ) as e:  # broad catch: top-level follow-up boundary; non-blocking, must not propagate
+        logger.warning(f"Follow-up issues failed for issue #{issue_number}: {e}")
+
+        # Save failure output to log file
+        follow_up_log = state_dir / f"follow-up-{issue_number}.log"
+        error_output = f"FAILED: {e}\n"
+        if hasattr(e, "stdout"):
+            error_output += f"\nSTDOUT:\n{e.stdout or ''}"
+        if hasattr(e, "stderr"):
+            error_output += f"\nSTDERR:\n{e.stderr or ''}"
+        follow_up_log.write_text(error_output)
+
+        # Non-blocking: never re-raise
+    finally:
+        # Clean up temp file
+        with contextlib.suppress(Exception):
+            prompt_file.unlink()

--- a/scylla/automation/implementer.py
+++ b/scylla/automation/implementer.py
@@ -12,7 +12,6 @@ from __future__ import annotations
 import contextlib
 import json
 import logging
-import re
 import subprocess
 import threading
 import time
@@ -23,8 +22,9 @@ from typing import Any, cast
 
 from .curses_ui import CursesUI, ThreadLogManager
 from .dependency_resolver import CyclicDependencyError, DependencyResolver
+from .follow_up import parse_follow_up_items, run_follow_up_issues
 from .git_utils import get_repo_root, run
-from .github_api import fetch_issue_info, gh_issue_comment, gh_issue_create, gh_pr_create
+from .github_api import fetch_issue_info
 from .models import (
     ImplementationPhase,
     ImplementationState,
@@ -32,11 +32,9 @@ from .models import (
     IssueState,
     WorkerResult,
 )
-from .prompts import (
-    get_follow_up_prompt,
-    get_implementation_prompt,
-    get_pr_description,
-)
+from .pr_manager import commit_changes, create_pr, ensure_pr_created
+from .prompts import get_implementation_prompt
+from .retrospective import retrospective_needs_rerun, run_retrospective
 from .status_tracker import StatusTracker
 from .worktree_manager import WorktreeManager
 
@@ -578,54 +576,8 @@ class IssueImplementer:
         )
 
     def _parse_follow_up_items(self, text: str) -> list[dict[str, Any]]:
-        """Parse follow-up items from Claude's JSON response.
-
-        Args:
-            text: Claude's response text (may contain JSON in code blocks)
-
-        Returns:
-            List of follow-up item dictionaries with title, body, labels
-
-        """
-        # Try to extract JSON from code blocks or bare JSON
-        json_match = re.search(r"```(?:json)?\s*(\[.*?\])\s*```", text, re.DOTALL)
-        if json_match:
-            json_str = json_match.group(1)
-        else:
-            # Try to find bare JSON array
-            json_match = re.search(r"(\[.*\])", text, re.DOTALL)
-            if json_match:
-                json_str = json_match.group(1)
-            else:
-                logger.warning("No JSON array found in follow-up response")
-                return []
-
-        try:
-            items = json.loads(json_str)
-            if not isinstance(items, list):
-                logger.warning("Follow-up response is not a JSON array")
-                return []
-
-            # Validate and filter items
-            valid_items = []
-            for item in items[:5]:  # Cap at 5
-                if not isinstance(item, dict):
-                    continue
-                if "title" not in item or "body" not in item:
-                    logger.warning(f"Skipping follow-up item missing required fields: {item}")
-                    continue
-
-                # Ensure labels is a list
-                if "labels" not in item or not isinstance(item["labels"], list):
-                    item["labels"] = []
-
-                valid_items.append(item)
-
-            return valid_items
-
-        except json.JSONDecodeError as e:
-            logger.warning(f"Failed to parse follow-up JSON: {e}")
-            return []
+        """Parse follow-up items from Claude's JSON response."""
+        return parse_follow_up_items(text)
 
     def _run_follow_up_issues(
         self,
@@ -634,138 +586,19 @@ class IssueImplementer:
         issue_number: int,
         slot_id: int | None = None,
     ) -> None:
-        """Resume Claude session to identify and file follow-up issues.
-
-        Args:
-            session_id: Claude session ID to resume
-            worktree_path: Path to git worktree
-            issue_number: Parent issue number
-            slot_id: Worker slot ID for status updates
-
-        """
-        self.state_dir.mkdir(parents=True, exist_ok=True)
-
-        # Write follow-up prompt to temp file in worktree
-        prompt_file = worktree_path / f".claude-followup-{issue_number}.md"
-        prompt_file.write_text(get_follow_up_prompt(issue_number))
-
-        try:
-            # Resume session and get follow-up items
-            result = run(
-                [
-                    "claude",
-                    "--resume",
-                    session_id,
-                    str(prompt_file),
-                    "--output-format",
-                    "json",
-                ],
-                cwd=worktree_path,
-                timeout=600,  # 10 minutes
-            )
-
-            # Save successful output to log file
-            follow_up_log = self.state_dir / f"follow-up-{issue_number}.log"
-            follow_up_log.write_text(result.stdout or "")
-
-            # Parse JSON output
-            try:
-                data = json.loads(result.stdout)
-                response_text = data.get("result", "")
-            except (json.JSONDecodeError, AttributeError) as e:
-                logger.warning(f"Could not parse follow-up response for issue #{issue_number}: {e}")
-                return
-
-            # Extract follow-up items
-            items = self._parse_follow_up_items(response_text)
-
-            if not items:
-                logger.info(f"No follow-up items identified for issue #{issue_number}")
-                return
-
-            # Create follow-up issues
-            created_issues = []
-            for i, item in enumerate(items, 1):
-                try:
-                    # Update status
-                    if slot_id is not None:
-                        self.status_tracker.update_slot(
-                            slot_id, f"#{issue_number}: Creating follow-up {i}/{len(items)}"
-                        )
-
-                    # Append reference to parent issue
-                    body_with_ref = f"{item['body']}\n\n_Follow-up from #{issue_number}_"
-
-                    # Create issue with labels
-                    new_issue_num = gh_issue_create(
-                        title=item["title"],
-                        body=body_with_ref,
-                        labels=item.get("labels"),
-                    )
-                    created_issues.append(new_issue_num)
-
-                    # Rate limit: sleep between creates
-                    time.sleep(1)
-
-                except (
-                    Exception
-                ) as e:  # broad catch: GitHub API can fail in many ways; continue with others
-                    logger.warning(f"Failed to create follow-up issue '{item['title']}': {e}")
-                    # Continue with remaining items
-
-            # Post summary comment on parent issue
-            if created_issues:
-                summary = f"Created {len(created_issues)} follow-up issue(s): " + ", ".join(
-                    f"#{num}" for num in created_issues
-                )
-                try:
-                    gh_issue_comment(issue_number, summary)
-                    logger.info(f"Posted follow-up summary to issue #{issue_number}")
-                except Exception as e:  # broad catch: GitHub API call; non-critical summary post
-                    logger.warning(f"Failed to post follow-up summary: {e}")
-
-            logger.info(
-                f"Follow-up issues completed for #{issue_number}: created {len(created_issues)}"
-            )
-
-        except (
-            Exception
-        ) as e:  # broad catch: top-level follow-up boundary; non-blocking, must not propagate
-            logger.warning(f"Follow-up issues failed for issue #{issue_number}: {e}")
-
-            # Save failure output to log file
-            follow_up_log = self.state_dir / f"follow-up-{issue_number}.log"
-            error_output = f"FAILED: {e}\n"
-            if hasattr(e, "stdout"):
-                error_output += f"\nSTDOUT:\n{e.stdout or ''}"
-            if hasattr(e, "stderr"):
-                error_output += f"\nSTDERR:\n{e.stderr or ''}"
-            follow_up_log.write_text(error_output)
-
-            # Non-blocking: never re-raise
-        finally:
-            # Clean up temp file
-            with contextlib.suppress(Exception):
-                prompt_file.unlink()
+        """Resume Claude session to identify and file follow-up issues."""
+        run_follow_up_issues(
+            session_id,
+            worktree_path,
+            issue_number,
+            self.state_dir,
+            self.status_tracker,
+            slot_id,
+        )
 
     def _retrospective_needs_rerun(self, issue_number: int) -> bool:
-        """Check if retrospective log indicates failure.
-
-        Args:
-            issue_number: Issue number
-
-        Returns:
-            True if retrospective needs to be re-run (missing or failed log)
-
-        """
-        log_file = self.state_dir / f"retrospective-{issue_number}.log"
-        if not log_file.exists():
-            return True
-        try:
-            content = log_file.read_text()
-            return content.startswith("FAILED:")
-        except OSError:
-            return True
+        """Check if retrospective log indicates failure."""
+        return retrospective_needs_rerun(issue_number, self.state_dir)
 
     def _rerun_failed_retrospectives(self) -> dict[int, bool]:
         """Re-run failed retrospectives for completed issues.
@@ -832,64 +665,8 @@ class IssueImplementer:
         issue_number: int,
         slot_id: int | None = None,
     ) -> bool:
-        """Resume Claude session to run /retrospective.
-
-        Args:
-            session_id: Claude session ID
-            worktree_path: Path to worktree
-            issue_number: Issue number
-            slot_id: Worker slot ID for status updates
-
-        Returns:
-            True if retrospective completed successfully, False otherwise
-
-        Runs from worktree directory so Claude can find the session.
-        Output is logged to .issue_implementer/retrospective-{issue_number}.log.
-
-        """
-        self.state_dir.mkdir(parents=True, exist_ok=True)
-        log_file = self.state_dir / f"retrospective-{issue_number}.log"
-        try:
-            result = run(
-                [
-                    "claude",
-                    "--resume",
-                    session_id,
-                    (
-                        "/skills-registry-commands:retrospective"
-                        " commit the results and create a PR."
-                        " IMPORTANT: Only push skills to ProjectMnemosyne."
-                        " Do NOT create files under .claude-plugin/ in this repo."
-                    ),
-                    "--print",
-                    "--permission-mode",
-                    "dontAsk",
-                    "--allowedTools",
-                    "Read,Write,Edit,Glob,Grep,Bash",
-                ],
-                cwd=worktree_path,
-                timeout=600,  # 10 minutes
-            )
-            # Write output to log file
-            log_file.write_text(result.stdout or "")
-            logger.info(f"Retrospective completed for issue #{issue_number}")
-            logger.info(f"Retrospective log: {log_file}")
-            return True
-        except (
-            Exception
-        ) as e:  # broad catch: external claude process; non-blocking, must not propagate
-            logger.warning(f"Retrospective failed for issue #{issue_number}: {e}")
-
-            # Save failure output to log file
-            error_output = f"FAILED: {e}\n"
-            if hasattr(e, "stdout"):
-                error_output += f"\nSTDOUT:\n{e.stdout or ''}"
-            if hasattr(e, "stderr"):
-                error_output += f"\nSTDERR:\n{e.stderr or ''}"
-            log_file.write_text(error_output)
-
-            # Non-blocking: never re-raise
-            return False
+        """Resume Claude session to run /retrospective."""
+        return run_retrospective(session_id, worktree_path, issue_number, self.state_dir, slot_id)
 
     def _run_claude_code(
         self, issue_number: int, worktree_path: Path, prompt: str, slot_id: int | None = None
@@ -979,91 +756,7 @@ class IssueImplementer:
 
     def _commit_changes(self, issue_number: int, worktree_path: Path) -> None:
         """Commit changes in worktree."""
-        # Check if there are changes
-        result = run(
-            ["git", "status", "--porcelain"],
-            cwd=worktree_path,
-            capture_output=True,
-        )
-
-        if not result.stdout.strip():
-            raise RuntimeError(
-                f"No changes to commit for issue #{issue_number}. "
-                "Check if the implementation was successful or if the plan needs revision."
-            )
-
-        # Parse git status --porcelain output to get all changed files
-        # Format: XY filename or XY "quoted filename" for special chars
-        # X = index status, Y = worktree status
-        # Common codes: M (modified), A (added), D (deleted), R (renamed), ?? (untracked)
-        files_to_add = []
-        secret_files = {
-            ".env",
-            ".secret",
-            "credentials.json",
-            "id_rsa",
-            "id_dsa",
-            "id_ecdsa",
-            "id_ed25519",
-        }
-        secret_extensions = {".key", ".pem", ".pfx", ".p12"}
-
-        for line in result.stdout.strip().split("\n"):
-            if not line:
-                continue
-
-            # Parse status code and filename
-            # Format: "XY filename" where X and Y are status codes
-            # Position 0-1: status codes, position 2: space, position 3+: filename
-            status = line[:2]
-            filename_part = line[3:]  # Don't strip - filename starts at position 3
-
-            # Handle renamed files (format: "old -> new")
-            if status.startswith("R") and " -> " in filename_part:
-                filename_part = filename_part.split(" -> ", 1)[1]
-
-            # Handle quoted filenames (git quotes names with special chars)
-            if filename_part.startswith('"') and filename_part.endswith('"'):
-                # Remove quotes - git uses C-style escaping
-                filename_part = filename_part[1:-1]
-
-            # Check if file is a potential secret
-            from pathlib import Path
-
-            filename = Path(filename_part).name
-
-            # Skip secret files (never stage these)
-            if filename in secret_files or any(filename.endswith(ext) for ext in secret_extensions):
-                logger.warning(f"Skipping potential secret file: {filename_part}")
-                continue
-
-            files_to_add.append(filename_part)
-
-        if not files_to_add:
-            raise RuntimeError(
-                f"No non-secret files to commit for issue #{issue_number}. "
-                "All changes appear to be secret files."
-            )
-
-        # Stage the files
-        run(["git", "add", *files_to_add], cwd=worktree_path)
-
-        # Generate commit message
-        issue = fetch_issue_info(issue_number)
-        commit_msg = f"""feat: Implement #{issue_number}
-
-{issue.title}
-
-Closes #{issue_number}
-
-Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>
-"""
-
-        # Commit
-        run(
-            ["git", "commit", "-m", commit_msg],
-            cwd=worktree_path,
-        )
+        commit_changes(issue_number, worktree_path)
 
     def _ensure_pr_created(
         self,
@@ -1072,96 +765,19 @@ Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>
         worktree_path: Path,
         slot_id: int | None = None,
     ) -> int:
-        """Ensure commit is pushed and PR is created (fallback if Claude didn't do it).
-
-        Args:
-            issue_number: Issue number
-            branch_name: Git branch name
-            worktree_path: Path to worktree
-            slot_id: Worker slot ID for status updates
-
-        Returns:
-            PR number
-
-        Raises:
-            RuntimeError: If commit doesn't exist or PR creation fails
-
-        """
-        # Check if commit exists
-        if slot_id is not None:
-            self.status_tracker.update_slot(slot_id, f"#{issue_number}: Checking commit")
-        result = run(
-            ["git", "log", "-1", "--oneline"],
-            cwd=worktree_path,
-            capture_output=True,
+        """Ensure commit is pushed and PR is created (fallback if Claude didn't do it)."""
+        return ensure_pr_created(
+            issue_number,
+            branch_name,
+            worktree_path,
+            self.options.auto_merge,
+            self.status_tracker,
+            slot_id,
         )
-        if not result.stdout.strip():
-            raise RuntimeError(
-                f"No commit found for issue #{issue_number}. Claude did not create any commits."
-            )
-
-        logger.info(f"✓ Commit exists: {result.stdout.strip()[:80]}")
-
-        # Check if branch was pushed, if not push it
-        if slot_id is not None:
-            self.status_tracker.update_slot(slot_id, f"#{issue_number}: Pushing branch")
-        result = run(
-            ["git", "ls-remote", "--heads", "origin", branch_name],
-            cwd=worktree_path,
-            capture_output=True,
-            check=False,
-        )
-        if not result.stdout.strip():
-            logger.warning(f"Branch {branch_name} not pushed, pushing now...")
-            run(["git", "push", "-u", "origin", branch_name], cwd=worktree_path)
-            logger.info(f"✓ Pushed branch {branch_name} to origin")
-        else:
-            logger.info(f"✓ Branch {branch_name} already on origin")
-
-        # Check if PR exists, if not create it
-        if slot_id is not None:
-            self.status_tracker.update_slot(slot_id, f"#{issue_number}: Creating PR")
-        import json
-
-        from .github_api import _gh_call
-
-        pr_number = None
-        try:
-            result = _gh_call(
-                ["pr", "list", "--head", branch_name, "--json", "number", "--limit", "1"]
-            )
-            pr_data = json.loads(result.stdout)
-            if pr_data and len(pr_data) > 0:
-                pr_number = cast(int, pr_data[0]["number"])
-                logger.info(f"✓ PR #{pr_number} already exists")
-                return pr_number
-        except Exception as e:  # broad catch: gh CLI + JSON parsing; fallback is to create PR
-            logger.debug(f"Could not find existing PR: {e}")
-
-        # PR doesn't exist, create it
-        logger.warning(f"No PR found for branch {branch_name}, creating one...")
-        pr_number = self._create_pr(issue_number, branch_name)
-        logger.info(f"✓ Created PR #{pr_number}")
-        return pr_number
 
     def _create_pr(self, issue_number: int, branch_name: str) -> int:
         """Create pull request for issue."""
-        issue = fetch_issue_info(issue_number)
-
-        pr_title = f"feat: {issue.title}"
-        pr_body = get_pr_description(
-            issue_number=issue_number,
-            summary=f"Implements #{issue_number}",
-            changes="- Automated implementation via Claude Code",
-            testing="- Automated tests included",
-        )
-
-        return gh_pr_create(
-            branch=branch_name,
-            title=pr_title,
-            body=pr_body,
-            auto_merge=self.options.auto_merge,
-        )
+        return create_pr(issue_number, branch_name, self.options.auto_merge)
 
     def _get_or_create_state(self, issue_number: int) -> ImplementationState:
         """Get or create implementation state for an issue."""

--- a/scylla/automation/pr_manager.py
+++ b/scylla/automation/pr_manager.py
@@ -1,0 +1,227 @@
+"""Pull request management functions for issue implementation.
+
+Provides:
+- Committing changes with secret file filtering
+- Ensuring PR is created (fallback when Claude doesn't do it)
+- Creating pull requests via GitHub CLI
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+from typing import cast
+
+from .git_utils import run
+from .github_api import _gh_call, fetch_issue_info, gh_pr_create
+from .prompts import get_pr_description
+from .status_tracker import StatusTracker
+
+logger = logging.getLogger(__name__)
+
+_SECRET_FILES = {
+    ".env",
+    ".secret",
+    "credentials.json",
+    "id_rsa",
+    "id_dsa",
+    "id_ecdsa",
+    "id_ed25519",
+}
+_SECRET_EXTENSIONS = {".key", ".pem", ".pfx", ".p12"}
+
+
+def commit_changes(issue_number: int, worktree_path: Path) -> None:
+    """Commit changes in worktree, filtering out secret files.
+
+    Args:
+        issue_number: Issue number (used in commit message and error text)
+        worktree_path: Path to git worktree
+
+    Raises:
+        RuntimeError: If there are no changes, or all changes are secret files.
+
+    """
+    # Check if there are changes
+    result = run(
+        ["git", "status", "--porcelain"],
+        cwd=worktree_path,
+        capture_output=True,
+    )
+
+    if not result.stdout.strip():
+        raise RuntimeError(
+            f"No changes to commit for issue #{issue_number}. "
+            "Check if the implementation was successful or if the plan needs revision."
+        )
+
+    # Parse git status --porcelain output to get all changed files
+    # Format: XY filename or XY "quoted filename" for special chars
+    # X = index status, Y = worktree status
+    # Common codes: M (modified), A (added), D (deleted), R (renamed), ?? (untracked)
+    files_to_add = []
+
+    for line in result.stdout.strip().split("\n"):
+        if not line:
+            continue
+
+        # Parse status code and filename
+        # Format: "XY filename" where X and Y are status codes
+        # Position 0-1: status codes, position 2: space, position 3+: filename
+        status = line[:2]
+        filename_part = line[3:]  # Don't strip - filename starts at position 3
+
+        # Handle renamed files (format: "old -> new")
+        if status.startswith("R") and " -> " in filename_part:
+            filename_part = filename_part.split(" -> ", 1)[1]
+
+        # Handle quoted filenames (git quotes names with special chars)
+        if filename_part.startswith('"') and filename_part.endswith('"'):
+            # Remove quotes - git uses C-style escaping
+            filename_part = filename_part[1:-1]
+
+        # Check if file is a potential secret
+        filename = Path(filename_part).name
+
+        # Skip secret files (never stage these)
+        if filename in _SECRET_FILES or any(filename.endswith(ext) for ext in _SECRET_EXTENSIONS):
+            logger.warning(f"Skipping potential secret file: {filename_part}")
+            continue
+
+        files_to_add.append(filename_part)
+
+    if not files_to_add:
+        raise RuntimeError(
+            f"No non-secret files to commit for issue #{issue_number}. "
+            "All changes appear to be secret files."
+        )
+
+    # Stage the files
+    run(["git", "add", *files_to_add], cwd=worktree_path)
+
+    # Generate commit message
+    issue = fetch_issue_info(issue_number)
+    commit_msg = f"""feat: Implement #{issue_number}
+
+{issue.title}
+
+Closes #{issue_number}
+
+Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>
+"""
+
+    # Commit
+    run(
+        ["git", "commit", "-m", commit_msg],
+        cwd=worktree_path,
+    )
+
+
+def ensure_pr_created(
+    issue_number: int,
+    branch_name: str,
+    worktree_path: Path,
+    auto_merge: bool = False,
+    status_tracker: StatusTracker | None = None,
+    slot_id: int | None = None,
+) -> int:
+    """Ensure commit is pushed and PR is created (fallback if Claude didn't do it).
+
+    Args:
+        issue_number: Issue number
+        branch_name: Git branch name
+        worktree_path: Path to worktree
+        auto_merge: Whether to enable auto-merge on the PR
+        status_tracker: StatusTracker instance for slot updates (optional)
+        slot_id: Worker slot ID for status updates
+
+    Returns:
+        PR number
+
+    Raises:
+        RuntimeError: If commit doesn't exist or PR creation fails
+
+    """
+
+    def _update_slot(msg: str) -> None:
+        if slot_id is not None and status_tracker is not None:
+            status_tracker.update_slot(slot_id, msg)
+
+    # Check if commit exists
+    _update_slot(f"#{issue_number}: Checking commit")
+    result = run(
+        ["git", "log", "-1", "--oneline"],
+        cwd=worktree_path,
+        capture_output=True,
+    )
+    if not result.stdout.strip():
+        raise RuntimeError(
+            f"No commit found for issue #{issue_number}. Claude did not create any commits."
+        )
+
+    logger.info(f"✓ Commit exists: {result.stdout.strip()[:80]}")
+
+    # Check if branch was pushed, if not push it
+    _update_slot(f"#{issue_number}: Pushing branch")
+    result = run(
+        ["git", "ls-remote", "--heads", "origin", branch_name],
+        cwd=worktree_path,
+        capture_output=True,
+        check=False,
+    )
+    if not result.stdout.strip():
+        logger.warning(f"Branch {branch_name} not pushed, pushing now...")
+        run(["git", "push", "-u", "origin", branch_name], cwd=worktree_path)
+        logger.info(f"✓ Pushed branch {branch_name} to origin")
+    else:
+        logger.info(f"✓ Branch {branch_name} already on origin")
+
+    # Check if PR exists, if not create it
+    _update_slot(f"#{issue_number}: Creating PR")
+    pr_number = None
+    try:
+        result = _gh_call(["pr", "list", "--head", branch_name, "--json", "number", "--limit", "1"])
+        pr_data = json.loads(result.stdout)
+        if pr_data and len(pr_data) > 0:
+            pr_number = cast(int, pr_data[0]["number"])
+            logger.info(f"✓ PR #{pr_number} already exists")
+            return pr_number
+    except Exception as e:  # broad catch: gh CLI + JSON parsing; fallback is to create PR
+        logger.debug(f"Could not find existing PR: {e}")
+
+    # PR doesn't exist, create it
+    logger.warning(f"No PR found for branch {branch_name}, creating one...")
+    pr_number = create_pr(issue_number, branch_name, auto_merge)
+    logger.info(f"✓ Created PR #{pr_number}")
+    return pr_number
+
+
+def create_pr(issue_number: int, branch_name: str, auto_merge: bool = False) -> int:
+    """Create pull request for issue.
+
+    Args:
+        issue_number: Issue number
+        branch_name: Git branch name
+        auto_merge: Whether to enable auto-merge on the PR
+
+    Returns:
+        PR number
+
+    """
+    issue = fetch_issue_info(issue_number)
+
+    pr_title = f"feat: {issue.title}"
+    pr_body = get_pr_description(
+        issue_number=issue_number,
+        summary=f"Implements #{issue_number}",
+        changes="- Automated implementation via Claude Code",
+        testing="- Automated tests included",
+    )
+
+    return gh_pr_create(
+        branch=branch_name,
+        title=pr_title,
+        body=pr_body,
+        auto_merge=auto_merge,
+    )

--- a/scylla/automation/retrospective.py
+++ b/scylla/automation/retrospective.py
@@ -1,0 +1,102 @@
+"""Retrospective lifecycle functions for issue implementation.
+
+Provides:
+- Running /retrospective skill in Claude sessions
+- Checking if retrospective needs re-run
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+from .git_utils import run
+
+logger = logging.getLogger(__name__)
+
+
+def run_retrospective(
+    session_id: str,
+    worktree_path: Path,
+    issue_number: int,
+    state_dir: Path,
+    slot_id: int | None = None,
+) -> bool:
+    """Resume Claude session to run /retrospective.
+
+    Args:
+        session_id: Claude session ID
+        worktree_path: Path to worktree
+        issue_number: Issue number
+        state_dir: Directory for state/log files
+        slot_id: Worker slot ID (unused; kept for interface symmetry)
+
+    Returns:
+        True if retrospective completed successfully, False otherwise
+
+    Runs from worktree directory so Claude can find the session.
+    Output is logged to state_dir/retrospective-{issue_number}.log.
+
+    """
+    state_dir.mkdir(parents=True, exist_ok=True)
+    log_file = state_dir / f"retrospective-{issue_number}.log"
+    try:
+        result = run(
+            [
+                "claude",
+                "--resume",
+                session_id,
+                (
+                    "/skills-registry-commands:retrospective"
+                    " commit the results and create a PR."
+                    " IMPORTANT: Only push skills to ProjectMnemosyne."
+                    " Do NOT create files under .claude-plugin/ in this repo."
+                ),
+                "--print",
+                "--permission-mode",
+                "dontAsk",
+                "--allowedTools",
+                "Read,Write,Edit,Glob,Grep,Bash",
+            ],
+            cwd=worktree_path,
+            timeout=600,  # 10 minutes
+        )
+        # Write output to log file
+        log_file.write_text(result.stdout or "")
+        logger.info(f"Retrospective completed for issue #{issue_number}")
+        logger.info(f"Retrospective log: {log_file}")
+        return True
+    except Exception as e:  # broad catch: external claude process; non-blocking, must not propagate
+        logger.warning(f"Retrospective failed for issue #{issue_number}: {e}")
+
+        # Save failure output to log file
+        error_output = f"FAILED: {e}\n"
+        if hasattr(e, "stdout"):
+            error_output += f"\nSTDOUT:\n{e.stdout or ''}"
+        if hasattr(e, "stderr"):
+            error_output += f"\nSTDERR:\n{e.stderr or ''}"
+        log_file.write_text(error_output)
+
+        # Non-blocking: never re-raise
+        return False
+
+
+def retrospective_needs_rerun(issue_number: int, state_dir: Path) -> bool:
+    """Check if retrospective log indicates failure.
+
+    Args:
+        issue_number: Issue number
+        state_dir: Directory containing retrospective log files
+
+    Returns:
+        True if retrospective needs to be re-run (missing or failed log)
+
+    """
+    log_file = state_dir / f"retrospective-{issue_number}.log"
+    if not log_file.exists():
+        return True
+    try:
+        content = log_file.read_text()
+        return content.startswith("FAILED:")
+    except OSError:
+        return True

--- a/tests/unit/automation/test_follow_up.py
+++ b/tests/unit/automation/test_follow_up.py
@@ -1,0 +1,198 @@
+"""Tests for the follow_up module."""
+
+import json
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+from scylla.automation.follow_up import parse_follow_up_items, run_follow_up_issues
+
+
+class TestParseFollowUpItems:
+    """Tests for parse_follow_up_items."""
+
+    def test_parses_json_in_code_block(self) -> None:
+        """Extracts items from fenced JSON code block."""
+        text = '```json\n[{"title": "T1", "body": "B1", "labels": ["bug"]}]\n```'
+        items = parse_follow_up_items(text)
+        assert len(items) == 1
+        assert items[0]["title"] == "T1"
+        assert items[0]["body"] == "B1"
+        assert items[0]["labels"] == ["bug"]
+
+    def test_parses_bare_json_array(self) -> None:
+        """Extracts items from bare JSON array without code block."""
+        text = 'Some text\n[{"title": "T2", "body": "B2"}]\nmore text'
+        items = parse_follow_up_items(text)
+        assert len(items) == 1
+        assert items[0]["title"] == "T2"
+        assert items[0]["labels"] == []  # default
+
+    def test_returns_empty_on_no_json(self) -> None:
+        """Returns empty list when no JSON array found."""
+        items = parse_follow_up_items("No JSON here.")
+        assert items == []
+
+    def test_caps_at_five_items(self) -> None:
+        """Caps returned items at 5 even if more are present."""
+        raw = json.dumps([{"title": f"T{i}", "body": f"B{i}"} for i in range(10)])
+        items = parse_follow_up_items(raw)
+        assert len(items) == 5
+
+    def test_skips_items_missing_required_fields(self) -> None:
+        """Skips items without title or body."""
+        raw = json.dumps(
+            [
+                {"title": "Good", "body": "Body"},
+                {"title": "Missing body"},
+                {"body": "Missing title"},
+            ]
+        )
+        items = parse_follow_up_items(raw)
+        assert len(items) == 1
+        assert items[0]["title"] == "Good"
+
+    def test_skips_non_dict_items(self) -> None:
+        """Skips non-dict entries in the array."""
+        raw = json.dumps(
+            [
+                {"title": "T1", "body": "B1"},
+                "not a dict",
+                42,
+            ]
+        )
+        items = parse_follow_up_items(raw)
+        assert len(items) == 1
+
+    def test_ensures_labels_is_list(self) -> None:
+        """Sets labels to [] when missing or not a list."""
+        raw = json.dumps(
+            [
+                {"title": "T1", "body": "B1", "labels": "not-a-list"},
+            ]
+        )
+        items = parse_follow_up_items(raw)
+        assert items[0]["labels"] == []
+
+    def test_returns_empty_on_invalid_json(self) -> None:
+        """Returns empty list on malformed JSON."""
+        items = parse_follow_up_items("[{bad json")
+        assert items == []
+
+    def test_returns_empty_when_root_not_array(self) -> None:
+        """Returns empty list when JSON root is not an array."""
+        items = parse_follow_up_items('{"key": "value"}')
+        assert items == []
+
+
+class TestRunFollowUpIssues:
+    """Tests for run_follow_up_issues."""
+
+    def _make_claude_output(self, items: list[dict[str, Any]]) -> str:
+        """Build fake JSON claude output with follow-up items."""
+        return json.dumps({"result": json.dumps(items)})
+
+    def test_creates_issues_and_posts_summary(self, tmp_path: Path) -> None:
+        """Creates follow-up issues and posts a summary comment."""
+        worktree_path = tmp_path / "worktree"
+        worktree_path.mkdir()
+
+        items = [
+            {"title": "Follow 1", "body": "Body 1", "labels": []},
+            {"title": "Follow 2", "body": "Body 2", "labels": []},
+        ]
+        mock_result = MagicMock()
+        mock_result.stdout = self._make_claude_output(items)
+
+        with (
+            patch("scylla.automation.follow_up.run", return_value=mock_result),
+            patch(
+                "scylla.automation.follow_up.gh_issue_create", side_effect=[101, 102]
+            ) as mock_create,
+            patch("scylla.automation.follow_up.gh_issue_comment") as mock_comment,
+            patch("scylla.automation.follow_up.time.sleep"),
+        ):
+            run_follow_up_issues("sess", worktree_path, 42, tmp_path)
+
+        assert mock_create.call_count == 2
+        mock_comment.assert_called_once()
+        comment_body = mock_comment.call_args[0][1]
+        assert "#101" in comment_body
+        assert "#102" in comment_body
+
+    def test_no_items_skips_issue_creation(self, tmp_path: Path) -> None:
+        """Does nothing when no items are identified."""
+        worktree_path = tmp_path / "worktree"
+        worktree_path.mkdir()
+
+        mock_result = MagicMock()
+        mock_result.stdout = json.dumps({"result": "No follow-ups needed."})
+
+        with (
+            patch("scylla.automation.follow_up.run", return_value=mock_result),
+            patch("scylla.automation.follow_up.gh_issue_create") as mock_create,
+        ):
+            run_follow_up_issues("sess", worktree_path, 42, tmp_path)
+
+        mock_create.assert_not_called()
+
+    def test_failure_writes_log_and_does_not_raise(self, tmp_path: Path) -> None:
+        """On failure, writes FAILED log and does not propagate exception."""
+        worktree_path = tmp_path / "worktree"
+        worktree_path.mkdir()
+
+        with patch("scylla.automation.follow_up.run", side_effect=RuntimeError("claude failed")):
+            # Should not raise
+            run_follow_up_issues("sess", worktree_path, 42, tmp_path)
+
+        log_file = tmp_path / "follow-up-42.log"
+        assert log_file.exists()
+        assert log_file.read_text().startswith("FAILED:")
+
+    def test_cleans_up_prompt_file_on_success(self, tmp_path: Path) -> None:
+        """Prompt file is removed after successful run."""
+        worktree_path = tmp_path / "worktree"
+        worktree_path.mkdir()
+
+        mock_result = MagicMock()
+        mock_result.stdout = json.dumps({"result": "[]"})
+
+        with (
+            patch("scylla.automation.follow_up.run", return_value=mock_result),
+            patch("scylla.automation.follow_up.time.sleep"),
+        ):
+            run_follow_up_issues("sess", worktree_path, 42, tmp_path)
+
+        prompt_file = worktree_path / ".claude-followup-42.md"
+        assert not prompt_file.exists()
+
+    def test_cleans_up_prompt_file_on_failure(self, tmp_path: Path) -> None:
+        """Prompt file is removed even after failure."""
+        worktree_path = tmp_path / "worktree"
+        worktree_path.mkdir()
+
+        with patch("scylla.automation.follow_up.run", side_effect=RuntimeError("fail")):
+            run_follow_up_issues("sess", worktree_path, 42, tmp_path)
+
+        prompt_file = worktree_path / ".claude-followup-42.md"
+        assert not prompt_file.exists()
+
+    def test_status_tracker_updated_per_item(self, tmp_path: Path) -> None:
+        """Status tracker is called for each item when slot_id is provided."""
+        worktree_path = tmp_path / "worktree"
+        worktree_path.mkdir()
+
+        items = [{"title": "T1", "body": "B1", "labels": []}]
+        mock_result = MagicMock()
+        mock_result.stdout = self._make_claude_output(items)
+        mock_tracker = MagicMock()
+
+        with (
+            patch("scylla.automation.follow_up.run", return_value=mock_result),
+            patch("scylla.automation.follow_up.gh_issue_create", return_value=201),
+            patch("scylla.automation.follow_up.gh_issue_comment"),
+            patch("scylla.automation.follow_up.time.sleep"),
+        ):
+            run_follow_up_issues("sess", worktree_path, 42, tmp_path, mock_tracker, slot_id=1)
+
+        mock_tracker.update_slot.assert_called_once_with(1, "#42: Creating follow-up 1/1")

--- a/tests/unit/automation/test_implementer.py
+++ b/tests/unit/automation/test_implementer.py
@@ -246,8 +246,8 @@ class TestRunRetrospective:
         implementer.state_dir.mkdir(exist_ok=True)
 
         with (
-            patch("scylla.automation.implementer.run") as mock_run,
-            patch("scylla.automation.implementer.logger") as mock_logger,
+            patch("scylla.automation.retrospective.run") as mock_run,
+            patch("scylla.automation.retrospective.logger") as mock_logger,
         ):
             # Mock successful run with stdout
             mock_run.return_value = MagicMock(stdout="Retrospective output")
@@ -295,8 +295,8 @@ class TestRunRetrospective:
         implementer.state_dir = tmp_path
 
         with (
-            patch("scylla.automation.implementer.run") as mock_run,
-            patch("scylla.automation.implementer.logger") as mock_logger,
+            patch("scylla.automation.retrospective.run") as mock_run,
+            patch("scylla.automation.retrospective.logger") as mock_logger,
         ):
             mock_run.side_effect = RuntimeError("Claude error")
 
@@ -320,8 +320,8 @@ class TestRunRetrospective:
         implementer.state_dir = tmp_path
 
         with (
-            patch("scylla.automation.implementer.run") as mock_run,
-            patch("scylla.automation.implementer.logger") as mock_logger,
+            patch("scylla.automation.retrospective.run") as mock_run,
+            patch("scylla.automation.retrospective.logger") as mock_logger,
         ):
             mock_run.side_effect = subprocess.TimeoutExpired("claude", 600)
 
@@ -346,8 +346,8 @@ class TestRunRetrospective:
         implementer.state_dir.mkdir(exist_ok=True)
 
         with (
-            patch("scylla.automation.implementer.run") as mock_run,
-            patch("scylla.automation.implementer.logger"),
+            patch("scylla.automation.retrospective.run") as mock_run,
+            patch("scylla.automation.retrospective.logger"),
         ):
             error = subprocess.CalledProcessError(
                 returncode=1,
@@ -692,10 +692,10 @@ class TestRunFollowUpIssues:
         )
 
         with (
-            patch("scylla.automation.implementer.run") as mock_run,
-            patch("scylla.automation.implementer.gh_issue_create") as mock_create,
-            patch("scylla.automation.implementer.gh_issue_comment") as mock_comment,
-            patch("scylla.automation.implementer.time.sleep"),
+            patch("scylla.automation.follow_up.run") as mock_run,
+            patch("scylla.automation.follow_up.gh_issue_create") as mock_create,
+            patch("scylla.automation.follow_up.gh_issue_comment") as mock_comment,
+            patch("scylla.automation.follow_up.time.sleep"),
         ):
             mock_run.return_value = mock_result
             mock_create.return_value = 456
@@ -717,9 +717,9 @@ class TestRunFollowUpIssues:
         mock_result.stdout = json.dumps({"result": "[]"})
 
         with (
-            patch("scylla.automation.implementer.run") as mock_run,
-            patch("scylla.automation.implementer.gh_issue_create") as mock_create,
-            patch("scylla.automation.implementer.logger") as mock_logger,
+            patch("scylla.automation.follow_up.run") as mock_run,
+            patch("scylla.automation.follow_up.gh_issue_create") as mock_create,
+            patch("scylla.automation.follow_up.logger") as mock_logger,
         ):
             mock_run.return_value = mock_result
 
@@ -735,8 +735,8 @@ class TestRunFollowUpIssues:
         implementer.state_dir = tmp_path
 
         with (
-            patch("scylla.automation.implementer.run") as mock_run,
-            patch("scylla.automation.implementer.logger") as mock_logger,
+            patch("scylla.automation.follow_up.run") as mock_run,
+            patch("scylla.automation.follow_up.logger") as mock_logger,
         ):
             mock_run.side_effect = subprocess.TimeoutExpired("claude", 600)
 
@@ -760,10 +760,10 @@ class TestRunFollowUpIssues:
         )
 
         with (
-            patch("scylla.automation.implementer.run") as mock_run,
-            patch("scylla.automation.implementer.gh_issue_create") as mock_create,
-            patch("scylla.automation.implementer.gh_issue_comment") as mock_comment,
-            patch("scylla.automation.implementer.time.sleep"),
+            patch("scylla.automation.follow_up.run") as mock_run,
+            patch("scylla.automation.follow_up.gh_issue_create") as mock_create,
+            patch("scylla.automation.follow_up.gh_issue_comment") as mock_comment,
+            patch("scylla.automation.follow_up.time.sleep"),
         ):
             mock_run.return_value = mock_result
             # First succeeds, second fails
@@ -788,10 +788,10 @@ class TestRunFollowUpIssues:
         )
 
         with (
-            patch("scylla.automation.implementer.run") as mock_run,
-            patch("scylla.automation.implementer.gh_issue_create", return_value=999),
-            patch("scylla.automation.implementer.gh_issue_comment"),
-            patch("scylla.automation.implementer.time.sleep"),
+            patch("scylla.automation.follow_up.run") as mock_run,
+            patch("scylla.automation.follow_up.gh_issue_create", return_value=999),
+            patch("scylla.automation.follow_up.gh_issue_comment"),
+            patch("scylla.automation.follow_up.time.sleep"),
         ):
             mock_run.return_value = mock_result
 
@@ -810,8 +810,8 @@ class TestRunFollowUpIssues:
         implementer.state_dir.mkdir(exist_ok=True)
 
         with (
-            patch("scylla.automation.implementer.run") as mock_run,
-            patch("scylla.automation.implementer.logger"),
+            patch("scylla.automation.follow_up.run") as mock_run,
+            patch("scylla.automation.follow_up.logger"),
         ):
             error = subprocess.CalledProcessError(
                 returncode=1,

--- a/tests/unit/automation/test_pr_manager.py
+++ b/tests/unit/automation/test_pr_manager.py
@@ -1,0 +1,265 @@
+"""Tests for the pr_manager module."""
+
+import json
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from scylla.automation.pr_manager import commit_changes, create_pr, ensure_pr_created
+
+
+class TestCommitChanges:
+    """Tests for commit_changes."""
+
+    def test_raises_on_no_changes(self, tmp_path: Path) -> None:
+        """Raises RuntimeError when git status shows no changes."""
+        mock_result = MagicMock()
+        mock_result.stdout = ""
+
+        with patch("scylla.automation.pr_manager.run", return_value=mock_result):
+            with pytest.raises(RuntimeError, match="No changes to commit"):
+                commit_changes(42, tmp_path)
+
+    def test_stages_and_commits_clean_files(self, tmp_path: Path) -> None:
+        """Stages files and creates commit for clean (non-secret) files."""
+        status_result = MagicMock()
+        status_result.stdout = "M  README.md\nA  new_file.py\n"
+
+        commit_result = MagicMock()
+        commit_result.stdout = ""
+
+        mock_issue = MagicMock()
+        mock_issue.title = "Fix something"
+
+        with (
+            patch(
+                "scylla.automation.pr_manager.run",
+                side_effect=[status_result, MagicMock(), commit_result],
+            ) as mock_run,
+            patch("scylla.automation.pr_manager.fetch_issue_info", return_value=mock_issue),
+        ):
+            commit_changes(42, tmp_path)
+
+        # Second call is git add, third is git commit
+        add_call = mock_run.call_args_list[1]
+        assert "git" in add_call[0][0]
+        assert "add" in add_call[0][0]
+        assert "README.md" in add_call[0][0]
+        assert "new_file.py" in add_call[0][0]
+
+    def test_skips_secret_files(self, tmp_path: Path) -> None:
+        """Skips known secret filenames when staging."""
+        status_result = MagicMock()
+        status_result.stdout = "M  .env\nM  id_rsa\nA  safe_file.py\n"
+
+        mock_issue = MagicMock()
+        mock_issue.title = "Fix something"
+
+        with (
+            patch(
+                "scylla.automation.pr_manager.run",
+                side_effect=[status_result, MagicMock(), MagicMock()],
+            ) as mock_run,
+            patch("scylla.automation.pr_manager.fetch_issue_info", return_value=mock_issue),
+        ):
+            commit_changes(42, tmp_path)
+
+        add_call = mock_run.call_args_list[1]
+        assert ".env" not in add_call[0][0]
+        assert "id_rsa" not in add_call[0][0]
+        assert "safe_file.py" in add_call[0][0]
+
+    def test_skips_secret_extensions(self, tmp_path: Path) -> None:
+        """Skips files with secret extensions (.pem, .key, etc.)."""
+        status_result = MagicMock()
+        status_result.stdout = "A  cert.pem\nA  key.key\nA  app.py\n"
+
+        mock_issue = MagicMock()
+        mock_issue.title = "Add certs"
+
+        with (
+            patch(
+                "scylla.automation.pr_manager.run",
+                side_effect=[status_result, MagicMock(), MagicMock()],
+            ) as mock_run,
+            patch("scylla.automation.pr_manager.fetch_issue_info", return_value=mock_issue),
+        ):
+            commit_changes(42, tmp_path)
+
+        add_call = mock_run.call_args_list[1]
+        assert "cert.pem" not in add_call[0][0]
+        assert "key.key" not in add_call[0][0]
+        assert "app.py" in add_call[0][0]
+
+    def test_raises_when_all_files_are_secrets(self, tmp_path: Path) -> None:
+        """Raises RuntimeError when all changed files are secret files."""
+        status_result = MagicMock()
+        status_result.stdout = "M  .env\nM  credentials.json\n"
+
+        with patch("scylla.automation.pr_manager.run", return_value=status_result):
+            with pytest.raises(RuntimeError, match="No non-secret files"):
+                commit_changes(42, tmp_path)
+
+    def test_handles_renamed_files(self, tmp_path: Path) -> None:
+        """Correctly parses renamed files (R  old -> new format)."""
+        status_result = MagicMock()
+        status_result.stdout = "R  old_name.py -> new_name.py\n"
+
+        mock_issue = MagicMock()
+        mock_issue.title = "Rename file"
+
+        with (
+            patch(
+                "scylla.automation.pr_manager.run",
+                side_effect=[status_result, MagicMock(), MagicMock()],
+            ) as mock_run,
+            patch("scylla.automation.pr_manager.fetch_issue_info", return_value=mock_issue),
+        ):
+            commit_changes(42, tmp_path)
+
+        add_call = mock_run.call_args_list[1]
+        assert "new_name.py" in add_call[0][0]
+        assert "old_name.py" not in add_call[0][0]
+
+
+class TestEnsurePrCreated:
+    """Tests for ensure_pr_created."""
+
+    def test_returns_existing_pr_number(self, tmp_path: Path) -> None:
+        """Returns existing PR number when PR already exists."""
+        log_result = MagicMock()
+        log_result.stdout = "abc1234 feat: implement"
+
+        remote_result = MagicMock()
+        remote_result.stdout = "abc1234\trefs/heads/branch"
+
+        pr_list_result = MagicMock()
+        pr_list_result.stdout = json.dumps([{"number": 99}])
+
+        with (
+            patch(
+                "scylla.automation.pr_manager.run",
+                side_effect=[log_result, remote_result],
+            ),
+            patch("scylla.automation.pr_manager._gh_call", return_value=pr_list_result),
+        ):
+            pr_num = ensure_pr_created(42, "42-branch", tmp_path)
+
+        assert pr_num == 99
+
+    def test_creates_pr_when_none_exists(self, tmp_path: Path) -> None:
+        """Creates a new PR when no existing PR is found."""
+        log_result = MagicMock()
+        log_result.stdout = "abc1234 feat: implement"
+
+        remote_result = MagicMock()
+        remote_result.stdout = "abc1234\trefs/heads/branch"
+
+        pr_list_result = MagicMock()
+        pr_list_result.stdout = json.dumps([])
+
+        mock_issue = MagicMock()
+        mock_issue.title = "Fix thing"
+
+        with (
+            patch(
+                "scylla.automation.pr_manager.run",
+                side_effect=[log_result, remote_result],
+            ),
+            patch("scylla.automation.pr_manager._gh_call", return_value=pr_list_result),
+            patch("scylla.automation.pr_manager.fetch_issue_info", return_value=mock_issue),
+            patch("scylla.automation.pr_manager.gh_pr_create", return_value=55),
+        ):
+            pr_num = ensure_pr_created(42, "42-branch", tmp_path)
+
+        assert pr_num == 55
+
+    def test_raises_when_no_commit_exists(self, tmp_path: Path) -> None:
+        """Raises RuntimeError when git log shows no commits."""
+        log_result = MagicMock()
+        log_result.stdout = ""
+
+        with patch("scylla.automation.pr_manager.run", return_value=log_result):
+            with pytest.raises(RuntimeError, match="No commit found"):
+                ensure_pr_created(42, "42-branch", tmp_path)
+
+    def test_pushes_branch_when_not_on_remote(self, tmp_path: Path) -> None:
+        """Pushes branch when it is not yet on remote."""
+        log_result = MagicMock()
+        log_result.stdout = "abc1234 feat: implement"
+
+        remote_result = MagicMock()
+        remote_result.stdout = ""  # Not on remote
+
+        push_result = MagicMock()
+        pr_list_result = MagicMock()
+        pr_list_result.stdout = json.dumps([{"number": 77}])
+
+        with (
+            patch(
+                "scylla.automation.pr_manager.run",
+                side_effect=[log_result, remote_result, push_result],
+            ),
+            patch("scylla.automation.pr_manager._gh_call", return_value=pr_list_result),
+        ):
+            pr_num = ensure_pr_created(42, "42-branch", tmp_path)
+
+        assert pr_num == 77
+
+    def test_status_tracker_updated(self, tmp_path: Path) -> None:
+        """Status tracker is updated when slot_id is provided."""
+        log_result = MagicMock()
+        log_result.stdout = "abc1234 feat: implement"
+
+        remote_result = MagicMock()
+        remote_result.stdout = "abc1234\trefs/heads/branch"
+
+        pr_list_result = MagicMock()
+        pr_list_result.stdout = json.dumps([{"number": 88}])
+
+        mock_tracker = MagicMock()
+
+        with (
+            patch(
+                "scylla.automation.pr_manager.run",
+                side_effect=[log_result, remote_result],
+            ),
+            patch("scylla.automation.pr_manager._gh_call", return_value=pr_list_result),
+        ):
+            ensure_pr_created(42, "42-branch", tmp_path, status_tracker=mock_tracker, slot_id=2)
+
+        assert mock_tracker.update_slot.call_count >= 2
+
+
+class TestCreatePr:
+    """Tests for create_pr."""
+
+    def test_creates_pr_with_correct_title(self) -> None:
+        """Creates PR with title derived from issue title."""
+        mock_issue = MagicMock()
+        mock_issue.title = "Add new feature"
+
+        with (
+            patch("scylla.automation.pr_manager.fetch_issue_info", return_value=mock_issue),
+            patch("scylla.automation.pr_manager.gh_pr_create", return_value=123) as mock_create,
+        ):
+            pr_num = create_pr(42, "42-branch")
+
+        assert pr_num == 123
+        call_kwargs = mock_create.call_args[1]
+        assert "Add new feature" in call_kwargs["title"]
+
+    def test_passes_auto_merge_flag(self) -> None:
+        """Passes auto_merge flag to gh_pr_create."""
+        mock_issue = MagicMock()
+        mock_issue.title = "Fix bug"
+
+        with (
+            patch("scylla.automation.pr_manager.fetch_issue_info", return_value=mock_issue),
+            patch("scylla.automation.pr_manager.gh_pr_create", return_value=99) as mock_create,
+        ):
+            create_pr(42, "42-branch", auto_merge=True)
+
+        call_kwargs = mock_create.call_args[1]
+        assert call_kwargs["auto_merge"] is True

--- a/tests/unit/automation/test_retrospective.py
+++ b/tests/unit/automation/test_retrospective.py
@@ -1,0 +1,104 @@
+"""Tests for the retrospective module."""
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from scylla.automation.retrospective import retrospective_needs_rerun, run_retrospective
+
+
+class TestRetrospectiveNeedsRerun:
+    """Tests for retrospective_needs_rerun."""
+
+    def test_missing_log_returns_true(self, tmp_path: Path) -> None:
+        """Returns True when log file doesn't exist."""
+        assert retrospective_needs_rerun(42, tmp_path) is True
+
+    def test_failed_log_returns_true(self, tmp_path: Path) -> None:
+        """Returns True when log file starts with FAILED:."""
+        log_file = tmp_path / "retrospective-42.log"
+        log_file.write_text("FAILED: something went wrong\nmore output")
+        assert retrospective_needs_rerun(42, tmp_path) is True
+
+    def test_successful_log_returns_false(self, tmp_path: Path) -> None:
+        """Returns False when log file has successful content."""
+        log_file = tmp_path / "retrospective-42.log"
+        log_file.write_text("Retrospective completed successfully.")
+        assert retrospective_needs_rerun(42, tmp_path) is False
+
+    def test_empty_log_returns_false(self, tmp_path: Path) -> None:
+        """Returns False for an empty log file (not failed)."""
+        log_file = tmp_path / "retrospective-42.log"
+        log_file.write_text("")
+        assert retrospective_needs_rerun(42, tmp_path) is False
+
+    def test_unreadable_log_returns_true(self, tmp_path: Path) -> None:
+        """Returns True when log file cannot be read."""
+        log_file = tmp_path / "retrospective-42.log"
+        log_file.write_text("content")
+        log_file.chmod(0o000)
+        try:
+            assert retrospective_needs_rerun(42, tmp_path) is True
+        finally:
+            log_file.chmod(0o644)
+
+
+class TestRunRetrospective:
+    """Tests for run_retrospective."""
+
+    def test_success_writes_log_and_returns_true(self, tmp_path: Path) -> None:
+        """Returns True and writes log on successful claude run."""
+        worktree_path = tmp_path / "worktree"
+        worktree_path.mkdir()
+
+        mock_result = MagicMock()
+        mock_result.stdout = "Retrospective complete. PR created."
+
+        with patch("scylla.automation.retrospective.run", return_value=mock_result):
+            result = run_retrospective("session-abc", worktree_path, 42, tmp_path)
+
+        assert result is True
+        log_file = tmp_path / "retrospective-42.log"
+        assert log_file.exists()
+        assert log_file.read_text() == "Retrospective complete. PR created."
+
+    def test_failure_writes_failed_log_and_returns_false(self, tmp_path: Path) -> None:
+        """Returns False and writes FAILED: log on exception."""
+        worktree_path = tmp_path / "worktree"
+        worktree_path.mkdir()
+
+        with patch(
+            "scylla.automation.retrospective.run", side_effect=RuntimeError("claude crashed")
+        ):
+            result = run_retrospective("session-abc", worktree_path, 42, tmp_path)
+
+        assert result is False
+        log_file = tmp_path / "retrospective-42.log"
+        assert log_file.exists()
+        assert log_file.read_text().startswith("FAILED:")
+
+    def test_creates_state_dir_if_missing(self, tmp_path: Path) -> None:
+        """Creates state_dir if it does not exist."""
+        state_dir = tmp_path / "nested" / "state"
+        worktree_path = tmp_path / "worktree"
+        worktree_path.mkdir()
+
+        mock_result = MagicMock()
+        mock_result.stdout = "done"
+
+        with patch("scylla.automation.retrospective.run", return_value=mock_result):
+            run_retrospective("session-abc", worktree_path, 42, state_dir)
+
+        assert state_dir.exists()
+
+    def test_slot_id_accepted(self, tmp_path: Path) -> None:
+        """slot_id parameter is accepted without error."""
+        worktree_path = tmp_path / "worktree"
+        worktree_path.mkdir()
+
+        mock_result = MagicMock()
+        mock_result.stdout = "done"
+
+        with patch("scylla.automation.retrospective.run", return_value=mock_result):
+            result = run_retrospective("session-abc", worktree_path, 42, tmp_path, slot_id=3)
+
+        assert result is True


### PR DESCRIPTION
## Summary

- Extracted 3 cohesive method clusters from `IssueImplementer` into dedicated modules, reducing `scylla/automation/implementer.py` from **1,221 → 837 lines**
- Created `scylla/automation/retrospective.py`: `run_retrospective()`, `retrospective_needs_rerun()`
- Created `scylla/automation/follow_up.py`: `run_follow_up_issues()`, `parse_follow_up_items()`
- Created `scylla/automation/pr_manager.py`: `ensure_pr_created()`, `create_pr()`, `commit_changes()`
- `IssueImplementer` retains thin delegation wrappers — no public interface changes
- Updated 10 existing tests in `test_implementer.py` to patch correct module paths
- Added 37 new unit tests across 3 new test files

## Test plan

- [x] All 336 `tests/unit/automation/` tests pass
- [x] Full unit suite (4363 tests) passes at 75.56% coverage
- [x] Pre-commit passes (ruff, mypy, all hooks)
- [x] Smoke imports: `IssueImplementer`, `run_retrospective`, `parse_follow_up_items`, `commit_changes`

Closes #1395

🤖 Generated with [Claude Code](https://claude.com/claude-code)