### PR TITLE
ci(lint): Add C901 complexity regression gate

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -47,6 +47,9 @@ jobs:
           pixi --version
           pixi run --environment lint pre-commit run --all-files --show-diff-on-failure
 
+      - name: Enforce complexity limit (C901)
+        run: pixi run --environment lint ruff check --select C901 scylla/ scripts/
+
       - name: Upload pre-commit diff
         if: failure()
         uses: actions/upload-artifact@v7

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -154,6 +154,14 @@ repos:
         language: system
         files: ^\.claude/shared/metrics-definitions\.md$
         pass_filenames: false
+      - id: ruff-check-complexity
+        name: Ruff Complexity Check (C901)
+        description: Fail if any function exceeds McCabe complexity 12 without a noqa directive
+        entry: pixi run ruff check --select C901 scripts/ scylla/
+        language: system
+        files: ^(scripts|scylla)/.*\.py$
+        types: [python]
+        pass_filenames: false
 
   # Markdown linting
   - repo: https://github.com/DavidAnson/markdownlint-cli2


### PR DESCRIPTION
## Summary

- Adds a named `Enforce complexity limit (C901)` step to `.github/workflows/pre-commit.yml` so complexity violations appear as a distinct, visible check in GitHub PR status
- Adds a `ruff-check-complexity` pre-commit hook to `.pre-commit-config.yaml` so the same check runs locally on commit

`pyproject.toml` already had `C901` in the ruff `select` list and `[tool.ruff.lint.mccabe] max-complexity = 12` configured. This PR adds the enforcement layer that makes violations block CI and local commits.

## Test plan

- [x] `pre-commit run ruff-check-complexity --all-files` → Passed
- [x] `pre-commit run --all-files` → all 28 hooks Passed
- [x] `pixi run ruff check --select C901 scylla/ scripts/` → exit 0 (no violations)
- [x] Full test suite: 4563 passed, 1 skipped

Closes #1432