### PR TITLE
[feat] Annotate all test functions in tests/unit/ for mypy compliance

### DIFF
--- a/pixi.lock
+++ b/pixi.lock
@@ -3786,7 +3786,7 @@ packages:
 - pypi: ./
   name: scylla
   version: 0.1.0
-  sha256: 01290b3a609a8308a4d6f7c4cae3a808e03932e24515422aa590d870e4cf9910
+  sha256: 85225c24fb61a808040dbbe59ab41208c8edc3635411d82225db5c66765927a4
   requires_dist:
   - click>=8.0
   - pydantic>=2.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -130,13 +130,6 @@ warn_unused_ignores = true
 allow_redefinition = false
 implicit_reexport = false
 
-# tests/unit/ has 635 unannotated test functions — suppress no-untyped-def
-# until they are annotated in a follow-up issue
-[[tool.mypy.overrides]]
-module = "tests.unit.*"
-disable_error_code = ["no-untyped-def"]
-
-
 [tool.coverage.run]
 branch = true
 source = ["scylla", "scripts"]

--- a/tests/unit/adapters/test_base.py
+++ b/tests/unit/adapters/test_base.py
@@ -2,6 +2,7 @@
 
 from pathlib import Path
 from tempfile import TemporaryDirectory
+from typing import Any
 from unittest.mock import MagicMock
 
 import pytest
