### PR TITLE
feat(scripts): add reverse mismatch patterns to tier label check

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -63,12 +63,13 @@ jobs:
 
       - name: Enforce tier label consistency in metrics-definitions.md
         run: |
-          count=$(grep -En "T3.*Tool|T4.*Deleg|T5.*Hier|T2.*Skill" \
+          BAD_PATS="T3.{0,10}Tool|T4.{0,10}Deleg|T5.{0,10}Hier|T2.{0,10}Skill|T2.{0,10}Deleg|T3.{0,10}Hier|T4.{0,10}Hybrid|T1.{0,10}Tool|T0.{0,10}Skill|T1.{0,10}Prompt|T2.{0,10}Prompt|T3.{0,10}Skill|T4.{0,10}Tool|T5.{0,10}Deleg|T6.{0,10}Hier|T6.{0,10}Hybrid|T0.{0,10}Tool|T0.{0,10}Deleg|T5.{0,10}Skill|T6.{0,10}Deleg"
+          count=$(grep -En "$BAD_PATS" \
             .claude/shared/metrics-definitions.md | wc -l)
           echo "Bad tier label count: $count"
           if [ "$count" -gt "0" ]; then
             echo "::error::Found $count tier label mismatch(es) in metrics-definitions.md"
-            grep -En "T3.*Tool|T4.*Deleg|T5.*Hier|T2.*Skill" .claude/shared/metrics-definitions.md
+            grep -En "$BAD_PATS" .claude/shared/metrics-definitions.md
             exit 1
           fi
 

--- a/scripts/check_tier_label_consistency.py
+++ b/scripts/check_tier_label_consistency.py
@@ -4,11 +4,33 @@
 Fails if any known-bad tier label pattern is found, preventing the recurring
 regression where tier identifiers (T0-T6) are paired with the wrong tier names.
 
+Tier → canonical name mapping:
+  T0=Prompts, T1=Skills, T2=Tooling, T3=Delegation, T4=Hierarchy, T5=Hybrid, T6=Super
+
 Known-bad patterns (tier number paired with wrong tier name):
+  Original set:
   - T3.*Tool   (T3 is Delegation, not Tooling/T2)
   - T4.*Deleg  (T4 is Hierarchy, not Delegation/T3)
   - T5.*Hier   (T5 is Hybrid, not Hierarchy/T4)
   - T2.*Skill  (T2 is Tooling, not Skills/T1)
+
+  Reverse/symmetric set (bounded .{0,10} to avoid cross-tier false positives):
+  - T2.{0,10}Deleg  (T2 is Tooling, not Delegation/T3)
+  - T3.{0,10}Hier   (T3 is Delegation, not Hierarchy/T4)
+  - T4.{0,10}Hybrid (T4 is Hierarchy, not Hybrid/T5)
+  - T1.{0,10}Tool   (T1 is Skills, not Tooling/T2)
+  - T0.{0,10}Skill  (T0 is Prompts, not Skills/T1)
+  - T1.{0,10}Prompt (T1 is Skills, not Prompts/T0)
+  - T2.{0,10}Prompt (T2 is Tooling, not Prompts/T0)
+  - T3.{0,10}Skill  (T3 is Delegation, not Skills/T1)
+  - T4.{0,10}Tool   (T4 is Hierarchy, not Tooling/T2)
+  - T5.{0,10}Deleg  (T5 is Hybrid, not Delegation/T3)
+  - T6.{0,10}Hier   (T6 is Super, not Hierarchy/T4)
+  - T6.{0,10}Hybrid (T6 is Super, not Hybrid/T5)
+  - T0.{0,10}Tool   (T0 is Prompts, not Tooling/T2)
+  - T0.{0,10}Deleg  (T0 is Prompts, not Delegation/T3)
+  - T5.{0,10}Skill  (T5 is Hybrid, not Skills/T1)
+  - T6.{0,10}Deleg  (T6 is Super, not Delegation/T3)
 
 Usage:
     python scripts/check_tier_label_consistency.py
@@ -27,10 +49,28 @@ from pathlib import Path
 DEFAULT_TARGET = Path(".claude/shared/metrics-definitions.md")
 
 BAD_PATTERNS: list[tuple[str, str]] = [
+    # Original set
     (r"T3.*Tool", "T3 is Delegation, not Tooling"),
     (r"T4.*Deleg", "T4 is Hierarchy, not Delegation"),
     (r"T5.*Hier", "T5 is Hybrid, not Hierarchy"),
     (r"T2.*Skill", "T2 is Tooling, not Skills"),
+    # Reverse/symmetric set (bounded to 10 chars to avoid cross-tier false positives)
+    (r"T2.{0,10}Deleg", "T2 is Tooling, not Delegation"),
+    (r"T3.{0,10}Hier", "T3 is Delegation, not Hierarchy"),
+    (r"T4.{0,10}Hybrid", "T4 is Hierarchy, not Hybrid"),
+    (r"T1.{0,10}Tool", "T1 is Skills, not Tooling"),
+    (r"T0.{0,10}Skill", "T0 is Prompts, not Skills"),
+    (r"T1.{0,10}Prompt", "T1 is Skills, not Prompts"),
+    (r"T2.{0,10}Prompt", "T2 is Tooling, not Prompts"),
+    (r"T3.{0,10}Skill", "T3 is Delegation, not Skills"),
+    (r"T4.{0,10}Tool", "T4 is Hierarchy, not Tooling"),
+    (r"T5.{0,10}Deleg", "T5 is Hybrid, not Delegation"),
+    (r"T6.{0,10}Hier", "T6 is Super, not Hierarchy"),
+    (r"T6.{0,10}Hybrid", "T6 is Super, not Hybrid"),
+    (r"T0.{0,10}Tool", "T0 is Prompts, not Tooling"),
+    (r"T0.{0,10}Deleg", "T0 is Prompts, not Delegation"),
+    (r"T5.{0,10}Skill", "T5 is Hybrid, not Skills"),
+    (r"T6.{0,10}Deleg", "T6 is Super, not Delegation"),
 ]
 
 

--- a/tests/unit/scripts/test_check_tier_label_consistency.py
+++ b/tests/unit/scripts/test_check_tier_label_consistency.py
@@ -22,10 +22,28 @@ class TestFindViolations:
     @pytest.mark.parametrize(
         "bad_line, expected_pattern",
         [
+            # Original set
             ("T3 Tooling tier", r"T3.*Tool"),
             ("T4 Delegation tier", r"T4.*Deleg"),
             ("T5 Hierarchy tier", r"T5.*Hier"),
             ("T2 Skills tier", r"T2.*Skill"),
+            # Reverse/symmetric set
+            ("T2 Delegation tier", r"T2.{0,10}Deleg"),
+            ("T3 Hierarchy tier", r"T3.{0,10}Hier"),
+            ("T4 Hybrid tier", r"T4.{0,10}Hybrid"),
+            ("T1 Tooling tier", r"T1.{0,10}Tool"),
+            ("T0 Skills tier", r"T0.{0,10}Skill"),
+            ("T1 Prompts tier", r"T1.{0,10}Prompt"),
+            ("T2 Prompts tier", r"T2.{0,10}Prompt"),
+            ("T3 Skills tier", r"T3.{0,10}Skill"),
+            ("T4 Tooling tier", r"T4.{0,10}Tool"),
+            ("T5 Delegation tier", r"T5.{0,10}Deleg"),
+            ("T6 Hierarchy tier", r"T6.{0,10}Hier"),
+            ("T6 Hybrid tier", r"T6.{0,10}Hybrid"),
+            ("T0 Tooling tier", r"T0.{0,10}Tool"),
+            ("T0 Delegation tier", r"T0.{0,10}Deleg"),
+            ("T5 Skills tier", r"T5.{0,10}Skill"),
+            ("T6 Delegation tier", r"T6.{0,10}Deleg"),
         ],
     )
     def test_detects_each_bad_pattern(self, bad_line: str, expected_pattern: str) -> None:
@@ -128,10 +146,28 @@ class TestCheckTierLabelConsistency:
     @pytest.mark.parametrize(
         "bad_line",
         [
+            # Original set
             "T3 Tooling",
             "T4 Delegation",
             "T5 Hierarchy",
             "T2 Skills",
+            # Reverse/symmetric set
+            "T2 Delegation",
+            "T3 Hierarchy",
+            "T4 Hybrid",
+            "T1 Tooling",
+            "T0 Skills",
+            "T1 Prompts",
+            "T2 Prompts",
+            "T3 Skills",
+            "T4 Tooling",
+            "T5 Delegation",
+            "T6 Hierarchy",
+            "T6 Hybrid",
+            "T0 Tooling",
+            "T0 Delegation",
+            "T5 Skills",
+            "T6 Delegation",
         ],
     )
     def test_each_bad_pattern_causes_failure(self, tmp_path: Path, bad_line: str) -> None:


### PR DESCRIPTION
## Summary

- Expands `BAD_PATTERNS` in `scripts/check_tier_label_consistency.py` from 4 to 20 entries, covering all symmetric tier/name swaps across T0–T6
- New reverse patterns use `.{0,10}` bounded quantifier to avoid false positives when multiple tier numbers appear on the same line (e.g., "between T1 (Skills) and T2 (Tooling)")
- Updates the CI grep gate in `.github/workflows/test.yml` to match the expanded pattern set
- Adds 32 new parametrized test cases (56 total, all passing)

## Test plan

- [x] All 56 tests in `tests/unit/scripts/test_check_tier_label_consistency.py` pass
- [x] `test_actual_metrics_definitions_file_is_clean` passes (no false positives on real file)
- [x] Full test suite: 4595 passed, 75.85% coverage
- [x] Pre-commit hooks pass (ruff, mypy, shellcheck, markdownlint, etc.)

Closes #1428

🤖 Generated with [Claude Code](https://claude.com/claude-code)