### PR TITLE
test(config): auto-discover tier fixtures in parametrize

### DIFF
--- a/tests/unit/config/test_json_schemas.py
+++ b/tests/unit/config/test_json_schemas.py
@@ -153,11 +153,12 @@ class TestTierSchema:
 
     @pytest.mark.parametrize(
         "fixture_file",
-        ["t0.yaml", "t1.yaml", "t2.yaml", "t3.yaml", "t4.yaml", "t5.yaml", "t6.yaml"],
+        sorted(TIER_FIXTURES_DIR.glob("t*.yaml")),
+        ids=lambda p: p.name,
     )
-    def test_real_tier_fixture_is_valid(self, schema: dict[str, Any], fixture_file: str) -> None:
+    def test_real_tier_fixture_is_valid(self, schema: dict[str, Any], fixture_file: Path) -> None:
         """Tier fixture files must conform to tier.schema.json."""
-        data = load_yaml(TIER_FIXTURES_DIR / fixture_file)
+        data = load_yaml(fixture_file)
         check_schema(data, schema)
 
     def test_rejects_missing_tier(self, schema: dict[str, Any]) -> None:


### PR DESCRIPTION
## Summary
- Replace hardcoded `["t0.yaml", ..., "t6.yaml"]` list in `TestTierSchema.test_real_tier_fixture_is_valid` with `sorted(TIER_FIXTURES_DIR.glob("t*.yaml"))`
- New tier fixtures are now picked up automatically without code changes
- Use `ids=lambda p: p.name` for readable test IDs

## Test plan
- [ ] All 43 tests in `tests/unit/config/test_json_schemas.py` pass
- [ ] Pre-commit hooks pass

Closes #1433

🤖 Generated with [Claude Code](https://claude.com/claude-code)