@@ -19,7 +20,7 @@ from scylla.adapters.base import (
 class ConcreteAdapter(BaseAdapter):
     """Concrete implementation for testing."""
 
-    def run(self, config: AdapterConfig, tier_config: object = None) -> AdapterResult:
+    def run(self, config: AdapterConfig, tier_config: Any = None) -> AdapterResult:
         """Return success result."""
         return AdapterResult(exit_code=0, stdout="success", stderr="")
 

--- a/tests/unit/adapters/test_base_cli_adapter.py
+++ b/tests/unit/adapters/test_base_cli_adapter.py
@@ -2,6 +2,7 @@
 
 import subprocess
 from pathlib import Path
+from typing import Any
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -16,7 +17,7 @@ class TestCliAdapter(BaseCliAdapter):
     CLI_EXECUTABLE = "test-cli"
     _api_call_fallback_pattern = r"test_pattern"
 
-    def _build_command(self, config: AdapterConfig, prompt: str, tier_config) -> list[str]:
+    def _build_command(self, config: AdapterConfig, prompt: str, tier_config: Any) -> list[str]:
         """Build test command."""
         return [self.CLI_EXECUTABLE, "--model", config.model, prompt]
 
@@ -248,7 +249,9 @@ class TestAbstractMethods:
         class IncompleteAdapter(BaseCliAdapter):
             CLI_EXECUTABLE = "incomplete"
 
-            def _build_command(self, config: AdapterConfig, prompt: str, tier_config) -> list[str]:
+            def _build_command(
+                self, config: AdapterConfig, prompt: str, tier_config: Any
+            ) -> list[str]:
                 return ["cmd"]
 
         with pytest.raises(TypeError):

--- a/tests/unit/analysis/conftest.py
+++ b/tests/unit/analysis/conftest.py
@@ -1,7 +1,9 @@
 """Shared fixtures for analysis tests."""
 
 import sys
+from collections.abc import Generator
 from pathlib import Path
+from typing import Any
 from unittest.mock import patch
 
 import numpy as np
@@ -17,7 +19,7 @@ if _scripts_dir not in sys.path:
 
 
 @pytest.fixture(autouse=True)
-def mock_power_simulations():
+def mock_power_simulations() -> Generator[Any, None, None]:
     """Mock expensive Monte Carlo simulations to prevent test hangs.
 
     mann_whitney_power() and kruskal_wallis_power() each run 10,000 simulations
@@ -42,7 +44,7 @@ def mock_power_simulations():
 
 
 @pytest.fixture
-def sample_runs_df():
+def sample_runs_df() -> Any:
     """Sample runs DataFrame for testing (~140 rows).
 
     Covers 2 models, 7 tiers (T0-T6), 2 subtests, 5 runs per combination.
@@ -135,7 +137,7 @@ def sample_runs_df():
 
 
 @pytest.fixture
-def sample_judges_df(sample_runs_df):
+def sample_judges_df(sample_runs_df: Any) -> Any:
     """Sample judges DataFrame (3 judges per run)."""
     np.random.seed(42)
     data = []
@@ -191,7 +193,7 @@ def sample_judges_df(sample_runs_df):
 
 
 @pytest.fixture
-def sample_criteria_df(sample_judges_df):
+def sample_criteria_df(sample_judges_df: Any) -> Any:
     """Sample criteria DataFrame (5 criteria per judge)."""
     np.random.seed(42)
     data = []
@@ -232,14 +234,14 @@ def sample_criteria_df(sample_judges_df):
 
 
 @pytest.fixture
-def sample_subtests_df(sample_runs_df):
+def sample_subtests_df(sample_runs_df: Any) -> Any:
     """Sample subtests DataFrame matching production build_subtests_df schema.
 
     Must match columns produced by dataframes.build_subtests_df().
     """
     from scylla.analysis.stats import compute_consistency, compute_cop
 
-    def compute_subtest_stats(group):
+    def compute_subtest_stats(group: Any) -> Any:
         """Compute statistics for a subtest group (matches production)."""
         pass_rate = group["passed"].mean()
         mean_score = group["score"].mean()
@@ -342,31 +344,31 @@ def sample_subtests_df(sample_runs_df):
 
 # Degenerate input fixtures for edge case testing
 @pytest.fixture
-def degenerate_single_element():
+def degenerate_single_element() -> Any:
     """Single-element array for testing n=1 edge cases."""
     return np.array([0.5])
 
 
 @pytest.fixture
-def degenerate_all_same():
+def degenerate_all_same() -> Any:
     """Array with all identical values for testing zero variance."""
     return np.array([0.7, 0.7, 0.7, 0.7, 0.7])
 
 
 @pytest.fixture
-def degenerate_all_pass():
+def degenerate_all_pass() -> Any:
     """Array with all passing (1) values."""
     return np.array([1, 1, 1, 1, 1])
 
 
 @pytest.fixture
-def degenerate_all_fail():
+def degenerate_all_fail() -> Any:
     """Array with all failing (0) values."""
     return np.array([0, 0, 0, 0, 0])
 
 
 @pytest.fixture
-def degenerate_unbalanced_groups():
+def degenerate_unbalanced_groups() -> Any:
     """Two groups with severely unbalanced sizes (n1=2, n2=50)."""
     return {
         "small": np.array([0.3, 0.4]),
@@ -375,42 +377,42 @@ def degenerate_unbalanced_groups():
 
 
 @pytest.fixture
-def degenerate_empty_array():
+def degenerate_empty_array() -> Any:
     """Empty array for testing n=0 edge cases."""
     return np.array([])
 
 
 @pytest.fixture
-def degenerate_nan_values():
+def degenerate_nan_values() -> Any:
     """Array containing NaN values for testing missing data handling."""
     return np.array([0.5, np.nan, 0.7, np.nan, 0.9])
 
 
 @pytest.fixture
-def degenerate_inf_values():
+def degenerate_inf_values() -> Any:
     """Array containing infinite values for testing boundary conditions."""
     return np.array([0.5, 0.7, np.inf, 0.9, -np.inf])
 
 
 @pytest.fixture
-def degenerate_binary_data():
+def degenerate_binary_data() -> Any:
     """Binary (0/1) data for testing categorical/boolean edge cases."""
     return np.array([0, 1, 0, 1, 1, 0, 0, 1])
 
 
 @pytest.fixture
-def degenerate_boundary_values():
+def degenerate_boundary_values() -> Any:
     """Return data at exact boundaries (0.0, 1.0) for testing threshold logic."""
     return np.array([0.0, 0.0, 1.0, 1.0, 0.5])
 
 
 @pytest.fixture
-def degenerate_near_zero():
+def degenerate_near_zero() -> Any:
     """Very small positive values for testing numerical stability."""
     return np.array([1e-10, 1e-9, 1e-8, 1e-7, 1e-6])
 
 
 @pytest.fixture
-def degenerate_high_variance():
+def degenerate_high_variance() -> Any:
     """Return data with extremely high variance for testing statistical robustness."""
     return np.array([0.01, 0.02, 0.98, 0.99, 0.5])

--- a/tests/unit/analysis/test_apareto.py
+++ b/tests/unit/analysis/test_apareto.py
@@ -4,7 +4,7 @@ import numpy as np
 import pandas as pd
 
 
-def test_pareto_frontier_basic():
+def test_pareto_frontier_basic() -> None:
     """Test Pareto frontier with clear domination relationships.
 
     Counterexample that exposed the bug:
@@ -58,7 +58,7 @@ def test_pareto_frontier_basic():
         assert np.isclose(pareto_points.iloc[0]["mean_score"], 0.8)
 
 
-def test_pareto_frontier_multiple_efficient():
+def test_pareto_frontier_multiple_efficient() -> None:
     """Test Pareto frontier with multiple non-dominated points.
 
     Points:
@@ -99,7 +99,7 @@ def test_pareto_frontier_multiple_efficient():
         assert pareto_tiers == {"T0", "T1", "T2"}
 
 
-def test_pareto_frontier_tied_points():
+def test_pareto_frontier_tied_points() -> None:
     """Test Pareto frontier with tied cost-score pairs.
 
     If two points have identical (cost, score), both should be Pareto efficient.
@@ -137,7 +137,7 @@ def test_pareto_frontier_tied_points():
         assert len(pareto_points) >= 2  # At least T0/T1 or T2
 
 
-def test_pareto_frontier_single_point():
+def test_pareto_frontier_single_point() -> None:
     """Test Pareto frontier with a single point (trivial case)."""
     from scylla.analysis.figures.cost_analysis import fig08_cost_quality_pareto
 

--- a/tests/unit/analysis/test_config.py
+++ b/tests/unit/analysis/test_config.py
@@ -5,27 +5,27 @@ import pytest
 from scylla.analysis.config import ALPHA, AnalysisConfig, config
 
 
-def test_config_singleton():
+def test_config_singleton() -> None:
     """Test config is a singleton."""
     config1 = AnalysisConfig()
     config2 = AnalysisConfig()
     assert config1 is config2
 
 
-def test_config_alpha():
+def test_config_alpha() -> None:
     """Test alpha parameter."""
     assert config.alpha == pytest.approx(0.05)
     assert pytest.approx(0.05) == ALPHA
 
 
-def test_config_bootstrap_params():
+def test_config_bootstrap_params() -> None:
     """Test bootstrap parameters."""
     assert config.bootstrap_resamples == 10000
     assert config.bootstrap_random_state == 42
     assert config.bootstrap_confidence == pytest.approx(0.95)
 
 
-def test_config_min_samples():
+def test_config_min_samples() -> None:
     """Test minimum sample size parameters."""
     assert config.min_sample_bootstrap == 2
     assert config.min_sample_mann_whitney == 2
@@ -33,21 +33,21 @@ def test_config_min_samples():
     assert config.min_sample_correlation == 3
 
 
-def test_config_figure_params():
+def test_config_figure_params() -> None:
     """Test figure parameters."""
     assert config.png_dpi_scale == pytest.approx(3.0)  # 300 DPI / 100
     assert config.figure_width == 400
     assert config.figure_height == 300
 
 
-def test_config_get_nested():
+def test_config_get_nested() -> None:
     """Test nested key access."""
     assert config.get("statistical", "alpha") == pytest.approx(0.05)
     assert config.get("figures", "dpi", "png") == 300
     assert config.get("nonexistent", "key", default="default") == "default"
 
 
-def test_config_versions():
+def test_config_versions() -> None:
     """Test version metadata."""
     assert config.pipeline_version == "1.0.0"
     assert config.config_version == "1.0.0"

--- a/tests/unit/analysis/test_cop_integration.py
+++ b/tests/unit/analysis/test_cop_integration.py
@@ -1,7 +1,9 @@
+from typing import Any
+
 """Tests for CoP and Frontier CoP integration (Issue #325)."""
 
 
-def test_cop_frontier_cop_integration(sample_runs_df):
+def test_cop_frontier_cop_integration(sample_runs_df: Any) -> None:
     """Test that CoP and Frontier CoP are integrated (Issue #325)."""
     from export_data import compute_statistical_results
 

--- a/tests/unit/analysis/test_dataframe_builders.py
+++ b/tests/unit/analysis/test_dataframe_builders.py
@@ -1,5 +1,7 @@
 """Unit tests for DataFrame builder functions using mock RunData."""
 
+from typing import Any
+
 import numpy as np
 import pandas as pd
 import pytest
@@ -10,7 +12,7 @@ from scylla.e2e.models import TokenStats
 
 
 @pytest.fixture
-def mock_criterion_scores():
+def mock_criterion_scores() -> Any:
     """Create mock criterion scores for testing."""
     return {
         "functional": CriterionScore(
@@ -39,7 +41,7 @@ def mock_criterion_scores():
 
 
 @pytest.fixture
-def mock_judges(mock_criterion_scores):
+def mock_judges(mock_criterion_scores: Any) -> Any:
     """Create mock judge evaluations for testing."""
     return [
         JudgeEvaluation(
@@ -76,7 +78,7 @@ def mock_judges(mock_criterion_scores):
 
 
 @pytest.fixture
-def mock_run_data(mock_judges):
+def mock_run_data(mock_judges: Any) -> Any:
     """Create a mock RunData object for testing."""
     return RunData(
         experiment="test-experiment-001",
@@ -102,7 +104,7 @@ def mock_run_data(mock_judges):
     )
 
 
-def test_build_runs_df_with_mock_data(mock_run_data):
+def test_build_runs_df_with_mock_data(mock_run_data: Any) -> None:
     """Test build_runs_df with mock RunData objects."""
     # Arrange
     experiments = {"test-experiment-001": [mock_run_data]}
@@ -123,7 +125,7 @@ def test_build_runs_df_with_mock_data(mock_run_data):
     assert df.iloc[0]["cost_usd"] == 0.05
 
 
-def test_build_runs_df_impl_rate_consensus(mock_run_data):
+def test_build_runs_df_impl_rate_consensus(mock_run_data: Any) -> None:
     """Test that build_runs_df correctly computes consensus impl_rate as median."""
     # Arrange
     experiments = {"test-001": [mock_run_data]}
@@ -138,7 +140,7 @@ def test_build_runs_df_impl_rate_consensus(mock_run_data):
     assert abs(df.iloc[0]["impl_rate"] - expected_impl_rate) < 1e-6
 
 
-def test_build_runs_df_token_stats(mock_run_data):
+def test_build_runs_df_token_stats(mock_run_data: Any) -> None:
     """Test that build_runs_df correctly extracts token statistics."""
     # Arrange
     experiments = {"test-001": [mock_run_data]}
@@ -156,7 +158,7 @@ def test_build_runs_df_token_stats(mock_run_data):
     assert df.iloc[0]["total_tokens"] == 2000
 
 
-def test_build_runs_df_multiple_runs(mock_run_data):
+def test_build_runs_df_multiple_runs(mock_run_data: Any) -> None:
     """Test build_runs_df with multiple runs."""
     # Arrange - create second run with different data
     run2 = RunData(
@@ -192,7 +194,7 @@ def test_build_runs_df_multiple_runs(mock_run_data):
     assert df.iloc[1]["tier"] == "T1"
 
 
-def test_build_runs_df_empty_experiments():
+def test_build_runs_df_empty_experiments() -> None:
     """Test build_runs_df with empty experiments dict."""
     # Arrange
     experiments: dict[str, list[RunData]] = {}
@@ -205,7 +207,7 @@ def test_build_runs_df_empty_experiments():
     assert isinstance(df, pd.DataFrame)
 
 
-def test_build_runs_df_empty_judges():
+def test_build_runs_df_empty_judges() -> None:
     """Test build_runs_df handles runs with no judges gracefully."""
     # Arrange
     run_no_judges = RunData(
@@ -238,7 +240,7 @@ def test_build_runs_df_empty_judges():
     assert np.isnan(df.iloc[0]["impl_rate"])  # Should be NaN when no judges
 
 
-def test_build_judges_df_with_mock_data(mock_run_data):
+def test_build_judges_df_with_mock_data(mock_run_data: Any) -> None:
     """Test build_judges_df with mock RunData objects."""
     # Arrange
     experiments = {"test-001": [mock_run_data]}
@@ -255,7 +257,7 @@ def test_build_judges_df_with_mock_data(mock_run_data):
     assert (df["run_number"] == 1).all()
 
 
-def test_build_judges_df_judge_fields(mock_run_data):
+def test_build_judges_df_judge_fields(mock_run_data: Any) -> None:
     """Test build_judges_df correctly extracts judge-specific fields."""
     # Arrange
     experiments = {"test-001": [mock_run_data]}
@@ -272,7 +274,7 @@ def test_build_judges_df_judge_fields(mock_run_data):
     assert judge1["judge_is_valid"]  # Check truthy (pandas returns np.True_)
 
 
-def test_build_judges_df_impl_rate_per_judge(mock_run_data):
+def test_build_judges_df_impl_rate_per_judge(mock_run_data: Any) -> None:
     """Test that build_judges_df computes impl_rate per judge."""
     # Arrange
     experiments = {"test-001": [mock_run_data]}
@@ -287,7 +289,7 @@ def test_build_judges_df_impl_rate_per_judge(mock_run_data):
         assert abs(row["judge_impl_rate"] - expected_impl_rate) < 1e-6
 
 
-def test_build_judges_df_multiple_runs(mock_run_data):
+def test_build_judges_df_multiple_runs(mock_run_data: Any) -> None:
     """Test build_judges_df with multiple runs."""
     # Arrange
     run2 = RunData(
@@ -323,7 +325,7 @@ def test_build_judges_df_multiple_runs(mock_run_data):
     assert len(run2_judges) == 3
 
 
-def test_build_criteria_df_with_mock_data(mock_run_data):
+def test_build_criteria_df_with_mock_data(mock_run_data: Any) -> None:
     """Test build_criteria_df with mock RunData objects."""
     # Arrange
     experiments = {"test-001": [mock_run_data]}
@@ -338,7 +340,7 @@ def test_build_criteria_df_with_mock_data(mock_run_data):
     assert (df["agent_model"] == "Sonnet 4.5").all()
 
 
-def test_build_criteria_df_criterion_fields(mock_run_data):
+def test_build_criteria_df_criterion_fields(mock_run_data: Any) -> None:
     """Test build_criteria_df correctly extracts criterion fields."""
     # Arrange
     experiments = {"test-001": [mock_run_data]}
@@ -359,7 +361,7 @@ def test_build_criteria_df_criterion_fields(mock_run_data):
     assert code_quality["criterion_max"] == 10.0
 
 
-def test_build_criteria_df_multiple_judges(mock_run_data):
+def test_build_criteria_df_multiple_judges(mock_run_data: Any) -> None:
     """Test build_criteria_df includes all judges."""
     # Arrange
     experiments = {"test-001": [mock_run_data]}
@@ -379,7 +381,7 @@ def test_build_criteria_df_multiple_judges(mock_run_data):
         assert set(judge_criteria["criterion"]) == {"functional", "code_quality"}
 
 
-def test_build_criteria_df_empty_experiments():
+def test_build_criteria_df_empty_experiments() -> None:
     """Test build_criteria_df with empty experiments."""
     # Arrange
     experiments: dict[str, list[RunData]] = {}
@@ -392,7 +394,7 @@ def test_build_criteria_df_empty_experiments():
     assert isinstance(df, pd.DataFrame)
 
 
-def test_compute_judge_impl_rate_helper():
+def test_compute_judge_impl_rate_helper() -> None:
     """Test the compute_judge_impl_rate helper function."""
     from scylla.analysis.dataframes import compute_judge_impl_rate
 
@@ -432,7 +434,7 @@ def test_compute_judge_impl_rate_helper():
     assert abs(impl_rate - 0.7) < 1e-6
 
 
-def test_compute_consensus_impl_rate_helper():
+def test_compute_consensus_impl_rate_helper() -> None:
     """Test the compute_consensus_impl_rate helper function."""
     from scylla.analysis.dataframes import compute_consensus_impl_rate
 
@@ -468,7 +470,7 @@ def test_compute_consensus_impl_rate_helper():
     assert abs(consensus - 0.7) < 1e-6
 
 
-def test_compute_consensus_impl_rate_empty_judges():
+def test_compute_consensus_impl_rate_empty_judges() -> None:
     """Test compute_consensus_impl_rate with empty judge list."""
     from scylla.analysis.dataframes import compute_consensus_impl_rate
 
@@ -479,7 +481,7 @@ def test_compute_consensus_impl_rate_empty_judges():
     assert np.isnan(consensus)
 
 
-def test_build_judges_df_invalid_judge():
+def test_build_judges_df_invalid_judge() -> None:
     """Test that judges with is_valid=False are marked as invalid.
 
     Regression test for issue #323: the loader must check the is_valid field

--- a/tests/unit/analysis/test_dataframes.py
+++ b/tests/unit/analysis/test_dataframes.py
@@ -1,11 +1,13 @@
 """Unit tests for DataFrame builders."""
 
+from typing import Any
+
 import numpy as np
 import pandas as pd
 import pytest
 
 
-def test_build_runs_df_structure(sample_runs_df):
+def test_build_runs_df_structure(sample_runs_df: Any) -> None:
     """Test runs DataFrame has expected structure."""
     # Verify required columns exist
     required_cols = [
@@ -39,7 +41,7 @@ def test_build_runs_df_structure(sample_runs_df):
     assert sample_runs_df["run_number"].dtype == np.int64
 
 
-def test_build_runs_df_values(sample_runs_df):
+def test_build_runs_df_values(sample_runs_df: Any) -> None:
     """Test runs DataFrame has valid values."""
     # Score should be in [0, 1]
     assert sample_runs_df["score"].min() >= 0.0
@@ -58,7 +60,7 @@ def test_build_runs_df_values(sample_runs_df):
     assert (sample_runs_df["cache_read_tokens"] >= 0).all()
 
 
-def test_build_judges_df_structure(sample_judges_df):
+def test_build_judges_df_structure(sample_judges_df: Any) -> None:
     """Test judges DataFrame has expected structure."""
     required_cols = [
         "experiment",
@@ -84,7 +86,7 @@ def test_build_judges_df_structure(sample_judges_df):
     assert (judges_per_run == 3).all()
 
 
-def test_build_criteria_df_structure(sample_criteria_df):
+def test_build_criteria_df_structure(sample_criteria_df: Any) -> None:
     """Test criteria DataFrame has expected structure."""
     required_cols = [
         "experiment",
@@ -110,7 +112,7 @@ def test_build_criteria_df_structure(sample_criteria_df):
     assert (criteria_per_judge == 5).all()
 
 
-def test_build_subtests_df_structure(sample_subtests_df):
+def test_build_subtests_df_structure(sample_subtests_df: Any) -> None:
     """Test subtests DataFrame has expected structure matching production.
 
     Must match columns produced by dataframes.build_subtests_df().
@@ -163,7 +165,7 @@ def test_build_subtests_df_structure(sample_subtests_df):
     assert sample_subtests_df["consistency"].max() <= 1.0
 
 
-def test_tier_summary_aggregation(sample_runs_df):
+def test_tier_summary_aggregation(sample_runs_df: Any) -> None:
     """Test tier_summary() aggregation function."""
     from scylla.analysis.dataframes import tier_summary
 
@@ -193,7 +195,7 @@ def test_tier_summary_aggregation(sample_runs_df):
     assert first_row["pass_rate"] == pytest.approx(expected_pass_rate, abs=1e-6)
 
 
-def test_model_comparison_aggregation(sample_runs_df):
+def test_model_comparison_aggregation(sample_runs_df: Any) -> None:
     """Test model_comparison() aggregation function."""
     from scylla.analysis.dataframes import model_comparison
 
@@ -214,7 +216,7 @@ def test_model_comparison_aggregation(sample_runs_df):
     assert len(comparison) == expected_rows
 
 
-def test_model_comparison_process_metric_columns(sample_runs_df):
+def test_model_comparison_process_metric_columns(sample_runs_df: Any) -> None:
     """Test model_comparison() includes process metric aggregation columns."""
     from scylla.analysis.dataframes import model_comparison
 
@@ -240,7 +242,7 @@ def test_model_comparison_process_metric_columns(sample_runs_df):
         assert col in column_tuples, f"Missing column: {col}"
 
 
-def test_model_comparison_process_metric_values(sample_runs_df):
+def test_model_comparison_process_metric_values(sample_runs_df: Any) -> None:
     """Test model_comparison() process metric values match manual aggregation."""
     from scylla.analysis.dataframes import model_comparison
 
@@ -277,7 +279,7 @@ def test_model_comparison_process_metric_values(sample_runs_df):
             )
 
 
-def test_model_comparison_process_metrics_all_nan():
+def test_model_comparison_process_metrics_all_nan() -> None:
     """Test model_comparison() handles all-NaN process metrics without error."""
     from scylla.analysis.dataframes import model_comparison
 
@@ -306,7 +308,7 @@ def test_model_comparison_process_metrics_all_nan():
         )
 
 
-def test_consistency_calculation():
+def test_consistency_calculation() -> None:
     """Test consistency metric calculation (1 - CV)."""
     from scylla.analysis.stats import compute_consistency
 
@@ -320,7 +322,7 @@ def test_consistency_calculation():
     assert compute_consistency(5.0, 10.0) == pytest.approx(0.0)
 
 
-def test_cop_calculation():
+def test_cop_calculation() -> None:
     """Test Cost-of-Pass calculation."""
     from scylla.analysis.stats import compute_cop
 
@@ -329,7 +331,7 @@ def test_cop_calculation():
     assert compute_cop(1.0, 0.0) == float("inf")
 
 
-def test_empty_dataframe_handling():
+def test_empty_dataframe_handling() -> None:
     """Test functions handle empty DataFrames gracefully."""
     from scylla.analysis.dataframes import tier_summary
 
@@ -352,7 +354,7 @@ def test_empty_dataframe_handling():
     assert len(summary) == 0
 
 
-def test_dataframe_filtering(sample_runs_df):
+def test_dataframe_filtering(sample_runs_df: Any) -> None:
     """Test filtering DataFrames by tier/model."""
     # Filter by single tier
     t0_only = sample_runs_df[sample_runs_df["tier"] == "T0"]
@@ -373,7 +375,7 @@ def test_dataframe_filtering(sample_runs_df):
     assert (t0_sonnet["agent_model"] == "Sonnet 4.5").all()
 
 
-def test_judge_summary_aggregation(sample_judges_df):
+def test_judge_summary_aggregation(sample_judges_df: Any) -> None:
     """Test judge_summary() aggregates judge scores correctly."""
     from scylla.analysis.dataframes import judge_summary
 
@@ -406,7 +408,7 @@ def test_judge_summary_aggregation(sample_judges_df):
     assert actual_mean == pytest.approx(expected_mean, abs=1e-6)
 
 
-def test_judge_summary_empty_dataframe():
+def test_judge_summary_empty_dataframe() -> None:
     """Test judge_summary() handles empty DataFrames gracefully."""
     from scylla.analysis.dataframes import judge_summary
 
@@ -429,7 +431,7 @@ def test_judge_summary_empty_dataframe():
     assert len(summary) == 0
 
 
-def test_criteria_summary_aggregation(sample_criteria_df):
+def test_criteria_summary_aggregation(sample_criteria_df: Any) -> None:
     """Test criteria_summary() aggregates by criterion correctly."""
     from scylla.analysis.dataframes import criteria_summary
 
@@ -472,7 +474,7 @@ def test_criteria_summary_aggregation(sample_criteria_df):
     assert actual_mean == pytest.approx(expected_mean, abs=1e-6)
 
 
-def test_criteria_summary_empty_dataframe():
+def test_criteria_summary_empty_dataframe() -> None:
     """Test criteria_summary() handles empty DataFrames gracefully."""
     from scylla.analysis.dataframes import criteria_summary
 

--- a/tests/unit/analysis/test_degenerate_fixtures.py
+++ b/tests/unit/analysis/test_degenerate_fixtures.py
@@ -1,37 +1,39 @@
 """Test degenerate input fixtures for edge case testing."""
 
+from typing import Any
+
 import numpy as np
 import pytest
 
 
-def test_degenerate_single_element(degenerate_single_element):
+def test_degenerate_single_element(degenerate_single_element: Any) -> None:
     """Verify single-element fixture."""
     assert len(degenerate_single_element) == 1
     assert degenerate_single_element[0] == pytest.approx(0.5)
 
 
-def test_degenerate_all_same(degenerate_all_same):
+def test_degenerate_all_same(degenerate_all_same: Any) -> None:
     """Verify all-same-value fixture."""
     assert len(degenerate_all_same) == 5
     assert np.all(degenerate_all_same == pytest.approx(0.7))
     assert np.std(degenerate_all_same) == pytest.approx(0.0)
 
 
-def test_degenerate_all_pass(degenerate_all_pass):
+def test_degenerate_all_pass(degenerate_all_pass: Any) -> None:
     """Verify all-pass fixture."""
     assert len(degenerate_all_pass) == 5
     assert np.all(degenerate_all_pass == 1)
     assert np.mean(degenerate_all_pass) == pytest.approx(1.0)
 
 
-def test_degenerate_all_fail(degenerate_all_fail):
+def test_degenerate_all_fail(degenerate_all_fail: Any) -> None:
     """Verify all-fail fixture."""
     assert len(degenerate_all_fail) == 5
     assert np.all(degenerate_all_fail == 0)
     assert np.mean(degenerate_all_fail) == pytest.approx(0.0)
 
 
-def test_degenerate_unbalanced_groups(degenerate_unbalanced_groups):
+def test_degenerate_unbalanced_groups(degenerate_unbalanced_groups: Any) -> None:
     """Verify unbalanced groups fixture."""
     assert len(degenerate_unbalanced_groups["small"]) == 2
     assert len(degenerate_unbalanced_groups["large"]) == 50
@@ -40,20 +42,20 @@ def test_degenerate_unbalanced_groups(degenerate_unbalanced_groups):
     )
 
 
-def test_degenerate_empty_array(degenerate_empty_array):
+def test_degenerate_empty_array(degenerate_empty_array: Any) -> None:
     """Verify empty array fixture."""
     assert len(degenerate_empty_array) == 0
     assert degenerate_empty_array.size == 0
 
 
-def test_degenerate_nan_values(degenerate_nan_values):
+def test_degenerate_nan_values(degenerate_nan_values: Any) -> None:
     """Verify NaN values fixture."""
     assert len(degenerate_nan_values) == 5
     assert np.sum(np.isnan(degenerate_nan_values)) == 2
     assert np.sum(~np.isnan(degenerate_nan_values)) == 3
 
 
-def test_degenerate_inf_values(degenerate_inf_values):
+def test_degenerate_inf_values(degenerate_inf_values: Any) -> None:
     """Verify infinite values fixture."""
     assert len(degenerate_inf_values) == 5
     assert np.sum(np.isinf(degenerate_inf_values)) == 2
@@ -61,14 +63,14 @@ def test_degenerate_inf_values(degenerate_inf_values):
     assert np.sum(np.isneginf(degenerate_inf_values)) == 1
 
 
-def test_degenerate_binary_data(degenerate_binary_data):
+def test_degenerate_binary_data(degenerate_binary_data: Any) -> None:
     """Verify binary data fixture."""
     assert len(degenerate_binary_data) == 8
     assert set(degenerate_binary_data) == {0, 1}
     assert np.all((degenerate_binary_data == 0) | (degenerate_binary_data == 1))
 
 
-def test_degenerate_boundary_values(degenerate_boundary_values):
+def test_degenerate_boundary_values(degenerate_boundary_values: Any) -> None:
     """Verify boundary values fixture."""
     assert len(degenerate_boundary_values) == 5
     assert np.min(degenerate_boundary_values) == pytest.approx(0.0)
@@ -76,7 +78,7 @@ def test_degenerate_boundary_values(degenerate_boundary_values):
     assert 0.5 in degenerate_boundary_values
 
 
-def test_degenerate_near_zero(degenerate_near_zero):
+def test_degenerate_near_zero(degenerate_near_zero: Any) -> None:
     """Verify near-zero values fixture."""
     assert len(degenerate_near_zero) == 5
     assert np.all(degenerate_near_zero > 0)
@@ -84,7 +86,7 @@ def test_degenerate_near_zero(degenerate_near_zero):
     assert np.max(degenerate_near_zero) == pytest.approx(1e-6)
 
 
-def test_degenerate_high_variance(degenerate_high_variance):
+def test_degenerate_high_variance(degenerate_high_variance: Any) -> None:
     """Verify high-variance fixture."""
     assert len(degenerate_high_variance) == 5
     variance = np.var(degenerate_high_variance)

--- a/tests/unit/analysis/test_duration_integration.py
+++ b/tests/unit/analysis/test_duration_integration.py
@@ -1,7 +1,9 @@
+from typing import Any
+
 """Tests for duration_seconds integration (Issue #327 partial)."""
 
 
-def test_duration_seconds_integration(sample_runs_df):
+def test_duration_seconds_integration(sample_runs_df: Any) -> None:
     """Test that duration_seconds is integrated into statistical tests (Issue #327)."""
     from export_data import compute_statistical_results
 

--- a/tests/unit/analysis/test_export_data.py
+++ b/tests/unit/analysis/test_export_data.py
@@ -6,7 +6,7 @@ from typing import Any
 import pytest
 
 
-def test_compute_statistical_results(sample_runs_df, tmp_path):
+def test_compute_statistical_results(sample_runs_df: Any, tmp_path: Any) -> None:
     """Test compute_statistical_results generates valid JSON."""
     from export_data import compute_statistical_results
 
@@ -79,7 +79,7 @@ def test_compute_statistical_results(sample_runs_df, tmp_path):
     assert len(json_str) > 0
 
 
-def test_enhanced_summary_json(sample_runs_df, tmp_path):
+def test_enhanced_summary_json(sample_runs_df: Any, tmp_path: Any) -> None:
     """Test enhanced summary.json includes new statistics."""
     from export_data import json_nan_handler
 
@@ -160,7 +160,7 @@ def test_enhanced_summary_json(sample_runs_df, tmp_path):
     assert len(json_str) > 0
 
 
-def test_json_nan_handler():
+def test_json_nan_handler() -> None:
     """Test json_nan_handler converts NaN/inf correctly."""
     import numpy as np
     from export_data import json_nan_handler
@@ -186,7 +186,7 @@ def test_json_nan_handler():
     assert json_nan_handler({"key": "value"}) == {"key": "value"}
 
 
-def test_compute_statistical_results_empty_df(tmp_path):
+def test_compute_statistical_results_empty_df(tmp_path: Any) -> None:
     """Test compute_statistical_results handles empty DataFrame gracefully."""
     import pandas as pd
     from export_data import compute_statistical_results
@@ -216,7 +216,7 @@ def test_compute_statistical_results_empty_df(tmp_path):
     assert results["correlations"] == []
 
 
-def test_compute_statistical_results_single_tier(sample_runs_df):
+def test_compute_statistical_results_single_tier(sample_runs_df: Any) -> None:
     """Test compute_statistical_results with only one tier (no pairwise comparisons)."""
     from export_data import compute_statistical_results
 
@@ -235,7 +235,7 @@ def test_compute_statistical_results_single_tier(sample_runs_df):
     assert "effect_sizes" in results
 
 
-def test_compute_statistical_results_degenerate_data():
+def test_compute_statistical_results_degenerate_data() -> None:
     """Test compute_statistical_results with degenerate data (small samples)."""
     import pandas as pd
     from export_data import compute_statistical_results
@@ -263,7 +263,7 @@ def test_compute_statistical_results_degenerate_data():
     assert "pairwise_comparisons" in results
 
 
-def test_compute_statistical_results_correlation_correction(sample_runs_df):
+def test_compute_statistical_results_correlation_correction(sample_runs_df: Any) -> None:
     """Test that correlations include multiple comparison correction."""
     from export_data import compute_statistical_results
 
@@ -281,7 +281,7 @@ def test_compute_statistical_results_correlation_correction(sample_runs_df):
         # This is a forward-looking test
 
 
-def test_export_data_validation_warnings(sample_runs_df, tmp_path, capsys):
+def test_export_data_validation_warnings(sample_runs_df: Any, tmp_path: Any, capsys: Any) -> None:
     """Test that export_data logs warnings for data validation issues."""
     from export_data import compute_statistical_results
 
@@ -299,7 +299,7 @@ def test_export_data_validation_warnings(sample_runs_df, tmp_path, capsys):
     assert "correlations" in results
 
 
-def test_impl_rate_integration(sample_runs_df):
+def test_impl_rate_integration(sample_runs_df: Any) -> None:
     """Test that impl_rate is integrated into all statistical tests (Issue #324)."""
     from export_data import compute_statistical_results
 
@@ -333,7 +333,7 @@ def test_impl_rate_integration(sample_runs_df):
     assert len(impl_rate_corr) > 0, "impl_rate should appear in correlations"
 
 
-def test_process_metrics_in_summary(sample_runs_df):
+def test_process_metrics_in_summary(sample_runs_df: Any) -> None:
     """Test that process metrics appear in overall_stats, by_model, and by_tier (Issue #1135)."""
     import numpy as np
     import pandas as pd
@@ -460,7 +460,7 @@ def test_process_metrics_in_summary(sample_runs_df):
 # ---------------------------------------------------------------------------
 
 
-def test_compute_normality_tests_structure(sample_runs_df):
+def test_compute_normality_tests_structure(sample_runs_df: Any) -> None:
     """_compute_normality_tests returns dicts with required fields for each metric."""
     from export_data import _compute_normality_tests
 
@@ -480,7 +480,7 @@ def test_compute_normality_tests_structure(sample_runs_df):
         assert entry["n"] >= 3
 
 
-def test_compute_normality_tests_all_four_metrics(sample_runs_df):
+def test_compute_normality_tests_all_four_metrics(sample_runs_df: Any) -> None:
     """_compute_normality_tests covers score, impl_rate, cost_usd, duration_seconds."""
     from export_data import _compute_normality_tests
 
@@ -497,7 +497,7 @@ def test_compute_normality_tests_all_four_metrics(sample_runs_df):
     assert "duration_seconds" in metrics_present
 
 
-def test_compute_omnibus_tests_structure(sample_runs_df):
+def test_compute_omnibus_tests_structure(sample_runs_df: Any) -> None:
     """_compute_omnibus_tests returns dicts with required fields."""
     from export_data import _compute_omnibus_tests
 
@@ -517,7 +517,7 @@ def test_compute_omnibus_tests_structure(sample_runs_df):
         assert entry["n_groups"] >= 2
 
 
-def test_compute_omnibus_tests_three_metrics(sample_runs_df):
+def test_compute_omnibus_tests_three_metrics(sample_runs_df: Any) -> None:
     """_compute_omnibus_tests covers pass_rate, impl_rate, duration_seconds."""
     from export_data import _compute_omnibus_tests
 
@@ -533,7 +533,7 @@ def test_compute_omnibus_tests_three_metrics(sample_runs_df):
     assert "duration_seconds" in metrics_present
 
 
-def test_collect_pairwise_pass_rate_includes_overall_contrast(sample_runs_df):
+def test_collect_pairwise_pass_rate_includes_overall_contrast(sample_runs_df: Any) -> None:
     """_collect_pairwise_pass_rate adds the first->last overall contrast."""
     from export_data import _collect_pairwise_pass_rate
 
@@ -556,7 +556,7 @@ def test_collect_pairwise_pass_rate_includes_overall_contrast(sample_runs_df):
     assert last["tier2"] == tier_order[-1]
 
 
-def test_compute_pairwise_comparisons_metrics(sample_runs_df):
+def test_compute_pairwise_comparisons_metrics(sample_runs_df: Any) -> None:
     """_compute_pairwise_comparisons covers pass_rate, impl_rate, duration_seconds."""
     from export_data import _compute_pairwise_comparisons
 
@@ -581,7 +581,7 @@ def test_compute_pairwise_comparisons_metrics(sample_runs_df):
         assert "is_significant" in entry
 
 
-def test_compute_effect_sizes_structure(sample_runs_df):
+def test_compute_effect_sizes_structure(sample_runs_df: Any) -> None:
     """_compute_effect_sizes returns Cliff's delta entries with CI bounds."""
     from export_data import _compute_effect_sizes
 
@@ -610,7 +610,7 @@ def test_compute_effect_sizes_structure(sample_runs_df):
         assert entry["ci_low"] <= entry["ci_high"]
 
 
-def test_compute_effect_sizes_three_metrics(sample_runs_df):
+def test_compute_effect_sizes_three_metrics(sample_runs_df: Any) -> None:
     """_compute_effect_sizes covers pass_rate, impl_rate, and duration_seconds."""
     from export_data import _compute_effect_sizes
 
@@ -626,7 +626,7 @@ def test_compute_effect_sizes_three_metrics(sample_runs_df):
     assert "duration_seconds" in metrics_present
 
 
-def test_compute_power_analysis_structure(sample_runs_df):
+def test_compute_power_analysis_structure(sample_runs_df: Any) -> None:
     """_compute_power_analysis returns entries with required power fields."""
     from export_data import _compute_effect_sizes, _compute_power_analysis
 
@@ -645,7 +645,7 @@ def test_compute_power_analysis_structure(sample_runs_df):
         assert required_fields <= entry.keys()
 
 
-def test_compute_power_analysis_includes_omnibus(sample_runs_df):
+def test_compute_power_analysis_includes_omnibus(sample_runs_df: Any) -> None:
     """_compute_power_analysis includes pass_rate_omnibus KW power entries."""
     from export_data import _compute_effect_sizes, _compute_power_analysis
 
@@ -661,7 +661,7 @@ def test_compute_power_analysis_includes_omnibus(sample_runs_df):
     assert len(omnibus_entries) == len(models)
 
 
-def test_compute_correlations_structure(sample_runs_df):
+def test_compute_correlations_structure(sample_runs_df: Any) -> None:
     """_compute_correlations returns Spearman rho entries with required fields."""
     from export_data import _compute_correlations
 
@@ -686,7 +686,7 @@ def test_compute_correlations_structure(sample_runs_df):
         assert entry["n"] >= 3
 
 
-def test_compute_correlations_includes_impl_rate(sample_runs_df):
+def test_compute_correlations_includes_impl_rate(sample_runs_df: Any) -> None:
     """_compute_correlations includes impl_rate pairs."""
     from export_data import _compute_correlations
 
@@ -699,7 +699,7 @@ def test_compute_correlations_includes_impl_rate(sample_runs_df):
     assert len(impl_rate_entries) > 0
 
 
-def test_compute_tier_descriptives_structure(sample_runs_df):
+def test_compute_tier_descriptives_structure(sample_runs_df: Any) -> None:
     """_compute_tier_descriptives returns tier stats including frontier row."""
     from export_data import _compute_tier_descriptives
 
@@ -718,7 +718,7 @@ def test_compute_tier_descriptives_structure(sample_runs_df):
         assert required_fields <= entry.keys()
 
 
-def test_compute_tier_descriptives_frontier_row(sample_runs_df):
+def test_compute_tier_descriptives_frontier_row(sample_runs_df: Any) -> None:
     """_compute_tier_descriptives includes one frontier row per model."""
     from export_data import _compute_tier_descriptives
 
@@ -735,7 +735,7 @@ def test_compute_tier_descriptives_frontier_row(sample_runs_df):
         assert entry["cop"] is not None
 
 
-def test_compute_interaction_tests_structure(sample_runs_df):
+def test_compute_interaction_tests_structure(sample_runs_df: Any) -> None:
     """_compute_interaction_tests returns SRH results for four metrics."""
     from export_data import _compute_interaction_tests
 
@@ -750,7 +750,7 @@ def test_compute_interaction_tests_structure(sample_runs_df):
         assert isinstance(entry["is_significant"], bool)
 
 
-def test_compute_interaction_tests_four_metrics(sample_runs_df):
+def test_compute_interaction_tests_four_metrics(sample_runs_df: Any) -> None:
     """_compute_interaction_tests covers score, impl_rate, cost_usd, duration_seconds."""
     from export_data import _compute_interaction_tests
 
@@ -764,7 +764,7 @@ def test_compute_interaction_tests_four_metrics(sample_runs_df):
 
 
 @pytest.mark.parametrize("metric", ["r_prog", "cfp", "pr_revert_rate"])
-def test_process_metrics_in_normality_tests(sample_runs_df, metric):
+def test_process_metrics_in_normality_tests(sample_runs_df: Any, metric: Any) -> None:
     """Process metrics appear in normality_tests with required fields (Issue #1186)."""
     from export_data import _compute_normality_tests
 
@@ -785,7 +785,7 @@ def test_process_metrics_in_normality_tests(sample_runs_df, metric):
 
 
 @pytest.mark.parametrize("metric", ["r_prog", "cfp", "pr_revert_rate"])
-def test_process_metrics_in_omnibus_tests(sample_runs_df, metric):
+def test_process_metrics_in_omnibus_tests(sample_runs_df: Any, metric: Any) -> None:
     """Process metrics appear in omnibus_tests with required fields (Issue #1186)."""
     from export_data import _compute_omnibus_tests
 
@@ -805,7 +805,7 @@ def test_process_metrics_in_omnibus_tests(sample_runs_df, metric):
 
 
 @pytest.mark.parametrize("metric", ["r_prog", "cfp", "pr_revert_rate"])
-def test_process_metrics_in_pairwise_comparisons(sample_runs_df, metric):
+def test_process_metrics_in_pairwise_comparisons(sample_runs_df: Any, metric: Any) -> None:
     """Process metrics appear in pairwise_comparisons with required fields (Issue #1186)."""
     from export_data import _compute_pairwise_comparisons
 
@@ -830,7 +830,7 @@ def test_process_metrics_in_pairwise_comparisons(sample_runs_df, metric):
 
 
 @pytest.mark.parametrize("metric", ["r_prog", "cfp", "pr_revert_rate"])
-def test_process_metrics_in_effect_sizes(sample_runs_df, metric):
+def test_process_metrics_in_effect_sizes(sample_runs_df: Any, metric: Any) -> None:
     """Process metrics appear in effect_sizes with required fields (Issue #1186)."""
     from export_data import _compute_effect_sizes
 
@@ -859,7 +859,7 @@ def test_process_metrics_in_effect_sizes(sample_runs_df, metric):
         assert entry["ci_low"] <= entry["ci_high"]
 
 
-def test_normality_tests_all_metrics(sample_runs_df):
+def test_normality_tests_all_metrics(sample_runs_df: Any) -> None:
     """normality_tests covers the full expected set of metrics (regression guard)."""
     from export_data import _compute_normality_tests
 
@@ -884,7 +884,7 @@ def test_normality_tests_all_metrics(sample_runs_df):
     )
 
 
-def test_sparse_process_metrics_graceful_degradation():
+def test_sparse_process_metrics_graceful_degradation() -> None:
     """When process metrics are all NaN for a tier, functions do not raise (Issue #1186)."""
     import numpy as np
     import pandas as pd
@@ -932,7 +932,7 @@ def test_sparse_process_metrics_graceful_degradation():
     assert not any(e["metric"] in process_metrics for e in effects)
 
 
-def test_helpers_compose_to_same_result(sample_runs_df):
+def test_helpers_compose_to_same_result(sample_runs_df: Any) -> None:
     """compute_statistical_results output matches direct helper composition."""
     from export_data import (
         _compute_correlations,

--- a/tests/unit/analysis/test_figures.py
+++ b/tests/unit/analysis/test_figures.py
@@ -1,7 +1,9 @@
+from typing import Any
+
 """Unit tests for figure generation."""
 
 
-def test_fig01_score_variance_by_tier(sample_runs_df, tmp_path):
+def test_fig01_score_variance_by_tier(sample_runs_df: Any, tmp_path: Any) -> None:
     """Test Fig 1 generates files correctly."""
     from scylla.analysis.figures.variance import fig01_score_variance_by_tier
 
@@ -11,7 +13,7 @@ def test_fig01_score_variance_by_tier(sample_runs_df, tmp_path):
     assert (tmp_path / "fig01_score_variance_by_tier.vl.json").exists()
 
 
-def test_fig04_pass_rate_by_tier(sample_runs_df, tmp_path):
+def test_fig04_pass_rate_by_tier(sample_runs_df: Any, tmp_path: Any) -> None:
     """Test Fig 4 generates files correctly."""
     from scylla.analysis.figures.tier_performance import fig04_pass_rate_by_tier
 
@@ -19,7 +21,7 @@ def test_fig04_pass_rate_by_tier(sample_runs_df, tmp_path):
     assert (tmp_path / "fig04_pass_rate_by_tier.vl.json").exists()
 
 
-def test_fig06_cop_by_tier(sample_runs_df, tmp_path):
+def test_fig06_cop_by_tier(sample_runs_df: Any, tmp_path: Any) -> None:
     """Test Fig 6 generates files correctly."""
     from scylla.analysis.figures.cost_analysis import fig06_cop_by_tier
 
@@ -27,7 +29,7 @@ def test_fig06_cop_by_tier(sample_runs_df, tmp_path):
     assert (tmp_path / "fig06_cop_by_tier.vl.json").exists()
 
 
-def test_fig11_tier_uplift(sample_runs_df, tmp_path):
+def test_fig11_tier_uplift(sample_runs_df: Any, tmp_path: Any) -> None:
     """Test Fig 11 generates files correctly."""
     from scylla.analysis.figures.model_comparison import fig11_tier_uplift
 
@@ -35,7 +37,7 @@ def test_fig11_tier_uplift(sample_runs_df, tmp_path):
     assert (tmp_path / "fig11_tier_uplift.vl.json").exists()
 
 
-def test_fig02_judge_variance(sample_judges_df, tmp_path):
+def test_fig02_judge_variance(sample_judges_df: Any, tmp_path: Any) -> None:
     """Test Fig 2 generates per-tier files correctly."""
     from scylla.analysis.figures.judge_analysis import fig02_judge_variance
 
@@ -43,7 +45,7 @@ def test_fig02_judge_variance(sample_judges_df, tmp_path):
     # Note: Generates per-tier files (fig02_t0_judge_variance.vl.json, etc.)
 
 
-def test_fig03_failure_rate_by_tier(sample_runs_df, tmp_path):
+def test_fig03_failure_rate_by_tier(sample_runs_df: Any, tmp_path: Any) -> None:
     """Test Fig 3 generates files correctly."""
     from scylla.analysis.figures.variance import fig03_failure_rate_by_tier
 
@@ -51,7 +53,7 @@ def test_fig03_failure_rate_by_tier(sample_runs_df, tmp_path):
     assert (tmp_path / "fig03_failure_rate_by_tier.vl.json").exists()
 
 
-def test_fig05_grade_heatmap(sample_runs_df, tmp_path):
+def test_fig05_grade_heatmap(sample_runs_df: Any, tmp_path: Any) -> None:
     """Test Fig 5 generates files correctly."""
     from scylla.analysis.figures.tier_performance import fig05_grade_heatmap
 
@@ -59,7 +61,7 @@ def test_fig05_grade_heatmap(sample_runs_df, tmp_path):
     assert (tmp_path / "fig05_grade_heatmap.vl.json").exists()
 
 
-def test_fig07_token_distribution(sample_runs_df, tmp_path):
+def test_fig07_token_distribution(sample_runs_df: Any, tmp_path: Any) -> None:
     """Test Fig 7 generates files correctly."""
     from scylla.analysis.figures.token_analysis import fig07_token_distribution
 
@@ -67,7 +69,7 @@ def test_fig07_token_distribution(sample_runs_df, tmp_path):
     assert (tmp_path / "fig07_token_distribution.vl.json").exists()
 
 
-def test_fig08_cost_quality_pareto(sample_runs_df, tmp_path):
+def test_fig08_cost_quality_pareto(sample_runs_df: Any, tmp_path: Any) -> None:
     """Test Fig 8 generates files correctly."""
     from scylla.analysis.figures.cost_analysis import fig08_cost_quality_pareto
 
@@ -75,7 +77,7 @@ def test_fig08_cost_quality_pareto(sample_runs_df, tmp_path):
     assert (tmp_path / "fig08_cost_quality_pareto.vl.json").exists()
 
 
-def test_fig09_criteria_by_tier(sample_criteria_df, tmp_path):
+def test_fig09_criteria_by_tier(sample_criteria_df: Any, tmp_path: Any) -> None:
     """Test Fig 9 generates files correctly."""
     from scylla.analysis.figures.criteria_analysis import fig09_criteria_by_tier
 
@@ -83,7 +85,7 @@ def test_fig09_criteria_by_tier(sample_criteria_df, tmp_path):
     assert (tmp_path / "fig09_criteria_by_tier.vl.json").exists()
 
 
-def test_fig12_consistency(sample_runs_df, tmp_path):
+def test_fig12_consistency(sample_runs_df: Any, tmp_path: Any) -> None:
     """Test Fig 12 generates files correctly."""
     from scylla.analysis.figures.model_comparison import fig12_consistency
 
@@ -91,7 +93,7 @@ def test_fig12_consistency(sample_runs_df, tmp_path):
     assert (tmp_path / "fig12_consistency.vl.json").exists()
 
 
-def test_fig13_latency(sample_runs_df, tmp_path):
+def test_fig13_latency(sample_runs_df: Any, tmp_path: Any) -> None:
     """Test Fig 13 generates files correctly."""
     from scylla.analysis.figures.subtest_detail import fig13_latency
 
@@ -99,7 +101,7 @@ def test_fig13_latency(sample_runs_df, tmp_path):
     assert (tmp_path / "fig13_latency.vl.json").exists()
 
 
-def test_fig14_judge_agreement(sample_judges_df, tmp_path):
+def test_fig14_judge_agreement(sample_judges_df: Any, tmp_path: Any) -> None:
     """Test Fig 14 generates per-tier files correctly."""
     from scylla.analysis.figures.judge_analysis import fig14_judge_agreement
 
@@ -107,7 +109,7 @@ def test_fig14_judge_agreement(sample_judges_df, tmp_path):
     # Note: Generates per-tier files (fig14_t0_judge_agreement.vl.json, etc.)
 
 
-def test_fig15a_subtest_run_heatmap(sample_runs_df, tmp_path):
+def test_fig15a_subtest_run_heatmap(sample_runs_df: Any, tmp_path: Any) -> None:
     """Test Fig 15a generates files correctly."""
     from scylla.analysis.figures.subtest_detail import fig15a_subtest_run_heatmap
 
@@ -115,7 +117,7 @@ def test_fig15a_subtest_run_heatmap(sample_runs_df, tmp_path):
     assert (tmp_path / "fig15a_subtest_run_heatmap.vl.json").exists()
 
 
-def test_fig15b_subtest_best_heatmap(sample_runs_df, tmp_path):
+def test_fig15b_subtest_best_heatmap(sample_runs_df: Any, tmp_path: Any) -> None:
     """Test Fig 15b generates files correctly."""
     from scylla.analysis.figures.subtest_detail import fig15b_subtest_best_heatmap
 
@@ -123,7 +125,7 @@ def test_fig15b_subtest_best_heatmap(sample_runs_df, tmp_path):
     assert (tmp_path / "fig15b_subtest_best_heatmap.vl.json").exists()
 
 
-def test_fig15c_tier_summary_heatmap(sample_runs_df, tmp_path):
+def test_fig15c_tier_summary_heatmap(sample_runs_df: Any, tmp_path: Any) -> None:
     """Test Fig 15c generates files correctly."""
     from scylla.analysis.figures.subtest_detail import fig15c_tier_summary_heatmap
 
@@ -131,7 +133,7 @@ def test_fig15c_tier_summary_heatmap(sample_runs_df, tmp_path):
     assert (tmp_path / "fig15c_tier_summary_heatmap.vl.json").exists()
 
 
-def test_fig16a_success_variance_per_subtest(sample_runs_df, tmp_path):
+def test_fig16a_success_variance_per_subtest(sample_runs_df: Any, tmp_path: Any) -> None:
     """Test Fig 16a generates files correctly."""
     from scylla.analysis.figures.variance import fig16a_success_variance_per_subtest
 
@@ -139,7 +141,7 @@ def test_fig16a_success_variance_per_subtest(sample_runs_df, tmp_path):
     assert (tmp_path / "fig16a_success_variance_per_subtest.vl.json").exists()
 
 
-def test_fig16b_success_variance_aggregate(sample_runs_df, tmp_path):
+def test_fig16b_success_variance_aggregate(sample_runs_df: Any, tmp_path: Any) -> None:
     """Test Fig 16b generates files correctly."""
     from scylla.analysis.figures.variance import fig16b_success_variance_aggregate
 
@@ -147,7 +149,7 @@ def test_fig16b_success_variance_aggregate(sample_runs_df, tmp_path):
     assert (tmp_path / "fig16b_success_variance_aggregate.vl.json").exists()
 
 
-def test_fig17_judge_variance_overall(sample_judges_df, tmp_path):
+def test_fig17_judge_variance_overall(sample_judges_df: Any, tmp_path: Any) -> None:
     """Test Fig 17 generates per-tier files correctly."""
     from scylla.analysis.figures.judge_analysis import fig17_judge_variance_overall
 
@@ -155,7 +157,7 @@ def test_fig17_judge_variance_overall(sample_judges_df, tmp_path):
     # Note: Generates per-tier files (fig17_t0_judge_variance_overall.vl.json, etc.)
 
 
-def test_fig18a_failure_rate_per_subtest(sample_runs_df, tmp_path):
+def test_fig18a_failure_rate_per_subtest(sample_runs_df: Any, tmp_path: Any) -> None:
     """Test Fig 18a generates files correctly."""
     from scylla.analysis.figures.variance import fig18a_failure_rate_per_subtest
 
@@ -163,7 +165,7 @@ def test_fig18a_failure_rate_per_subtest(sample_runs_df, tmp_path):
     assert (tmp_path / "fig18a_failure_rate_per_subtest.vl.json").exists()
 
 
-def test_fig18b_failure_rate_aggregate(sample_runs_df, tmp_path):
+def test_fig18b_failure_rate_aggregate(sample_runs_df: Any, tmp_path: Any) -> None:
     """Test Fig 18b generates files correctly."""
     from scylla.analysis.figures.variance import fig18b_failure_rate_aggregate
 
@@ -171,7 +173,7 @@ def test_fig18b_failure_rate_aggregate(sample_runs_df, tmp_path):
     assert (tmp_path / "fig18b_failure_rate_aggregate.vl.json").exists()
 
 
-def test_publication_theme():
+def test_publication_theme() -> None:
     """Test publication theme is applied correctly."""
     from scylla.analysis.figures.spec_builder import apply_publication_theme
 
@@ -186,7 +188,7 @@ def test_publication_theme():
     assert alt.themes.active is not None
 
 
-def test_model_color_scale():
+def test_model_color_scale() -> None:
     """Test model color scale helper."""
     from scylla.analysis.figures.spec_builder import model_color_scale
 
@@ -209,7 +211,7 @@ def test_model_color_scale():
     assert len(scale.range) == len(models)
 
 
-def test_tier_order_constant():
+def test_tier_order_constant() -> None:
     """Test TIER_ORDER constant is available."""
     from scylla.analysis.figures import TIER_ORDER
 
@@ -219,7 +221,7 @@ def test_tier_order_constant():
     assert TIER_ORDER[-1] == "T6"
 
 
-def test_colors_constant():
+def test_colors_constant() -> None:
     """Test COLORS constant has required palettes."""
     from scylla.analysis.figures import COLORS
 
@@ -247,7 +249,7 @@ def test_colors_constant():
     assert "Output" in COLORS["token_types"]
 
 
-def test_fig19_effect_size_forest(sample_runs_df, tmp_path):
+def test_fig19_effect_size_forest(sample_runs_df: Any, tmp_path: Any) -> None:
     """Test Fig 19 effect size forest plot generates files correctly."""
     from scylla.analysis.figures.effect_size import fig19_effect_size_forest
 
@@ -255,7 +257,7 @@ def test_fig19_effect_size_forest(sample_runs_df, tmp_path):
     assert (tmp_path / "fig19_effect_size_forest.vl.json").exists()
 
 
-def test_fig20_metric_correlation_heatmap(sample_runs_df, tmp_path):
+def test_fig20_metric_correlation_heatmap(sample_runs_df: Any, tmp_path: Any) -> None:
     """Test Fig 20 correlation heatmap generates files correctly."""
     from scylla.analysis.figures.correlation import fig20_metric_correlation_heatmap
 
@@ -263,7 +265,7 @@ def test_fig20_metric_correlation_heatmap(sample_runs_df, tmp_path):
     assert (tmp_path / "fig20_metric_correlation_heatmap.vl.json").exists()
 
 
-def test_fig21_cost_quality_regression(sample_runs_df, tmp_path):
+def test_fig21_cost_quality_regression(sample_runs_df: Any, tmp_path: Any) -> None:
     """Test Fig 21 regression plot generates files correctly."""
     from scylla.analysis.figures.correlation import fig21_cost_quality_regression
 
@@ -271,7 +273,7 @@ def test_fig21_cost_quality_regression(sample_runs_df, tmp_path):
     assert (tmp_path / "fig21_cost_quality_regression.vl.json").exists()
 
 
-def test_fig22_cumulative_cost(sample_runs_df, tmp_path):
+def test_fig22_cumulative_cost(sample_runs_df: Any, tmp_path: Any) -> None:
     """Test Fig 22 cumulative cost curve generates files correctly."""
     from scylla.analysis.figures.cost_analysis import fig22_cumulative_cost
 
@@ -279,7 +281,7 @@ def test_fig22_cumulative_cost(sample_runs_df, tmp_path):
     assert (tmp_path / "fig22_cumulative_cost.vl.json").exists()
 
 
-def test_fig23_qq_plots(sample_runs_df, tmp_path):
+def test_fig23_qq_plots(sample_runs_df: Any, tmp_path: Any) -> None:
     """Test Fig 23 Q-Q plots generate per-tier files correctly."""
     from scylla.analysis.figures.diagnostics import fig23_qq_plots
 
@@ -287,7 +289,7 @@ def test_fig23_qq_plots(sample_runs_df, tmp_path):
     # Note: Generates per-tier files, may not create files if insufficient data
 
 
-def test_fig24_score_histograms(sample_runs_df, tmp_path):
+def test_fig24_score_histograms(sample_runs_df: Any, tmp_path: Any) -> None:
     """Test Fig 24 histograms with KDE generate per-tier files correctly."""
     from scylla.analysis.figures.diagnostics import fig24_score_histograms
 
@@ -295,7 +297,7 @@ def test_fig24_score_histograms(sample_runs_df, tmp_path):
     # Note: Generates per-tier files, may not create files if insufficient data
 
 
-def test_register_colors():
+def test_register_colors() -> None:
     """Test dynamic color registration."""
     from scylla.analysis.figures import COLORS, register_colors
 
@@ -316,7 +318,7 @@ def test_register_colors():
     del COLORS["models"]["New Model"]
 
 
-def test_figure_module_structure():
+def test_figure_module_structure() -> None:
     """Test that all figure modules exist."""
     figure_modules = [
         "tier_performance",
@@ -337,7 +339,7 @@ def test_figure_module_structure():
         assert module is not None
 
 
-def test_latex_snippet_generation(sample_runs_df, tmp_path):
+def test_latex_snippet_generation(sample_runs_df: Any, tmp_path: Any) -> None:
     """Test LaTeX snippet generation for figures."""
     import altair as alt
 
@@ -370,7 +372,7 @@ def test_latex_snippet_generation(sample_runs_df, tmp_path):
     assert "\\end{figure}" in content
 
 
-def test_latex_snippet_with_custom_caption(tmp_path):
+def test_latex_snippet_with_custom_caption(tmp_path: Any) -> None:
     """Test LaTeX snippet with custom caption."""
     import altair as alt
     import pandas as pd
@@ -399,7 +401,7 @@ def test_latex_snippet_with_custom_caption(tmp_path):
     assert "\\caption{Custom caption for testing}" in content
 
 
-def test_fig25_impl_rate_by_tier(sample_runs_df, tmp_path):
+def test_fig25_impl_rate_by_tier(sample_runs_df: Any, tmp_path: Any) -> None:
     """Test Fig 25 generates files correctly."""
     from scylla.analysis.figures.impl_rate_analysis import fig25_impl_rate_by_tier
 
@@ -407,7 +409,7 @@ def test_fig25_impl_rate_by_tier(sample_runs_df, tmp_path):
     assert (tmp_path / "fig25_impl_rate_by_tier.vl.json").exists()
 
 
-def test_fig26_impl_rate_vs_pass_rate(sample_runs_df, tmp_path):
+def test_fig26_impl_rate_vs_pass_rate(sample_runs_df: Any, tmp_path: Any) -> None:
     """Test Fig 26 generates files correctly."""
     from scylla.analysis.figures.impl_rate_analysis import fig26_impl_rate_vs_pass_rate
 
@@ -415,7 +417,7 @@ def test_fig26_impl_rate_vs_pass_rate(sample_runs_df, tmp_path):
     assert (tmp_path / "fig26_impl_rate_vs_pass_rate.vl.json").exists()
 
 
-def test_fig27_impl_rate_distribution(sample_runs_df, tmp_path):
+def test_fig27_impl_rate_distribution(sample_runs_df: Any, tmp_path: Any) -> None:
     """Test Fig 27 generates files correctly."""
     from scylla.analysis.figures.impl_rate_analysis import fig27_impl_rate_distribution
 
@@ -423,7 +425,7 @@ def test_fig27_impl_rate_distribution(sample_runs_df, tmp_path):
     assert (tmp_path / "fig27_impl_rate_distribution.vl.json").exists()
 
 
-def test_impl_rate_figures_handle_missing_column(tmp_path):
+def test_impl_rate_figures_handle_missing_column(tmp_path: Any) -> None:
     """Test Impl-Rate figures handle missing impl_rate column gracefully."""
     import pandas as pd
 
@@ -454,7 +456,7 @@ def test_impl_rate_figures_handle_missing_column(tmp_path):
     assert not (tmp_path / "fig27_impl_rate_distribution.vl.json").exists()
 
 
-def test_get_color_with_static_colors():
+def test_get_color_with_static_colors() -> None:
     """Test get_color() returns static colors from config."""
     from scylla.analysis.figures import get_color
 
@@ -474,7 +476,7 @@ def test_get_color_with_static_colors():
     assert len(a_grade_color) == 7
 
 
-def test_get_color_with_dynamic_palette():
+def test_get_color_with_dynamic_palette() -> None:
     """Test get_color() falls back to dynamic palette for unknown keys."""
     from scylla.analysis.figures import get_color
 
@@ -494,7 +496,7 @@ def test_get_color_with_dynamic_palette():
     assert color1 == color2
 
 
-def test_get_color_deterministic_hash():
+def test_get_color_deterministic_hash() -> None:
     """Test get_color() uses deterministic hash for dynamic colors."""
     from scylla.analysis.figures import get_color
 
@@ -507,7 +509,7 @@ def test_get_color_deterministic_hash():
     assert color1 == color2 == color3
 
 
-def test_get_color_scale_with_known_keys():
+def test_get_color_scale_with_known_keys() -> None:
     """Test get_color_scale() returns correct domain and range for known keys."""
     from scylla.analysis.figures import get_color_scale
 
@@ -526,7 +528,7 @@ def test_get_color_scale_with_known_keys():
         assert len(color) == 7
 
 
-def test_get_color_scale_with_unknown_keys():
+def test_get_color_scale_with_unknown_keys() -> None:
     """Test get_color_scale() handles unknown keys with dynamic palette."""
     from scylla.analysis.figures import get_color_scale
 
@@ -544,7 +546,7 @@ def test_get_color_scale_with_unknown_keys():
         assert len(color) == 7
 
 
-def test_get_color_scale_with_mixed_keys():
+def test_get_color_scale_with_mixed_keys() -> None:
     """Test get_color_scale() handles mix of known and unknown keys."""
     from scylla.analysis.figures import get_color_scale
 
@@ -562,7 +564,7 @@ def test_get_color_scale_with_mixed_keys():
         assert len(color) == 7
 
 
-def test_get_color_scale_empty_list():
+def test_get_color_scale_empty_list() -> None:
     """Test get_color_scale() handles empty list gracefully."""
     from scylla.analysis.figures import get_color_scale
 
@@ -573,7 +575,7 @@ def test_get_color_scale_empty_list():
     assert range_ == []
 
 
-def test_get_color_scale_single_key():
+def test_get_color_scale_single_key() -> None:
     """Test get_color_scale() handles single key correctly."""
     from scylla.analysis.figures import get_color_scale
 
@@ -585,7 +587,7 @@ def test_get_color_scale_single_key():
     assert range_[0].startswith("#")
 
 
-def test_compute_dynamic_domain():
+def test_compute_dynamic_domain() -> None:
     """Test compute_dynamic_domain with various data patterns."""
     import pandas as pd
 
@@ -651,7 +653,7 @@ def test_generate_figures_process_metrics_use_tier_category() -> None:
     assert FIGURES["fig_strategic_drift_by_tier"][0] == "tier"
 
 
-def test_compute_dynamic_domain_padding():
+def test_compute_dynamic_domain_padding() -> None:
     """Test padding behavior."""
     import pandas as pd
 
@@ -669,7 +671,7 @@ def test_compute_dynamic_domain_padding():
     assert domain_pad[1] - domain_pad[0] >= domain_no_pad[1] - domain_no_pad[0]
 
 
-def test_fig28_r_prog_by_tier(sample_runs_df, tmp_path):
+def test_fig28_r_prog_by_tier(sample_runs_df: Any, tmp_path: Any) -> None:
     """Smoke test: fig28_r_prog_by_tier generates output file without error."""
     from scylla.analysis.figures.process_metrics import fig28_r_prog_by_tier
 
@@ -677,7 +679,7 @@ def test_fig28_r_prog_by_tier(sample_runs_df, tmp_path):
     assert (tmp_path / "fig28_r_prog_by_tier.vl.json").exists()
 
 
-def test_fig29_cfp_by_tier(sample_runs_df, tmp_path):
+def test_fig29_cfp_by_tier(sample_runs_df: Any, tmp_path: Any) -> None:
     """Smoke test: fig29_cfp_by_tier generates output file without error."""
     from scylla.analysis.figures.process_metrics import fig29_cfp_by_tier
 
@@ -685,7 +687,7 @@ def test_fig29_cfp_by_tier(sample_runs_df, tmp_path):
     assert (tmp_path / "fig29_cfp_by_tier.vl.json").exists()
 
 
-def test_fig30_pr_revert_by_tier(sample_runs_df, tmp_path):
+def test_fig30_pr_revert_by_tier(sample_runs_df: Any, tmp_path: Any) -> None:
     """Smoke test: fig30_pr_revert_by_tier generates output file without error."""
     from scylla.analysis.figures.process_metrics import fig30_pr_revert_by_tier
 
@@ -693,7 +695,7 @@ def test_fig30_pr_revert_by_tier(sample_runs_df, tmp_path):
     assert (tmp_path / "fig30_pr_revert_by_tier.vl.json").exists()
 
 
-def test_process_metrics_figures_handle_missing_columns(tmp_path):
+def test_process_metrics_figures_handle_missing_columns(tmp_path: Any) -> None:
     """Process-metrics figures skip gracefully when their column is absent."""
     import pandas as pd
 
@@ -724,7 +726,7 @@ def test_process_metrics_figures_handle_missing_columns(tmp_path):
     assert not (tmp_path / "fig30_pr_revert_by_tier.vl.json").exists()
 
 
-def test_fig_strategic_drift_by_tier(sample_runs_df, tmp_path):
+def test_fig_strategic_drift_by_tier(sample_runs_df: Any, tmp_path: Any) -> None:
     """Smoke test: fig_strategic_drift_by_tier generates output file without error."""
     from scylla.analysis.figures.process_metrics import fig_strategic_drift_by_tier
 
@@ -732,7 +734,7 @@ def test_fig_strategic_drift_by_tier(sample_runs_df, tmp_path):
     assert (tmp_path / "fig_strategic_drift_by_tier.vl.json").exists()
 
 
-def test_fig_strategic_drift_by_tier_missing_column(tmp_path):
+def test_fig_strategic_drift_by_tier_missing_column(tmp_path: Any) -> None:
     """fig_strategic_drift_by_tier skips gracefully when column absent."""
     import pandas as pd
 
@@ -743,7 +745,7 @@ def test_fig_strategic_drift_by_tier_missing_column(tmp_path):
     assert not (tmp_path / "fig_strategic_drift_by_tier.vl.json").exists()
 
 
-def test_fig_strategic_drift_by_tier_all_null(tmp_path):
+def test_fig_strategic_drift_by_tier_all_null(tmp_path: Any) -> None:
     """fig_strategic_drift_by_tier skips gracefully when column all-null."""
     import pandas as pd
 

--- a/tests/unit/analysis/test_integration.py
+++ b/tests/unit/analysis/test_integration.py
@@ -5,12 +5,13 @@ Tests the full pipeline flow: load -> build DataFrames -> generate outputs.
 
 from pathlib import Path
 from tempfile import TemporaryDirectory
+from typing import Any
 
 import pandas as pd
 import pytest
 
 
-def test_e2e_pipeline_with_sample_data(sample_runs_df):
+def test_e2e_pipeline_with_sample_data(sample_runs_df: Any) -> None:
     """End-to-end test: complete analysis pipeline with sample data.
 
     Verifies that the full pipeline can execute without crashes:
@@ -54,7 +55,7 @@ def test_e2e_pipeline_with_sample_data(sample_runs_df):
         assert len(csv_files) > 0, "Expected CSV data files from fig08"
 
 
-def test_e2e_empty_dataframe_handling():
+def test_e2e_empty_dataframe_handling() -> None:
     """Test pipeline gracefully handles empty DataFrames."""
     from scylla.analysis.tables.summary import table01_tier_summary
 
@@ -69,7 +70,7 @@ def test_e2e_empty_dataframe_handling():
     assert isinstance(table_tex, str)
 
 
-def test_e2e_dataframe_types_validation(sample_runs_df):
+def test_e2e_dataframe_types_validation(sample_runs_df: Any) -> None:
     """Verify DataFrame has correct column types for analysis."""
     # Critical columns must exist
     required_cols = ["tier", "agent_model", "passed", "score"]
@@ -101,7 +102,7 @@ def test_e2e_dataframe_types_validation(sample_runs_df):
         ("table01_tier_summary", "scylla.analysis.tables.summary"),
     ],
 )
-def test_e2e_smoke_test_outputs(function_name, module_path, sample_runs_df):
+def test_e2e_smoke_test_outputs(function_name: Any, module_path: Any, sample_runs_df: Any) -> None:
     """Smoke test: verify key outputs can be generated without crashes."""
     import importlib
 
@@ -124,7 +125,7 @@ def test_e2e_smoke_test_outputs(function_name, module_path, sample_runs_df):
             assert len(list(output_dir.iterdir())) > 0
 
 
-def test_e2e_statistical_pipeline_integration(sample_runs_df):
+def test_e2e_statistical_pipeline_integration(sample_runs_df: Any) -> None:
     """Test that statistical functions integrate properly with DataFrames."""
     from scylla.analysis.stats import bootstrap_ci, cliffs_delta, mann_whitney_u
 

--- a/tests/unit/analysis/test_loader.py
+++ b/tests/unit/analysis/test_loader.py
@@ -4,10 +4,12 @@ Note: These tests use the public API of the loader module.
 Internal/private helper functions are not tested directly.
 """
 
+from typing import Any
+
 import pytest
 
 
-def test_loader_imports():
+def test_loader_imports() -> None:
     """Test that loader module can be imported."""
     # Basic smoke test - can import the module
     import scylla.analysis.loader
@@ -15,7 +17,7 @@ def test_loader_imports():
     assert scylla.analysis.loader is not None
 
 
-def test_load_run_signature():
+def test_load_run_signature() -> None:
     """Test load_run function has expected signature."""
     import inspect
 
@@ -32,7 +34,7 @@ def test_load_run_signature():
     assert "subtest" in params
 
 
-def test_load_all_experiments_signature():
+def test_load_all_experiments_signature() -> None:
     """Test load_all_experiments function has expected signature."""
     import inspect
 
@@ -47,7 +49,7 @@ def test_load_all_experiments_signature():
     assert "rubric_conflict" not in sig.parameters
 
 
-def test_validate_numeric_with_valid_values():
+def test_validate_numeric_with_valid_values() -> None:
     """Test validate_numeric with valid numeric inputs."""
     from scylla.analysis.loader import validate_numeric
 
@@ -65,7 +67,7 @@ def test_validate_numeric_with_valid_values():
     assert validate_numeric(0.0, "test") == pytest.approx(0.0)
 
 
-def test_validate_numeric_with_invalid_values():
+def test_validate_numeric_with_invalid_values() -> None:
     """Test validate_numeric with invalid inputs returns default."""
     import numpy as np
 
@@ -83,7 +85,7 @@ def test_validate_numeric_with_invalid_values():
     assert np.isnan(validate_numeric({"a": 1}, "test", np.nan))
 
 
-def test_validate_numeric_with_special_values():
+def test_validate_numeric_with_special_values() -> None:
     """Test validate_numeric handles inf and nan."""
     import numpy as np
 
@@ -100,7 +102,7 @@ def test_validate_numeric_with_special_values():
     assert np.isnan(validate_numeric(np.nan, "test", np.nan))
 
 
-def test_validate_bool_with_valid_values():
+def test_validate_bool_with_valid_values() -> None:
     """Test validate_bool with valid boolean inputs."""
     from scylla.analysis.loader import validate_bool
 
@@ -126,7 +128,7 @@ def test_validate_bool_with_valid_values():
     assert validate_bool(0, "test") is False
 
 
-def test_validate_bool_with_invalid_values():
+def test_validate_bool_with_invalid_values() -> None:
     """Test validate_bool with invalid inputs returns default."""
     from scylla.analysis.loader import validate_bool
 
@@ -142,7 +144,7 @@ def test_validate_bool_with_invalid_values():
     assert validate_bool({"a": True}, "test", False) is False
 
 
-def test_validate_int_with_valid_values():
+def test_validate_int_with_valid_values() -> None:
     """Test validate_int with valid integer inputs."""
     from scylla.analysis.loader import validate_int
 
@@ -163,7 +165,7 @@ def test_validate_int_with_valid_values():
     assert validate_int(-5, "test") == -5
 
 
-def test_validate_int_with_invalid_values():
+def test_validate_int_with_invalid_values() -> None:
     """Test validate_int with invalid inputs returns default."""
     from scylla.analysis.loader import validate_int
 
@@ -184,7 +186,7 @@ def test_validate_int_with_invalid_values():
 # or run analysis pipeline on real data in ~/fullruns/
 
 
-def test_model_id_to_display_removes_date_suffix():
+def test_model_id_to_display_removes_date_suffix() -> None:
     """Test that model_id_to_display removes date suffix from model IDs.
 
     Regression test for P0 bug where re.sub replaced pattern within full string,
@@ -206,7 +208,7 @@ def test_model_id_to_display_removes_date_suffix():
     assert model_id_to_display("unknown-model") == "unknown-model"
 
 
-def test_dynamic_judge_discovery(tmp_path):
+def test_dynamic_judge_discovery(tmp_path: Any) -> None:
     """Test that judge loading discovers judge directories dynamically.
 
     Regression test for P1 bug where hardcoded loop [1,2,3] silently ignored
@@ -282,7 +284,7 @@ def test_dynamic_judge_discovery(tmp_path):
     assert judge_scores[5] == pytest.approx(0.95, abs=0.01)
 
 
-def test_load_run_with_missing_fields(tmp_path):
+def test_load_run_with_missing_fields(tmp_path: Any) -> None:
     """Test that load_run handles missing fields with NaN defaults."""
     from scylla.analysis.loader import load_run
 
@@ -322,7 +324,7 @@ def test_load_run_with_missing_fields(tmp_path):
     assert len(run_data.judges) == 0
 
 
-def test_load_run_with_malformed_json(tmp_path):
+def test_load_run_with_malformed_json(tmp_path: Any) -> None:
     """Test that load_run handles malformed JSON gracefully."""
     from scylla.analysis.loader import load_run
 
@@ -344,7 +346,7 @@ def test_load_run_with_malformed_json(tmp_path):
         )
 
 
-def test_load_run_missing_file(tmp_path):
+def test_load_run_missing_file(tmp_path: Any) -> None:
     """Test that load_run raises FileNotFoundError for missing run_result.json."""
     from scylla.analysis.loader import load_run
 
@@ -363,7 +365,7 @@ def test_load_run_missing_file(tmp_path):
         )
 
 
-def test_load_judgment_with_criteria(tmp_path):
+def test_load_judgment_with_criteria(tmp_path: Any) -> None:
     """Test loading judgment with full criteria scores."""
     from scylla.analysis.loader import load_judgment
 
@@ -428,7 +430,7 @@ def test_load_judgment_with_criteria(tmp_path):
     assert func_crit.items["req1"].max_points == pytest.approx(5)
 
 
-def test_load_judgment_with_none_criteria(tmp_path):
+def test_load_judgment_with_none_criteria(tmp_path: Any) -> None:
     """Test loading judgment with None criteria (edge case)."""
     from scylla.analysis.loader import load_judgment
 
@@ -454,7 +456,7 @@ def test_load_judgment_with_none_criteria(tmp_path):
     assert len(judge_eval.criteria) == 0  # Should be empty dict
 
 
-def test_load_experiment_skips_corrupted_runs(tmp_path):
+def test_load_experiment_skips_corrupted_runs(tmp_path: Any) -> None:
     """Test that load_experiment skips corrupted runs with warnings."""
     from scylla.analysis.loader import load_experiment
 
@@ -495,7 +497,7 @@ def test_load_experiment_skips_corrupted_runs(tmp_path):
     assert run_numbers == {1, 3}
 
 
-def test_parse_judge_model_handles_missing_file(tmp_path):
+def test_parse_judge_model_handles_missing_file(tmp_path: Any) -> None:
     """Test parse_judge_model raises FileNotFoundError for missing MODEL.md."""
     from scylla.analysis.loader import parse_judge_model
 
@@ -507,7 +509,7 @@ def test_parse_judge_model_handles_missing_file(tmp_path):
         parse_judge_model(model_path)
 
 
-def test_parse_judge_model_handles_invalid_format(tmp_path):
+def test_parse_judge_model_handles_invalid_format(tmp_path: Any) -> None:
     """Test parse_judge_model raises ValueError for invalid format."""
     from scylla.analysis.loader import parse_judge_model
 
@@ -520,7 +522,7 @@ def test_parse_judge_model_handles_invalid_format(tmp_path):
         parse_judge_model(model_path)
 
 
-def test_parse_judge_model_success(tmp_path):
+def test_parse_judge_model_success(tmp_path: Any) -> None:
     """Test parse_judge_model extracts model correctly."""
     from scylla.analysis.loader import parse_judge_model
 
@@ -531,7 +533,7 @@ def test_parse_judge_model_success(tmp_path):
     assert result == "claude-sonnet-4-5-20250929"
 
 
-def test_model_id_to_display_comprehensive():
+def test_model_id_to_display_comprehensive() -> None:
     """Comprehensive test for model_id_to_display function."""
     from scylla.analysis.loader import model_id_to_display
 
@@ -555,7 +557,7 @@ def test_model_id_to_display_comprehensive():
     assert model_id_to_display("claude") == "claude"
 
 
-def test_schema_validation_valid_data(tmp_path):
+def test_schema_validation_valid_data(tmp_path: Any) -> None:
     """Test that valid run_result.json passes schema validation."""
     from scylla.analysis.loader import load_run
 
@@ -616,7 +618,7 @@ def test_schema_validation_valid_data(tmp_path):
     assert run_data.passed is True
 
 
-def test_schema_validation_invalid_grade(tmp_path, caplog):
+def test_schema_validation_invalid_grade(tmp_path: Any, caplog: Any) -> None:
     """Test that invalid grade triggers schema validation warning."""
     from scylla.analysis.loader import load_run
 
@@ -651,7 +653,7 @@ def test_schema_validation_invalid_grade(tmp_path, caplog):
     assert run_data.grade == "X"  # Data loaded despite validation failure
 
 
-def test_schema_validation_missing_required_field(tmp_path, caplog):
+def test_schema_validation_missing_required_field(tmp_path: Any, caplog: Any) -> None:
     """Test that missing required field triggers schema validation warning."""
     from scylla.analysis.loader import load_run
 
@@ -684,7 +686,7 @@ def test_schema_validation_missing_required_field(tmp_path, caplog):
     assert run_data.run_number == 1
 
 
-def test_resolve_agent_model_from_experiment_json(tmp_path):
+def test_resolve_agent_model_from_experiment_json(tmp_path: Any) -> None:
     """Test resolve_agent_model() reads from experiment.json first."""
     import json
 
@@ -707,7 +709,7 @@ def test_resolve_agent_model_from_experiment_json(tmp_path):
     assert model == "Sonnet 4.5"
 
 
-def test_resolve_agent_model_from_model_md_fallback(tmp_path):
+def test_resolve_agent_model_from_model_md_fallback(tmp_path: Any) -> None:
     """Test resolve_agent_model() falls back to MODEL.md if experiment.json missing."""
     from scylla.analysis.loader import resolve_agent_model
 
@@ -724,7 +726,7 @@ def test_resolve_agent_model_from_model_md_fallback(tmp_path):
     assert model == "Opus 4.5"
 
 
-def test_resolve_agent_model_raises_on_missing_data(tmp_path):
+def test_resolve_agent_model_raises_on_missing_data(tmp_path: Any) -> None:
     """Test resolve_agent_model() raises ValueError when no model found."""
     from scylla.analysis.loader import resolve_agent_model
 
@@ -737,7 +739,7 @@ def test_resolve_agent_model_raises_on_missing_data(tmp_path):
         resolve_agent_model(exp_dir)
 
 
-def test_load_all_experiments_functionality(tmp_path):
+def test_load_all_experiments_functionality(tmp_path: Any) -> None:
     """Test load_all_experiments() loads multiple experiments from directory."""
     import json
 
@@ -806,7 +808,7 @@ def test_load_all_experiments_functionality(tmp_path):
     assert experiments["experiment2"][0].score == pytest.approx(0.6)
 
 
-def test_load_all_experiments_excludes_experiments(tmp_path):
+def test_load_all_experiments_excludes_experiments(tmp_path: Any) -> None:
     """Test load_all_experiments() excludes specified experiments."""
     import json
 
@@ -851,7 +853,7 @@ def test_load_all_experiments_excludes_experiments(tmp_path):
     assert "experiment2" in experiments
 
 
-def test_load_rubric_weights_from_rubric_yaml(tmp_path):
+def test_load_rubric_weights_from_rubric_yaml(tmp_path: Any) -> None:
     """Test load_rubric_weights() parses category weights from rubric.yaml."""
     import yaml
 
@@ -883,7 +885,7 @@ def test_load_rubric_weights_from_rubric_yaml(tmp_path):
     assert weights["proportionality"] == pytest.approx(3.0)
 
 
-def test_load_rubric_weights_returns_empty_dict_if_missing(tmp_path):
+def test_load_rubric_weights_returns_empty_dict_if_missing(tmp_path: Any) -> None:
     """Test load_rubric_weights() returns {} if no rubric.yaml found."""
     from scylla.analysis.loader import load_rubric_weights
 
@@ -898,7 +900,7 @@ def test_load_rubric_weights_returns_empty_dict_if_missing(tmp_path):
     assert weights == {}
 
 
-def test_load_rubric_weights_excludes_experiments(tmp_path):
+def test_load_rubric_weights_excludes_experiments(tmp_path: Any) -> None:
     """Test load_rubric_weights() respects exclude list."""
     import yaml
 

--- a/tests/unit/analysis/test_process_metrics_aggregation.py
+++ b/tests/unit/analysis/test_process_metrics_aggregation.py
@@ -7,6 +7,7 @@ are correctly aggregated at both the subtest and tier levels.
 from __future__ import annotations
 
 from collections.abc import Sequence
+from typing import Any
 
 import numpy as np
 import pandas as pd
@@ -285,7 +286,7 @@ def test_tier_summary_all_nan_yields_nan() -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_fixture_symmetry_subtests_df(sample_runs_df, sample_subtests_df) -> None:
+def test_fixture_symmetry_subtests_df(sample_runs_df: Any, sample_subtests_df: Any) -> None:
     """sample_subtests_df fixture columns match production build_subtests_df output."""
     from scylla.analysis.dataframes import build_subtests_df
 

--- a/tests/unit/analysis/test_process_metrics_integration.py
+++ b/tests/unit/analysis/test_process_metrics_integration.py
@@ -399,7 +399,9 @@ def sample_runs_df_with_process_metrics() -> pd.DataFrame:
     return pd.DataFrame(data)
 
 
-def test_fig28_r_prog_by_tier_smoke(sample_runs_df_with_process_metrics, tmp_path) -> None:
+def test_fig28_r_prog_by_tier_smoke(
+    sample_runs_df_with_process_metrics: Any, tmp_path: Any
+) -> None:
     """fig28_r_prog_by_tier executes without error and produces output file."""
     from scylla.analysis.figures.process_metrics import fig28_r_prog_by_tier
 
@@ -408,7 +410,7 @@ def test_fig28_r_prog_by_tier_smoke(sample_runs_df_with_process_metrics, tmp_pat
     assert (tmp_path / "fig28_r_prog_by_tier.vl.json").exists()
 
 
-def test_fig29_cfp_by_tier_smoke(sample_runs_df_with_process_metrics, tmp_path) -> None:
+def test_fig29_cfp_by_tier_smoke(sample_runs_df_with_process_metrics: Any, tmp_path: Any) -> None:
     """fig29_cfp_by_tier executes without error and produces output file."""
     from scylla.analysis.figures.process_metrics import fig29_cfp_by_tier
 
@@ -417,7 +419,9 @@ def test_fig29_cfp_by_tier_smoke(sample_runs_df_with_process_metrics, tmp_path) 
     assert (tmp_path / "fig29_cfp_by_tier.vl.json").exists()
 
 
-def test_fig30_pr_revert_by_tier_smoke(sample_runs_df_with_process_metrics, tmp_path) -> None:
+def test_fig30_pr_revert_by_tier_smoke(
+    sample_runs_df_with_process_metrics: Any, tmp_path: Any
+) -> None:
     """fig30_pr_revert_by_tier executes without error and produces output file."""
     from scylla.analysis.figures.process_metrics import fig30_pr_revert_by_tier
 
@@ -426,7 +430,7 @@ def test_fig30_pr_revert_by_tier_smoke(sample_runs_df_with_process_metrics, tmp_
     assert (tmp_path / "fig30_pr_revert_by_tier.vl.json").exists()
 
 
-def test_fig28_r_prog_by_tier_skips_missing_column(tmp_path) -> None:
+def test_fig28_r_prog_by_tier_skips_missing_column(tmp_path: Any) -> None:
     """fig28_r_prog_by_tier skips gracefully when r_prog column is absent."""
     from scylla.analysis.figures.process_metrics import fig28_r_prog_by_tier
 
@@ -437,7 +441,7 @@ def test_fig28_r_prog_by_tier_skips_missing_column(tmp_path) -> None:
     assert not (tmp_path / "fig28_r_prog_by_tier.vl.json").exists()
 
 
-def test_fig28_r_prog_by_tier_skips_all_null(tmp_path) -> None:
+def test_fig28_r_prog_by_tier_skips_all_null(tmp_path: Any) -> None:
     """fig28_r_prog_by_tier skips gracefully when r_prog column is all-null."""
     from scylla.analysis.figures.process_metrics import fig28_r_prog_by_tier
 

--- a/tests/unit/analysis/test_rubric_conflict.py
+++ b/tests/unit/analysis/test_rubric_conflict.py
@@ -5,19 +5,22 @@ float tolerance, and error message contents.
 """
 
 import warnings
+from typing import Any
 
 import pytest
 import yaml
 
 
-def _write_rubric(path, categories: dict[str, object]) -> None:
+def _write_rubric(path: Any, categories: dict[str, object]) -> None:
     """Write a rubric.yaml file at path/rubric.yaml."""
     path.mkdir(parents=True, exist_ok=True)
     with (path / "rubric.yaml").open("w") as f:
         yaml.dump({"categories": categories}, f)
 
 
-def _make_two_experiment_dir(tmp_path, cats1: dict[str, object], cats2: dict[str, object]):
+def _make_two_experiment_dir(
+    tmp_path: Any, cats1: dict[str, object], cats2: dict[str, object]
+) -> Any:
     """Create data_dir with two experiments having different rubric weights."""
     data_dir = tmp_path / "fullruns"
     exp1_dir = data_dir / "experiment1" / "2026-01-31T10-00-00-run"
@@ -32,7 +35,7 @@ def _make_two_experiment_dir(tmp_path, cats1: dict[str, object], cats2: dict[str
 # ---------------------------------------------------------------------------
 
 
-def test_rubric_conflict_raises_by_default(tmp_path):
+def test_rubric_conflict_raises_by_default(tmp_path: Any) -> Any:
     """Two experiments with same category, different weights → RubricConflictError."""
     from scylla.analysis.loader import RubricConflictError, load_rubric_weights
 
@@ -46,7 +49,7 @@ def test_rubric_conflict_raises_by_default(tmp_path):
         load_rubric_weights(data_dir)
 
 
-def test_rubric_conflict_raises_explicitly(tmp_path):
+def test_rubric_conflict_raises_explicitly(tmp_path: Any) -> None:
     """Passing rubric_conflict='error' raises RubricConflictError."""
     from scylla.analysis.loader import RubricConflictError, load_rubric_weights
 
@@ -60,7 +63,7 @@ def test_rubric_conflict_raises_explicitly(tmp_path):
         load_rubric_weights(data_dir, rubric_conflict="error")
 
 
-def test_rubric_conflict_error_message_contains_details(tmp_path):
+def test_rubric_conflict_error_message_contains_details(tmp_path: Any) -> None:
     """Error message includes category name, both experiment names, both weights."""
     from scylla.analysis.loader import RubricConflictError, load_rubric_weights
 
@@ -86,7 +89,7 @@ def test_rubric_conflict_error_message_contains_details(tmp_path):
 # ---------------------------------------------------------------------------
 
 
-def test_rubric_conflict_warn(tmp_path):
+def test_rubric_conflict_warn(tmp_path: Any) -> None:
     """rubric_conflict='warn' emits UserWarning and returns weights."""
     from scylla.analysis.loader import load_rubric_weights
 
@@ -104,7 +107,7 @@ def test_rubric_conflict_warn(tmp_path):
     assert any(issubclass(w.category, UserWarning) for w in caught)
 
 
-def test_rubric_conflict_warn_message_contains_details(tmp_path):
+def test_rubric_conflict_warn_message_contains_details(tmp_path: Any) -> None:
     """Warning message includes category name and conflicting weights."""
     from scylla.analysis.loader import load_rubric_weights
 
@@ -127,7 +130,7 @@ def test_rubric_conflict_warn_message_contains_details(tmp_path):
 # ---------------------------------------------------------------------------
 
 
-def test_rubric_conflict_first(tmp_path):
+def test_rubric_conflict_first(tmp_path: Any) -> None:
     """rubric_conflict='first' keeps the first experiment's weights."""
     from scylla.analysis.loader import load_rubric_weights
 
@@ -143,7 +146,7 @@ def test_rubric_conflict_first(tmp_path):
     assert weights["functional"] == pytest.approx(10.0)
 
 
-def test_rubric_conflict_last(tmp_path):
+def test_rubric_conflict_last(tmp_path: Any) -> None:
     """rubric_conflict='last' keeps the last experiment's weights."""
     from scylla.analysis.loader import load_rubric_weights
 
@@ -164,7 +167,7 @@ def test_rubric_conflict_last(tmp_path):
 # ---------------------------------------------------------------------------
 
 
-def test_rubric_no_conflict_identical_weights(tmp_path):
+def test_rubric_no_conflict_identical_weights(tmp_path: Any) -> None:
     """Same weights across experiments → no error or warning raised."""
     from scylla.analysis.loader import load_rubric_weights
 
@@ -185,7 +188,7 @@ def test_rubric_no_conflict_identical_weights(tmp_path):
     assert len(rubric_warnings) == 0
 
 
-def test_rubric_conflict_float_tolerance(tmp_path):
+def test_rubric_conflict_float_tolerance(tmp_path: Any) -> None:
     """Weights differing by ≤ 1e-6 are not treated as a conflict."""
     from scylla.analysis.loader import load_rubric_weights
 
@@ -201,7 +204,7 @@ def test_rubric_conflict_float_tolerance(tmp_path):
     assert weights["functional"] == pytest.approx(10.0)
 
 
-def test_rubric_new_category_in_second_experiment(tmp_path):
+def test_rubric_new_category_in_second_experiment(tmp_path: Any) -> None:
     """Second experiment adds a new category → no conflict, weights merged."""
     from scylla.analysis.loader import load_rubric_weights
 
@@ -222,7 +225,7 @@ def test_rubric_new_category_in_second_experiment(tmp_path):
 # ---------------------------------------------------------------------------
 
 
-def test_load_all_experiments_no_rubric_conflict_param(tmp_path):
+def test_load_all_experiments_no_rubric_conflict_param(tmp_path: Any) -> None:
     """load_all_experiments() does not accept rubric_conflict; callers use load_rubric_weights()."""
     import inspect
 
@@ -235,7 +238,7 @@ def test_load_all_experiments_no_rubric_conflict_param(tmp_path):
     assert "rubric_conflict" not in sig.parameters
 
 
-def test_load_rubric_weights_is_independent_callable(tmp_path):
+def test_load_rubric_weights_is_independent_callable(tmp_path: Any) -> None:
     """load_rubric_weights() can be called independently with rubric_conflict policy."""
     from scylla.analysis.loader import load_rubric_weights
 

--- a/tests/unit/analysis/test_stats.py
+++ b/tests/unit/analysis/test_stats.py
@@ -5,7 +5,7 @@ import pandas as pd
 import pytest
 
 
-def test_cliffs_delta_basic():
+def test_cliffs_delta_basic() -> None:
     """Test Cliff's delta with known values."""
     # Group 1 has higher values than Group 2
     g1 = [5, 6, 7, 8, 9]
@@ -27,7 +27,7 @@ def test_cliffs_delta_basic():
     assert delta == pytest.approx(expected)
 
 
-def test_cliffs_delta_identical():
+def test_cliffs_delta_identical() -> None:
     """Test Cliff's delta with identical groups (delta should be 0)."""
     from scylla.analysis.stats import cliffs_delta
 
@@ -38,7 +38,7 @@ def test_cliffs_delta_identical():
     assert delta == pytest.approx(0.0, abs=1e-6)
 
 
-def test_cliffs_delta_negative():
+def test_cliffs_delta_negative() -> None:
     """Test Cliff's delta when group2 dominates group1."""
     from scylla.analysis.stats import cliffs_delta
 
@@ -51,7 +51,7 @@ def test_cliffs_delta_negative():
     assert delta == pytest.approx(-1.0)
 
 
-def test_cliffs_delta_empty():
+def test_cliffs_delta_empty() -> None:
     """Test Cliff's delta with empty groups."""
     import numpy as np
 
@@ -63,7 +63,7 @@ def test_cliffs_delta_empty():
     assert np.isnan(cliffs_delta([], []))
 
 
-def test_cliffs_delta_pandas_series():
+def test_cliffs_delta_pandas_series() -> None:
     """Test Cliff's delta with pandas Series input."""
     from scylla.analysis.stats import cliffs_delta
 
@@ -76,7 +76,7 @@ def test_cliffs_delta_pandas_series():
     assert delta == pytest.approx(1.0)
 
 
-def test_cliffs_delta_reference():
+def test_cliffs_delta_reference() -> None:
     """Test Cliff's delta against hand-calculated reference.
 
     Reference implementation (O(n²) loops):
@@ -105,7 +105,7 @@ def test_cliffs_delta_reference():
     assert delta == pytest.approx(expected)
 
 
-def test_bootstrap_ci_deterministic():
+def test_bootstrap_ci_deterministic() -> None:
     """Test bootstrap CI is deterministic with fixed random state."""
     from scylla.analysis.stats import bootstrap_ci
 
@@ -118,7 +118,7 @@ def test_bootstrap_ci_deterministic():
     assert mean1 == pytest.approx(mean2)
 
 
-def test_bootstrap_ci_single_element():
+def test_bootstrap_ci_single_element() -> None:
     """Test bootstrap CI handles single-element arrays gracefully.
 
     Regression test for P1 bug where scipy BCa bootstrap requires n >= 2.
@@ -134,7 +134,7 @@ def test_bootstrap_ci_single_element():
     assert upper == pytest.approx(5.0)
 
 
-def test_bootstrap_ci_empty_array():
+def test_bootstrap_ci_empty_array() -> None:
     """Test bootstrap CI handles empty arrays."""
     from scylla.analysis.stats import bootstrap_ci
 
@@ -148,7 +148,7 @@ def test_bootstrap_ci_empty_array():
     assert np.isnan(upper)
 
 
-def test_mann_whitney_u_basic():
+def test_mann_whitney_u_basic() -> None:
     """Test Mann-Whitney U returns reasonable values."""
     from scylla.analysis.stats import mann_whitney_u
 
@@ -163,7 +163,7 @@ def test_mann_whitney_u_basic():
     assert u_stat >= 0
 
 
-def test_mann_whitney_u_identical():
+def test_mann_whitney_u_identical() -> None:
     """Test Mann-Whitney U with identical groups."""
     from scylla.analysis.stats import mann_whitney_u
 
@@ -176,7 +176,7 @@ def test_mann_whitney_u_identical():
     assert p_value > 0.9
 
 
-def test_mann_whitney_u_degenerate_input():
+def test_mann_whitney_u_degenerate_input() -> None:
     """Test Mann-Whitney U with degenerate input (n < 2).
 
     Regression test for P1 bug: ensure function doesn't raise on
@@ -206,7 +206,7 @@ def test_mann_whitney_u_degenerate_input():
     assert p_value == pytest.approx(1.0)
 
 
-def test_krippendorff_alpha_perfect_agreement():
+def test_krippendorff_alpha_perfect_agreement() -> None:
     """Test Krippendorff's alpha with perfect inter-rater agreement."""
     from scylla.analysis.stats import krippendorff_alpha
 
@@ -225,7 +225,7 @@ def test_krippendorff_alpha_perfect_agreement():
     assert alpha == pytest.approx(1.0)
 
 
-def test_krippendorff_alpha_ordinal():
+def test_krippendorff_alpha_ordinal() -> None:
     """Test Krippendorff's alpha with ordinal data."""
     from scylla.analysis.stats import krippendorff_alpha
 
@@ -243,7 +243,7 @@ def test_krippendorff_alpha_ordinal():
     assert 0.7 < alpha < 1.0
 
 
-def test_krippendorff_alpha_nominal():
+def test_krippendorff_alpha_nominal() -> None:
     """Test Krippendorff's alpha with nominal data."""
     from scylla.analysis.stats import krippendorff_alpha
 
@@ -262,7 +262,7 @@ def test_krippendorff_alpha_nominal():
     assert 0.6 < alpha < 1.0
 
 
-def test_bonferroni_correction():
+def test_bonferroni_correction() -> None:
     """Test Bonferroni correction for multiple comparisons."""
     from scylla.analysis.stats import bonferroni_correction
 
@@ -275,7 +275,7 @@ def test_bonferroni_correction():
     assert bonferroni_correction(1.0, 2) == pytest.approx(1.0)
 
 
-def test_compute_consistency():
+def test_compute_consistency() -> None:
     """Test consistency metric (1 - CV)."""
     from scylla.analysis.stats import compute_consistency
 
@@ -297,7 +297,7 @@ def test_compute_consistency():
     assert consistency == pytest.approx(0.0)
 
 
-def test_compute_cop():
+def test_compute_cop() -> None:
     """Test Cost-of-Pass metric."""
     from scylla.analysis.stats import compute_cop
 
@@ -314,7 +314,7 @@ def test_compute_cop():
     assert cop == float("inf")
 
 
-def test_compute_frontier_cop():
+def test_compute_frontier_cop() -> None:
     """Test Frontier CoP metric."""
     from scylla.analysis.stats import compute_frontier_cop
 
@@ -342,7 +342,7 @@ def test_compute_frontier_cop():
     assert frontier == pytest.approx(2.50, abs=1e-6)
 
 
-def test_compute_impl_rate():
+def test_compute_impl_rate() -> None:
     """Test Implementation Rate (Impl-Rate) metric."""
     import numpy as np
 
@@ -369,7 +369,7 @@ def test_compute_impl_rate():
     assert impl_rate == pytest.approx(0.584, abs=1e-6)
 
 
-def test_spearman_correlation():
+def test_spearman_correlation() -> None:
     """Test Spearman rank correlation."""
     from scylla.analysis.stats import spearman_correlation
 
@@ -387,7 +387,7 @@ def test_spearman_correlation():
     assert corr == pytest.approx(-1.0, abs=1e-6)
 
 
-def test_pearson_correlation():
+def test_pearson_correlation() -> None:
     """Test Pearson correlation."""
     from scylla.analysis.stats import pearson_correlation
 
@@ -405,7 +405,7 @@ def test_pearson_correlation():
     assert np.isnan(corr)  # Pearson undefined for constant series
 
 
-def test_shapiro_wilk_normal_data():
+def test_shapiro_wilk_normal_data() -> None:
     """Test Shapiro-Wilk with normal distribution."""
     from scylla.analysis.stats import shapiro_wilk
 
@@ -420,7 +420,7 @@ def test_shapiro_wilk_normal_data():
     assert p_value > 0.05
 
 
-def test_shapiro_wilk_uniform_data():
+def test_shapiro_wilk_uniform_data() -> None:
     """Test Shapiro-Wilk with non-normal (uniform) distribution."""
     from scylla.analysis.stats import shapiro_wilk
 
@@ -435,7 +435,7 @@ def test_shapiro_wilk_uniform_data():
     assert p_value < 0.05
 
 
-def test_kruskal_wallis_different_groups():
+def test_kruskal_wallis_different_groups() -> None:
     """Test Kruskal-Wallis with significantly different groups."""
     from scylla.analysis.stats import kruskal_wallis
 
@@ -451,7 +451,7 @@ def test_kruskal_wallis_different_groups():
     assert p_value < 0.01
 
 
-def test_kruskal_wallis_identical_groups():
+def test_kruskal_wallis_identical_groups() -> None:
     """Test Kruskal-Wallis with identical groups."""
     from scylla.analysis.stats import kruskal_wallis
 
@@ -467,7 +467,7 @@ def test_kruskal_wallis_identical_groups():
     assert p_value > 0.9
 
 
-def test_holm_bonferroni_less_conservative_than_bonferroni():
+def test_holm_bonferroni_less_conservative_than_bonferroni() -> None:
     """Test that Holm-Bonferroni is less conservative than Bonferroni."""
     from scylla.analysis.stats import bonferroni_correction, holm_bonferroni_correction
 
@@ -486,14 +486,14 @@ def test_holm_bonferroni_less_conservative_than_bonferroni():
     assert holm_corrected[1] < bonf_corrected[1]  # Larger p-values: less conservative
 
 
-def test_holm_bonferroni_empty():
+def test_holm_bonferroni_empty() -> None:
     """Test Holm-Bonferroni with empty list."""
     from scylla.analysis.stats import holm_bonferroni_correction
 
     assert holm_bonferroni_correction([]) == []
 
 
-def test_holm_bonferroni_single():
+def test_holm_bonferroni_single() -> None:
     """Test Holm-Bonferroni with single p-value."""
     from scylla.analysis.stats import holm_bonferroni_correction
 
@@ -502,7 +502,7 @@ def test_holm_bonferroni_single():
     assert result == [0.05]
 
 
-def test_holm_bonferroni_monotonicity():
+def test_holm_bonferroni_monotonicity() -> None:
     """Test that Holm-Bonferroni produces monotonically non-decreasing corrected p-values.
 
     Regression test for P0 bug: corrected p-values must be monotonically
@@ -554,7 +554,7 @@ def test_holm_bonferroni_monotonicity():
         assert corrected_general[curr_idx] >= corrected_general[prev_idx]
 
 
-def test_benjamini_hochberg_correction():
+def test_benjamini_hochberg_correction() -> None:
     """Test Benjamini-Hochberg FDR correction."""
     from scylla.analysis.stats import benjamini_hochberg_correction
 
@@ -570,14 +570,14 @@ def test_benjamini_hochberg_correction():
         assert 0 <= corr <= 1
 
 
-def test_benjamini_hochberg_empty():
+def test_benjamini_hochberg_empty() -> None:
     """Test Benjamini-Hochberg with empty list."""
     from scylla.analysis.stats import benjamini_hochberg_correction
 
     assert benjamini_hochberg_correction([]) == []
 
 
-def test_cliffs_delta_ci_covers_point_estimate():
+def test_cliffs_delta_ci_covers_point_estimate() -> None:
     """Test that Cliff's delta CI covers the point estimate."""
     from scylla.analysis.stats import cliffs_delta_ci
 
@@ -594,7 +594,7 @@ def test_cliffs_delta_ci_covers_point_estimate():
     assert ci_low < ci_high
 
 
-def test_cliffs_delta_ci_small_sample():
+def test_cliffs_delta_ci_small_sample() -> None:
     """Test Cliff's delta CI with insufficient sample size."""
     from scylla.analysis.stats import cliffs_delta_ci
 
@@ -604,7 +604,7 @@ def test_cliffs_delta_ci_small_sample():
     assert delta == ci_low == ci_high
 
 
-def test_ols_regression_perfect_line():
+def test_ols_regression_perfect_line() -> None:
     """Test OLS regression with perfect linear relationship."""
     from scylla.analysis.stats import ols_regression
 
@@ -621,7 +621,7 @@ def test_ols_regression_perfect_line():
     assert result["std_err"] < 1e-10  # Nearly zero error
 
 
-def test_ols_regression_basic():
+def test_ols_regression_basic() -> None:
     """Test OLS regression with realistic data."""
     from scylla.analysis.stats import ols_regression
 
@@ -639,7 +639,7 @@ def test_ols_regression_basic():
     assert result["std_err"] > 0  # Non-zero error due to noise
 
 
-def test_scheirer_ray_hare_no_effects():
+def test_scheirer_ray_hare_no_effects() -> None:
     """Test Scheirer-Ray-Hare when no effects exist (null case)."""
     from scylla.analysis.stats import scheirer_ray_hare
 
@@ -666,7 +666,7 @@ def test_scheirer_ray_hare_no_effects():
     assert results["interaction"]["df"] == 2  # (2-1) * (3-1)
 
 
-def test_scheirer_ray_hare_main_effect_a():
+def test_scheirer_ray_hare_main_effect_a() -> None:
     """Test Scheirer-Ray-Hare with strong main effect in factor A."""
     from scylla.analysis.stats import scheirer_ray_hare
 
@@ -689,7 +689,7 @@ def test_scheirer_ray_hare_main_effect_a():
     # Interaction should be non-significant (parallel lines)
 
 
-def test_scheirer_ray_hare_main_effect_b():
+def test_scheirer_ray_hare_main_effect_b() -> None:
     """Test Scheirer-Ray-Hare with strong main effect in factor B."""
     from scylla.analysis.stats import scheirer_ray_hare
 
@@ -709,7 +709,7 @@ def test_scheirer_ray_hare_main_effect_b():
     assert results["tier"]["p_value"] < 0.001
 
 
-def test_scheirer_ray_hare_interaction():
+def test_scheirer_ray_hare_interaction() -> None:
     """Test Scheirer-Ray-Hare with interaction effect."""
     from scylla.analysis.stats import scheirer_ray_hare
 
@@ -736,7 +736,7 @@ def test_scheirer_ray_hare_interaction():
     assert results["interaction"]["df"] == 1  # (2-1) * (2-1)
 
 
-def test_scheirer_ray_hare_returns_correct_structure():
+def test_scheirer_ray_hare_returns_correct_structure() -> None:
     """Test that Scheirer-Ray-Hare returns correctly structured output."""
     from scylla.analysis.stats import scheirer_ray_hare
 

--- a/tests/unit/analysis/test_stats_degenerate.py
+++ b/tests/unit/analysis/test_stats_degenerate.py
@@ -3,6 +3,8 @@
 Tests edge cases and boundary conditions using degenerate fixtures from conftest.py.
 """
 
+from typing import Any
+
 import numpy as np
 import pytest
 
@@ -11,7 +13,7 @@ import pytest
 class TestCliffsDetaDegenerate:
     """Test Cliff's delta with degenerate inputs."""
 
-    def test_cliffs_delta_all_same_groups(self, degenerate_all_same):
+    def test_cliffs_delta_all_same_groups(self, degenerate_all_same: Any) -> None:
         """Test Cliff's delta with identical values in both groups."""
         from scylla.analysis.stats import cliffs_delta
 
@@ -19,7 +21,7 @@ class TestCliffsDetaDegenerate:
         delta = cliffs_delta(degenerate_all_same, degenerate_all_same)
         assert delta == pytest.approx(0.0)
 
-    def test_cliffs_delta_single_element_groups(self, degenerate_single_element):
+    def test_cliffs_delta_single_element_groups(self, degenerate_single_element: Any) -> None:
         """Test Cliff's delta with single-element groups."""
         from scylla.analysis.stats import cliffs_delta
 
@@ -33,7 +35,7 @@ class TestCliffsDetaDegenerate:
         delta = cliffs_delta(g1, g2)
         assert delta == pytest.approx(-1.0)  # g1 < g2
 
-    def test_cliffs_delta_unbalanced_groups(self, degenerate_unbalanced_groups):
+    def test_cliffs_delta_unbalanced_groups(self, degenerate_unbalanced_groups: Any) -> None:
         """Test Cliff's delta with severely unbalanced group sizes."""
         from scylla.analysis.stats import cliffs_delta
 
@@ -44,7 +46,7 @@ class TestCliffsDetaDegenerate:
         delta = cliffs_delta(small, large)
         assert -1.0 <= delta <= 1.0  # Valid range
 
-    def test_cliffs_delta_nan_handling(self, degenerate_nan_values):
+    def test_cliffs_delta_nan_handling(self, degenerate_nan_values: Any) -> None:
         """Test Cliff's delta with NaN values."""
         from scylla.analysis.stats import cliffs_delta
 
@@ -53,7 +55,7 @@ class TestCliffsDetaDegenerate:
         # If NaNs are not filtered, result should be NaN
         assert np.isnan(result) or isinstance(result, float)
 
-    def test_cliffs_delta_inf_handling(self, degenerate_inf_values):
+    def test_cliffs_delta_inf_handling(self, degenerate_inf_values: Any) -> None:
         """Test Cliff's delta with infinite values."""
         from scylla.analysis.stats import cliffs_delta
 
@@ -67,7 +69,7 @@ class TestCliffsDetaDegenerate:
 class TestBootstrapCIDegenerate:
     """Test bootstrap confidence intervals with degenerate inputs."""
 
-    def test_bootstrap_all_same(self, degenerate_all_same):
+    def test_bootstrap_all_same(self, degenerate_all_same: Any) -> None:
         """Test bootstrap CI with zero variance data."""
         from scylla.analysis.stats import bootstrap_ci
 
@@ -77,7 +79,7 @@ class TestBootstrapCIDegenerate:
         assert ci_low == pytest.approx(0.7, abs=1e-6)
         assert ci_high == pytest.approx(0.7, abs=1e-6)
 
-    def test_bootstrap_binary(self, degenerate_binary_data):
+    def test_bootstrap_binary(self, degenerate_binary_data: Any) -> None:
         """Test bootstrap CI with binary data."""
         from scylla.analysis.stats import bootstrap_ci
 
@@ -85,7 +87,7 @@ class TestBootstrapCIDegenerate:
         # Binary data should produce valid CI
         assert 0.0 <= ci_low <= mean <= ci_high <= 1.0
 
-    def test_bootstrap_boundary_values(self, degenerate_boundary_values):
+    def test_bootstrap_boundary_values(self, degenerate_boundary_values: Any) -> None:
         """Test bootstrap CI with exact boundary values (0.0, 1.0)."""
         from scylla.analysis.stats import bootstrap_ci
 
@@ -93,7 +95,7 @@ class TestBootstrapCIDegenerate:
         # Should handle boundaries gracefully
         assert 0.0 <= ci_low <= mean <= ci_high <= 1.0
 
-    def test_bootstrap_near_zero(self, degenerate_near_zero):
+    def test_bootstrap_near_zero(self, degenerate_near_zero: Any) -> None:
         """Test bootstrap CI with very small values (numerical stability)."""
         from scylla.analysis.stats import bootstrap_ci
 
@@ -102,7 +104,7 @@ class TestBootstrapCIDegenerate:
         assert 0.0 < ci_low <= mean <= ci_high
         assert mean < 1e-5  # All values are very small
 
-    def test_bootstrap_high_variance(self, degenerate_high_variance):
+    def test_bootstrap_high_variance(self, degenerate_high_variance: Any) -> None:
         """Test bootstrap CI with extreme variance."""
         from scylla.analysis.stats import bootstrap_ci
 
@@ -117,7 +119,7 @@ class TestBootstrapCIDegenerate:
 class TestMannWhitneyDegenerate:
     """Test Mann-Whitney U with degenerate inputs."""
 
-    def test_mann_whitney_all_same(self, degenerate_all_same):
+    def test_mann_whitney_all_same(self, degenerate_all_same: Any) -> None:
         """Test Mann-Whitney U with identical distributions."""
         from scylla.analysis.stats import mann_whitney_u
 
@@ -125,7 +127,9 @@ class TestMannWhitneyDegenerate:
         # Identical distributions -> not significant
         assert p_value > 0.05
 
-    def test_mann_whitney_all_pass_vs_all_fail(self, degenerate_all_pass, degenerate_all_fail):
+    def test_mann_whitney_all_pass_vs_all_fail(
+        self, degenerate_all_pass: Any, degenerate_all_fail: Any
+    ) -> None:
         """Test Mann-Whitney U with completely separated groups."""
         from scylla.analysis.stats import mann_whitney_u
 
@@ -133,7 +137,7 @@ class TestMannWhitneyDegenerate:
         # Completely separated -> highly significant
         assert p_value < 0.01
 
-    def test_mann_whitney_single_element(self, degenerate_single_element):
+    def test_mann_whitney_single_element(self, degenerate_single_element: Any) -> None:
         """Test Mann-Whitney U with single-element groups."""
         from scylla.analysis.stats import mann_whitney_u
 
@@ -145,7 +149,7 @@ class TestMannWhitneyDegenerate:
         # With very small samples, expect high p-value or warning
         assert isinstance(p_value, float)
 
-    def test_mann_whitney_unbalanced(self, degenerate_unbalanced_groups):
+    def test_mann_whitney_unbalanced(self, degenerate_unbalanced_groups: Any) -> None:
         """Test Mann-Whitney U with unbalanced group sizes."""
         from scylla.analysis.stats import mann_whitney_u
 
@@ -162,7 +166,7 @@ class TestMannWhitneyDegenerate:
 class TestConsistencyDegenerate:
     """Test consistency (1-CV) with degenerate inputs."""
 
-    def test_consistency_all_same(self, degenerate_all_same):
+    def test_consistency_all_same(self, degenerate_all_same: Any) -> None:
         """Test consistency with zero variance."""
         from scylla.analysis.stats import compute_consistency
 
@@ -172,7 +176,7 @@ class TestConsistencyDegenerate:
         consistency = compute_consistency(mean, std)
         assert consistency == pytest.approx(1.0, abs=1e-6)
 
-    def test_consistency_single_element(self, degenerate_single_element):
+    def test_consistency_single_element(self, degenerate_single_element: Any) -> None:
         """Test consistency with single element."""
         from scylla.analysis.stats import compute_consistency
 
@@ -182,7 +186,7 @@ class TestConsistencyDegenerate:
         consistency = compute_consistency(mean, std)
         assert consistency == pytest.approx(1.0, abs=1e-6)
 
-    def test_consistency_high_variance(self, degenerate_high_variance):
+    def test_consistency_high_variance(self, degenerate_high_variance: Any) -> None:
         """Test consistency with extreme variance."""
         from scylla.analysis.stats import compute_consistency
 
@@ -192,7 +196,7 @@ class TestConsistencyDegenerate:
         # High CV -> low consistency (could be negative, clamped to 0)
         assert 0.0 <= consistency <= 1.0
 
-    def test_consistency_near_zero_mean(self, degenerate_near_zero):
+    def test_consistency_near_zero_mean(self, degenerate_near_zero: Any) -> None:
         """Test consistency when mean is near zero."""
         from scylla.analysis.stats import compute_consistency
 
@@ -208,7 +212,7 @@ class TestConsistencyDegenerate:
 class TestKruskalWallisDegenerate:
     """Test Kruskal-Wallis with degenerate inputs."""
 
-    def test_kruskal_all_same_groups(self, degenerate_all_same):
+    def test_kruskal_all_same_groups(self, degenerate_all_same: Any) -> None:
         """Test Kruskal-Wallis with identical groups."""
         from scylla.analysis.stats import kruskal_wallis
 
@@ -221,7 +225,9 @@ class TestKruskalWallisDegenerate:
         # This is expected behavior from scipy when all values are identical
         assert np.isnan(p_value) or p_value > 0.05
 
-    def test_kruskal_two_groups_only(self, degenerate_all_pass, degenerate_all_fail):
+    def test_kruskal_two_groups_only(
+        self, degenerate_all_pass: Any, degenerate_all_fail: Any
+    ) -> None:
         """Test Kruskal-Wallis with minimum 2 groups."""
         from scylla.analysis.stats import kruskal_wallis
 
@@ -231,7 +237,7 @@ class TestKruskalWallisDegenerate:
         # Completely different groups -> significant
         assert p_value < 0.05
 
-    def test_kruskal_unbalanced_groups(self, degenerate_unbalanced_groups):
+    def test_kruskal_unbalanced_groups(self, degenerate_unbalanced_groups: Any) -> None:
         """Test Kruskal-Wallis with severely unbalanced groups."""
         from scylla.analysis.stats import kruskal_wallis
 
@@ -258,7 +264,7 @@ class TestKruskalWallisDegenerate:
         "degenerate_binary_data",
     ],
 )
-def test_stats_pipeline_with_degenerate_data(fixture_name, request):
+def test_stats_pipeline_with_degenerate_data(fixture_name: Any, request: Any) -> None:
     """Integration test: ensure stats pipeline handles degenerate data gracefully.
 
     This test verifies that the core statistical pipeline (used in tables/figures)

--- a/tests/unit/analysis/test_stats_parametrized.py
+++ b/tests/unit/analysis/test_stats_parametrized.py
@@ -6,6 +6,8 @@ Complements test_stats.py with broader coverage using pytest.mark.parametrize.
 
 from __future__ import annotations
 
+from typing import Any
+
 import numpy as np
 import pandas as pd
 import pytest
@@ -48,7 +50,7 @@ class TestCliffsDeltaParametrized:
             "single_eq",
         ],
     )
-    def test_cliffs_delta_values(self, g1, g2, expected_delta):
+    def test_cliffs_delta_values(self, g1: Any, g2: Any, expected_delta: Any) -> None:
         """Test Cliff's delta with various input combinations."""
         from scylla.analysis.stats import cliffs_delta
 
@@ -65,7 +67,7 @@ class TestCliffsDeltaParametrized:
         ],
         ids=["empty_g1", "empty_g2", "both_empty", "pandas_empty"],
     )
-    def test_cliffs_delta_empty_groups(self, g1, g2):
+    def test_cliffs_delta_empty_groups(self, g1: Any, g2: Any) -> None:
         """Test Cliff's delta returns NaN for empty groups."""
         from scylla.analysis.stats import cliffs_delta
 
@@ -81,7 +83,7 @@ class TestCliffsDeltaParametrized:
         ],
         ids=["pandas_pos", "pandas_neg", "numpy"],
     )
-    def test_cliffs_delta_input_types(self, g1, g2):
+    def test_cliffs_delta_input_types(self, g1: Any, g2: Any) -> None:
         """Test Cliff's delta works with different input types."""
         from scylla.analysis.stats import cliffs_delta
 
@@ -104,7 +106,7 @@ class TestBootstrapCIParametrized:
         ],
         ids=["int_1-5", "int_10-50", "float_decimals", "numpy", "pandas"],
     )
