### PR TITLE
fix(manage_experiment): skip null result_dir entries in --max-subtests expansion check

### DIFF
--- a/scripts/manage_experiment.py
+++ b/scripts/manage_experiment.py
@@ -611,21 +611,22 @@ def _run_batch(test_dirs: list[Path], args: argparse.Namespace) -> int:  # noqa:
                     # has fewer subtests than requested. If so, re-run to expand.
                     if args.max_subtests is not None:
                         result_dir = r.get("result_dir")
-                        if result_dir:
-                            cp_path = Path(result_dir) / "checkpoint.json"
-                            try:
-                                with open(cp_path) as cp_f:
-                                    cp = json.load(cp_f)
-                                subtest_states = cp.get("subtest_states", {})
-                                needs_expansion = False
-                                for tier_subtests in subtest_states.values():
-                                    if len(tier_subtests) < args.max_subtests:
-                                        needs_expansion = True
-                                        break
-                                if needs_expansion:
-                                    continue
-                            except Exception:
-                                pass
+                        if not result_dir:
+                            continue  # Cannot verify subtest count; don't mark completed
+                        cp_path = Path(result_dir) / "checkpoint.json"
+                        try:
+                            with open(cp_path) as cp_f:
+                                cp = json.load(cp_f)
+                            subtest_states = cp.get("subtest_states", {})
+                            needs_expansion = False
+                            for tier_subtests in subtest_states.values():
+                                if len(tier_subtests) < args.max_subtests:
+                                    needs_expansion = True
+                                    break
+                            if needs_expansion:
+                                continue
+                        except Exception:
+                            pass
                     completed_ids.add(r["test_id"])
             except Exception:
                 pass


### PR DESCRIPTION
## Summary

- `batch_summary.json` can contain entries with `result_dir: null` from previous reruns
- The previous code only entered the subtest-expansion check when `result_dir` was truthy, so null entries fell through and unconditionally added the test_id to `completed_ids`
- This overrode any earlier correct "needs expansion" decision from a valid entry, causing "All tests already completed" when reruns with a higher `--max-subtests` were attempted

## Fix

When `result_dir` is `None`, `continue` immediately — a null entry cannot be verified for subtest count and must never count as completed.

Closes #(the related issue if any)

## Test plan
- [ ] Run experiment with lower `--max-subtests`, then re-run with higher value; confirm tests proceed rather than reporting "All tests already completed"
- [ ] Existing test suite: `pixi run python -m pytest tests/ -k "manage_experiment or batch" -v`

🤖 Generated with [Claude Code](https://claude.com/claude-code)