-    def test_bootstrap_ci_mean(self, data, expected_mean):
+    def test_bootstrap_ci_mean(self, data: Any, expected_mean: Any) -> None:
         """Test bootstrap CI computes correct mean."""
         from scylla.analysis.stats import bootstrap_ci
 
@@ -120,7 +122,7 @@ class TestBootstrapCIParametrized:
         ],
         ids=["5_elements", "3_elements", "4_elements"],
     )
-    def test_bootstrap_ci_bounds(self, data):
+    def test_bootstrap_ci_bounds(self, data: Any) -> None:
         """Test bootstrap CI bounds satisfy ci_low <= mean <= ci_high."""
         from scylla.analysis.stats import bootstrap_ci
 
@@ -136,7 +138,7 @@ class TestBootstrapCIParametrized:
         ],
         ids=["single_element", "single_zero", "zero_variance"],
     )
-    def test_bootstrap_ci_degenerate(self, data, expected):
+    def test_bootstrap_ci_degenerate(self, data: Any, expected: Any) -> None:
         """Test bootstrap CI with degenerate inputs (zero variance)."""
         from scylla.analysis.stats import bootstrap_ci
 
@@ -160,7 +162,7 @@ class TestMannWhitneyUParametrized:
         ],
         ids=["clearly_different", "identical", "overlap"],
     )
-    def test_mann_whitney_significance(self, g1, g2, expect_significant):
+    def test_mann_whitney_significance(self, g1: Any, g2: Any, expect_significant: Any) -> None:
         """Test Mann-Whitney U significance detection."""
         from scylla.analysis.stats import mann_whitney_u
 
@@ -180,7 +182,7 @@ class TestMannWhitneyUParametrized:
         ],
         ids=["single_g1", "single_g2", "empty_g1", "empty_g2"],
     )
-    def test_mann_whitney_degenerate_safe_defaults(self, g1, g2):
+    def test_mann_whitney_degenerate_safe_defaults(self, g1: Any, g2: Any) -> None:
         """Test Mann-Whitney U returns safe defaults for degenerate input."""
         from scylla.analysis.stats import mann_whitney_u
 
@@ -204,7 +206,9 @@ class TestConsistencyParametrized:
         ],
         ids=["zero_variance", "cv_0.1", "cv_0.2", "cv_0.5", "cv_1.0"],
     )
-    def test_consistency_values(self, mean_score, std_score, expected_consistency):
+    def test_consistency_values(
+        self, mean_score: Any, std_score: Any, expected_consistency: Any
+    ) -> None:
         """Test consistency calculation with known values."""
         from scylla.analysis.stats import compute_consistency
 
@@ -219,7 +223,7 @@ class TestConsistencyParametrized:
         ],
         ids=["zero_mean_zero_std", "zero_mean_nonzero_std"],
     )
-    def test_consistency_edge_cases(self, mean_score, std_score, expected):
+    def test_consistency_edge_cases(self, mean_score: Any, std_score: Any, expected: Any) -> None:
         """Test consistency with edge cases."""
         from scylla.analysis.stats import compute_consistency
 
@@ -240,7 +244,7 @@ class TestCostOfPassParametrized:
         ],
         ids=["perfect_pass", "half_pass", "quarter_pass", "tenth_pass"],
     )
-    def test_cop_values(self, mean_cost, pass_rate, expected_cop):
+    def test_cop_values(self, mean_cost: Any, pass_rate: Any, expected_cop: Any) -> None:
         """Test CoP calculation with known values."""
         from scylla.analysis.stats import compute_cop
 
@@ -256,7 +260,7 @@ class TestCostOfPassParametrized:
         ],
         ids=["zero_pass_nonzero_cost", "zero_pass_high_cost", "zero_both"],
     )
-    def test_cop_zero_pass_rate(self, mean_cost, pass_rate):
+    def test_cop_zero_pass_rate(self, mean_cost: Any, pass_rate: Any) -> None:
         """Test CoP returns infinity for zero pass rate."""
         from scylla.analysis.stats import compute_cop
 
@@ -287,7 +291,7 @@ class TestHolmBonferroniParametrized:
             "single_not_significant",
         ],
     )
-    def test_holm_bonferroni_rejections(self, p_values, expected_rejections):
+    def test_holm_bonferroni_rejections(self, p_values: Any, expected_rejections: Any) -> None:
         """Test Holm-Bonferroni correction rejection pattern (alpha=0.05)."""
         from scylla.analysis.stats import holm_bonferroni_correction
 
@@ -306,7 +310,7 @@ class TestHolmBonferroniParametrized:
         ],
         ids=["ascending", "descending"],
     )
-    def test_holm_bonferroni_monotonicity(self, p_values):
+    def test_holm_bonferroni_monotonicity(self, p_values: Any) -> None:
         """Test corrected p-values are monotonically increasing."""
         from scylla.analysis.stats import holm_bonferroni_correction
 
@@ -332,7 +336,7 @@ class TestImplRateParametrized:
         ],
         ids=["perfect", "half", "three_quarters", "zero", "different_scale"],
     )
-    def test_impl_rate_values(self, achieved, max_points, expected_rate):
+    def test_impl_rate_values(self, achieved: Any, max_points: Any, expected_rate: Any) -> None:
         """Test implementation rate calculation."""
         from scylla.analysis.stats import compute_impl_rate
 
@@ -347,7 +351,7 @@ class TestImplRateParametrized:
         ],
         ids=["zero_both", "zero_max"],
     )
-    def test_impl_rate_edge_cases(self, achieved, max_points):
+    def test_impl_rate_edge_cases(self, achieved: Any, max_points: Any) -> None:
         """Test implementation rate edge cases (division by zero)."""
         from scylla.analysis.stats import compute_impl_rate
 

--- a/tests/unit/analysis/test_tables.py
+++ b/tests/unit/analysis/test_tables.py
@@ -4,11 +4,13 @@ Note: These are basic smoke tests to ensure tables can be generated.
 Full validation of table content is deferred to integration tests.
 """
 
+from typing import Any
+
 import numpy as np
 import pytest
 
 
-def test_table01_tier_summary_format(sample_runs_df):
+def test_table01_tier_summary_format(sample_runs_df: Any) -> None:
     """Test Table 1 returns valid dual-format output."""
     from scylla.analysis.tables import table01_tier_summary
 
@@ -25,14 +27,14 @@ def test_table01_tier_summary_format(sample_runs_df):
     assert "tabular" in latex or "table" in latex.lower()
 
 
-def test_tables_module_imports():
+def test_tables_module_imports() -> None:
     """Test that tables module can be imported."""
     import scylla.analysis.tables
 
     assert scylla.analysis.tables is not None
 
 
-def test_table_function_signatures():
+def test_table_function_signatures() -> None:
     """Test that all table functions exist with expected signature."""
     import inspect
 
@@ -68,7 +70,7 @@ def test_table_function_signatures():
         assert is_valid, f"Invalid return annotation for {func_name}: {ann}"
 
 
-def test_table01_consistency_clamped():
+def test_table01_consistency_clamped() -> None:
     """Test that consistency values are clamped to [0, 1].
 
     Regression test for P0 bug where inline formula 1 - (std/mean) could produce
@@ -108,7 +110,7 @@ def test_table01_consistency_clamped():
     )
 
 
-def test_table01_uses_compute_cop():
+def test_table01_uses_compute_cop() -> None:
     """Test that table01 uses shared compute_cop function.
 
     Regression test for P1 bug where inline formula duplicated compute_cop logic.
@@ -139,7 +141,7 @@ def test_table01_uses_compute_cop():
     assert "inf" in markdown.lower() or "∞" in markdown
 
 
-def test_table08_summary_statistics():
+def test_table08_summary_statistics() -> None:
     """Test Table 8 summary statistics smoke test."""
     import pandas as pd
 
@@ -172,7 +174,7 @@ def test_table08_summary_statistics():
     assert "Kurt" in markdown
 
 
-def test_table09_experiment_config():
+def test_table09_experiment_config() -> None:
     """Test Table 9 experiment configuration smoke test."""
     import pandas as pd
 
@@ -201,7 +203,7 @@ def test_table09_experiment_config():
     assert "Total Runs" in markdown
 
 
-def test_table10_normality_tests():
+def test_table10_normality_tests() -> None:
     """Test Table 10 normality tests smoke test."""
     import pandas as pd
 
@@ -237,7 +239,7 @@ def test_table10_normality_tests():
 # ============================================================================
 
 
-def test_table02_tier_comparison_statistical_workflow(sample_runs_df):
+def test_table02_tier_comparison_statistical_workflow(sample_runs_df: Any) -> None:
     """Test Table 2 statistical workflow: Kruskal-Wallis → pairwise → Holm-Bonferroni."""
     from scylla.analysis.tables import table02_tier_comparison
 
@@ -261,7 +263,7 @@ def test_table02_tier_comparison_statistical_workflow(sample_runs_df):
     assert "p=" in markdown or "p <" in markdown
 
 
-def test_table02_handles_single_tier(sample_runs_df):
+def test_table02_handles_single_tier(sample_runs_df: Any) -> None:
     """Test Table 2 handles edge case of single tier."""
     from scylla.analysis.tables import table02_tier_comparison
 
@@ -276,7 +278,7 @@ def test_table02_handles_single_tier(sample_runs_df):
     assert len(markdown) > 0
 
 
-def test_table02_holm_bonferroni_correction_applied(sample_runs_df):
+def test_table02_holm_bonferroni_correction_applied(sample_runs_df: Any) -> None:
     """Test that Holm-Bonferroni correction is actually applied."""
     from scylla.analysis.tables import table02_tier_comparison
 
@@ -289,7 +291,7 @@ def test_table02_holm_bonferroni_correction_applied(sample_runs_df):
     assert "Holm-Bonferroni" in markdown
 
 
-def test_table03_judge_agreement(sample_judges_df):
+def test_table03_judge_agreement(sample_judges_df: Any) -> None:
     """Test Table 3 judge agreement with Krippendorff's alpha."""
     from scylla.analysis.tables import table03_judge_agreement
 
@@ -309,7 +311,7 @@ def test_table03_judge_agreement(sample_judges_df):
     assert "0." in markdown or "1." in markdown or "-" in markdown
 
 
-def test_table03_handles_single_judge(sample_runs_df):
+def test_table03_handles_single_judge(sample_runs_df: Any) -> None:
     """Test Table 3 handles edge case of single judge."""
     import pandas as pd
 
@@ -335,7 +337,9 @@ def test_table03_handles_single_judge(sample_runs_df):
         table03_judge_agreement(single_judge)
 
 
-def test_table04_criteria_performance_holm_bonferroni(sample_criteria_df, sample_runs_df):
+def test_table04_criteria_performance_holm_bonferroni(
+    sample_criteria_df: Any, sample_runs_df: Any
+) -> None:
     """Test Table 4 uses Holm-Bonferroni for criteria comparisons."""
     from scylla.analysis.tables import table04_criteria_performance
 
@@ -354,7 +358,7 @@ def test_table04_criteria_performance_holm_bonferroni(sample_criteria_df, sample
     assert "p-value" in markdown or "p =" in markdown or "Winner" in markdown
 
 
-def test_table04_handles_single_model(sample_criteria_df, sample_runs_df):
+def test_table04_handles_single_model(sample_criteria_df: Any, sample_runs_df: Any) -> None:
     """Test Table 4 handles single model gracefully."""
     from scylla.analysis.tables import table04_criteria_performance
 
@@ -370,7 +374,7 @@ def test_table04_handles_single_model(sample_criteria_df, sample_runs_df):
     assert len(markdown) > 50
 
 
-def test_table04_data_driven_criteria_weights(sample_criteria_df, sample_runs_df):
+def test_table04_data_driven_criteria_weights(sample_criteria_df: Any, sample_runs_df: Any) -> None:
     """Test Table 4 derives criteria weights from data when not provided."""
     from scylla.analysis.tables import table04_criteria_performance
 
@@ -392,7 +396,7 @@ def test_table04_data_driven_criteria_weights(sample_criteria_df, sample_runs_df
     assert present_criteria >= 3
 
 
-def test_table05_cost_analysis_token_breakdown(sample_runs_df):
+def test_table05_cost_analysis_token_breakdown(sample_runs_df: Any) -> None:
     """Test Table 5 cost analysis includes token breakdown."""
     from scylla.analysis.tables import table05_cost_analysis
 
@@ -412,7 +416,7 @@ def test_table05_cost_analysis_token_breakdown(sample_runs_df):
     assert "Input" in markdown or "Output" in markdown or "Token" in markdown
 
 
-def test_table05_handles_zero_cost_runs(sample_runs_df):
+def test_table05_handles_zero_cost_runs(sample_runs_df: Any) -> None:
     """Test Table 5 handles runs with zero cost gracefully."""
     from scylla.analysis.tables import table05_cost_analysis
 
@@ -427,7 +431,7 @@ def test_table05_handles_zero_cost_runs(sample_runs_df):
     assert isinstance(latex, str)
 
 
-def test_table06_model_comparison_holm_bonferroni(sample_runs_df):
+def test_table06_model_comparison_holm_bonferroni(sample_runs_df: Any) -> None:
     """Test Table 6 uses Holm-Bonferroni for model comparisons."""
     from scylla.analysis.tables import table06_model_comparison
 
@@ -447,7 +451,7 @@ def test_table06_model_comparison_holm_bonferroni(sample_runs_df):
     assert "p-value" in markdown or "p =" in markdown
 
 
-def test_table06_handles_single_model():
+def test_table06_handles_single_model() -> None:
     """Test Table 6 handles single model error case."""
     import pandas as pd
 
@@ -469,7 +473,7 @@ def test_table06_handles_single_model():
     assert "Error" in markdown or "Need at least 2 models" in markdown
 
 
-def test_table06_multiple_models_pairwise():
+def test_table06_multiple_models_pairwise() -> None:
     """Test Table 6 handles multiple models with pairwise comparisons."""
     import pandas as pd
 
@@ -496,7 +500,7 @@ def test_table06_multiple_models_pairwise():
     assert "Model B vs Model C" in markdown
 
 
-def test_table07_subtest_detail_appendix(sample_runs_df):
+def test_table07_subtest_detail_appendix(sample_runs_df: Any) -> None:
     """Test Table 7 subtest detail generates appendix table."""
     from scylla.analysis.dataframes import build_subtests_df
     from scylla.analysis.tables import table07_subtest_detail
@@ -523,7 +527,7 @@ def test_table07_subtest_detail_appendix(sample_runs_df):
     assert "longtable" in latex or "tabular" in latex
 
 
-def test_table07_handles_empty_subtests():
+def test_table07_handles_empty_subtests() -> None:
     """Test Table 7 handles empty subtest data gracefully."""
     import pandas as pd
 
@@ -551,7 +555,7 @@ def test_table07_handles_empty_subtests():
     assert isinstance(latex, str)
 
 
-def test_table02b_impl_rate_comparison_format(sample_runs_df):
+def test_table02b_impl_rate_comparison_format(sample_runs_df: Any) -> None:
     """Test Table 2b returns valid dual-format output."""
     from scylla.analysis.tables import table02b_impl_rate_comparison
 
@@ -568,7 +572,7 @@ def test_table02b_impl_rate_comparison_format(sample_runs_df):
     assert "tabular" in latex or "table" in latex.lower()
 
 
-def test_table02b_impl_rate_statistical_workflow(sample_runs_df):
+def test_table02b_impl_rate_statistical_workflow(sample_runs_df: Any) -> None:
     """Test Table 2b follows correct statistical workflow."""
     from scylla.analysis.tables import table02b_impl_rate_comparison
 
@@ -584,7 +588,7 @@ def test_table02b_impl_rate_statistical_workflow(sample_runs_df):
     assert "Omnibus Test Results" in markdown
 
 
-def test_table02b_handles_missing_impl_rate():
+def test_table02b_handles_missing_impl_rate() -> None:
     """Test Table 2b handles missing impl_rate column gracefully."""
     import pandas as pd
 
@@ -607,7 +611,7 @@ def test_table02b_handles_missing_impl_rate():
     assert "impl_rate" in markdown
 
 
-def test_table02b_holm_bonferroni_correction_applied(sample_runs_df):
+def test_table02b_holm_bonferroni_correction_applied(sample_runs_df: Any) -> None:
     """Test that Holm-Bonferroni correction is applied to p-values."""
     from scylla.analysis.tables import table02b_impl_rate_comparison
 
@@ -618,7 +622,7 @@ def test_table02b_holm_bonferroni_correction_applied(sample_runs_df):
     assert "correction" in markdown.lower()
 
 
-def test_table08_calculation_verification():
+def test_table08_calculation_verification() -> None:
     """Test Table 8 calculates summary statistics correctly."""
     import pandas as pd
 
@@ -659,7 +663,7 @@ def test_table08_calculation_verification():
     assert "Score" in latex or "score" in latex.lower()
 
 
-def test_table09_calculation_verification():
+def test_table09_calculation_verification() -> None:
     """Test Table 9 correctly extracts experiment configuration."""
     import pandas as pd
 
@@ -697,7 +701,7 @@ def test_table09_calculation_verification():
     assert "exp001" in latex or len(latex) > 100
 
 
-def test_table02_power_column_present(sample_runs_df):
+def test_table02_power_column_present(sample_runs_df: Any) -> None:
     """Test that Power column is present in Table 2 markdown and LaTeX output."""
     from scylla.analysis.tables import table02_tier_comparison
 
@@ -707,7 +711,7 @@ def test_table02_power_column_present(sample_runs_df):
     assert "Power" in latex
 
 
-def test_table02b_power_column_present(sample_runs_df):
+def test_table02b_power_column_present(sample_runs_df: Any) -> None:
     """Test that Power column is present in Table 2b markdown and LaTeX output."""
     from scylla.analysis.tables import table02b_impl_rate_comparison
 
@@ -717,7 +721,7 @@ def test_table02b_power_column_present(sample_runs_df):
     assert "Power" in latex
 
 
-def test_table02_power_is_numeric(sample_runs_df):
+def test_table02_power_is_numeric(sample_runs_df: Any) -> None:
     """Test that power values in Table 2 are floating-point parseable.
 
     The mock_power_simulations autouse fixture returns 0.8 for mann_whitney_power,
@@ -731,7 +735,7 @@ def test_table02_power_is_numeric(sample_runs_df):
     assert "0.800" in markdown
 
 
-def test_table02_power_nan_for_small_samples():
+def test_table02_power_nan_for_small_samples() -> None:
     """Test that '—' sentinel appears for small-sample rows (N < 5)."""
     import pandas as pd
 
@@ -775,7 +779,7 @@ def test_table02_power_nan_for_small_samples():
     assert "—" in markdown
 
 
-def test_table02_omnibus_power_in_footer(sample_runs_df):
+def test_table02_omnibus_power_in_footer(sample_runs_df: Any) -> None:
     """Test that omnibus KW power value appears in Table 2 footer section."""
     from scylla.analysis.tables import table02_tier_comparison
 
@@ -786,7 +790,7 @@ def test_table02_omnibus_power_in_footer(sample_runs_df):
     assert "power=0.750" in latex
 
 
-def test_table10_calculation_verification():
+def test_table10_calculation_verification() -> None:
     """Test Table 10 calculates Shapiro-Wilk normality tests correctly."""
     import numpy as np
     import pandas as pd
@@ -842,7 +846,7 @@ def test_table10_calculation_verification():
 # ============================================================================
 
 
-def test_table_cfp_comparison_format(sample_runs_df):
+def test_table_cfp_comparison_format(sample_runs_df: Any) -> None:
     """Test table_cfp_comparison returns valid dual-format output."""
     from scylla.analysis.tables import table_cfp_comparison
 
@@ -858,7 +862,7 @@ def test_table_cfp_comparison_format(sample_runs_df):
     assert "tabular" in latex or "table" in latex.lower()
 
 
-def test_table_cfp_comparison_missing_column():
+def test_table_cfp_comparison_missing_column() -> None:
     """Test table_cfp_comparison returns placeholder when cfp column is absent."""
     import pandas as pd
 
@@ -882,7 +886,7 @@ def test_table_cfp_comparison_missing_column():
     assert len(latex) > 0
 
 
-def test_table_cfp_comparison_all_nan(sample_runs_df):
+def test_table_cfp_comparison_all_nan(sample_runs_df: Any) -> None:
     """Test table_cfp_comparison handles all-NaN cfp column without error."""
     from scylla.analysis.tables import table_cfp_comparison
 
@@ -897,7 +901,7 @@ def test_table_cfp_comparison_all_nan(sample_runs_df):
     assert isinstance(latex, str)
 
 
-def test_table_cfp_comparison_statistical_workflow(sample_runs_df):
+def test_table_cfp_comparison_statistical_workflow(sample_runs_df: Any) -> None:
     """Test table_cfp_comparison uses correct statistical workflow."""
     from scylla.analysis.tables import table_cfp_comparison
 

--- a/tests/unit/automation/test_dependency_resolver.py
+++ b/tests/unit/automation/test_dependency_resolver.py
@@ -12,7 +12,7 @@ from scylla.automation.models import IssueInfo
 class TestDependencyResolver:
     """Tests for DependencyResolver class."""
 
-    def test_add_issue(self):
+    def test_add_issue(self) -> None:
         """Test adding issues to resolver."""
         resolver = DependencyResolver()
 
@@ -22,7 +22,7 @@ class TestDependencyResolver:
         assert 123 in resolver.graph.issues
         assert resolver.graph.issues[123] == issue
 
-    def test_add_issue_with_dependencies(self):
+    def test_add_issue_with_dependencies(self) -> None:
         """Test adding issue with dependencies."""
         resolver = DependencyResolver()
 
@@ -35,7 +35,7 @@ class TestDependencyResolver:
 
         assert resolver.graph.get_dependencies(123) == [100, 101]
 
-    def test_detect_cycles_no_cycle(self):
+    def test_detect_cycles_no_cycle(self) -> None:
         """Test cycle detection with no cycles."""
         resolver = DependencyResolver()
 
@@ -47,7 +47,7 @@ class TestDependencyResolver:
         cycles = resolver.detect_cycles()
         assert cycles == []
 
-    def test_detect_cycles_with_cycle(self):
+    def test_detect_cycles_with_cycle(self) -> None:
         """Test cycle detection with a cycle."""
         resolver = DependencyResolver()
 
@@ -59,7 +59,7 @@ class TestDependencyResolver:
         with pytest.raises(CyclicDependencyError):
             resolver.detect_cycles()
 
-    def test_get_ready_issues_none_ready(self):
+    def test_get_ready_issues_none_ready(self) -> None:
         """Test getting ready issues when none are ready."""
         resolver = DependencyResolver()
 
@@ -70,7 +70,7 @@ class TestDependencyResolver:
         ready = resolver.get_ready_issues()
         assert len(ready) == 0
 
-    def test_get_ready_issues_some_ready(self):
+    def test_get_ready_issues_some_ready(self) -> None:
         """Test getting ready issues when some are ready."""
         resolver = DependencyResolver()
 
@@ -83,7 +83,7 @@ class TestDependencyResolver:
         assert len(ready) == 1
         assert ready[0].number == 1
 
-    def test_get_ready_issues_after_completion(self):
+    def test_get_ready_issues_after_completion(self) -> None:
         """Test getting ready issues after marking one complete."""
         resolver = DependencyResolver()
 
@@ -97,7 +97,7 @@ class TestDependencyResolver:
         assert len(ready) == 1
         assert ready[0].number == 2
 
-    def test_get_ready_issues_priority_sorting(self):
+    def test_get_ready_issues_priority_sorting(self) -> None:
         """Test that ready issues are sorted by priority."""
         resolver = DependencyResolver()
 
@@ -110,7 +110,7 @@ class TestDependencyResolver:
         # Should be sorted by priority descending
         assert [i.number for i in ready] == [2, 3, 1]
 
-    def test_topological_sort_linear(self):
+    def test_topological_sort_linear(self) -> None:
         """Test topological sort with linear dependencies."""
         resolver = DependencyResolver()
 
@@ -125,7 +125,7 @@ class TestDependencyResolver:
         assert order.index(1) < order.index(2)
         assert order.index(2) < order.index(3)
 
-    def test_topological_sort_diamond(self):
+    def test_topological_sort_diamond(self) -> None:
         """Test topological sort with diamond pattern."""
         resolver = DependencyResolver()
 
@@ -144,7 +144,7 @@ class TestDependencyResolver:
         assert order.index(2) < order.index(4)
         assert order.index(3) < order.index(4)
 
-    def test_topological_sort_with_cycle(self):
+    def test_topological_sort_with_cycle(self) -> None:
         """Test topological sort fails with cycle."""
         resolver = DependencyResolver()
 
@@ -155,7 +155,7 @@ class TestDependencyResolver:
         with pytest.raises(CyclicDependencyError):
             resolver.topological_sort()
 
-    def test_get_stats(self):
+    def test_get_stats(self) -> None:
         """Test getting resolver statistics."""
         resolver = DependencyResolver()
 
@@ -172,7 +172,7 @@ class TestDependencyResolver:
         assert stats["remaining_issues"] == 2
         assert stats["ready_issues"] == 1  # Issue 2 is now ready
 
-    def test_mark_completed(self):
+    def test_mark_completed(self) -> None:
         """Test marking issues as completed."""
         resolver = DependencyResolver()
 

--- a/tests/unit/automation/test_git_utils.py
+++ b/tests/unit/automation/test_git_utils.py
@@ -2,6 +2,7 @@
 
 import subprocess
 from pathlib import Path
+from typing import Any
 from unittest.mock import Mock, patch
 
 import pytest
@@ -19,24 +20,24 @@ from scylla.automation.git_utils import (
 class TestRun:
     """Tests for run function."""
 
-    def test_successful_command(self):
+    def test_successful_command(self) -> None:
         """Test running a successful command."""
         result = run(["echo", "hello"], check=True, capture_output=True)
 
         assert result.returncode == 0
         assert "hello" in result.stdout
 
-    def test_failed_command_with_check(self):
+    def test_failed_command_with_check(self) -> None:
         """Test running a failed command with check=True."""
         with pytest.raises(subprocess.CalledProcessError):
             run(["false"], check=True)
 
-    def test_failed_command_without_check(self):
+    def test_failed_command_without_check(self) -> None:
         """Test running a failed command with check=False."""
         result = run(["false"], check=False)
         assert result.returncode != 0
 
-    def test_with_cwd(self, tmp_path):
+    def test_with_cwd(self, tmp_path: Any) -> None:
         """Test running command with custom working directory."""
         test_file = tmp_path / "test.txt"
         test_file.write_text("content")
@@ -51,7 +52,7 @@ class TestGetRepoRoot:
     """Tests for get_repo_root function."""
 
     @patch("scylla.automation.git_utils.run")
-    def test_successful_detection(self, mock_run):
+    def test_successful_detection(self, mock_run: Any) -> None:
         """Test successful repository root detection."""
         mock_result = Mock()
         mock_result.stdout = "/home/user/repo\n"
@@ -63,7 +64,7 @@ class TestGetRepoRoot:
         mock_run.assert_called_once()
 
     @patch("scylla.automation.git_utils.run")
-    def test_not_in_git_repo(self, mock_run):
+    def test_not_in_git_repo(self, mock_run: Any) -> None:
         """Test when not in a git repository."""
         mock_run.side_effect = subprocess.CalledProcessError(128, "git")
 
@@ -76,7 +77,7 @@ class TestGetRepoInfo:
 
     @patch("scylla.automation.git_utils.run")
     @patch("scylla.automation.git_utils.get_repo_root")
-    def test_ssh_url_format(self, mock_get_root, mock_run):
+    def test_ssh_url_format(self, mock_get_root: Any, mock_run: Any) -> None:
         """Test parsing SSH URL format."""
         mock_get_root.return_value = Path("/home/user/repo")
         mock_result = Mock()
@@ -90,7 +91,7 @@ class TestGetRepoInfo:
 
     @patch("scylla.automation.git_utils.run")
     @patch("scylla.automation.git_utils.get_repo_root")
-    def test_https_url_format(self, mock_get_root, mock_run):
+    def test_https_url_format(self, mock_get_root: Any, mock_run: Any) -> None:
         """Test parsing HTTPS URL format."""
         mock_get_root.return_value = Path("/home/user/repo")
         mock_result = Mock()
@@ -104,7 +105,7 @@ class TestGetRepoInfo:
 
     @patch("scylla.automation.git_utils.run")
     @patch("scylla.automation.git_utils.get_repo_root")
-    def test_invalid_url_format(self, mock_get_root, mock_run):
+    def test_invalid_url_format(self, mock_get_root: Any, mock_run: Any) -> None:
         """Test handling invalid URL format."""
         mock_get_root.return_value = Path("/home/user/repo")
         mock_result = Mock()
@@ -120,7 +121,7 @@ class TestGetCurrentBranch:
 
     @patch("scylla.automation.git_utils.run")
     @patch("scylla.automation.git_utils.get_repo_root")
-    def test_successful_detection(self, mock_get_root, mock_run):
+    def test_successful_detection(self, mock_get_root: Any, mock_run: Any) -> None:
         """Test successful branch detection."""
         mock_get_root.return_value = Path("/home/user/repo")
         mock_result = Mock()
@@ -133,7 +134,7 @@ class TestGetCurrentBranch:
 
     @patch("scylla.automation.git_utils.run")
     @patch("scylla.automation.git_utils.get_repo_root")
-    def test_failed_detection(self, mock_get_root, mock_run):
+    def test_failed_detection(self, mock_get_root: Any, mock_run: Any) -> None:
         """Test failed branch detection."""
         mock_get_root.return_value = Path("/home/user/repo")
         mock_run.side_effect = subprocess.CalledProcessError(128, "git")
@@ -147,7 +148,7 @@ class TestIsCleanWorkingTree:
 
     @patch("scylla.automation.git_utils.run")
     @patch("scylla.automation.git_utils.get_repo_root")
-    def test_clean_tree(self, mock_get_root, mock_run):
+    def test_clean_tree(self, mock_get_root: Any, mock_run: Any) -> None:
         """Test clean working tree."""
         mock_get_root.return_value = Path("/home/user/repo")
         mock_result = Mock()
@@ -158,7 +159,7 @@ class TestIsCleanWorkingTree:
 
     @patch("scylla.automation.git_utils.run")
     @patch("scylla.automation.git_utils.get_repo_root")
-    def test_dirty_tree(self, mock_get_root, mock_run):
+    def test_dirty_tree(self, mock_get_root: Any, mock_run: Any) -> None:
         """Test dirty working tree."""
         mock_get_root.return_value = Path("/home/user/repo")
         mock_result = Mock()
@@ -169,7 +170,7 @@ class TestIsCleanWorkingTree:
 
     @patch("scylla.automation.git_utils.run")
     @patch("scylla.automation.git_utils.get_repo_root")
-    def test_error_returns_false(self, mock_get_root, mock_run):
+    def test_error_returns_false(self, mock_get_root: Any, mock_run: Any) -> None:
         """Test error returns False."""
         mock_get_root.return_value = Path("/home/user/repo")
         mock_run.side_effect = subprocess.CalledProcessError(128, "git")
@@ -181,7 +182,7 @@ class TestSafeGitFetch:
     """Tests for safe_git_fetch function."""
 
     @patch("scylla.automation.git_utils.run")
-    def test_successful_fetch(self, mock_run):
+    def test_successful_fetch(self, mock_run: Any) -> None:
         """Test successful git fetch."""
         repo_root = Path("/home/user/repo")
 
@@ -192,7 +193,7 @@ class TestSafeGitFetch:
 
     @patch("scylla.automation.git_utils.run")
     @patch("scylla.automation.git_utils.time.sleep")
-    def test_retry_on_failure(self, mock_sleep, mock_run):
+    def test_retry_on_failure(self, mock_sleep: Any, mock_run: Any) -> None:
         """Test retry on fetch failure."""
         repo_root = Path("/home/user/repo")
         mock_run.side_effect = [
@@ -208,7 +209,7 @@ class TestSafeGitFetch:
 
     @patch("scylla.automation.git_utils.run")
     @patch("scylla.automation.git_utils.time.sleep")
-    def test_all_retries_fail(self, mock_sleep, mock_run):
+    def test_all_retries_fail(self, mock_sleep: Any, mock_run: Any) -> None:
         """Test when all retries fail."""
         repo_root = Path("/home/user/repo")
         mock_run.side_effect = subprocess.CalledProcessError(1, "git")

--- a/tests/unit/automation/test_github_api.py
+++ b/tests/unit/automation/test_github_api.py
@@ -2,6 +2,7 @@
 
 import json
 import subprocess
+from typing import Any
 from unittest.mock import Mock, patch
 
 import pytest
@@ -25,7 +26,7 @@ class TestGhIssueJson:
     """Tests for gh_issue_json function."""
 
     @patch("scylla.automation.github_api._gh_call")
-    def test_successful_fetch(self, mock_gh_call):
+    def test_successful_fetch(self, mock_gh_call: Any) -> None:
         """Test successful issue fetch."""
         mock_result = Mock()
         mock_result.stdout = json.dumps(
@@ -46,7 +47,7 @@ class TestGhIssueJson:
         assert data["state"] == "OPEN"
 
     @patch("scylla.automation.github_api._gh_call")
-    def test_failed_fetch(self, mock_gh_call):
+    def test_failed_fetch(self, mock_gh_call: Any) -> None:
         """Test failed issue fetch."""
         mock_gh_call.side_effect = subprocess.CalledProcessError(1, "gh")
 
@@ -57,7 +58,7 @@ class TestGhIssueJson:
 class TestParseIssueDependencies:
     """Tests for parse_issue_dependencies function."""
 
-    def test_depends_on_pattern(self):
+    def test_depends_on_pattern(self) -> None:
         """Test parsing 'depends on' pattern."""
         body = "This depends on #123 and also #456"
         deps = parse_issue_dependencies(body)
@@ -65,21 +66,21 @@ class TestParseIssueDependencies:
         assert 123 in deps
         assert 456 in deps
 
-    def test_blocked_by_pattern(self):
+    def test_blocked_by_pattern(self) -> None:
         """Test parsing 'blocked by' pattern."""
         body = "Blocked by #789"
         deps = parse_issue_dependencies(body)
 
         assert 789 in deps
 
-    def test_requires_pattern(self):
+    def test_requires_pattern(self) -> None:
         """Test parsing 'requires' pattern."""
         body = "Requires #111"
         deps = parse_issue_dependencies(body)
 
         assert 111 in deps
 
-    def test_dependencies_section(self):
+    def test_dependencies_section(self) -> None:
         """Test parsing dependencies section."""
         body = """
         ## Dependencies
@@ -91,14 +92,14 @@ class TestParseIssueDependencies:
         assert 100 in deps
         assert 200 in deps
 
-    def test_no_dependencies(self):
+    def test_no_dependencies(self) -> None:
         """Test when there are no dependencies."""
         body = "This is a simple issue with no dependencies"
         deps = parse_issue_dependencies(body)
 
         assert len(deps) == 0
 
-    def test_duplicate_removal(self):
+    def test_duplicate_removal(self) -> None:
         """Test that duplicates are removed."""
         body = "Depends on #123, blocked by #123"
         deps = parse_issue_dependencies(body)
@@ -111,7 +112,7 @@ class TestFetchIssueInfo:
     """Tests for fetch_issue_info function."""
 
     @patch("scylla.automation.github_api.gh_issue_json")
-    def test_successful_fetch(self, mock_gh_json):
+    def test_successful_fetch(self, mock_gh_json: Any) -> None:
         """Test successful issue info fetch."""
         mock_gh_json.return_value = {
             "number": 123,
@@ -133,34 +134,34 @@ class TestFetchIssueInfo:
 class TestIsIssueClosed:
     """Tests for is_issue_closed function."""
 
-    def test_with_cached_state_closed(self):
+    def test_with_cached_state_closed(self) -> None:
         """Test with cached state showing closed."""
         cached = {123: IssueState.CLOSED}
 
         assert is_issue_closed(123, cached) is True
 
-    def test_with_cached_state_open(self):
+    def test_with_cached_state_open(self) -> None:
         """Test with cached state showing open."""
         cached = {123: IssueState.OPEN}
 
         assert is_issue_closed(123, cached) is False
 
     @patch("scylla.automation.github_api.gh_issue_json")
-    def test_without_cache_closed(self, mock_gh_json):
+    def test_without_cache_closed(self, mock_gh_json: Any) -> None:
         """Test without cache, issue is closed."""
         mock_gh_json.return_value = {"state": "CLOSED"}
 
         assert is_issue_closed(123) is True
 
     @patch("scylla.automation.github_api.gh_issue_json")
-    def test_without_cache_open(self, mock_gh_json):
+    def test_without_cache_open(self, mock_gh_json: Any) -> None:
         """Test without cache, issue is open."""
         mock_gh_json.return_value = {"state": "OPEN"}
 
         assert is_issue_closed(123) is False
 
     @patch("scylla.automation.github_api.gh_issue_json")
-    def test_error_returns_false(self, mock_gh_json):
+    def test_error_returns_false(self, mock_gh_json: Any) -> None:
         """Test that errors return False."""
         mock_gh_json.side_effect = Exception("API error")
 
@@ -170,14 +171,14 @@ class TestIsIssueClosed:
 class TestPrefetchIssueStates:
     """Tests for prefetch_issue_states function."""
 
-    def test_empty_list(self):
+    def test_empty_list(self) -> None:
         """Test with empty issue list."""
         states = prefetch_issue_states([])
         assert states == {}
 
     @patch("scylla.automation.github_api._gh_call")
     @patch("scylla.automation.github_api.get_repo_info")
-    def test_successful_batch_fetch(self, mock_repo_info, mock_gh_call):
+    def test_successful_batch_fetch(self, mock_repo_info: Any, mock_gh_call: Any) -> None:
         """Test successful batch fetch."""
         mock_repo_info.return_value = ("owner", "repo")
 
@@ -200,7 +201,7 @@ class TestPrefetchIssueStates:
         assert states[456] == IssueState.CLOSED
 
     @patch("scylla.automation.github_api.get_repo_info")
-    def test_repo_info_failure(self, mock_repo_info):
+    def test_repo_info_failure(self, mock_repo_info: Any) -> None:
         """Test when repo info fails."""
         mock_repo_info.side_effect = RuntimeError("Not in repo")
 
@@ -213,7 +214,7 @@ class TestGhCall:
     """Tests for _gh_call function."""
 
     @patch("scylla.automation.github_api.run")
-    def test_successful_call(self, mock_run):
+    def test_successful_call(self, mock_run: Any) -> None:
         """Test successful gh call."""
         mock_result = Mock()
         mock_result.stdout = "success"
@@ -226,7 +227,7 @@ class TestGhCall:
 
     @patch("scylla.automation.github_api.run")
     @patch("scylla.automation.github_api.wait_until")
-    def test_retry_on_rate_limit(self, mock_wait, mock_run):
+    def test_retry_on_rate_limit(self, mock_wait: Any, mock_run: Any) -> None:
         """Test retry on rate limit."""
         # First call fails with rate limit, second succeeds
         mock_run.side_effect = [
@@ -243,7 +244,7 @@ class TestGhCall:
         mock_wait.assert_called_once_with(1234567890, "GitHub API rate limit")
 
     @patch("scylla.automation.github_api.run")
-    def test_fail_fast_on_permission_error(self, mock_run):
+    def test_fail_fast_on_permission_error(self, mock_run: Any) -> None:
         """Test that permission errors fail fast without retry."""
         mock_run.side_effect = subprocess.CalledProcessError(
             1, "gh", stderr="403 Forbidden: permission denied"
@@ -256,7 +257,7 @@ class TestGhCall:
         assert mock_run.call_count == 1
 
     @patch("scylla.automation.github_api.run")
-    def test_fail_fast_on_not_found(self, mock_run):
+    def test_fail_fast_on_not_found(self, mock_run: Any) -> None:
         """Test that 404 errors fail fast without retry."""
         mock_run.side_effect = subprocess.CalledProcessError(1, "gh", stderr="404 Not Found")
 
@@ -266,7 +267,7 @@ class TestGhCall:
         assert mock_run.call_count == 1
 
     @patch("scylla.automation.github_api.run")
-    def test_fail_fast_on_bad_request(self, mock_run):
+    def test_fail_fast_on_bad_request(self, mock_run: Any) -> None:
         """Test that 400 errors fail fast without retry."""
         mock_run.side_effect = subprocess.CalledProcessError(1, "gh", stderr="400 Bad Request")
 
@@ -277,7 +278,7 @@ class TestGhCall:
 
     @patch("scylla.automation.github_api.run")
     @patch("scylla.automation.github_api.time.sleep")
-    def test_retry_on_transient_error(self, mock_sleep, mock_run):
+    def test_retry_on_transient_error(self, mock_sleep: Any, mock_run: Any) -> None:
         """Test retry on transient errors."""
         # Fail twice with transient error, then succeed
         mock_run.side_effect = [
@@ -293,7 +294,7 @@ class TestGhCall:
         assert mock_sleep.call_count == 2  # Sleep between retries
 
     @patch("scylla.automation.github_api.run")
-    def test_claude_usage_limit_detection(self, mock_run):
+    def test_claude_usage_limit_detection(self, mock_run: Any) -> None:
         """Test detection of Claude usage limit."""
         mock_run.side_effect = subprocess.CalledProcessError(
             1, "gh", stderr="Usage limit exceeded for your account"
@@ -307,7 +308,7 @@ class TestGhIssueComment:
     """Tests for gh_issue_comment function."""
 
     @patch("scylla.automation.github_api._gh_call")
-    def test_successful_comment(self, mock_gh_call):
+    def test_successful_comment(self, mock_gh_call: Any) -> None:
         """Test successful comment posting."""
         mock_gh_call.return_value = Mock()
 
@@ -318,7 +319,7 @@ class TestGhIssueComment:
         assert call_args == ["issue", "comment", "123", "--body", "Test comment"]
 
     @patch("scylla.automation.github_api._gh_call")
-    def test_failed_comment(self, mock_gh_call):
+    def test_failed_comment(self, mock_gh_call: Any) -> None:
         """Test failed comment posting."""
         mock_gh_call.side_effect = subprocess.CalledProcessError(1, "gh")
 
@@ -330,7 +331,7 @@ class TestGhIssueCreate:
     """Tests for gh_issue_create function."""
 
     @patch("scylla.automation.github_api._gh_call")
-    def test_successful_creation(self, mock_gh_call):
+    def test_successful_creation(self, mock_gh_call: Any) -> None:
         """Test successful issue creation."""
         mock_result = Mock()
         mock_result.stdout = "https://github.com/owner/repo/issues/789"
@@ -347,7 +348,7 @@ class TestGhIssueCreate:
         assert call_args == ["issue", "create", "--title", "Test issue", "--body", "Test body"]
 
     @patch("scylla.automation.github_api._gh_call")
-    def test_creation_with_labels(self, mock_gh_call):
+    def test_creation_with_labels(self, mock_gh_call: Any) -> None:
         """Test issue creation with labels."""
         mock_result = Mock()
         mock_result.stdout = "https://github.com/owner/repo/issues/790"
@@ -366,7 +367,7 @@ class TestGhIssueCreate:
         assert "enhancement" in call_args
 
     @patch("scylla.automation.github_api._gh_call")
-    def test_creation_without_labels(self, mock_gh_call):
+    def test_creation_without_labels(self, mock_gh_call: Any) -> None:
         """Test issue creation without labels."""
         mock_result = Mock()
         mock_result.stdout = "https://github.com/owner/repo/issues/791"
@@ -383,7 +384,7 @@ class TestGhIssueCreate:
         assert "--label" not in call_args
 
     @patch("scylla.automation.github_api._gh_call")
-    def test_failed_creation(self, mock_gh_call):
+    def test_failed_creation(self, mock_gh_call: Any) -> None:
         """Test failed issue creation."""
         mock_gh_call.side_effect = subprocess.CalledProcessError(1, "gh")
 
@@ -395,7 +396,7 @@ class TestGhPrCreate:
     """Tests for gh_pr_create function."""
 
     @patch("scylla.automation.github_api._gh_call")
-    def test_successful_pr_creation(self, mock_gh_call):
+    def test_successful_pr_creation(self, mock_gh_call: Any) -> None:
         """Test successful PR creation."""
         # Mock PR creation response
         mock_create_result = Mock()
@@ -417,7 +418,7 @@ class TestGhPrCreate:
         assert mock_gh_call.call_count == 2  # create + auto-merge
 
     @patch("scylla.automation.github_api._gh_call")
-    def test_pr_creation_without_auto_merge(self, mock_gh_call):
+    def test_pr_creation_without_auto_merge(self, mock_gh_call: Any) -> None:
         """Test PR creation without auto-merge."""
         mock_result = Mock()
         mock_result.stdout = "https://github.com/owner/repo/pull/789"
@@ -434,7 +435,7 @@ class TestGhPrCreate:
         assert mock_gh_call.call_count == 1  # Only create, no auto-merge
 
     @patch("scylla.automation.github_api._gh_call")
-    def test_pr_creation_with_fallback_parsing(self, mock_gh_call):
+    def test_pr_creation_with_fallback_parsing(self, mock_gh_call: Any) -> None:
         """Test PR number extraction fallback."""
         mock_result = Mock()
         # URL without /pull/ pattern
@@ -451,7 +452,7 @@ class TestGhPrCreate:
         assert pr_number == 123
 
     @patch("scylla.automation.github_api._gh_call")
-    def test_pr_creation_auto_merge_failure(self, mock_gh_call):
+    def test_pr_creation_auto_merge_failure(self, mock_gh_call: Any) -> None:
         """Test PR creation when auto-merge fails."""
         mock_create_result = Mock()
         mock_create_result.stdout = "https://github.com/owner/repo/pull/456"
@@ -476,7 +477,7 @@ class TestGhPrCreate:
 class TestWriteSecure:
     """Tests for write_secure function."""
 
-    def test_write_new_file(self, tmp_path):
+    def test_write_new_file(self, tmp_path: Any) -> None:
         """Test writing to a new file."""
         test_file = tmp_path / "test.txt"
         content = "test content"
@@ -486,7 +487,7 @@ class TestWriteSecure:
         assert test_file.exists()
         assert test_file.read_text() == content
 
-    def test_overwrite_existing_file(self, tmp_path):
+    def test_overwrite_existing_file(self, tmp_path: Any) -> None:
         """Test overwriting an existing file."""
         test_file = tmp_path / "test.txt"
         test_file.write_text("old content")
@@ -495,7 +496,7 @@ class TestWriteSecure:
 
         assert test_file.read_text() == "new content"
 
-    def test_create_parent_directories(self, tmp_path):
+    def test_create_parent_directories(self, tmp_path: Any) -> None:
         """Test that parent directories are created."""
         test_file = tmp_path / "subdir" / "nested" / "test.txt"
 
@@ -504,7 +505,7 @@ class TestWriteSecure:
         assert test_file.exists()
         assert test_file.read_text() == "content"
 
-    def test_atomic_write(self, tmp_path):
+    def test_atomic_write(self, tmp_path: Any) -> None:
         """Test that write is atomic (uses temp file + rename)."""
         test_file = tmp_path / "test.txt"
 
@@ -521,7 +522,7 @@ class TestWriteSecure:
         # Content should be updated
         assert test_file.read_text() == "updated"
 
-    def test_cleanup_on_error(self, tmp_path):
+    def test_cleanup_on_error(self, tmp_path: Any) -> None:
         """Test that temp files are cleaned up on error."""
         test_file = tmp_path / "test.txt"
 

--- a/tests/unit/automation/test_github_api_errors.py
+++ b/tests/unit/automation/test_github_api_errors.py
@@ -11,7 +11,7 @@ from scylla.automation.github_api import _gh_call, gh_pr_create
 class TestAutoMergeErrorHandling:
     """Tests for auto-merge error handling."""
 
-    def test_auto_merge_runtime_error_caught(self):
+    def test_auto_merge_runtime_error_caught(self) -> None:
         """Test that RuntimeError from rate limit doesn't escape gh_pr_create."""
         with (
             patch("scylla.automation.github_api._gh_call") as mock_gh_call,
@@ -40,7 +40,7 @@ class TestAutoMergeErrorHandling:
             warning_msg = str(mock_logger.warning.call_args)
             assert "auto-merge" in warning_msg.lower()
 
-    def test_auto_merge_called_process_error_caught(self):
+    def test_auto_merge_called_process_error_caught(self) -> None:
         """Test that CalledProcessError is also caught."""
         with (
             patch("scylla.automation.github_api._gh_call") as mock_gh_call,
@@ -68,7 +68,7 @@ class TestAutoMergeErrorHandling:
 class TestGhCallTimeout:
     """Tests for gh CLI timeout."""
 
-    def test_gh_call_timeout(self):
+    def test_gh_call_timeout(self) -> None:
         """Test that timeout is passed to subprocess."""
         with patch("scylla.automation.github_api.run") as mock_run:
             mock_run.return_value = MagicMock(stdout="output")
@@ -81,7 +81,7 @@ class TestGhCallTimeout:
             assert "timeout" in call_kwargs
             assert call_kwargs["timeout"] == 120
 
-    def test_gh_call_timeout_expired(self):
+    def test_gh_call_timeout_expired(self) -> None:
         """Test that TimeoutExpired is propagated."""
         with patch("scylla.automation.github_api.run") as mock_run:
             mock_run.side_effect = subprocess.TimeoutExpired(["gh", "issue", "view"], 120)

--- a/tests/unit/automation/test_implementer.py
+++ b/tests/unit/automation/test_implementer.py
@@ -3,6 +3,7 @@
 import json
 import subprocess
 from pathlib import Path
+from typing import Any
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -12,7 +13,7 @@ from scylla.automation.models import ImplementerOptions, IssueInfo
 
 
 @pytest.fixture
-def mock_options():
+def mock_options() -> Any:
     """Create mock ImplementerOptions."""
     return ImplementerOptions(
         epic_number=123,
@@ -24,7 +25,7 @@ def mock_options():
 
 
 @pytest.fixture
-def implementer(mock_options):
+def implementer(mock_options: Any) -> Any:
     """Create an IssueImplementer instance."""
     with (
         patch("scylla.automation.implementer.get_repo_root") as mock_repo,
@@ -37,7 +38,7 @@ def implementer(mock_options):
 class TestRunClaudeCode:
     """Tests for _run_claude_code method."""
 
-    def test_captures_session_id_from_json(self, implementer, tmp_path):
+    def test_captures_session_id_from_json(self, implementer: Any, tmp_path: Any) -> None:
         """Test successful session_id capture from JSON output."""
         implementer.state_dir = tmp_path
         worktree_path = tmp_path / "worktree"
@@ -78,7 +79,7 @@ class TestRunClaudeCode:
             assert "--allowedTools" in args
             assert "Read,Write,Edit,Glob,Grep,Bash" in args
 
-    def test_graceful_failure_on_json_parse_error(self, implementer, tmp_path):
+    def test_graceful_failure_on_json_parse_error(self, implementer: Any, tmp_path: Any) -> None:
         """Test graceful handling when JSON parse fails."""
         implementer.state_dir = tmp_path
         worktree_path = tmp_path / "worktree"
@@ -103,7 +104,7 @@ class TestRunClaudeCode:
             mock_logger.warning.assert_called_once()
             assert "Could not parse session_id" in str(mock_logger.warning.call_args)
 
-    def test_graceful_failure_on_missing_session_id(self, implementer, tmp_path):
+    def test_graceful_failure_on_missing_session_id(self, implementer: Any, tmp_path: Any) -> None:
         """Test graceful handling when session_id is missing from JSON."""
         implementer.state_dir = tmp_path
         worktree_path = tmp_path / "worktree"
@@ -131,7 +132,7 @@ class TestRunClaudeCode:
             # Should return None when session_id is missing
             assert session_id is None
 
-    def test_timeout_raises_runtime_error(self, implementer, tmp_path):
+    def test_timeout_raises_runtime_error(self, implementer: Any, tmp_path: Any) -> None:
         """Test timeout handling."""
         implementer.state_dir = tmp_path
         worktree_path = tmp_path / "worktree"
@@ -149,7 +150,7 @@ class TestRunClaudeCode:
                     prompt="Implement issue",
                 )
 
-    def test_dry_run_returns_none(self, mock_options):
+    def test_dry_run_returns_none(self, mock_options: Any) -> None:
         """Test dry run mode returns None."""
         mock_options.dry_run = True
         implementer = IssueImplementer(mock_options)
@@ -162,7 +163,7 @@ class TestRunClaudeCode:
 
         assert session_id is None
 
-    def test_claude_code_output_saved_to_log(self, implementer, tmp_path):
+    def test_claude_code_output_saved_to_log(self, implementer: Any, tmp_path: Any) -> None:
         """Test that Claude Code stdout is saved to log file on success."""
         # Use tmp_path for state_dir to enable actual file writes
         implementer.state_dir = tmp_path
@@ -197,7 +198,7 @@ class TestRunClaudeCode:
             assert log_file.exists()
             assert "test-session-123" in log_file.read_text()
 
-    def test_claude_code_failure_saved_to_log(self, implementer, tmp_path):
+    def test_claude_code_failure_saved_to_log(self, implementer: Any, tmp_path: Any) -> None:
         """Test that Claude Code failure output is saved to log file."""
         # Use tmp_path for state_dir
         implementer.state_dir = tmp_path
@@ -239,7 +240,7 @@ class TestRunClaudeCode:
 class TestRunRetrospective:
     """Tests for _run_retrospective method."""
 
-    def test_successful_retrospective(self, implementer, tmp_path):
+    def test_successful_retrospective(self, implementer: Any, tmp_path: Any) -> None:
         """Test successful retrospective run."""
         # Use tmp_path for state_dir to enable actual file writes
         implementer.state_dir = tmp_path
@@ -290,7 +291,7 @@ class TestRunRetrospective:
             # Should return True on success
             assert result is True
 
-    def test_graceful_failure_on_error(self, implementer, tmp_path):
+    def test_graceful_failure_on_error(self, implementer: Any, tmp_path: Any) -> None:
         """Test graceful failure when retrospective errors."""
         implementer.state_dir = tmp_path
 
@@ -315,7 +316,7 @@ class TestRunRetrospective:
             # Should return False on failure
             assert result is False
 
-    def test_timeout_is_non_blocking(self, implementer, tmp_path):
+    def test_timeout_is_non_blocking(self, implementer: Any, tmp_path: Any) -> None:
         """Test timeout in retrospective doesn't block pipeline."""
         implementer.state_dir = tmp_path
 
@@ -339,7 +340,7 @@ class TestRunRetrospective:
             # Should return False on timeout
             assert result is False
 
-    def test_retrospective_failure_saved_to_log(self, implementer, tmp_path):
+    def test_retrospective_failure_saved_to_log(self, implementer: Any, tmp_path: Any) -> None:
         """Test that retrospective failure output is saved to log file."""
         # Use tmp_path for state_dir
         implementer.state_dir = tmp_path
@@ -377,7 +378,7 @@ class TestRunRetrospective:
             # Should return False on failure
             assert result is False
 
-    def test_retrospective_needs_rerun_failed_log(self, implementer, tmp_path):
+    def test_retrospective_needs_rerun_failed_log(self, implementer: Any, tmp_path: Any) -> None:
         """Test _retrospective_needs_rerun returns True for failed log."""
         implementer.state_dir = tmp_path
 
@@ -388,14 +389,14 @@ class TestRunRetrospective:
         result = implementer._retrospective_needs_rerun(123)
         assert result is True
 
-    def test_retrospective_needs_rerun_no_log(self, implementer, tmp_path):
+    def test_retrospective_needs_rerun_no_log(self, implementer: Any, tmp_path: Any) -> None:
         """Test _retrospective_needs_rerun returns True when no log exists."""
         implementer.state_dir = tmp_path
 
         result = implementer._retrospective_needs_rerun(123)
         assert result is True
 
-    def test_retrospective_no_rerun_successful_log(self, implementer, tmp_path):
+    def test_retrospective_no_rerun_successful_log(self, implementer: Any, tmp_path: Any) -> None:
         """Test _retrospective_needs_rerun returns False for successful log."""
         implementer.state_dir = tmp_path
 
@@ -406,7 +407,9 @@ class TestRunRetrospective:
         result = implementer._retrospective_needs_rerun(123)
         assert result is False
 
-    def test_rerun_failed_retrospectives_finds_failures(self, implementer, tmp_path):
+    def test_rerun_failed_retrospectives_finds_failures(
+        self, implementer: Any, tmp_path: Any
+    ) -> None:
         """Test _rerun_failed_retrospectives re-runs failed retrospectives."""
         implementer.state_dir = tmp_path
 
@@ -442,7 +445,7 @@ class TestRunRetrospective:
             assert state.retrospective_completed is True
             mock_save.assert_called_once()
 
-    def test_rerun_skips_already_successful(self, implementer, tmp_path):
+    def test_rerun_skips_already_successful(self, implementer: Any, tmp_path: Any) -> None:
         """Test _rerun_failed_retrospectives skips already successful retrospectives."""
         implementer.state_dir = tmp_path
 
@@ -465,7 +468,9 @@ class TestRunRetrospective:
             mock_retro.assert_not_called()
             assert results == {}
 
-    def test_old_state_without_retrospective_completed(self, implementer, tmp_path):
+    def test_old_state_without_retrospective_completed(
+        self, implementer: Any, tmp_path: Any
+    ) -> None:
         """Test backward compatibility for old JSON files without retrospective_completed."""
         # Simulate loading old state JSON that doesn't have retrospective_completed field
         old_state_json = """
@@ -492,7 +497,7 @@ class TestRunRetrospective:
 class TestImplementIssuePipeline:
     """Tests for _implement_issue pipeline with retrospective."""
 
-    def test_retrospective_phase_when_enabled(self, mock_options):
+    def test_retrospective_phase_when_enabled(self, mock_options: Any) -> None:
         """Test retrospective phase runs when enabled."""
         mock_options.enable_retrospective = True
 
@@ -528,7 +533,7 @@ class TestImplementIssuePipeline:
                 assert mock_retro.call_args[0][0] == "session123"
                 assert result.success is True
 
-    def test_retrospective_phase_when_disabled(self, mock_options):
+    def test_retrospective_phase_when_disabled(self, mock_options: Any) -> None:
         """Test retrospective phase skipped when disabled."""
         mock_options.enable_retrospective = False
 
@@ -563,7 +568,7 @@ class TestImplementIssuePipeline:
                 mock_retro.assert_not_called()
                 assert result.success is True
 
-    def test_retrospective_skipped_when_no_session_id(self, mock_options):
+    def test_retrospective_skipped_when_no_session_id(self, mock_options: Any) -> None:
         """Test retrospective skipped when session_id is None."""
         mock_options.enable_retrospective = True
 
@@ -602,7 +607,7 @@ class TestImplementIssuePipeline:
 class TestParseFollowUpItems:
     """Tests for _parse_follow_up_items method."""
 
-    def test_valid_json_in_code_block(self, implementer):
+    def test_valid_json_in_code_block(self, implementer: Any) -> None:
         """Test parsing JSON from code blocks."""
         text = """Here are the follow-up items:
 ```json
@@ -622,7 +627,7 @@ class TestParseFollowUpItems:
         assert items[0]["body"] == "Need more tests"
         assert items[0]["labels"] == ["test"]
 
-    def test_valid_bare_json(self, implementer):
+    def test_valid_bare_json(self, implementer: Any) -> None:
         """Test parsing bare JSON array."""
         text = '[{"title": "Fix bug", "body": "Found a bug", "labels": ["bug"]}]'
 
@@ -631,7 +636,7 @@ class TestParseFollowUpItems:
         assert len(items) == 1
         assert items[0]["title"] == "Fix bug"
 
-    def test_empty_array(self, implementer):
+    def test_empty_array(self, implementer: Any) -> None:
         """Test parsing empty array."""
         text = "```json\n[]\n```"
 
@@ -639,13 +644,13 @@ class TestParseFollowUpItems:
 
         assert items == []
 
-    def test_empty_string(self, implementer):
+    def test_empty_string(self, implementer: Any) -> None:
         """Test handling empty string."""
         items = implementer._parse_follow_up_items("")
 
         assert items == []
 
-    def test_invalid_json(self, implementer):
+    def test_invalid_json(self, implementer: Any) -> None:
         """Test graceful handling of invalid JSON."""
         text = "This is not valid JSON {{"
 
@@ -653,7 +658,7 @@ class TestParseFollowUpItems:
 
         assert items == []
 
-    def test_missing_required_fields_skipped(self, implementer):
+    def test_missing_required_fields_skipped(self, implementer: Any) -> None:
         """Test that items missing required fields are skipped."""
         text = """
 [
@@ -669,7 +674,7 @@ class TestParseFollowUpItems:
         assert items[0]["title"] == "Valid item"
         assert items[1]["title"] == "Another valid"
 
-    def test_caps_at_five_items(self, implementer):
+    def test_caps_at_five_items(self, implementer: Any) -> None:
         """Test that items are capped at 5."""
         items_json = [{"title": f"Item {i}", "body": f"Body {i}", "labels": []} for i in range(10)]
         text = f"```json\n{json.dumps(items_json)}\n```"
@@ -682,7 +687,7 @@ class TestParseFollowUpItems:
 class TestRunFollowUpIssues:
     """Tests for _run_follow_up_issues method."""
 
-    def test_successful_creation(self, implementer, tmp_path):
+    def test_successful_creation(self, implementer: Any, tmp_path: Any) -> None:
         """Test successful follow-up issue creation."""
         implementer.state_dir = tmp_path
 
@@ -709,7 +714,7 @@ class TestRunFollowUpIssues:
             mock_comment.assert_called_once()
             assert "#456" in mock_comment.call_args[0][1]
 
-    def test_no_items_identified(self, implementer, tmp_path):
+    def test_no_items_identified(self, implementer: Any, tmp_path: Any) -> None:
         """Test when no follow-up items are identified."""
         implementer.state_dir = tmp_path
 
@@ -730,7 +735,7 @@ class TestRunFollowUpIssues:
                 "No follow-up items" in str(call) for call in mock_logger.info.call_args_list
             )
 
-    def test_graceful_failure_on_error(self, implementer, tmp_path):
+    def test_graceful_failure_on_error(self, implementer: Any, tmp_path: Any) -> None:
         """Test graceful handling when run fails."""
         implementer.state_dir = tmp_path
 
@@ -745,7 +750,9 @@ class TestRunFollowUpIssues:
 
             assert any("failed" in str(call).lower() for call in mock_logger.warning.call_args_list)
 
-    def test_partial_failure_creates_available_issues(self, implementer, tmp_path):
+    def test_partial_failure_creates_available_issues(
+        self, implementer: Any, tmp_path: Any
+    ) -> None:
         """Test that partial failures still create available issues."""
         implementer.state_dir = tmp_path
 
@@ -776,7 +783,7 @@ class TestRunFollowUpIssues:
             # Only successful issue in summary
             assert "#789" in mock_comment.call_args[0][1]
 
-    def test_follow_up_output_saved_to_log(self, implementer, tmp_path):
+    def test_follow_up_output_saved_to_log(self, implementer: Any, tmp_path: Any) -> None:
         """Test that follow-up output is saved to log file on success."""
         # Use tmp_path for state_dir
         implementer.state_dir = tmp_path
@@ -803,7 +810,7 @@ class TestRunFollowUpIssues:
             content = log_file.read_text()
             assert "Follow-up" in content
 
-    def test_follow_up_failure_saved_to_log(self, implementer, tmp_path):
+    def test_follow_up_failure_saved_to_log(self, implementer: Any, tmp_path: Any) -> None:
         """Test that follow-up failure output is saved to log file."""
         # Use tmp_path for state_dir
         implementer.state_dir = tmp_path
@@ -838,7 +845,7 @@ class TestRunFollowUpIssues:
 class TestImplementIssuePipelineFollowUp:
     """Tests for follow-up phase in _implement_issue pipeline."""
 
-    def test_follow_up_enabled_runs_phase(self):
+    def test_follow_up_enabled_runs_phase(self) -> None:
         """Test that follow-up phase runs when enabled and session_id exists."""
         mock_options = ImplementerOptions(
             epic_number=123,
@@ -878,7 +885,7 @@ class TestImplementIssuePipelineFollowUp:
                 mock_follow_up.assert_called_once()
                 assert result.success is True
 
-    def test_follow_up_disabled_skips_phase(self):
+    def test_follow_up_disabled_skips_phase(self) -> None:
         """Test that follow-up phase is skipped when disabled."""
         mock_options = ImplementerOptions(
             epic_number=123,
@@ -918,7 +925,7 @@ class TestImplementIssuePipelineFollowUp:
                 mock_follow_up.assert_not_called()
                 assert result.success is True
 
-    def test_no_session_id_skips_follow_up(self):
+    def test_no_session_id_skips_follow_up(self) -> None:
         """Test that follow-up is skipped when session_id is None."""
         mock_options = ImplementerOptions(
             epic_number=123,
@@ -962,7 +969,7 @@ class TestImplementIssuePipelineFollowUp:
 class TestLogHelper:
     """Tests for _log helper method."""
 
-    def test_log_helper_routes_to_ui(self, implementer):
+    def test_log_helper_routes_to_ui(self, implementer: Any) -> None:
         """Test that _log writes to both logger and log_manager."""
         with (
             patch("scylla.automation.implementer.logger") as mock_logger,
@@ -979,7 +986,7 @@ class TestLogHelper:
             # Should log to UI with ERROR prefix
             mock_log_manager.assert_called_once_with(12345, "ERROR: Test error message")
 
-    def test_log_helper_warning_level(self, implementer):
+    def test_log_helper_warning_level(self, implementer: Any) -> None:
         """Test _log with warning level."""
         with (
             patch("scylla.automation.implementer.logger") as mock_logger,
@@ -993,7 +1000,7 @@ class TestLogHelper:
             mock_logger.warning.assert_called_once_with("Test warning")
             mock_log_manager.assert_called_once_with(12345, "WARN: Test warning")
 
-    def test_log_helper_info_level(self, implementer):
+    def test_log_helper_info_level(self, implementer: Any) -> None:
         """Test _log with info level (no prefix)."""
         with (
             patch("scylla.automation.implementer.logger") as mock_logger,
@@ -1007,7 +1014,7 @@ class TestLogHelper:
             mock_logger.info.assert_called_once_with("Test info")
             mock_log_manager.assert_called_once_with(12345, "Test info")
 
-    def test_log_helper_custom_thread_id(self, implementer):
+    def test_log_helper_custom_thread_id(self, implementer: Any) -> None:
         """Test _log with custom thread_id."""
         with (
             patch("scylla.automation.implementer.logger") as mock_logger,
@@ -1022,7 +1029,7 @@ class TestLogHelper:
 class TestErrorVisibility:
     """Tests for error visibility in UI."""
 
-    def test_failure_shows_in_status_slot(self, mock_options):
+    def test_failure_shows_in_status_slot(self, mock_options: Any) -> None:
         """Test that slot shows FAILED before release."""
         with (
             patch("scylla.automation.implementer.get_repo_root"),
@@ -1058,7 +1065,7 @@ class TestErrorVisibility:
                 )
                 assert result.success is False
 
-    def test_exception_classification_timeout(self, mock_options):
+    def test_exception_classification_timeout(self, mock_options: Any) -> None:
         """Test TimeoutExpired exceptions are classified correctly."""
         with (
             patch("scylla.automation.implementer.get_repo_root"),
@@ -1092,7 +1099,7 @@ class TestErrorVisibility:
                 assert any("Timeout" in str(call) for call in mock_log.call_args_list)
                 assert result.success is False
 
-    def test_exception_classification_called_process_error(self, mock_options):
+    def test_exception_classification_called_process_error(self, mock_options: Any) -> None:
         """Test CalledProcessError exceptions are classified correctly."""
         with (
             patch("scylla.automation.implementer.get_repo_root"),
@@ -1132,7 +1139,7 @@ class TestErrorVisibility:
 class TestGranularStatusUpdates:
     """Tests for granular status updates."""
 
-    def test_granular_status_updates(self, mock_options):
+    def test_granular_status_updates(self, mock_options: Any) -> None:
         """Test that status shows granular sub-steps."""
         with (
             patch("scylla.automation.implementer.get_repo_root"),

--- a/tests/unit/automation/test_models.py
+++ b/tests/unit/automation/test_models.py
@@ -18,7 +18,7 @@ from scylla.automation.models import (
 class TestIssueInfo:
     """Tests for IssueInfo model."""
 
-    def test_basic_creation(self):
+    def test_basic_creation(self) -> None:
         """Test creating a basic IssueInfo."""
         issue = IssueInfo(
             number=123,
@@ -33,7 +33,7 @@ class TestIssueInfo:
         assert issue.dependencies == []
         assert issue.priority == 0
 
-    def test_with_dependencies(self):
+    def test_with_dependencies(self) -> None:
         """Test IssueInfo with dependencies."""
         issue = IssueInfo(
             number=123,
@@ -43,7 +43,7 @@ class TestIssueInfo:
 
         assert issue.dependencies == [100, 101, 102]
 
-    def test_hashable(self):
+    def test_hashable(self) -> None:
         """Test IssueInfo is hashable."""
         issue1 = IssueInfo(number=123, title="Test")
         issue2 = IssueInfo(number=123, title="Different title")
@@ -58,7 +58,7 @@ class TestIssueInfo:
         issues = {issue1, issue2, issue3}
         assert len(issues) == 2  # issue1 and issue2 are considered equal
 
-    def test_equality(self):
+    def test_equality(self) -> None:
         """Test IssueInfo equality."""
         issue1 = IssueInfo(number=123, title="Test")
         issue2 = IssueInfo(number=123, title="Different title")
@@ -71,7 +71,7 @@ class TestIssueInfo:
 class TestImplementationState:
     """Tests for ImplementationState model."""
 
-    def test_default_values(self):
+    def test_default_values(self) -> None:
         """Test ImplementationState default values."""
         state = ImplementationState(issue_number=123)
 
@@ -86,7 +86,7 @@ class TestImplementationState:
         assert state.error is None
         assert state.attempts == 0
 
-    def test_serialization(self):
+    def test_serialization(self) -> None:
         """Test ImplementationState JSON serialization."""
         state = ImplementationState(
             issue_number=123,
@@ -109,7 +109,7 @@ class TestImplementationState:
         assert restored.worktree_path == state.worktree_path
         assert restored.session_id == state.session_id
 
-    def test_retrospective_phase(self):
+    def test_retrospective_phase(self) -> None:
         """Test RETROSPECTIVE phase in ImplementationPhase enum."""
         assert ImplementationPhase.RETROSPECTIVE == "retrospective"
 
@@ -120,7 +120,7 @@ class TestImplementationState:
         )
         assert state.phase == ImplementationPhase.RETROSPECTIVE
 
-    def test_follow_up_issues_phase(self):
+    def test_follow_up_issues_phase(self) -> None:
         """Test FOLLOW_UP_ISSUES phase in ImplementationPhase enum."""
         assert ImplementationPhase.FOLLOW_UP_ISSUES == "follow_up_issues"
 
@@ -135,7 +135,7 @@ class TestImplementationState:
 class TestDependencyGraph:
     """Tests for DependencyGraph model."""
 
-    def test_add_issue(self):
+    def test_add_issue(self) -> None:
         """Test adding issues to graph."""
         graph = DependencyGraph()
         issue = IssueInfo(number=123, title="Test")
@@ -146,7 +146,7 @@ class TestDependencyGraph:
         assert graph.issues[123] == issue
         assert 123 in graph.edges
 
-    def test_add_dependency(self):
+    def test_add_dependency(self) -> None:
         """Test adding dependency edges."""
         graph = DependencyGraph()
 
@@ -160,7 +160,7 @@ class TestDependencyGraph:
 
         assert graph.get_dependencies(123) == [100, 101]
 
-    def test_get_all_dependencies(self):
+    def test_get_all_dependencies(self) -> None:
         """Test transitive dependency resolution."""
         graph = DependencyGraph()
 
@@ -177,7 +177,7 @@ class TestDependencyGraph:
 
         assert deps == {100, 50}
 
-    def test_get_all_dependencies_diamond(self):
+    def test_get_all_dependencies_diamond(self) -> None:
         """Test transitive dependencies with diamond pattern."""
         graph = DependencyGraph()
 
@@ -201,7 +201,7 @@ class TestDependencyGraph:
 class TestPlanResult:
     """Tests for PlanResult model."""
 
-    def test_successful_plan(self):
+    def test_successful_plan(self) -> None:
         """Test successful plan result."""
         result = PlanResult(
             issue_number=123,
@@ -213,7 +213,7 @@ class TestPlanResult:
         assert result.error is None
         assert result.plan_already_exists is False
 
-    def test_failed_plan(self):
+    def test_failed_plan(self) -> None:
         """Test failed plan result."""
         result = PlanResult(
             issue_number=123,
@@ -228,7 +228,7 @@ class TestPlanResult:
 class TestWorkerResult:
     """Tests for WorkerResult model."""
 
-    def test_successful_implementation(self):
+    def test_successful_implementation(self) -> None:
         """Test successful implementation result."""
         result = WorkerResult(
             issue_number=123,
@@ -243,7 +243,7 @@ class TestWorkerResult:
         assert result.pr_number == 456
         assert result.branch_name == "123-test"
 
-    def test_failed_implementation(self):
+    def test_failed_implementation(self) -> None:
         """Test failed implementation result."""
         result = WorkerResult(
             issue_number=123,
@@ -259,7 +259,7 @@ class TestWorkerResult:
 class TestPlannerOptions:
     """Tests for PlannerOptions model."""
 
-    def test_default_values(self):
+    def test_default_values(self) -> None:
         """Test PlannerOptions default values."""
         options = PlannerOptions(issues=[123, 456])
 
@@ -271,7 +271,7 @@ class TestPlannerOptions:
         assert options.skip_closed is True
         assert options.enable_advise is True
 
-    def test_custom_values(self):
+    def test_custom_values(self) -> None:
         """Test PlannerOptions with custom values."""
         from pathlib import Path
 
@@ -295,7 +295,7 @@ class TestPlannerOptions:
 class TestImplementerOptions:
     """Tests for ImplementerOptions model."""
 
-    def test_default_values(self):
+    def test_default_values(self) -> None:
         """Test ImplementerOptions default values."""
         options = ImplementerOptions(epic_number=123)
 
@@ -310,7 +310,7 @@ class TestImplementerOptions:
         assert options.enable_retrospective is True
         assert options.enable_follow_up is True  # Enabled by default
 
-    def test_custom_values(self):
+    def test_custom_values(self) -> None:
         """Test ImplementerOptions with custom values."""
         options = ImplementerOptions(
             epic_number=456,

--- a/tests/unit/automation/test_planner.py
+++ b/tests/unit/automation/test_planner.py
@@ -3,6 +3,7 @@
 import subprocess
 import threading
 from pathlib import Path
+from typing import Any
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -12,7 +13,7 @@ from scylla.automation.planner import Planner
 
 
 @pytest.fixture
-def mock_options():
+def mock_options() -> Any:
     """Create mock PlannerOptions."""
     return PlannerOptions(
         issues=[123],
@@ -26,7 +27,7 @@ def mock_options():
 
 
 @pytest.fixture
-def planner(mock_options):
+def planner(mock_options: Any) -> Any:
     """Create a Planner instance."""
     return Planner(mock_options)
 
@@ -34,7 +35,7 @@ def planner(mock_options):
 class TestCallClaude:
     """Tests for _call_claude method."""
 
-    def test_successful_call(self, planner):
+    def test_successful_call(self, planner: Any) -> None:
         """Test successful Claude call."""
         with patch("subprocess.run") as mock_run:
             mock_run.return_value = MagicMock(stdout="This is a plan", returncode=0)
@@ -50,7 +51,7 @@ class TestCallClaude:
             assert "--output-format" in args
             assert "text" in args
 
-    def test_empty_response(self, planner):
+    def test_empty_response(self, planner: Any) -> None:
         """Test handling of empty response."""
         with patch("subprocess.run") as mock_run:
             mock_run.return_value = MagicMock(stdout="   ", returncode=0)
@@ -58,7 +59,7 @@ class TestCallClaude:
             with pytest.raises(RuntimeError, match="empty response"):
                 planner._call_claude("Test prompt")
 
-    def test_timeout(self, planner):
+    def test_timeout(self, planner: Any) -> None:
         """Test timeout handling."""
         import subprocess
 
@@ -68,7 +69,7 @@ class TestCallClaude:
             with pytest.raises(RuntimeError, match="timed out"):
                 planner._call_claude("Test prompt", timeout=300)
 
-    def test_rate_limit_retry(self, planner):
+    def test_rate_limit_retry(self, planner: Any) -> None:
         """Test rate limit retry logic."""
         import subprocess
 
@@ -91,7 +92,7 @@ class TestCallClaude:
             assert result == "Success"
             assert mock_run.call_count == 2
 
-    def test_system_prompt_passthrough(self, mock_options):
+    def test_system_prompt_passthrough(self, mock_options: Any) -> None:
         """Test system prompt file is passed through."""
         mock_options.system_prompt_file = Path("/tmp/system.md")
 
@@ -112,7 +113,7 @@ class TestCallClaude:
 class TestRunAdvise:
     """Tests for _run_advise method."""
 
-    def test_returns_findings(self, planner):
+    def test_returns_findings(self, planner: Any) -> None:
         """Test successful advise returns findings."""
         with (
             patch("scylla.automation.planner.get_repo_root") as mock_get_repo,
@@ -128,7 +129,7 @@ class TestRunAdvise:
                 assert "Related Skills" in result
                 assert "Found 3 skills" in result
 
-    def test_graceful_failure_on_error(self, planner):
+    def test_graceful_failure_on_error(self, planner: Any) -> None:
         """Test graceful failure when advise errors."""
         with patch("scylla.automation.planner.get_repo_root") as mock_get_repo:
             mock_get_repo.side_effect = RuntimeError("Git error")
@@ -137,7 +138,7 @@ class TestRunAdvise:
 
             assert result == ""
 
-    def test_skips_when_mnemosyne_missing_and_clone_fails(self, planner):
+    def test_skips_when_mnemosyne_missing_and_clone_fails(self, planner: Any) -> None:
         """Test returns empty string when ProjectMnemosyne is missing and clone fails."""
         with (
             patch("scylla.automation.planner.get_repo_root") as mock_get_repo,
@@ -151,7 +152,7 @@ class TestRunAdvise:
             assert result == ""
             mock_ensure.assert_called_once()
 
-    def test_clones_mnemosyne_when_missing(self, planner):
+    def test_clones_mnemosyne_when_missing(self, planner: Any) -> None:
         """Test proceeds with advise after cloning ProjectMnemosyne."""
         call_count = [0]
 
@@ -172,7 +173,7 @@ class TestRunAdvise:
 
         assert "Related Skills" in result
 
-    def test_marketplace_missing_triggers_reclone_and_succeeds(self, planner):
+    def test_marketplace_missing_triggers_reclone_and_succeeds(self, planner: Any) -> None:
         """Test that missing marketplace.json triggers re-clone and succeeds on retry."""
         # mnemosyne_root exists but marketplace.json is absent initially.
         # After re-clone, marketplace.json becomes present.
@@ -203,7 +204,7 @@ class TestRunAdvise:
         mock_ensure.assert_called_once()
         assert "Found Skills" in result
 
-    def test_marketplace_missing_reclone_fails_returns_empty(self, planner):
+    def test_marketplace_missing_reclone_fails_returns_empty(self, planner: Any) -> None:
         """Test that missing marketplace.json with failed re-clone returns empty string."""
 
         def patched_exists(p: Path) -> bool:
@@ -229,7 +230,7 @@ class TestRunAdvise:
 class TestGeneratePlan:
     """Tests for _generate_plan method."""
 
-    def test_plan_with_advise_findings(self, planner):
+    def test_plan_with_advise_findings(self, planner: Any) -> None:
         """Test plan generation with advise findings injected."""
         with (
             patch("scylla.automation.planner.gh_issue_json") as mock_gh,
@@ -253,7 +254,7 @@ class TestGeneratePlan:
             assert "Prior Learnings" in call_args
             assert "Related Skills" in call_args
 
-    def test_plan_without_advise(self, mock_options):
+    def test_plan_without_advise(self, mock_options: Any) -> None:
         """Test plan generation with advise disabled."""
         mock_options.enable_advise = False
         planner = Planner(mock_options)
@@ -280,7 +281,7 @@ class TestGeneratePlan:
 class TestEnsureMnemosyne:
     """Tests for _ensure_mnemosyne method."""
 
-    def test_clone_success(self, planner, tmp_path):
+    def test_clone_success(self, planner: Any, tmp_path: Any) -> None:
         """Test successful clone returns True and runs correct command."""
         mnemosyne_root = tmp_path / "ProjectMnemosyne"
 
@@ -298,7 +299,7 @@ class TestEnsureMnemosyne:
         assert "HomericIntelligence/ProjectMnemosyne" in cmd
         assert str(mnemosyne_root) in cmd
 
-    def test_clone_failure(self, planner, tmp_path):
+    def test_clone_failure(self, planner: Any, tmp_path: Any) -> None:
         """Test clone failure returns False and logs warning."""
         mnemosyne_root = tmp_path / "ProjectMnemosyne"
 
@@ -311,7 +312,7 @@ class TestEnsureMnemosyne:
 
         assert result is False
 
-    def test_no_clone_if_exists(self, planner, tmp_path):
+    def test_no_clone_if_exists(self, planner: Any, tmp_path: Any) -> None:
         """Test does not clone when directory already exists (runs git pull instead)."""
         mnemosyne_root = tmp_path / "ProjectMnemosyne"
         mnemosyne_root.mkdir()
@@ -328,7 +329,7 @@ class TestEnsureMnemosyne:
         assert "pull" in cmd
         assert "gh" not in cmd
 
-    def test_lock_file_removed_after_successful_clone(self, planner, tmp_path):
+    def test_lock_file_removed_after_successful_clone(self, planner: Any, tmp_path: Any) -> None:
         """Test that the lock file is removed after a successful clone."""
         mnemosyne_root = tmp_path / "ProjectMnemosyne"
         lock_path = tmp_path / ".mnemosyne.lock"
@@ -341,7 +342,7 @@ class TestEnsureMnemosyne:
         assert result is True
         assert not lock_path.exists(), "Lock file should be removed after successful clone"
 
-    def test_git_pull_called_when_directory_exists(self, planner, tmp_path):
+    def test_git_pull_called_when_directory_exists(self, planner: Any, tmp_path: Any) -> None:
         """Test that git pull --ff-only is called when directory already exists."""
         mnemosyne_root = tmp_path / "ProjectMnemosyne"
         mnemosyne_root.mkdir()
@@ -360,7 +361,9 @@ class TestEnsureMnemosyne:
         assert "pull" in cmd
         assert "--ff-only" in cmd
 
-    def test_git_pull_failure_logs_warning_and_returns_true(self, planner, tmp_path):
+    def test_git_pull_failure_logs_warning_and_returns_true(
+        self, planner: Any, tmp_path: Any
+    ) -> None:
         """Test that a git pull failure logs a warning but still returns True."""
         mnemosyne_root = tmp_path / "ProjectMnemosyne"
         mnemosyne_root.mkdir()
@@ -374,14 +377,14 @@ class TestEnsureMnemosyne:
 
         assert result is True
 
-    def test_concurrent_clone_only_once(self, mock_options, tmp_path):
+    def test_concurrent_clone_only_once(self, mock_options: Any, tmp_path: Any) -> None:
         """Test concurrent calls only clone once (lock prevents double-clone)."""
         mnemosyne_root = tmp_path / "ProjectMnemosyne"
 
         clone_calls = []
         start_event = threading.Event()
 
-        def fake_subprocess(cmd: list[str], **kwargs: object) -> MagicMock:
+        def fake_subprocess(cmd: list[str], **kwargs: Any) -> MagicMock:
             # Only count gh repo clone calls, not git pull calls
             if "gh" in cmd and "clone" in cmd:
                 clone_calls.append(1)

--- a/tests/unit/automation/test_prompts.py
+++ b/tests/unit/automation/test_prompts.py
@@ -9,7 +9,7 @@ from scylla.automation.prompts import (
 )
 
 
-def test_get_implementation_prompt():
+def test_get_implementation_prompt() -> None:
     """Test implementation prompt generation with backward compatibility."""
     # Test backward compatibility - should work with just issue_number
     prompt = get_implementation_prompt(123)
@@ -20,7 +20,7 @@ def test_get_implementation_prompt():
     assert "backup file" in prompt.lower() or ".orig" in prompt
 
 
-def test_get_implementation_prompt_with_context():
+def test_get_implementation_prompt_with_context() -> None:
     """Test implementation prompt with full context."""
     prompt = get_implementation_prompt(
         issue_number=123,
@@ -38,7 +38,7 @@ def test_get_implementation_prompt_with_context():
     assert "gh issue view" in prompt
 
 
-def test_get_plan_prompt():
+def test_get_plan_prompt() -> None:
     """Test plan prompt generation."""
     prompt = get_plan_prompt(456)
     assert "456" in prompt
@@ -48,7 +48,7 @@ def test_get_plan_prompt():
     assert "Prior Learnings" in prompt or "knowledge base" in prompt
 
 
-def test_get_advise_prompt():
+def test_get_advise_prompt() -> None:
     """Test advise prompt generation."""
     prompt = get_advise_prompt(
         issue_number=789,
@@ -66,7 +66,7 @@ def test_get_advise_prompt():
     assert "What Failed" in prompt
 
 
-def test_get_follow_up_prompt():
+def test_get_follow_up_prompt() -> None:
     """Test follow-up prompt generation."""
     prompt = get_follow_up_prompt(789)
     assert "789" in prompt
@@ -79,7 +79,7 @@ def test_get_follow_up_prompt():
     assert "testing" in prompt
 
 
-def test_get_pr_description():
+def test_get_pr_description() -> None:
     """Test PR description generation."""
     desc = get_pr_description(
         issue_number=123,

--- a/tests/unit/automation/test_rate_limit.py
+++ b/tests/unit/automation/test_rate_limit.py
@@ -12,35 +12,35 @@ from scylla.automation.rate_limit import (
 class TestParseResetEpoch:
     """Tests for parse_reset_epoch function."""
 
-    def test_parse_unix_epoch(self):
+    def test_parse_unix_epoch(self) -> None:
         """Test parsing Unix epoch timestamp."""
         epoch = parse_reset_epoch("1234567890")
         assert epoch == 1234567890
 
-    def test_parse_iso8601(self):
+    def test_parse_iso8601(self) -> None:
         """Test parsing ISO 8601 format."""
         epoch = parse_reset_epoch("2024-01-15T12:30:45Z")
         expected = int(datetime(2024, 1, 15, 12, 30, 45, tzinfo=timezone.utc).timestamp())
         assert epoch == expected
 
-    def test_parse_human_readable(self):
+    def test_parse_human_readable(self) -> None:
         """Test parsing human-readable format."""
         epoch = parse_reset_epoch("2024-01-15 12:30:45 +0000 UTC")
         expected = int(datetime(2024, 1, 15, 12, 30, 45, tzinfo=timezone.utc).timestamp())
         assert epoch == expected
 
-    def test_parse_human_readable_no_tz_name(self):
+    def test_parse_human_readable_no_tz_name(self) -> None:
         """Test parsing human-readable format without timezone name."""
         epoch = parse_reset_epoch("2024-01-15 12:30:45 +0000")
         expected = int(datetime(2024, 1, 15, 12, 30, 45, tzinfo=timezone.utc).timestamp())
         assert epoch == expected
 
-    def test_parse_invalid_format(self):
+    def test_parse_invalid_format(self) -> None:
         """Test parsing invalid format returns None."""
         epoch = parse_reset_epoch("invalid timestamp")
         assert epoch is None
 
-    def test_parse_empty_string(self):
+    def test_parse_empty_string(self) -> None:
         """Test parsing empty string returns None."""
         epoch = parse_reset_epoch("")
         assert epoch is None
@@ -49,7 +49,7 @@ class TestParseResetEpoch:
 class TestDetectRateLimit:
     """Tests for detect_rate_limit function."""
 
-    def test_detect_with_reset_time(self):
+    def test_detect_with_reset_time(self) -> None:
         """Test detecting rate limit with reset time."""
         stderr = "API rate limit exceeded. Resets at 2024-01-15 12:30:45 +0000 UTC"
 
@@ -58,7 +58,7 @@ class TestDetectRateLimit:
         assert is_limited is True
         assert reset_epoch > 0
 
-    def test_detect_with_reset_time_iso(self):
+    def test_detect_with_reset_time_iso(self) -> None:
         """Test detecting rate limit with ISO format reset time."""
         stderr = "API rate limit exceeded. Reset time: 2024-01-15T12:30:45Z"
 
@@ -67,7 +67,7 @@ class TestDetectRateLimit:
         assert is_limited is True
         assert reset_epoch > 0
 
-    def test_detect_without_reset_time(self):
+    def test_detect_without_reset_time(self) -> None:
         """Test detecting rate limit without reset time."""
         stderr = "rate limit exceeded"
 
@@ -76,7 +76,7 @@ class TestDetectRateLimit:
         assert is_limited is True
         assert reset_epoch == 0
 
-    def test_detect_429_status(self):
+    def test_detect_429_status(self) -> None:
         """Test detecting 429 status code."""
         stderr = "Error: 429 Too Many Requests"
 
@@ -84,7 +84,7 @@ class TestDetectRateLimit:
 
         assert is_limited is True
 
-    def test_no_rate_limit(self):
+    def test_no_rate_limit(self) -> None:
         """Test when there's no rate limit."""
         stderr = "Some other error occurred"
 
@@ -97,32 +97,32 @@ class TestDetectRateLimit:
 class TestDetectClaudeUsageLimit:
     """Tests for detect_claude_usage_limit function."""
 
-    def test_detect_usage_limit(self):
+    def test_detect_usage_limit(self) -> None:
         """Test detecting Claude usage limit."""
         stderr = "Error: usage limit exceeded"
         assert detect_claude_usage_limit(stderr) is True
 
-    def test_detect_quota_exceeded(self):
+    def test_detect_quota_exceeded(self) -> None:
         """Test detecting quota exceeded."""
         stderr = "quota exceeded for your account"
         assert detect_claude_usage_limit(stderr) is True
 
-    def test_detect_credit_exhausted(self):
+    def test_detect_credit_exhausted(self) -> None:
         """Test detecting credit exhausted."""
         stderr = "Your credit is exhausted"
         assert detect_claude_usage_limit(stderr) is True
 
-    def test_detect_billing_issue(self):
+    def test_detect_billing_issue(self) -> None:
         """Test detecting billing limit specifically."""
         stderr = "billing limit exceeded"
         assert detect_claude_usage_limit(stderr) is True
 
-    def test_no_usage_limit(self):
+    def test_no_usage_limit(self) -> None:
         """Test when there's no usage limit."""
         stderr = "Some other error"
         assert detect_claude_usage_limit(stderr) is False
 
-    def test_case_insensitive(self):
+    def test_case_insensitive(self) -> None:
         """Test detection is case-insensitive."""
         stderr = "USAGE LIMIT exceeded"
         assert detect_claude_usage_limit(stderr) is True

--- a/tests/unit/automation/test_retry.py
+++ b/tests/unit/automation/test_retry.py
@@ -1,5 +1,6 @@
 """Tests for retry decorator with exponential backoff."""
 
+from typing import Any
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -10,17 +11,17 @@ from scylla.automation.retry import is_network_error, retry_on_network_error, re
 class TestIsNetworkError:
     """Tests for is_network_error function."""
 
-    def test_detects_connection_error(self):
+    def test_detects_connection_error(self) -> None:
         """Test detection of connection-related errors."""
         error = ConnectionError("Connection refused")
         assert is_network_error(error) is True
 
-    def test_detects_timeout_error(self):
+    def test_detects_timeout_error(self) -> None:
         """Test detection of timeout errors."""
         error = TimeoutError("Request timed out")
         assert is_network_error(error) is True
 
-    def test_detects_network_keywords(self):
+    def test_detects_network_keywords(self) -> None:
         """Test detection of network error keywords in error messages."""
         test_cases = [
             "network unavailable",
@@ -37,7 +38,7 @@ class TestIsNetworkError:
             error = Exception(message)
             assert is_network_error(error) is True, f"Failed to detect: {message}"
 
-    def test_does_not_detect_non_network_errors(self):
+    def test_does_not_detect_non_network_errors(self) -> None:
         """Test that non-network errors are not detected."""
         test_cases = [
             "ValueError: invalid input",
@@ -53,7 +54,7 @@ class TestIsNetworkError:
 class TestRetryWithBackoff:
     """Tests for retry_with_backoff decorator."""
 
-    def test_succeeds_on_first_attempt(self):
+    def test_succeeds_on_first_attempt(self) -> None:
         """Test function that succeeds on first attempt."""
         mock_func = MagicMock(return_value="success")
         decorated = retry_with_backoff(max_retries=3)(mock_func)
@@ -63,7 +64,7 @@ class TestRetryWithBackoff:
         assert result == "success"
         assert mock_func.call_count == 1
 
-    def test_retries_on_failure(self):
+    def test_retries_on_failure(self) -> None:
         """Test function that fails then succeeds."""
         mock_func = MagicMock(side_effect=[ValueError("fail"), ValueError("fail"), "success"])
         decorated = retry_with_backoff(max_retries=3, initial_delay=0.01)(mock_func)
@@ -74,7 +75,7 @@ class TestRetryWithBackoff:
         assert result == "success"
         assert mock_func.call_count == 3
 
-    def test_raises_after_max_retries(self):
+    def test_raises_after_max_retries(self) -> None:
         """Test function that exhausts all retries."""
         mock_func = MagicMock(side_effect=ValueError("fail"))
         decorated = retry_with_backoff(max_retries=2, initial_delay=0.01)(mock_func)
@@ -85,7 +86,7 @@ class TestRetryWithBackoff:
 
         assert mock_func.call_count == 3  # initial + 2 retries
 
-    def test_exponential_backoff_delay(self):
+    def test_exponential_backoff_delay(self) -> None:
         """Test exponential backoff delays are calculated correctly."""
         mock_func = MagicMock(side_effect=[ValueError("fail"), ValueError("fail"), "success"])
         decorated = retry_with_backoff(max_retries=3, initial_delay=0.1, backoff_factor=2)(
@@ -102,7 +103,7 @@ class TestRetryWithBackoff:
         mock_sleep.assert_any_call(0.1)
         mock_sleep.assert_any_call(0.2)
 
-    def test_respects_retry_on_parameter(self):
+    def test_respects_retry_on_parameter(self) -> None:
         """Test retry_on parameter filters exception types."""
         mock_func = MagicMock(side_effect=TypeError("wrong type"))
         # Only retry on ValueError, not TypeError
@@ -117,7 +118,7 @@ class TestRetryWithBackoff:
         # Should not retry since TypeError is not in retry_on
         assert mock_func.call_count == 1
 
-    def test_logger_called_on_retry(self):
+    def test_logger_called_on_retry(self) -> None:
         """Test logger is called with retry information."""
         mock_logger = MagicMock()
         mock_func = MagicMock(side_effect=[ValueError("fail"), "success"])
@@ -135,18 +136,18 @@ class TestRetryWithBackoff:
         assert "Retry 1/2" in log_message
         assert "ValueError" in log_message
 
-    def test_preserves_function_metadata(self):
+    def test_preserves_function_metadata(self) -> None:
         """Test decorator preserves function name and docstring."""
 
         @retry_with_backoff(max_retries=2)
-        def example_function():
+        def example_function() -> Any:
             """Return example result."""
             return "result"
 
         assert example_function.__name__ == "example_function"
         assert example_function.__doc__ == "Return example result."
 
-    def test_passes_arguments_correctly(self):
+    def test_passes_arguments_correctly(self) -> None:
         """Test decorated function receives correct arguments."""
         mock_func = MagicMock(return_value="success")
         decorated = retry_with_backoff(max_retries=2)(mock_func)
@@ -160,7 +161,7 @@ class TestRetryWithBackoff:
 class TestRetryOnNetworkError:
     """Tests for retry_on_network_error convenience decorator."""
 
-    def test_retries_connection_error(self):
+    def test_retries_connection_error(self) -> None:
         """Test retry on ConnectionError."""
         mock_func = MagicMock(side_effect=[ConnectionError("connection refused"), "success"])
         decorated = retry_on_network_error(max_retries=2)(mock_func)
@@ -171,7 +172,7 @@ class TestRetryOnNetworkError:
         assert result == "success"
         assert mock_func.call_count == 2
 
-    def test_retries_timeout_error(self):
+    def test_retries_timeout_error(self) -> None:
         """Test retry on TimeoutError."""
         mock_func = MagicMock(side_effect=[TimeoutError("timed out"), "success"])
         decorated = retry_on_network_error(max_retries=2)(mock_func)
@@ -182,7 +183,7 @@ class TestRetryOnNetworkError:
         assert result == "success"
         assert mock_func.call_count == 2
 
-    def test_does_not_retry_value_error(self):
+    def test_does_not_retry_value_error(self) -> None:
         """Test ValueError is not retried."""
         mock_func = MagicMock(side_effect=ValueError("invalid value"))
         decorated = retry_on_network_error(max_retries=2)(mock_func)
@@ -193,7 +194,7 @@ class TestRetryOnNetworkError:
         # Should not retry non-network errors
         assert mock_func.call_count == 1
 
-    def test_uses_longer_initial_delay(self):
+    def test_uses_longer_initial_delay(self) -> None:
         """Test retry_on_network_error uses 2.0s initial delay."""
         mock_func = MagicMock(side_effect=[ConnectionError("fail"), "success"])
         decorated = retry_on_network_error(max_retries=1)(mock_func)
@@ -209,7 +210,7 @@ class TestRetryOnNetworkError:
 class TestRetryWithMaxDelay:
     """Tests for max_delay parameter in retry_with_backoff."""
 
-    def test_max_delay_none_by_default(self):
+    def test_max_delay_none_by_default(self) -> None:
         """Test max_delay is None by default and delays are uncapped."""
         mock_func = MagicMock(side_effect=[ValueError("fail"), ValueError("fail"), "success"])
         # With initial_delay=0.1, backoff_factor=2: delays are 0.1, 0.2 (uncapped)
@@ -224,7 +225,7 @@ class TestRetryWithMaxDelay:
         sleep_calls = [call.args[0] for call in mock_sleep.call_args_list]
         assert sleep_calls == [0.1, 0.2]
 
-    def test_max_delay_caps_large_delays(self):
+    def test_max_delay_caps_large_delays(self) -> None:
         """Test max_delay caps the computed delay when it would exceed the cap."""
         mock_func = MagicMock(side_effect=[ValueError("fail"), ValueError("fail"), "success"])
         # With initial_delay=1.0, backoff_factor=2: delays would be 1.0, 2.0 (uncapped)
@@ -241,7 +242,7 @@ class TestRetryWithMaxDelay:
         assert sleep_calls[0] == 1.0  # 1.0 * 2^0 = 1.0, not capped
         assert sleep_calls[1] == 1.5  # 1.0 * 2^1 = 2.0, capped to 1.5
 
-    def test_max_delay_does_not_affect_delays_below_cap(self):
+    def test_max_delay_does_not_affect_delays_below_cap(self) -> None:
         """Test max_delay does not modify delays that are already below the cap."""
         mock_func = MagicMock(side_effect=[ValueError("fail"), "success"])
         # With initial_delay=0.5, backoff_factor=2, max_delay=10.0:
@@ -256,7 +257,7 @@ class TestRetryWithMaxDelay:
         assert result == "success"
         mock_sleep.assert_called_once_with(0.5)
 
-    def test_max_delay_applied_before_jitter(self):
+    def test_max_delay_applied_before_jitter(self) -> None:
         """Test max_delay cap is applied before jitter so jitter acts on capped value."""
         mock_func = MagicMock(side_effect=[ValueError("fail"), "success"])
         # initial_delay=1.0, backoff_factor=4: first delay would be 4.0 without cap
@@ -277,7 +278,7 @@ class TestRetryWithMaxDelay:
         # delay = min(4.0 * 2^0, 2.0) = 2.0, then * 1.5 = 3.0
         mock_sleep.assert_called_once_with(pytest.approx(3.0))
 
-    def test_max_delay_with_many_retries_all_capped(self):
+    def test_max_delay_with_many_retries_all_capped(self) -> None:
         """Test all delays are capped when exponential backoff quickly exceeds max_delay."""
         side_effects = [ValueError("fail")] * 4 + ["success"]
         mock_func = MagicMock(side_effect=side_effects)
@@ -297,7 +298,7 @@ class TestRetryWithMaxDelay:
         assert sleep_calls[2] == 15.0  # 10 * 2^2 = 40.0, capped to 15.0
         assert sleep_calls[3] == 15.0  # 10 * 2^3 = 80.0, capped to 15.0
 
-    def test_max_delay_with_logger_reports_capped_delay(self):
+    def test_max_delay_with_logger_reports_capped_delay(self) -> None:
         """Test logger receives the capped delay value."""
         mock_logger = MagicMock()
         mock_func = MagicMock(side_effect=[ValueError("fail"), "success"])
@@ -318,7 +319,7 @@ class TestRetryWithMaxDelay:
 class TestRetryWithJitter:
     """Tests for jitter parameter in retry_with_backoff."""
 
-    def test_jitter_false_by_default(self):
+    def test_jitter_false_by_default(self) -> None:
         """Test jitter is disabled by default and delays are unmodified."""
         mock_func = MagicMock(side_effect=[ValueError("fail"), "success"])
         decorated = retry_with_backoff(max_retries=2, initial_delay=0.1, backoff_factor=2)(
@@ -333,7 +334,7 @@ class TestRetryWithJitter:
         mock_uniform.assert_not_called()
         mock_sleep.assert_called_once_with(0.1)
 
-    def test_jitter_true_applies_random_factor(self):
+    def test_jitter_true_applies_random_factor(self) -> None:
         """Test jitter=True multiplies delay by random.uniform(0.5, 1.5)."""
         mock_func = MagicMock(side_effect=[ValueError("fail"), "success"])
         decorated = retry_with_backoff(
@@ -349,7 +350,7 @@ class TestRetryWithJitter:
         # delay = 0.1 * 2^0 * 1.2 = 0.12
         mock_sleep.assert_called_once_with(0.1 * 1.2)
 
-    def test_jitter_applied_to_each_retry(self):
+    def test_jitter_applied_to_each_retry(self) -> None:
         """Test jitter is applied independently to each retry delay."""
         mock_func = MagicMock(side_effect=[ValueError("fail"), ValueError("fail"), "success"])
         decorated = retry_with_backoff(
@@ -373,7 +374,7 @@ class TestRetryWithJitter:
         assert sleep_calls[0] == pytest.approx(0.1 * 0.8)
         assert sleep_calls[1] == pytest.approx(0.2 * 1.3)
 
-    def test_jitter_with_logger_reports_jittered_delay(self):
+    def test_jitter_with_logger_reports_jittered_delay(self) -> None:
         """Test logger receives the jittered delay value."""
         mock_logger = MagicMock()
         mock_func = MagicMock(side_effect=[ValueError("fail"), "success"])

--- a/tests/unit/automation/test_status_tracker.py
+++ b/tests/unit/automation/test_status_tracker.py
@@ -9,7 +9,7 @@ from scylla.automation.status_tracker import StatusTracker
 class TestStatusTracker:
     """Tests for StatusTracker class."""
 
-    def test_initialization(self):
+    def test_initialization(self) -> None:
         """Test tracker initialization."""
         tracker = StatusTracker(num_slots=3)
 
@@ -17,7 +17,7 @@ class TestStatusTracker:
         assert len(tracker.slots) == 3
         assert all(slot is None for slot in tracker.slots)
 
-    def test_acquire_slot(self):
+    def test_acquire_slot(self) -> None:
         """Test acquiring a slot."""
         tracker = StatusTracker(num_slots=2)
 
@@ -27,7 +27,7 @@ class TestStatusTracker:
         assert 0 <= slot_id < 2
         assert tracker.slots[slot_id] == "acquired"
 
-    def test_acquire_all_slots(self):
+    def test_acquire_all_slots(self) -> None:
         """Test acquiring all available slots."""
         tracker = StatusTracker(num_slots=2)
 
@@ -39,7 +39,7 @@ class TestStatusTracker:
         assert slot1 != slot2
         assert tracker.get_active_count() == 2
 
-    def test_acquire_slot_timeout(self):
+    def test_acquire_slot_timeout(self) -> None:
         """Test slot acquisition timeout when all slots occupied."""
         tracker = StatusTracker(num_slots=1)
 
@@ -51,7 +51,7 @@ class TestStatusTracker:
         slot2 = tracker.acquire_slot(timeout=0.1)
         assert slot2 is None
 
-    def test_release_slot(self):
+    def test_release_slot(self) -> None:
         """Test releasing a slot."""
         tracker = StatusTracker(num_slots=2)
 
@@ -63,7 +63,7 @@ class TestStatusTracker:
         assert tracker.slots[slot_id] is None
         assert tracker.get_active_count() == 0
 
-    def test_release_invalid_slot(self):
+    def test_release_invalid_slot(self) -> None:
         """Test releasing invalid slot ID."""
         tracker = StatusTracker(num_slots=2)
 
@@ -71,7 +71,7 @@ class TestStatusTracker:
         tracker.release_slot(999)
         tracker.release_slot(-1)
 
-    def test_update_slot(self):
+    def test_update_slot(self) -> None:
         """Test updating slot status."""
         tracker = StatusTracker(num_slots=2)
 
@@ -81,7 +81,7 @@ class TestStatusTracker:
 
         assert tracker.slots[slot_id] == "Processing issue #123"
 
-    def test_update_invalid_slot(self):
+    def test_update_invalid_slot(self) -> None:
         """Test updating invalid slot ID."""
         tracker = StatusTracker(num_slots=2)
 
@@ -89,7 +89,7 @@ class TestStatusTracker:
         tracker.update_slot(999, "invalid")
         tracker.update_slot(-1, "invalid")
 
-    def test_get_status(self):
+    def test_get_status(self) -> None:
         """Test getting status snapshot."""
         tracker = StatusTracker(num_slots=3)
 
@@ -105,7 +105,7 @@ class TestStatusTracker:
         status[slot1] = "Modified"
         assert tracker.slots[slot1] == "Working"
 
-    def test_get_active_count(self):
+    def test_get_active_count(self) -> None:
         """Test getting active slot count."""
         tracker = StatusTracker(num_slots=3)
 
@@ -121,7 +121,7 @@ class TestStatusTracker:
         tracker.release_slot(slot1)
         assert tracker.get_active_count() == 1
 
-    def test_wait_for_available(self):
+    def test_wait_for_available(self) -> None:
         """Test waiting for slot availability."""
         tracker = StatusTracker(num_slots=1)
 
@@ -130,7 +130,7 @@ class TestStatusTracker:
         assert slot_id is not None
 
         # Start thread that releases slot after delay
-        def release_after_delay():
+        def release_after_delay() -> None:
             time.sleep(0.1)
             tracker.release_slot(slot_id)
 
@@ -143,7 +143,7 @@ class TestStatusTracker:
 
         thread.join()
 
-    def test_wait_for_available_timeout(self):
+    def test_wait_for_available_timeout(self) -> None:
         """Test wait_for_available timeout."""
         tracker = StatusTracker(num_slots=1)
 
@@ -154,7 +154,7 @@ class TestStatusTracker:
         result = tracker.wait_for_available(timeout=0.1)
         assert result is False
 
-    def test_wait_all_complete(self):
+    def test_wait_all_complete(self) -> None:
         """Test waiting for all slots to complete."""
         tracker = StatusTracker(num_slots=2)
 
@@ -164,7 +164,7 @@ class TestStatusTracker:
         assert slot2 is not None
 
         # Start thread that releases slots after delay
-        def release_after_delay():
+        def release_after_delay() -> None:
             time.sleep(0.05)
             tracker.release_slot(slot1)
             time.sleep(0.05)
@@ -179,7 +179,7 @@ class TestStatusTracker:
 
         thread.join()
 
-    def test_wait_all_complete_timeout(self):
+    def test_wait_all_complete_timeout(self) -> None:
         """Test wait_all_complete timeout."""
         tracker = StatusTracker(num_slots=1)
 
@@ -190,7 +190,7 @@ class TestStatusTracker:
         result = tracker.wait_all_complete(timeout=0.1)
         assert result is False
 
-    def test_clear(self):
+    def test_clear(self) -> None:
         """Test clearing all slots."""
         tracker = StatusTracker(num_slots=3)
 
@@ -206,13 +206,13 @@ class TestStatusTracker:
         assert all(slot is None for slot in tracker.slots)
         assert tracker.get_active_count() == 0
 
-    def test_concurrent_acquire_release(self):
+    def test_concurrent_acquire_release(self) -> None:
         """Test concurrent slot acquisition and release."""
         tracker = StatusTracker(num_slots=5)
         acquired_slots = []
         lock = threading.Lock()
 
-        def worker():
+        def worker() -> None:
             slot_id = tracker.acquire_slot(timeout=2.0)
             if slot_id is not None:
                 with lock:
@@ -232,7 +232,7 @@ class TestStatusTracker:
         # All slots should be released
         assert tracker.get_active_count() == 0
 
-    def test_notify_all_on_release(self):
+    def test_notify_all_on_release(self) -> None:
         """Test that release_slot wakes all waiting threads."""
         tracker = StatusTracker(num_slots=1)
 
@@ -242,7 +242,7 @@ class TestStatusTracker:
 
         results = []
 
-        def waiter():
+        def waiter() -> None:
             # Both wait_for_available and acquire_slot should wake
             if tracker.wait_for_available(timeout=1.0):
                 results.append("available")
@@ -264,7 +264,7 @@ class TestStatusTracker:
         # All waiters should have been notified
         assert len(results) == 3
 
-    def test_notify_all_on_clear(self):
+    def test_notify_all_on_clear(self) -> None:
         """Test that clear wakes waiting threads."""
         tracker = StatusTracker(num_slots=1)
 
@@ -273,7 +273,7 @@ class TestStatusTracker:
 
         result = []
 
-        def waiter():
+        def waiter() -> None:
             if tracker.wait_for_available(timeout=1.0):
                 result.append(True)
 

--- a/tests/unit/automation/test_worktree_manager.py
+++ b/tests/unit/automation/test_worktree_manager.py
@@ -2,6 +2,7 @@
 
 import subprocess
 from pathlib import Path
+from typing import Any
 from unittest.mock import Mock, patch
 
 import pytest
@@ -13,7 +14,7 @@ class TestWorktreeManager:
     """Tests for WorktreeManager class."""
 
     @patch("scylla.automation.worktree_manager.get_repo_root")
-    def test_initialization_default_base_dir(self, mock_get_root, tmp_path):
+    def test_initialization_default_base_dir(self, mock_get_root: Any, tmp_path: Any) -> None:
         """Test initialization with default base directory."""
         mock_get_root.return_value = tmp_path
 
@@ -24,7 +25,7 @@ class TestWorktreeManager:
         assert manager.worktrees == {}
 
     @patch("scylla.automation.worktree_manager.get_repo_root")
-    def test_initialization_custom_base_dir(self, mock_get_root, tmp_path):
+    def test_initialization_custom_base_dir(self, mock_get_root: Any, tmp_path: Any) -> None:
         """Test initialization with custom base directory."""
         mock_get_root.return_value = tmp_path
         custom_dir = tmp_path / "custom_worktrees"
@@ -35,7 +36,9 @@ class TestWorktreeManager:
 
     @patch("scylla.automation.worktree_manager.run")
     @patch("scylla.automation.worktree_manager.get_repo_root")
-    def test_create_worktree_success(self, mock_get_root, mock_run, tmp_path):
+    def test_create_worktree_success(
+        self, mock_get_root: Any, mock_run: Any, tmp_path: Any
+    ) -> None:
         """Test successful worktree creation."""
         mock_get_root.return_value = tmp_path
         # Mock base branch auto-detection
@@ -56,7 +59,9 @@ class TestWorktreeManager:
 
     @patch("scylla.automation.worktree_manager.run")
     @patch("scylla.automation.worktree_manager.get_repo_root")
-    def test_create_worktree_default_branch_name(self, mock_get_root, mock_run, tmp_path):
+    def test_create_worktree_default_branch_name(
+        self, mock_get_root: Any, mock_run: Any, tmp_path: Any
+    ) -> None:
         """Test worktree creation with default branch name."""
         mock_get_root.return_value = tmp_path
         manager = WorktreeManager()
@@ -69,7 +74,9 @@ class TestWorktreeManager:
 
     @patch("scylla.automation.worktree_manager.run")
     @patch("scylla.automation.worktree_manager.get_repo_root")
-    def test_create_worktree_already_exists(self, mock_get_root, mock_run, tmp_path):
+    def test_create_worktree_already_exists(
+        self, mock_get_root: Any, mock_run: Any, tmp_path: Any
+    ) -> None:
         """Test creating worktree when already exists."""
         mock_get_root.return_value = tmp_path
         # Mock base branch auto-detection
@@ -91,8 +98,8 @@ class TestWorktreeManager:
     @patch("scylla.automation.worktree_manager.run")
     @patch("scylla.automation.worktree_manager.get_repo_root")
     def test_create_worktree_removes_stale_directory(
-        self, mock_get_root, mock_run, mock_rmtree, tmp_path
-    ):
+        self, mock_get_root: Any, mock_run: Any, mock_rmtree: Any, tmp_path: Any
+    ) -> None:
         """Test that stale directories are removed before creation."""
         mock_get_root.return_value = tmp_path
         manager = WorktreeManager()
@@ -113,7 +120,9 @@ class TestWorktreeManager:
 
     @patch("scylla.automation.worktree_manager.run")
     @patch("scylla.automation.worktree_manager.get_repo_root")
-    def test_create_worktree_failure(self, mock_get_root, mock_run, tmp_path):
+    def test_create_worktree_failure(
+        self, mock_get_root: Any, mock_run: Any, tmp_path: Any
+    ) -> None:
         """Test worktree creation failure."""
         mock_get_root.return_value = tmp_path
         mock_run.side_effect = subprocess.CalledProcessError(1, "git")
@@ -125,7 +134,9 @@ class TestWorktreeManager:
 
     @patch("scylla.automation.worktree_manager.run")
     @patch("scylla.automation.worktree_manager.get_repo_root")
-    def test_remove_worktree_success(self, mock_get_root, mock_run, tmp_path):
+    def test_remove_worktree_success(
+        self, mock_get_root: Any, mock_run: Any, tmp_path: Any
+    ) -> None:
         """Test successful worktree removal."""
         mock_get_root.return_value = tmp_path
         # Mock base branch auto-detection
@@ -146,7 +157,7 @@ class TestWorktreeManager:
 
     @patch("scylla.automation.worktree_manager.run")
     @patch("scylla.automation.worktree_manager.get_repo_root")
-    def test_remove_worktree_force(self, mock_get_root, mock_run, tmp_path):
+    def test_remove_worktree_force(self, mock_get_root: Any, mock_run: Any, tmp_path: Any) -> None:
         """Test forced worktree removal."""
         mock_get_root.return_value = tmp_path
         manager = WorktreeManager()
@@ -161,7 +172,9 @@ class TestWorktreeManager:
 
     @patch("scylla.automation.worktree_manager.run")
     @patch("scylla.automation.worktree_manager.get_repo_root")
-    def test_remove_worktree_not_found(self, mock_get_root, mock_run, tmp_path):
+    def test_remove_worktree_not_found(
+        self, mock_get_root: Any, mock_run: Any, tmp_path: Any
+    ) -> None:
         """Test removing non-existent worktree."""
         mock_get_root.return_value = tmp_path
         # Mock base branch auto-detection
@@ -176,7 +189,9 @@ class TestWorktreeManager:
 
     @patch("scylla.automation.worktree_manager.run")
     @patch("scylla.automation.worktree_manager.get_repo_root")
-    def test_remove_worktree_failure(self, mock_get_root, mock_run, tmp_path):
+    def test_remove_worktree_failure(
+        self, mock_get_root: Any, mock_run: Any, tmp_path: Any
+    ) -> None:
         """Test worktree removal failure."""
         mock_get_root.return_value = tmp_path
         manager = WorktreeManager()
@@ -190,7 +205,7 @@ class TestWorktreeManager:
             manager.remove_worktree(123)
 
     @patch("scylla.automation.worktree_manager.get_repo_root")
-    def test_get_worktree(self, mock_get_root, tmp_path):
+    def test_get_worktree(self, mock_get_root: Any, tmp_path: Any) -> None:
         """Test getting worktree path."""
         mock_get_root.return_value = tmp_path
         manager = WorktreeManager()
@@ -203,7 +218,7 @@ class TestWorktreeManager:
 
     @patch("scylla.automation.worktree_manager.run")
     @patch("scylla.automation.worktree_manager.get_repo_root")
-    def test_cleanup_all(self, mock_get_root, mock_run, tmp_path):
+    def test_cleanup_all(self, mock_get_root: Any, mock_run: Any, tmp_path: Any) -> None:
         """Test cleaning up all worktrees."""
         mock_get_root.return_value = tmp_path
         manager = WorktreeManager()
@@ -222,7 +237,9 @@ class TestWorktreeManager:
 
     @patch("scylla.automation.worktree_manager.run")
     @patch("scylla.automation.worktree_manager.get_repo_root")
-    def test_cleanup_all_with_failures(self, mock_get_root, mock_run, tmp_path):
+    def test_cleanup_all_with_failures(
+        self, mock_get_root: Any, mock_run: Any, tmp_path: Any
+    ) -> None:
         """Test cleanup continues even if some removals fail."""
         mock_get_root.return_value = tmp_path
         manager = WorktreeManager()
@@ -241,7 +258,7 @@ class TestWorktreeManager:
 
     @patch("scylla.automation.worktree_manager.run")
     @patch("scylla.automation.worktree_manager.get_repo_root")
-    def test_prune_worktrees(self, mock_get_root, mock_run, tmp_path):
+    def test_prune_worktrees(self, mock_get_root: Any, mock_run: Any, tmp_path: Any) -> None:
         """Test pruning stale worktree metadata."""
         mock_get_root.return_value = tmp_path
         # Mock base branch auto-detection
@@ -257,7 +274,7 @@ class TestWorktreeManager:
 
     @patch("scylla.automation.worktree_manager.run")
     @patch("scylla.automation.worktree_manager.get_repo_root")
-    def test_list_worktrees(self, mock_get_root, mock_run, tmp_path):
+    def test_list_worktrees(self, mock_get_root: Any, mock_run: Any, tmp_path: Any) -> None:
         """Test listing all worktrees."""
         mock_get_root.return_value = tmp_path
         manager = WorktreeManager()
@@ -283,7 +300,7 @@ branch refs/heads/123-feature
 
     @patch("scylla.automation.worktree_manager.run")
     @patch("scylla.automation.worktree_manager.get_repo_root")
-    def test_ensure_branch_deleted(self, mock_get_root, mock_run, tmp_path):
+    def test_ensure_branch_deleted(self, mock_get_root: Any, mock_run: Any, tmp_path: Any) -> None:
         """Test deleting branch from local and remote."""
         mock_get_root.return_value = tmp_path
         # Mock base branch auto-detection
@@ -303,7 +320,9 @@ branch refs/heads/123-feature
 
     @patch("scylla.automation.worktree_manager.run")
     @patch("scylla.automation.worktree_manager.get_repo_root")
-    def test_ensure_branch_deleted_handles_failure(self, mock_get_root, mock_run, tmp_path):
+    def test_ensure_branch_deleted_handles_failure(
+        self, mock_get_root: Any, mock_run: Any, tmp_path: Any
+    ) -> None:
         """Test branch deletion handles failures gracefully."""
         mock_get_root.return_value = tmp_path
         manager = WorktreeManager()

--- a/tests/unit/cli/test_cli.py
+++ b/tests/unit/cli/test_cli.py
@@ -77,7 +77,7 @@ class TestRunCommand:
         mock_orchestrator_instance = MagicMock()
         mock_orchestrator_instance.run_batch.return_value = []
 
-        def capture_config(config: object) -> MagicMock:
+        def capture_config(config: Any) -> MagicMock:
             captured["model"] = getattr(config, "model", None)
             return mock_orchestrator_instance
 

--- a/tests/unit/config/test_pixi_upper_bounds.py
+++ b/tests/unit/config/test_pixi_upper_bounds.py
@@ -6,6 +6,7 @@ unexpected breakage when a major version is released.
 
 import sys
 from pathlib import Path
+from typing import Any
 
 import pytest
 
@@ -39,7 +40,7 @@ def _load_pypi_deps() -> dict[str, object]:
     return deps
 
 
-def _has_upper_bound(spec: object) -> bool:
+def _has_upper_bound(spec: Any) -> bool:
     """Return True if the version spec string contains a '<' upper bound."""
     if not isinstance(spec, str):
         # Table form (e.g. {path = ".", editable = true}) — not a version spec

--- a/tests/unit/e2e/test_experiment_state_machine.py
+++ b/tests/unit/e2e/test_experiment_state_machine.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 
 from datetime import datetime, timezone
 from pathlib import Path
+from typing import Any
 from unittest.mock import MagicMock
 
 import pytest
@@ -303,8 +304,8 @@ class TestExperimentStateMachineAdvanceToCompletion:
         """advance_to_completion runs through all states to COMPLETE."""
         actions_called = []
 
-        def make_action(state: ExperimentState):
-            def action():
+        def make_action(state: ExperimentState) -> Any:
+            def action() -> Any:
                 actions_called.append(state)
 
             return action
@@ -319,10 +320,10 @@ class TestExperimentStateMachineAdvanceToCompletion:
 
     def test_marks_failed_on_exception(
         self, esm: ExperimentStateMachine, checkpoint: E2ECheckpoint, checkpoint_path: Path
-    ) -> None:
+    ) -> Any:
         """If action raises, experiment is marked FAILED and exception re-raised."""
 
-        def failing_action():
+        def failing_action() -> Any:
             raise RuntimeError("simulated experiment failure")
 
         with pytest.raises(RuntimeError, match="simulated experiment failure"):
@@ -338,8 +339,8 @@ class TestExperimentStateMachineAdvanceToCompletion:
 
         actions_called = []
 
-        def make_action(state: ExperimentState):
-            def action():
+        def make_action(state: ExperimentState) -> Any:
+            def action() -> Any:
                 actions_called.append(state)
 
             return action
@@ -394,7 +395,7 @@ class TestExperimentStateMachineAdvanceToCompletion:
             detected_at=datetime.now(timezone.utc).isoformat(),
         )
 
-        def rate_limit_action():
+        def rate_limit_action() -> None:
             raise RateLimitError(rate_limit_info)
 
         with pytest.raises(RateLimitError):
@@ -417,7 +418,7 @@ class TestExperimentStateMachineAdvanceToCompletion:
             detected_at=datetime.now(timezone.utc).isoformat(),
         )
 
-        def rate_limit_action():
+        def rate_limit_action() -> None:
             raise RateLimitError(rate_limit_info)
 
         with pytest.raises(RateLimitError):
@@ -434,7 +435,7 @@ class TestExperimentStateMachineAdvanceToCompletion:
         """ShutdownInterruptedError marks experiment as INTERRUPTED (resumable), not FAILED."""
         from scylla.e2e.runner import ShutdownInterruptedError
 
-        def interrupted_action():
+        def interrupted_action() -> None:
             raise ShutdownInterruptedError("simulated ctrl+c")
 
         with pytest.raises(ShutdownInterruptedError):

--- a/tests/unit/e2e/test_manage_experiment_cli.py
+++ b/tests/unit/e2e/test_manage_experiment_cli.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import logging
 from pathlib import Path
+from typing import Any
 from unittest.mock import patch
 
 import pytest
@@ -427,7 +428,7 @@ class TestBatchModeDetection:
 
         call_args = []
 
-        def mock_run_batch(test_dirs, passed_args):
+        def mock_run_batch(test_dirs: Any, passed_args: Any) -> Any:
             call_args.append(test_dirs)
             return 0
 
@@ -461,7 +462,7 @@ class TestBatchModeDetection:
 
         call_args = []
 
-        def mock_run_batch(test_dirs, passed_args):
+        def mock_run_batch(test_dirs: Any, passed_args: Any) -> Any:
             call_args.append(test_dirs)
             return 0
 

--- a/tests/unit/e2e/test_manage_experiment_run.py
+++ b/tests/unit/e2e/test_manage_experiment_run.py
@@ -80,11 +80,11 @@ class TestCmdRunFromWithCheckpoint:
         reset_calls = []
         run_calls = []
 
-        def mock_reset_runs(checkpoint, from_state, **kwargs):
+        def mock_reset_runs(checkpoint: Any, from_state: Any, **kwargs: Any) -> Any:
             reset_calls.append(("runs", from_state, kwargs))
             return 1
 
-        def mock_run_experiment(config, tiers_dir, results_dir, fresh):
+        def mock_run_experiment(config: Any, tiers_dir: Any, results_dir: Any, fresh: Any) -> Any:
             run_calls.append((config, fresh))
             return {"T0": {}}  # truthy result
 
@@ -150,7 +150,7 @@ class TestCmdRunFromWithCheckpoint:
 
         tier_reset_calls = []
 
-        def mock_reset_tiers(checkpoint, from_state, **kwargs):
+        def mock_reset_tiers(checkpoint: Any, from_state: Any, **kwargs: Any) -> Any:
             tier_reset_calls.append(from_state)
             return 1
 
@@ -211,7 +211,7 @@ class TestCmdRunFromWithCheckpoint:
 
         tier_reset_kwargs: list[dict[str, Any]] = []
 
-        def mock_reset_tiers(checkpoint, from_state, **kwargs):
+        def mock_reset_tiers(checkpoint: Any, from_state: Any, **kwargs: Any) -> Any:
             tier_reset_kwargs.append(kwargs)
             return 1
 
@@ -264,7 +264,7 @@ class TestCmdRunFromWithCheckpoint:
 
         experiment_reset_calls: list[str] = []
 
-        def mock_reset_experiment(checkpoint, from_state):
+        def mock_reset_experiment(checkpoint: Any, from_state: Any) -> Any:
             experiment_reset_calls.append(from_state)
             return 1
 
@@ -358,7 +358,7 @@ class TestCmdRunFromInBatchMode:
 
         reset_calls: list[str] = []
 
-        def mock_reset_runs(checkpoint, from_state, **kwargs):
+        def mock_reset_runs(checkpoint: Any, from_state: Any, **kwargs: Any) -> Any:
             reset_calls.append(from_state)
             return 1
 
@@ -490,7 +490,7 @@ class TestAddJudgeDedup:
 
         captured_configs: list[Any] = []
 
-        def mock_run_experiment(config, tiers_dir, results_dir, fresh):
+        def mock_run_experiment(config: Any, tiers_dir: Any, results_dir: Any, fresh: Any) -> Any:
             captured_configs.append(config)
             return {"T0": {}}
 
@@ -528,7 +528,7 @@ class TestAddJudgeDedup:
 
         captured_configs: list[Any] = []
 
-        def mock_run_experiment(config, tiers_dir, results_dir, fresh):
+        def mock_run_experiment(config: Any, tiers_dir: Any, results_dir: Any, fresh: Any) -> Any:
             captured_configs.append(config)
             return {"T0": {}}
 
@@ -565,7 +565,7 @@ class TestAddJudgeDedup:
 
         captured_configs: list[Any] = []
 
-        def mock_run_experiment(config, tiers_dir, results_dir, fresh):
+        def mock_run_experiment(config: Any, tiers_dir: Any, results_dir: Any, fresh: Any) -> Any:
             captured_configs.append(config)
             return {"T0": {}}
 
@@ -626,7 +626,7 @@ class TestYamlConfigFileMode:
 
         captured_configs: list[Any] = []
 
-        def mock_run_experiment(config, tiers_dir, results_dir, fresh):
+        def mock_run_experiment(config: Any, tiers_dir: Any, results_dir: Any, fresh: Any) -> Any:
             captured_configs.append(config)
             return {"T0": {}}
 
@@ -687,7 +687,7 @@ class TestYamlConfigFileMode:
 
         captured_configs: list[Any] = []
 
-        def mock_run_experiment(config, tiers_dir, results_dir, fresh):
+        def mock_run_experiment(config: Any, tiers_dir: Any, results_dir: Any, fresh: Any) -> Any:
             captured_configs.append(config)
             return {"T0": {}}
 
@@ -726,7 +726,7 @@ class TestTestConfigLoaderExclusion:
 
         call_args = []
 
-        def mock_run_batch(test_dirs, passed_args):
+        def mock_run_batch(test_dirs: Any, passed_args: Any) -> Any:
             call_args.append(list(test_dirs))
             return 0
 
@@ -824,7 +824,7 @@ class TestFilterJudgeSlotNoEffect:
 
         reset_kwargs_captured: list[dict[str, Any]] = []
 
-        def mock_reset_runs(checkpoint, from_state, **kwargs):
+        def mock_reset_runs(checkpoint: Any, from_state: Any, **kwargs: Any) -> Any:
             reset_kwargs_captured.append(kwargs)
             return 0
 
@@ -948,7 +948,7 @@ class TestFreshFlag:
 
         captured_fresh: list[bool] = []
 
-        def mock_run_experiment(config, tiers_dir, results_dir, fresh):
+        def mock_run_experiment(config: Any, tiers_dir: Any, results_dir: Any, fresh: Any) -> Any:
             captured_fresh.append(fresh)
             return {"T0": {}}
 
@@ -981,7 +981,7 @@ class TestFreshFlag:
 
         captured_fresh: list[bool] = []
 
-        def mock_run_experiment(config, tiers_dir, results_dir, fresh):
+        def mock_run_experiment(config: Any, tiers_dir: Any, results_dir: Any, fresh: Any) -> Any:
             captured_fresh.append(fresh)
             return {"T0": {}}
 
@@ -1047,7 +1047,7 @@ class TestUntilStateFlowsToConfig:
 
         captured_configs: list[Any] = []
 
-        def mock_run_experiment(config, tiers_dir, results_dir, fresh):
+        def mock_run_experiment(config: Any, tiers_dir: Any, results_dir: Any, fresh: Any) -> Any:
             captured_configs.append(config)
             return {"T0": {}}
 
@@ -1084,7 +1084,7 @@ class TestUntilStateFlowsToConfig:
 
         captured_configs: list[Any] = []
 
-        def mock_run_experiment(config, tiers_dir, results_dir, fresh):
+        def mock_run_experiment(config: Any, tiers_dir: Any, results_dir: Any, fresh: Any) -> Any:
             captured_configs.append(config)
             return {"T0": {}}
 
@@ -1121,7 +1121,7 @@ class TestUntilStateFlowsToConfig:
 
         captured_configs: list[Any] = []
 
-        def mock_run_experiment(config, tiers_dir, results_dir, fresh):
+        def mock_run_experiment(config: Any, tiers_dir: Any, results_dir: Any, fresh: Any) -> Any:
             captured_configs.append(config)
             return {"T0": {}}
 
@@ -1192,7 +1192,7 @@ class TestBatchFromMissingCheckpoint:
 
         run_experiment_calls: list[str] = []
 
-        def mock_run_experiment(config, tiers_dir, results_dir, fresh):
+        def mock_run_experiment(config: Any, tiers_dir: Any, results_dir: Any, fresh: Any) -> Any:
             run_experiment_calls.append(config.experiment_id)
             return {"T0": {}}
 
@@ -1267,7 +1267,7 @@ class TestBatchTestsFilter:
 
         executed_ids: list[str] = []
 
-        def mock_run_experiment(config, tiers_dir, results_dir, fresh):
+        def mock_run_experiment(config: Any, tiers_dir: Any, results_dir: Any, fresh: Any) -> Any:
             executed_ids.append(config.experiment_id)
             return {"T0": {}}
 
@@ -1350,7 +1350,7 @@ class TestRetryErrorsInBatch:
 
         executed_ids: list[str] = []
 
-        def mock_run_experiment(config, tiers_dir, results_dir, fresh):
+        def mock_run_experiment(config: Any, tiers_dir: Any, results_dir: Any, fresh: Any) -> Any:
             executed_ids.append(config.experiment_id)
             return {"T0": {}}
 
@@ -1401,7 +1401,7 @@ class TestRetryErrorsInBatch:
 
         executed_ids: list[str] = []
 
-        def mock_run_experiment(config, tiers_dir, results_dir, fresh):
+        def mock_run_experiment(config: Any, tiers_dir: Any, results_dir: Any, fresh: Any) -> Any:
             executed_ids.append(config.experiment_id)
             return {"T0": {}}
 
@@ -1460,7 +1460,7 @@ class TestRetryErrorsInBatch:
 
         executed_ids: list[str] = []
 
-        def mock_run_experiment(config, tiers_dir, results_dir, fresh):
+        def mock_run_experiment(config: Any, tiers_dir: Any, results_dir: Any, fresh: Any) -> Any:
             executed_ids.append(config.experiment_id)
             return {"T0": {}}
 
@@ -1553,7 +1553,7 @@ class TestRetryErrorsInBatch:
 
         executed_ids: list[str] = []
 
-        def mock_run_experiment(config, tiers_dir, results_dir, fresh):
+        def mock_run_experiment(config: Any, tiers_dir: Any, results_dir: Any, fresh: Any) -> Any:
             executed_ids.append(config.experiment_id)
             return {"T0": {}}
 
@@ -1628,7 +1628,7 @@ class TestRetryErrorsInBatch:
 
         executed_ids: list[str] = []
 
-        def mock_run_experiment(config, tiers_dir, results_dir, fresh):
+        def mock_run_experiment(config: Any, tiers_dir: Any, results_dir: Any, fresh: Any) -> Any:
             executed_ids.append(config.experiment_id)
             return {"T0": {}}
 
@@ -1745,7 +1745,7 @@ class TestAddJudgeBatchMode:
 
         captured_configs: list[Any] = []
 
-        def mock_run_experiment(config, tiers_dir, results_dir, fresh):
+        def mock_run_experiment(config: Any, tiers_dir: Any, results_dir: Any, fresh: Any) -> Any:
             captured_configs.append(config)
             return {"T0": {}}
 
@@ -1850,13 +1850,13 @@ class TestParallelSemaphoreFlowsToConfig:
         (path / "test.yaml").write_text(yaml.dump(test_yaml))
         (path / "prompt.md").write_text("test prompt")
 
-    def _run_and_capture(self, args) -> Any:
+    def _run_and_capture(self, args: Any) -> Any:
         """Run cmd_run with args and return captured ExperimentConfig."""
         from manage_experiment import cmd_run
 
         captured: list[Any] = []
 
-        def mock_run_experiment(config, tiers_dir, results_dir, fresh):
+        def mock_run_experiment(config: Any, tiers_dir: Any, results_dir: Any, fresh: Any) -> Any:
             captured.append(config)
             return {"T0": {}}
 
@@ -1975,7 +1975,7 @@ class TestModelAliasResolution:
 
         captured: list[Any] = []
 
-        def mock_run_experiment(config, tiers_dir, results_dir, fresh):
+        def mock_run_experiment(config: Any, tiers_dir: Any, results_dir: Any, fresh: Any) -> Any:
             captured.append(config)
             return {"T0": {}}
 
@@ -2009,7 +2009,7 @@ class TestModelAliasResolution:
 
         captured: list[Any] = []
 
-        def mock_run_experiment(config, tiers_dir, results_dir, fresh):
+        def mock_run_experiment(config: Any, tiers_dir: Any, results_dir: Any, fresh: Any) -> Any:
             captured.append(config)
             return {"T0": {}}
 
@@ -2199,7 +2199,7 @@ class TestTimeoutOverride:
 
         captured: list[Any] = []
 
-        def mock_run_experiment(config, tiers_dir, results_dir, fresh):
+        def mock_run_experiment(config: Any, tiers_dir: Any, results_dir: Any, fresh: Any) -> Any:
             captured.append(config)
             return {"T0": {}}
 
@@ -2257,7 +2257,7 @@ class TestThinkingModeFlowsToConfig:
 
         captured: list[Any] = []
 
-        def mock_run_experiment(config, tiers_dir, results_dir, fresh):
+        def mock_run_experiment(config: Any, tiers_dir: Any, results_dir: Any, fresh: Any) -> Any:
             captured.append(config)
             return {"T0": {}}
 
@@ -2315,7 +2315,7 @@ class TestTimeoutFallbackToTestYaml:
 
         captured: list[Any] = []
 
-        def mock_run_experiment(config, tiers_dir, results_dir, fresh):
+        def mock_run_experiment(config: Any, tiers_dir: Any, results_dir: Any, fresh: Any) -> Any:
             captured.append(config)
             return {"T0": {}}
 
@@ -2462,7 +2462,7 @@ class TestBatchEarlyValidation:
 class TestConfigPathExistence:
     """Tests that a non-existent --config path gives a clear error message."""
 
-    def test_nonexistent_config_reports_clear_error(self, tmp_path: Path, caplog) -> None:
+    def test_nonexistent_config_reports_clear_error(self, tmp_path: Path, caplog: Any) -> None:
         """--config /nonexistent/path returns 1 and error message mentions the path."""
         nonexistent = tmp_path / "does-not-exist-at-all"
 
@@ -2715,7 +2715,7 @@ class TestFilterSubtestAndRunWiring:
 
         reset_kwargs: list[dict[str, Any]] = []
 
-        def mock_reset_runs(checkpoint, from_state, **kwargs):
+        def mock_reset_runs(checkpoint: Any, from_state: Any, **kwargs: Any) -> Any:
             reset_kwargs.append(kwargs)
             return 1
 
@@ -2760,7 +2760,7 @@ class TestFilterSubtestAndRunWiring:
 
         reset_kwargs: list[dict[str, Any]] = []
 
-        def mock_reset_runs(checkpoint, from_state, **kwargs):
+        def mock_reset_runs(checkpoint: Any, from_state: Any, **kwargs: Any) -> Any:
             reset_kwargs.append(kwargs)
             return 1
 
@@ -2830,7 +2830,7 @@ class TestPromptOverride:
 
         captured: list[Any] = []
 
-        def mock_run_experiment(config, tiers_dir, results_dir, fresh):
+        def mock_run_experiment(config: Any, tiers_dir: Any, results_dir: Any, fresh: Any) -> Any:
             captured.append(config)
             return {"T0": {}}
 
@@ -3075,7 +3075,7 @@ class TestCmdRunTiersAndMaxSubtests:
 
         captured_configs: list[Any] = []
 
-        def mock_run_experiment(config, tiers_dir, results_dir, fresh):
+        def mock_run_experiment(config: Any, tiers_dir: Any, results_dir: Any, fresh: Any) -> Any:
             captured_configs.append(config)
             return {"T0": {}}
 
@@ -3110,7 +3110,7 @@ class TestCmdRunTiersAndMaxSubtests:
 
         captured_configs: list[Any] = []
 
-        def mock_run_experiment(config, tiers_dir, results_dir, fresh):
+        def mock_run_experiment(config: Any, tiers_dir: Any, results_dir: Any, fresh: Any) -> Any:
             captured_configs.append(config)
             return {"T0": {}}
 
@@ -3143,7 +3143,7 @@ class TestCmdRunTiersAndMaxSubtests:
 
         captured_configs: list[Any] = []
 
-        def mock_run_experiment(config, tiers_dir, results_dir, fresh):
+        def mock_run_experiment(config: Any, tiers_dir: Any, results_dir: Any, fresh: Any) -> Any:
             captured_configs.append(config)
             return {"T0": {}}
 

--- a/tests/unit/e2e/test_manage_experiment_visualize.py
+++ b/tests/unit/e2e/test_manage_experiment_visualize.py
@@ -90,7 +90,7 @@ class TestCmdVisualize:
         result = cmd_visualize(args)
         assert result == 0
 
-    def test_visualize_tree_complete_experiment(self, tmp_path: Path, capsys) -> None:
+    def test_visualize_tree_complete_experiment(self, tmp_path: Path, capsys: Any) -> None:
         """Tree format renders experiment name and tier states for a complete experiment."""
         self._make_checkpoint_file(
             tmp_path,
@@ -116,7 +116,7 @@ class TestCmdVisualize:
         assert "passed" in out
         assert "failed" in out
 
-    def test_visualize_tree_failed_experiment(self, tmp_path: Path, capsys) -> None:
+    def test_visualize_tree_failed_experiment(self, tmp_path: Path, capsys: Any) -> None:
         """Tree format renders 'failed' state for a failed experiment."""
         self._make_checkpoint_file(
             tmp_path,
@@ -134,7 +134,7 @@ class TestCmdVisualize:
         assert "test-fail" in out
         assert "failed" in out
 
-    def test_visualize_tree_partial_experiment(self, tmp_path: Path, capsys) -> None:
+    def test_visualize_tree_partial_experiment(self, tmp_path: Path, capsys: Any) -> None:
         """Tree format renders mixed states (partial / in-progress) correctly."""
         self._make_checkpoint_file(
             tmp_path,
@@ -157,7 +157,7 @@ class TestCmdVisualize:
         assert "T1" in out
         assert "complete" in out
 
-    def test_visualize_table_format(self, tmp_path: Path, capsys) -> None:
+    def test_visualize_table_format(self, tmp_path: Path, capsys: Any) -> None:
         """Table format includes a header row and a data row per run."""
         self._make_checkpoint_file(
             tmp_path,
@@ -177,7 +177,7 @@ class TestCmdVisualize:
         assert "worktree_cleaned" in out
         assert "passed" in out
 
-    def test_visualize_json_format(self, tmp_path: Path, capsys) -> None:
+    def test_visualize_json_format(self, tmp_path: Path, capsys: Any) -> None:
         """JSON format outputs valid JSON containing expected keys."""
         self._make_checkpoint_file(
             tmp_path,
@@ -197,7 +197,7 @@ class TestCmdVisualize:
         assert "tier_states" in data
         assert "run_states" in data
 
-    def test_visualize_tier_filter(self, tmp_path: Path, capsys) -> None:
+    def test_visualize_tier_filter(self, tmp_path: Path, capsys: Any) -> None:
         """--tier T0 limits output to T0 only, omitting T1."""
         self._make_checkpoint_file(
             tmp_path,
@@ -217,7 +217,7 @@ class TestCmdVisualize:
         assert "T0" in out
         assert "T1" not in out
 
-    def test_visualize_verbose_timestamps(self, tmp_path: Path, capsys) -> None:
+    def test_visualize_verbose_timestamps(self, tmp_path: Path, capsys: Any) -> None:
         """--verbose shows Started line and PID."""
         self._make_checkpoint_file(
             tmp_path,
@@ -233,7 +233,7 @@ class TestCmdVisualize:
         assert "Started:" in out
         assert "PID: 12345" in out
 
-    def test_visualize_empty_tiers(self, tmp_path: Path, capsys) -> None:
+    def test_visualize_empty_tiers(self, tmp_path: Path, capsys: Any) -> None:
         """Checkpoint with no tier_states renders '(no tiers)' message."""
         self._make_checkpoint_file(
             tmp_path,
@@ -248,7 +248,7 @@ class TestCmdVisualize:
         out = capsys.readouterr().out
         assert "(no tiers)" in out
 
-    def test_visualize_batch_directory(self, tmp_path: Path, capsys) -> None:
+    def test_visualize_batch_directory(self, tmp_path: Path, capsys: Any) -> None:
         """Batch mode: results dir with multiple experiment subdirs shows all experiments."""
         for exp_id in ["exp-01", "exp-02"]:
             exp_dir = tmp_path / exp_id
@@ -267,7 +267,7 @@ class TestCmdVisualize:
         assert "exp-01" in out
         assert "exp-02" in out
 
-    def test_visualize_states_only_single(self, tmp_path: Path, capsys) -> None:
+    def test_visualize_states_only_single(self, tmp_path: Path, capsys: Any) -> None:
         """--states-only with single experiment: shows TIER/SUBTEST/RUN/STATE, no EXP or RESULT."""
         self._make_checkpoint_file(
             tmp_path,
@@ -289,7 +289,7 @@ class TestCmdVisualize:
         assert "T0" in out
         assert "worktree_cleaned" in out
 
-    def test_visualize_states_only_batch(self, tmp_path: Path, capsys) -> None:
+    def test_visualize_states_only_batch(self, tmp_path: Path, capsys: Any) -> None:
         """--states-only with multiple experiments shows EXP column in unified table."""
         for exp_id in ["exp-01", "exp-02"]:
             exp_dir = tmp_path / exp_id
@@ -315,7 +315,7 @@ class TestCmdVisualize:
         assert "exp-02" in out
         assert "worktree_cleaned" in out
 
-    def test_visualize_states_only_tier_filter(self, tmp_path: Path, capsys) -> None:
+    def test_visualize_states_only_tier_filter(self, tmp_path: Path, capsys: Any) -> None:
         """--states-only with --tier T0 limits output to T0 only."""
         self._make_checkpoint_file(
             tmp_path,

--- a/tests/unit/e2e/test_orchestrator.py
+++ b/tests/unit/e2e/test_orchestrator.py
@@ -2,6 +2,7 @@
 
 from collections.abc import Generator
 from pathlib import Path
+from typing import Any
 from unittest.mock import patch
 
 import pytest
@@ -63,7 +64,7 @@ class TestEvalOrchestrator:
         """Test Set adapter."""
         orchestrator = EvalOrchestrator()
 
-        def mock_adapter(**kwargs):
+        def mock_adapter(**kwargs: Any) -> Any:
             return {"tokens_in": 100, "tokens_out": 50}
 
         orchestrator.set_adapter(mock_adapter)
@@ -73,7 +74,7 @@ class TestEvalOrchestrator:
         """Test Set judge."""
         orchestrator = EvalOrchestrator()
 
-        def mock_judge(**kwargs):
+        def mock_judge(**kwargs: Any) -> Any:
             return {"passed": True, "score": 1.0}
 
         orchestrator.set_judge(mock_judge)
@@ -295,7 +296,7 @@ output:
         orchestrator = EvalOrchestrator(config)
 
         # Set mock adapter
-        def mock_adapter(**kwargs):
+        def mock_adapter(**kwargs: Any) -> Any:
             return {
                 "tokens_in": 1000,
                 "tokens_out": 500,
@@ -304,7 +305,7 @@ output:
             }
 
         # Set mock judge
-        def mock_judge(**kwargs):
+        def mock_judge(**kwargs: Any) -> Any:
             return {
                 "passed": True,
                 "score": 0.85,

--- a/tests/unit/e2e/test_parallel_executor.py
+++ b/tests/unit/e2e/test_parallel_executor.py
@@ -408,7 +408,7 @@ class TestRunSubtestInProcessSafe:
     by catching all exceptions and returning structured SubTestResult objects.
     """
 
-    def _make_subtest_config(self):
+    def _make_subtest_config(self) -> Any:
         """Create a minimal SubTestConfig for testing."""
         from scylla.e2e.models import SubTestConfig
 
@@ -447,7 +447,7 @@ class TestRunSubtestInProcessSafe:
             "experiment_dir": None,
         }
 
-    def test_success_passthrough(self, tmp_path) -> None:
+    def test_success_passthrough(self, tmp_path: Any) -> None:
         """When _run_subtest_in_process succeeds, result is passed through unchanged."""
         from scylla.e2e.models import SubTestResult, TierID
         from scylla.e2e.parallel_executor import _run_subtest_in_process_safe
@@ -477,7 +477,7 @@ class TestRunSubtestInProcessSafe:
         mock_inner.assert_called_once()
         assert result is expected_result
 
-    def test_rate_limit_error_handling(self, tmp_path) -> None:
+    def test_rate_limit_error_handling(self, tmp_path: Any) -> None:
         """RateLimitError is caught; SubTestResult has rate_limit_info set."""
         from scylla.e2e.models import SubTestResult, TierID
         from scylla.e2e.parallel_executor import _run_subtest_in_process_safe
@@ -508,7 +508,7 @@ class TestRunSubtestInProcessSafe:
         assert result.tier_id == TierID.T0
         assert result.pass_rate == 0.0
 
-    def test_generic_exception_handling(self, tmp_path) -> None:
+    def test_generic_exception_handling(self, tmp_path: Any) -> None:
         """Generic Exception is caught; SubTestResult carries error info."""
         from scylla.e2e.models import SubTestResult, TierID
         from scylla.e2e.parallel_executor import _run_subtest_in_process_safe
@@ -530,7 +530,7 @@ class TestRunSubtestInProcessSafe:
         assert result.tier_id == TierID.T0
         assert result.pass_rate == 0.0
 
-    def test_never_raises(self, tmp_path) -> None:
+    def test_never_raises(self, tmp_path: Any) -> None:
         """Safe wrapper never raises for any Exception subclass from inner function.
 
         The wrapper catches Exception (and RateLimitError), converting them to
@@ -559,7 +559,7 @@ class TestRunSubtestInProcessSafe:
                         f"when it should never raise"
                     ) from raised
 
-    def test_returns_subtest_result_type(self, tmp_path) -> None:
+    def test_returns_subtest_result_type(self, tmp_path: Any) -> None:
         """Return type is always SubTestResult regardless of inner outcome."""
         from scylla.e2e.models import SubTestResult
         from scylla.e2e.parallel_executor import _run_subtest_in_process_safe

--- a/tests/unit/e2e/test_parallel_rate_limit_handling.py
+++ b/tests/unit/e2e/test_parallel_rate_limit_handling.py
@@ -15,6 +15,7 @@ import tempfile
 from datetime import datetime, timezone
 from multiprocessing import Manager
 from pathlib import Path
+from typing import Any
 from unittest.mock import Mock, patch
 
 from scylla.e2e.checkpoint import E2ECheckpoint
@@ -384,7 +385,9 @@ class TestParallelCheckpointIntegration:
             pause_signaled = []
             resume_signaled = []
 
-            def mock_wait(retry_after, checkpoint, checkpoint_path, log_func=None):
+            def mock_wait(
+                retry_after: Any, checkpoint: Any, checkpoint_path: Any, log_func: Any = None
+            ) -> None:
                 pause_signaled.append(True)
                 # Simulate checkpoint update during wait
                 checkpoint.status = "paused_rate_limit"

--- a/tests/unit/e2e/test_parallel_tier_runner.py
+++ b/tests/unit/e2e/test_parallel_tier_runner.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 from collections.abc import Callable
 from pathlib import Path
+from typing import Any
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -173,7 +174,7 @@ class TestExecuteTierGroups:
 
         call_count = [0]
 
-        def run_tier(tier_id: TierID, *args: object) -> TierResult:
+        def run_tier(tier_id: TierID, *args: Any) -> TierResult:
             call_count[0] += 1
             return t0_result if tier_id == TierID.T0 else t1_result
 
@@ -206,7 +207,7 @@ class TestExecuteTierGroups:
         t1_result = _make_tier_result(TierID.T1)
         t2_result = _make_tier_result(TierID.T2)
 
-        def run_tier(tier_id: TierID, *args: object) -> TierResult:
+        def run_tier(tier_id: TierID, *args: Any) -> TierResult:
             return t1_result if tier_id == TierID.T1 else t2_result
 
         config = ExperimentConfig(
@@ -237,7 +238,7 @@ class TestExecuteParallelTierGroup:
         t1_result = _make_tier_result(TierID.T1)
         t2_result = _make_tier_result(TierID.T2)
 
-        def run_tier(tier_id: TierID, *args: object) -> TierResult:
+        def run_tier(tier_id: TierID, *args: Any) -> TierResult:
             return t1_result if tier_id == TierID.T1 else t2_result
 
         runner = _make_runner(run_tier_fn=run_tier)
@@ -252,7 +253,7 @@ class TestExecuteParallelTierGroup:
         """One failure doesn't abort sibling tiers."""
         t1_result = _make_tier_result(TierID.T1)
 
-        def run_tier(tier_id: TierID, *args: object) -> TierResult:
+        def run_tier(tier_id: TierID, *args: Any) -> TierResult:
             if tier_id == TierID.T2:
                 raise RuntimeError("T2 failed")
             return t1_result
@@ -268,7 +269,7 @@ class TestExecuteParallelTierGroup:
     def test_all_fail_raises_runtime_error(self) -> None:
         """All tiers failing raises RuntimeError."""
 
-        def run_tier(tier_id: TierID, *args: object) -> TierResult:
+        def run_tier(tier_id: TierID, *args: Any) -> TierResult:
             raise RuntimeError(f"{tier_id.value} failed")
 
         runner = _make_runner(run_tier_fn=run_tier)

--- a/tests/unit/e2e/test_rate_limit.py
+++ b/tests/unit/e2e/test_rate_limit.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 import tempfile
 from pathlib import Path
+from typing import Any
 from unittest.mock import patch
 
 import pytest
@@ -669,7 +670,7 @@ class TestCheckApiRateLimitStatus:
     """Tests for check_api_rate_limit_status function."""
 
     @patch("scylla.e2e.rate_limit.subprocess.run")
-    def test_no_rate_limit(self, mock_run) -> None:
+    def test_no_rate_limit(self, mock_run: Any) -> None:
         """Test when API is not rate limited."""
         mock_run.return_value.stderr = "Success"
         mock_run.return_value.returncode = 0
@@ -679,7 +680,7 @@ class TestCheckApiRateLimitStatus:
         assert result is None
 
     @patch("scylla.e2e.rate_limit.subprocess.run")
-    def test_rate_limit_detected(self, mock_run) -> None:
+    def test_rate_limit_detected(self, mock_run: Any) -> None:
         """Test when rate limit is detected in stderr."""
         from subprocess import CompletedProcess
 
@@ -698,7 +699,7 @@ class TestCheckApiRateLimitStatus:
         assert "Rate limit" in result.error_message
 
     @patch("scylla.e2e.rate_limit.subprocess.run")
-    def test_hit_your_limit_detected(self, mock_run) -> None:
+    def test_hit_your_limit_detected(self, mock_run: Any) -> None:
         """Test when 'hit your limit' message is detected."""
         from subprocess import CompletedProcess
 
@@ -716,7 +717,7 @@ class TestCheckApiRateLimitStatus:
         assert "hit your limit" in result.error_message.lower()
 
     @patch("scylla.e2e.rate_limit.subprocess.run")
-    def test_timeout_returns_none(self, mock_run) -> None:
+    def test_timeout_returns_none(self, mock_run: Any) -> None:
         """Test that subprocess timeout returns None (not treated as rate limit)."""
         from subprocess import TimeoutExpired
 
@@ -727,7 +728,7 @@ class TestCheckApiRateLimitStatus:
         assert result is None
 
     @patch("scylla.e2e.rate_limit.subprocess.run")
-    def test_other_exception_returns_none(self, mock_run) -> None:
+    def test_other_exception_returns_none(self, mock_run: Any) -> None:
         """Test that other exceptions return None."""
         mock_run.side_effect = OSError("Command not found")
 

--- a/tests/unit/e2e/test_rerun_judges.py
+++ b/tests/unit/e2e/test_rerun_judges.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
+from typing import Any
 from unittest.mock import patch
 
 import pytest
@@ -700,7 +701,7 @@ class TestRerunJudgeStats:
         assert stats.agent_failed == 0
         assert stats.per_slot_stats == {}
 
-    def test_print_summary(self, capsys) -> None:
+    def test_print_summary(self, capsys: Any) -> None:
         """Test print_summary output."""
         stats = RerunJudgeStats(
             total_expected_slots=10,

--- a/tests/unit/e2e/test_resume.py
+++ b/tests/unit/e2e/test_resume.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 from datetime import datetime, timezone
 from pathlib import Path
+from typing import Any
 
 import pytest
 
@@ -377,7 +378,7 @@ class TestResumeConfigMismatch:
         self,
         experiment_config: ExperimentConfig,
         field: str,
-        new_value: object,
+        new_value: Any,
     ) -> None:
         """Hash must differ for each field that is included in the config hash."""
         config_original = experiment_config.model_copy()

--- a/tests/unit/e2e/test_runner.py
+++ b/tests/unit/e2e/test_runner.py
@@ -606,7 +606,7 @@ class TestResumeTierConfigPreload:
         )
         runner.checkpoint = checkpoint
 
-        def noop_complete(tier_id_str: str, actions: dict[str, Any], until_state: object) -> None:
+        def noop_complete(tier_id_str: str, actions: dict[str, Any], until_state: Any) -> None:
             pass
 
         with patch.object(TierStateMachine, "advance_to_completion", side_effect=noop_complete):
@@ -649,7 +649,7 @@ class TestResumeTierConfigPreload:
         )
         runner.checkpoint = checkpoint
 
-        def noop_complete(tier_id_str: str, actions: dict[str, Any], until_state: object) -> None:
+        def noop_complete(tier_id_str: str, actions: dict[str, Any], until_state: Any) -> None:
             pass
 
         with patch.object(TierStateMachine, "advance_to_completion", side_effect=noop_complete):
@@ -690,7 +690,7 @@ class TestResumeTierConfigPreload:
         )
         runner.checkpoint = checkpoint
 
-        def noop_complete(tier_id_str: str, actions: dict[str, Any], until_state: object) -> None:
+        def noop_complete(tier_id_str: str, actions: dict[str, Any], until_state: Any) -> None:
             pass
 
         with patch.object(TierStateMachine, "advance_to_completion", side_effect=noop_complete):

--- a/tests/unit/e2e/test_runner_state_machine.py
+++ b/tests/unit/e2e/test_runner_state_machine.py
@@ -274,7 +274,7 @@ class TestRunTierUsesTierStateMachine:
             patch.object(runner, "_build_tier_actions") as mock_build_actions,
         ):
             # Make advance_to_completion return COMPLETE and set up tier_results side effect
-            def advance_side_effect(tier_id, actions, until_state=None):
+            def advance_side_effect(tier_id: Any, actions: Any, until_state: Any = None) -> Any:
                 # Simulate completing the tier — populate tier_results via the action
                 return TierState.COMPLETE
 

--- a/tests/unit/e2e/test_scheduler.py
+++ b/tests/unit/e2e/test_scheduler.py
@@ -12,7 +12,9 @@ Tests cover:
 from __future__ import annotations
 
 import threading
+from collections.abc import Generator
 from multiprocessing import Manager
+from typing import Any
 
 import pytest
 
@@ -25,7 +27,7 @@ from scylla.e2e.scheduler import (
 
 
 @pytest.fixture(scope="module")
-def mp_manager():
+def mp_manager() -> Generator[Any, None, None]:
     """Create a multiprocessing Manager shared across tests in this module."""
     mgr = Manager()
     yield mgr
@@ -33,7 +35,7 @@ def mp_manager():
 
 
 @pytest.fixture
-def scheduler(mp_manager) -> ParallelismScheduler:
+def scheduler(mp_manager: Any) -> ParallelismScheduler:
     """Create a ParallelismScheduler with small limits for testing."""
     return ParallelismScheduler(
         manager=mp_manager,
@@ -53,7 +55,7 @@ class TestParallelismSchedulerInit:
         assert config.parallel_med == 4
         assert config.parallel_low == 8
 
-    def test_semaphores_created_for_all_classes(self, mp_manager) -> None:
+    def test_semaphores_created_for_all_classes(self, mp_manager: Any) -> None:
         """All three memory class semaphores are created."""
         s = ParallelismScheduler(mp_manager, parallel_high=1, parallel_med=2, parallel_low=3)
         # Acquire and release each semaphore to verify they work
@@ -125,7 +127,7 @@ class TestParallelismSchedulerRawControl:
 class TestParallelismSchedulerConcurrency:
     """Tests for ParallelismScheduler concurrency limiting."""
 
-    def test_high_semaphore_limits_concurrency(self, mp_manager) -> None:
+    def test_high_semaphore_limits_concurrency(self, mp_manager: Any) -> None:
         """High semaphore with count 1 prevents more than 1 concurrent acquisition."""
         s = ParallelismScheduler(mp_manager, parallel_high=1, parallel_med=4, parallel_low=8)
 
@@ -133,7 +135,7 @@ class TestParallelismSchedulerConcurrency:
         max_concurrent = [0]
         lock = threading.Lock()
 
-        def acquire_and_hold():
+        def acquire_and_hold() -> None:
             s.acquire_raw("high")
             with lock:
                 acquired_count[0] += 1
@@ -159,7 +161,7 @@ class TestParallelismSchedulerConcurrency:
 class TestCreateSchedulerFromConfig:
     """Tests for create_scheduler_from_config() factory function."""
 
-    def test_factory_creates_scheduler(self, mp_manager) -> None:
+    def test_factory_creates_scheduler(self, mp_manager: Any) -> None:
         """Verify factory creates a ParallelismScheduler with given config."""
         s = create_scheduler_from_config(
             mp_manager, parallel_high=3, parallel_med=5, parallel_low=10
@@ -170,7 +172,7 @@ class TestCreateSchedulerFromConfig:
         assert config.parallel_med == 5
         assert config.parallel_low == 10
 
-    def test_factory_uses_defaults(self, mp_manager) -> None:
+    def test_factory_uses_defaults(self, mp_manager: Any) -> None:
         """Verify factory uses default parallelism values when none provided."""
         s = create_scheduler_from_config(mp_manager)
         config = s.get_config()

--- a/tests/unit/e2e/test_state_machine.py
+++ b/tests/unit/e2e/test_state_machine.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 
 from datetime import datetime, timezone
 from pathlib import Path
+from typing import Any
 from unittest.mock import MagicMock
 
 import pytest
@@ -356,8 +357,8 @@ class TestStateMachineAdvanceToCompletion:
         """advance_to_completion runs through all states to WORKTREE_CLEANED."""
         actions_called = []
 
-        def make_action(state: RunState):
-            def action():
+        def make_action(state: RunState) -> Any:
+            def action() -> Any:
                 actions_called.append(state)
 
             return action
@@ -371,10 +372,10 @@ class TestStateMachineAdvanceToCompletion:
 
     def test_advance_to_completion_marks_failed_on_exception(
         self, sm: StateMachine, checkpoint: E2ECheckpoint, checkpoint_path: Path
-    ) -> None:
+    ) -> Any:
         """If an action raises, run is marked FAILED and exception re-raised."""
 
-        def failing_action():
+        def failing_action() -> Any:
             raise RuntimeError("simulated failure")
 
         with pytest.raises(RuntimeError, match="simulated failure"):
@@ -394,7 +395,7 @@ class TestStateMachineAdvanceToCompletion:
         """
         from scylla.e2e.runner import ShutdownInterruptedError
 
-        def interrupted_action():
+        def interrupted_action() -> None:
             raise ShutdownInterruptedError("simulated ctrl+c")
 
         with pytest.raises(ShutdownInterruptedError):
@@ -418,7 +419,7 @@ class TestStateMachineAdvanceToCompletion:
             detected_at=datetime.now(timezone.utc).isoformat(),
         )
 
-        def rate_limited_action():
+        def rate_limited_action() -> None:
             raise RateLimitError(rate_info)
 
         with pytest.raises(RateLimitError):
@@ -436,8 +437,8 @@ class TestStateMachineAdvanceToCompletion:
 
         actions_called = []
 
-        def make_action(state: RunState):
-            def action():
+        def make_action(state: RunState) -> Any:
+            def action() -> Any:
                 actions_called.append(state)
 
             return action
@@ -476,8 +477,8 @@ class TestStateMachineAdvanceToCompletion:
         """advance_to_completion stops cleanly AFTER transitioning into until_state (inclusive)."""
         actions_called: list[RunState] = []
 
-        def make_action(state: RunState):
-            def action():
+        def make_action(state: RunState) -> Any:
+            def action() -> Any:
                 actions_called.append(state)
 
             return action

--- a/tests/unit/e2e/test_subtest_executor.py
+++ b/tests/unit/e2e/test_subtest_executor.py
@@ -305,7 +305,7 @@ class TestParseJudgeResponse:
 class TestCheckpointResumeWithNullCriteriaScores:
     """Tests for checkpoint resume when criteria_scores is null in stored data."""
 
-    def _make_report_data(self, criteria_scores_value: object) -> dict[str, Any]:
+    def _make_report_data(self, criteria_scores_value: Any) -> dict[str, Any]:
         """Build a minimal report_data dict with the given criteria_scores value."""
         from scylla.e2e.models import TokenStats
 

--- a/tests/unit/e2e/test_subtest_state_machine.py
+++ b/tests/unit/e2e/test_subtest_state_machine.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 
 from datetime import datetime, timezone
 from pathlib import Path
+from typing import Any
 from unittest.mock import MagicMock
 
 import pytest
@@ -344,8 +345,8 @@ class TestSubtestStateMachineAdvanceToCompletion:
         """advance_to_completion runs through all states to AGGREGATED."""
         actions_called = []
 
-        def make_action(state: SubtestState):
-            def action():
+        def make_action(state: SubtestState) -> Any:
+            def action() -> Any:
                 actions_called.append(state)
 
             return action
@@ -363,14 +364,14 @@ class TestSubtestStateMachineAdvanceToCompletion:
         ssm: SubtestStateMachine,
         checkpoint: E2ECheckpoint,
         checkpoint_path: Path,
-    ) -> None:
+    ) -> Any:
         """advance_to_completion skips already-completed states on resume."""
         checkpoint.set_subtest_state(TIER_ID, SUBTEST_ID, SubtestState.RUNS_COMPLETE.value)
 
         actions_called = []
 
-        def make_action(state: SubtestState):
-            def action():
+        def make_action(state: SubtestState) -> Any:
+            def action() -> Any:
                 actions_called.append(state)
 
             return action
@@ -399,8 +400,8 @@ class TestSubtestStateMachineAdvanceToCompletion:
 
         actions_called = []
 
-        def make_action(state: SubtestState):
-            def action():
+        def make_action(state: SubtestState) -> Any:
+            def action() -> Any:
                 actions_called.append(state)
 
             return action

--- a/tests/unit/e2e/test_tier_state_machine.py
+++ b/tests/unit/e2e/test_tier_state_machine.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 
 from datetime import datetime, timezone
 from pathlib import Path
+from typing import Any
 from unittest.mock import MagicMock
 
 import pytest
@@ -292,8 +293,8 @@ class TestTierStateMachineAdvanceToCompletion:
         """advance_to_completion runs through all states to COMPLETE."""
         actions_called = []
 
-        def make_action(state: TierState):
-            def action():
+        def make_action(state: TierState) -> Any:
+            def action() -> Any:
                 actions_called.append(state)
 
             return action
@@ -306,14 +307,14 @@ class TestTierStateMachineAdvanceToCompletion:
 
     def test_resumes_from_mid_state(
         self, tsm: TierStateMachine, checkpoint: E2ECheckpoint, checkpoint_path: Path
-    ) -> None:
+    ) -> Any:
         """advance_to_completion skips already-completed states on resume."""
         checkpoint.set_tier_state("T0", TierState.SUBTESTS_COMPLETE.value)
 
         actions_called = []
 
-        def make_action(state: TierState):
-            def action():
+        def make_action(state: TierState) -> Any:
+            def action() -> Any:
                 actions_called.append(state)
 
             return action

--- a/tests/unit/executor/test_agent_container.py
+++ b/tests/unit/executor/test_agent_container.py
@@ -5,6 +5,7 @@ environment variable setup, and container configuration.
 """
 
 from pathlib import Path
+from typing import Any
 from unittest.mock import Mock, patch
 
 import pytest
@@ -18,13 +19,13 @@ from scylla.executor.docker import DockerExecutor
 
 
 @pytest.fixture
-def mock_docker_executor():
+def mock_docker_executor() -> Any:
     """Create a mock Docker executor."""
     return Mock(spec=DockerExecutor)
 
 
 @pytest.fixture
-def temp_directories(tmp_path):
+def temp_directories(tmp_path: Any) -> Any:
     """Create temporary directories for testing."""
     workspace_dir = tmp_path / "workspace"
     workspace_dir.mkdir()
@@ -46,7 +47,7 @@ def temp_directories(tmp_path):
     }
 
 
-def test_agent_container_config_defaults():
+def test_agent_container_config_defaults() -> None:
     """Test AgentContainerConfig has correct defaults."""
     config = AgentContainerConfig(
         workspace_dir=Path("/tmp/workspace"),
@@ -61,7 +62,7 @@ def test_agent_container_config_defaults():
     assert config.claude_md_path is None
 
 
-def test_build_volumes_without_claude_md(mock_docker_executor, temp_directories):
+def test_build_volumes_without_claude_md(mock_docker_executor: Any, temp_directories: Any) -> None:
     """Test volume mount configuration without CLAUDE.md."""
     manager = AgentContainerManager(mock_docker_executor)
 
@@ -93,7 +94,7 @@ def test_build_volumes_without_claude_md(mock_docker_executor, temp_directories)
     assert volumes[prompt_key]["mode"] == "ro"
 
 
-def test_build_volumes_with_claude_md(mock_docker_executor, temp_directories):
+def test_build_volumes_with_claude_md(mock_docker_executor: Any, temp_directories: Any) -> None:
     """Test volume mount configuration with CLAUDE.md."""
     manager = AgentContainerManager(mock_docker_executor)
 
@@ -117,7 +118,7 @@ def test_build_volumes_with_claude_md(mock_docker_executor, temp_directories):
     assert volumes[claude_md_key]["mode"] == "ro"
 
 
-def test_build_environment_with_api_keys(mock_docker_executor):
+def test_build_environment_with_api_keys(mock_docker_executor: Any) -> None:
     """Test environment variable configuration with API keys."""
     manager = AgentContainerManager(mock_docker_executor)
 
@@ -145,7 +146,7 @@ def test_build_environment_with_api_keys(mock_docker_executor):
     assert env_vars["OPENAI_API_KEY"] == "test-openai-key"
 
 
-def test_build_environment_without_api_keys(mock_docker_executor):
+def test_build_environment_without_api_keys(mock_docker_executor: Any) -> None:
     """Test environment variable configuration without API keys."""
     manager = AgentContainerManager(mock_docker_executor)
 
@@ -167,7 +168,9 @@ def test_build_environment_without_api_keys(mock_docker_executor):
 
 
 @patch("subprocess.run")
-def test_run_with_volumes_success(mock_subprocess_run, mock_docker_executor, temp_directories):
+def test_run_with_volumes_success(
+    mock_subprocess_run: Any, mock_docker_executor: Any, temp_directories: Any
+) -> None:
     """Test successful container execution."""
     manager = AgentContainerManager(mock_docker_executor)
 
@@ -205,7 +208,9 @@ def test_run_with_volumes_success(mock_subprocess_run, mock_docker_executor, tem
 
 
 @patch("subprocess.run")
-def test_run_with_volumes_timeout(mock_subprocess_run, mock_docker_executor, temp_directories):
+def test_run_with_volumes_timeout(
+    mock_subprocess_run: Any, mock_docker_executor: Any, temp_directories: Any
+) -> None:
     """Test container execution timeout."""
     manager = AgentContainerManager(mock_docker_executor)
 
@@ -234,10 +239,10 @@ def test_run_with_volumes_timeout(mock_subprocess_run, mock_docker_executor, tem
 
 @patch("subprocess.run")
 def test_run_with_custom_container_name(
-    mock_subprocess_run,
-    mock_docker_executor,
-    temp_directories,
-):
+    mock_subprocess_run: Any,
+    mock_docker_executor: Any,
+    temp_directories: Any,
+) -> None:
     """Test container execution with custom container name."""
     manager = AgentContainerManager(mock_docker_executor)
 

--- a/tests/unit/executor/test_capture.py
+++ b/tests/unit/executor/test_capture.py
@@ -3,6 +3,7 @@
 import json
 from pathlib import Path
 from tempfile import TemporaryDirectory
+from typing import Any
 
 import pytest
 
@@ -181,7 +182,7 @@ class TestLogCapture:
             mock_file2 = Mock()
             open_results = [mock_file1, mock_file2, OSError("Permission denied")]
 
-            def side_effect(*args, **kwargs):
+            def side_effect(*args: Any, **kwargs: Any) -> Any:
                 result = open_results.pop(0)
                 if isinstance(result, Exception):
                     raise result

--- a/tests/unit/judge/test_evaluator.py
+++ b/tests/unit/judge/test_evaluator.py
@@ -2,6 +2,7 @@
 
 from pathlib import Path
 from tempfile import TemporaryDirectory
+from typing import Any
 
 import pytest
 
@@ -319,7 +320,7 @@ class TestRunConsensus:
         evaluator = JudgeEvaluator(config=config)
         call_count = 0
 
-        def mock_eval(*args, **kwargs):
+        def mock_eval(*args: Any, **kwargs: Any) -> Any:
             nonlocal call_count
             call_count += 1
             return Judgment(
@@ -493,7 +494,7 @@ class TestEvaluatorWithConsensusConfig:
         evaluator = JudgeEvaluator(consensus_config=consensus_config)
         call_count = 0
 
-        def fake_single_run(*args, **kwargs):
+        def fake_single_run(*args: Any, **kwargs: Any) -> Any:
             nonlocal call_count
             call_count += 1
             # Alternating scores to create variance
@@ -529,7 +530,7 @@ class TestEvaluatorWithConsensusConfig:
         evaluator = JudgeEvaluator(consensus_config=consensus_config)
         call_count = 0
 
-        def fake_single_run(*args, **kwargs):
+        def fake_single_run(*args: Any, **kwargs: Any) -> Any:
             nonlocal call_count
             call_count += 1
             # Consistent scores - no variance

--- a/tests/unit/judge/test_utils.py
+++ b/tests/unit/judge/test_utils.py
@@ -6,25 +6,25 @@ from scylla.judge.utils import extract_json_from_llm_response
 class TestExtractJsonFromLlmResponse:
     """Tests for extract_json_from_llm_response utility."""
 
-    def test_raw_json_happy_path(self):
+    def test_raw_json_happy_path(self) -> None:
         """Test extraction of raw JSON object."""
         output = '{"score": 5, "passed": true}'
         result = extract_json_from_llm_response(output)
         assert result == {"score": 5, "passed": True}
 
-    def test_json_in_markdown_code_block_with_json_label(self):
+    def test_json_in_markdown_code_block_with_json_label(self) -> None:
         """Test extraction from ```json code block."""
         output = '```json\n{"score": 5, "passed": true}\n```'
         result = extract_json_from_llm_response(output)
         assert result == {"score": 5, "passed": True}
 
-    def test_json_in_markdown_code_block_without_label(self):
+    def test_json_in_markdown_code_block_without_label(self) -> None:
         """Test extraction from ``` code block without json label."""
         output = '```\n{"score": 5, "passed": true}\n```'
         result = extract_json_from_llm_response(output)
         assert result == {"score": 5, "passed": True}
 
-    def test_json_wrapped_in_xml_tags_with_preamble(self):
+    def test_json_wrapped_in_xml_tags_with_preamble(self) -> None:
         """Test extraction from XML-wrapped JSON with preamble text."""
         output = """Here is the evaluation result:
 <json_evaluation>
@@ -38,37 +38,37 @@ class TestExtractJsonFromLlmResponse:
             "reasoning": "Good work",
         }
 
-    def test_json_with_preamble_text_no_tags(self):
+    def test_json_with_preamble_text_no_tags(self) -> None:
         """Test extraction of JSON with leading preamble text."""
         output = 'Here is the result: {"score": 5, "passed": true}'
         result = extract_json_from_llm_response(output)
         assert result == {"score": 5, "passed": True}
 
-    def test_json_with_trailing_text(self):
+    def test_json_with_trailing_text(self) -> None:
         """Test extraction of JSON with trailing text."""
         output = '{"score": 5, "passed": true} - This is a good result'
         result = extract_json_from_llm_response(output)
         assert result == {"score": 5, "passed": True}
 
-    def test_no_json_in_output(self):
+    def test_no_json_in_output(self) -> None:
         """Test that None is returned when no JSON is found."""
         output = "This is just plain text with no JSON"
         result = extract_json_from_llm_response(output)
         assert result is None
 
-    def test_malformed_json(self):
+    def test_malformed_json(self) -> None:
         """Test that None is returned for malformed JSON."""
         output = '{"score": 5, "passed": true'  # Missing closing brace
         result = extract_json_from_llm_response(output)
         assert result is None
 
-    def test_unbalanced_braces(self):
+    def test_unbalanced_braces(self) -> None:
         """Test that None is returned for unbalanced braces."""
         output = '{"score": 5, "nested": {"key": "value"}'  # Missing closing brace
         result = extract_json_from_llm_response(output)
         assert result is None
 
-    def test_nested_json_objects(self):
+    def test_nested_json_objects(self) -> None:
         """Test extraction of nested JSON objects."""
         output = '{"score": 5, "metadata": {"author": "test", "version": 1}}'
         result = extract_json_from_llm_response(output)
@@ -77,13 +77,13 @@ class TestExtractJsonFromLlmResponse:
             "metadata": {"author": "test", "version": 1},
         }
 
-    def test_json_with_arrays(self):
+    def test_json_with_arrays(self) -> None:
         """Test extraction of JSON with arrays."""
         output = '{"scores": [1, 2, 3], "passed": true}'
         result = extract_json_from_llm_response(output)
         assert result == {"scores": [1, 2, 3], "passed": True}
 
-    def test_complex_real_world_example(self):
+    def test_complex_real_world_example(self) -> None:
         """Test extraction from complex real-world LLM response."""
         output = """I'll evaluate this submission based on the rubric.
 
@@ -106,25 +106,25 @@ Let me know if you need clarification!"""
         assert result["passed"] is True
         assert "criteria_scores" in result
 
-    def test_empty_string(self):
+    def test_empty_string(self) -> None:
         """Test that None is returned for empty string."""
         output = ""
         result = extract_json_from_llm_response(output)
         assert result is None
 
-    def test_whitespace_only(self):
+    def test_whitespace_only(self) -> None:
         """Test that None is returned for whitespace-only input."""
         output = "   \n\t  "
         result = extract_json_from_llm_response(output)
         assert result is None
 
-    def test_json_with_escaped_quotes(self):
+    def test_json_with_escaped_quotes(self) -> None:
         """Test extraction of JSON with escaped quotes in strings."""
         output = r'{"message": "He said \"hello\" to me"}'
         result = extract_json_from_llm_response(output)
         assert result == {"message": 'He said "hello" to me'}
 
-    def test_multiple_json_objects_extracts_first(self):
+    def test_multiple_json_objects_extracts_first(self) -> None:
         """Test that only the first JSON object is extracted."""
         output = '{"first": 1} {"second": 2}'
         result = extract_json_from_llm_response(output)

--- a/tests/unit/metrics/test_grading_consistency.py
+++ b/tests/unit/metrics/test_grading_consistency.py
@@ -15,7 +15,7 @@ from scylla.metrics.grading import assign_letter_grade
 class TestGradingConsistency:
     """Test grading consistency across codebase."""
 
-    def test_grade_thresholds_match_documentation(self):
+    def test_grade_thresholds_match_documentation(self) -> None:
         """Verify grade thresholds match grading-scale.md."""
         # These values are from docs/design/grading-scale.md
         # Grade assignment logic is in scylla.metrics.grading.assign_letter_grade()
@@ -29,7 +29,7 @@ class TestGradingConsistency:
         assert assign_letter_grade(0.20) == "D"
         assert assign_letter_grade(0.00) == "F"
 
-    def test_s_grade_requires_perfect_score(self):
+    def test_s_grade_requires_perfect_score(self) -> None:
         """S grade should ONLY be assigned to exactly 1.0."""
         # Perfect score = S
         assert assign_letter_grade(1.0) == "S"
@@ -39,7 +39,7 @@ class TestGradingConsistency:
         assert assign_letter_grade(0.95) == "A"
         assert assign_letter_grade(0.999) == "A"
 
-    def test_grade_assignment_boundaries(self):
+    def test_grade_assignment_boundaries(self) -> None:
         """Test grade assignment at exact threshold boundaries."""
         test_cases = [
             # (score, expected_grade)
@@ -62,7 +62,7 @@ class TestGradingConsistency:
                 f"Score {score} should be grade {expected_grade}, got {actual_grade}"
             )
 
-    def test_metrics_grading_validates_range(self):
+    def test_metrics_grading_validates_range(self) -> None:
         """Test that assign_letter_grade raises ValueError on invalid scores."""
         # Scores > 1.0 should raise ValueError
         with pytest.raises(ValueError, match="score must be in"):
@@ -78,7 +78,7 @@ class TestGradingConsistency:
         with pytest.raises(ValueError, match="score must be in"):
             assign_letter_grade(-1.0)
 
-    def test_grade_assignment_exhaustive(self):
+    def test_grade_assignment_exhaustive(self) -> None:
         """Exhaustively test grade assignment for all integer percentages."""
         expected_grades = {
             range(0, 20): "F",
@@ -97,7 +97,7 @@ class TestGradingConsistency:
                     f"Score {score} ({percentage}%) should be {expected_grade}, got {actual_grade}"
                 )
 
-    def test_s_grade_exclusively_for_perfect(self):
+    def test_s_grade_exclusively_for_perfect(self) -> None:
         """Verify S grade is NEVER assigned to scores less than 1.0."""
         # Test many scores below 1.0
         for i in range(95, 100):  # 0.95 to 0.99

--- a/tests/unit/scripts/agents/test_agent_utils.py
+++ b/tests/unit/scripts/agents/test_agent_utils.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from pathlib import Path
+from typing import Any
 
 from agents.agent_utils import (
     AgentInfo,
@@ -163,7 +164,7 @@ class TestExtractFrontmatterFull:
 class TestAgentInfo:
     """Tests for AgentInfo class."""
 
-    def make_agent(self, **overrides: object) -> AgentInfo:
+    def make_agent(self, **overrides: Any) -> AgentInfo:
         """Create an AgentInfo with default fields."""
         frontmatter = {
             "name": "test-agent",

--- a/tests/unit/scripts/test_check_defaults_filename.py
+++ b/tests/unit/scripts/test_check_defaults_filename.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from pathlib import Path
+from typing import Any
 from unittest.mock import patch
 
 from check_defaults_filename import main
@@ -52,7 +53,7 @@ class TestMain:
 
         assert result == 1
 
-    def test_prints_errors_when_validation_fails(self, tmp_path: Path, capsys: object) -> None:
+    def test_prints_errors_when_validation_fails(self, tmp_path: Path, capsys: Any) -> None:
         """Prints each warning to stderr when validation fails."""
         config_dir = tmp_path / "config"
         config_dir.mkdir()


### PR DESCRIPTION
## Summary

- Add `-> None` return type annotations to ~590 unannotated test functions, fixture functions, and helper methods in `tests/unit/`
- Add `typing.Any` parameter annotations for pytest fixture parameters and inner helper functions with dynamic types
- Fix 489 additional mypy errors (argument types, return types, inner functions returning values)
- Remove the `[[tool.mypy.overrides]]` block that suppressed `no-untyped-def` for `tests.unit.*` — mypy now enforces full type coverage across all 200 source files with zero errors

## Test plan

- [x] All 4455 unit tests pass (4563 total including integration tests)
- [x] `pixi run mypy tests/unit/` reports: `Success: no issues found in 200 source files`
- [x] All pre-commit hooks pass
- [x] Coverage at 75.85% (above 9% floor)

Closes #1379