### PR TITLE
test(config): add explicit-false capability field tests for t0/t1 schema completeness

### DIFF
--- a/tests/unit/config/test_config_loader.py
+++ b/tests/unit/config/test_config_loader.py
@@ -230,6 +230,45 @@ class TestConfigLoaderTier:
         for key, config in tiers.items():
             assert key == config.tier, f"Key {key!r} does not match config.tier {config.tier!r}"
 
+    @pytest.mark.parametrize("tier_id", ["t0", "t1"])
+    def test_load_tier_capability_fields_explicit_false(self, tier_id: str) -> None:
+        """t0 and t1 fixture files have explicit false capability fields that load correctly."""
+        loader = ConfigLoader(base_path=FIXTURES_PATH)
+        tier = loader.load_tier(tier_id)
+
+        assert tier.uses_tools is False
+        assert tier.uses_delegation is False
+        assert tier.uses_hierarchy is False
+
+    def test_load_tier_explicit_false_fields_via_tmp_path(self, tmp_path: Path) -> None:
+        """Explicit-false capability fields in a tier YAML load as False (not absent-default)."""
+        tiers_dir = tmp_path / "config" / "tiers"
+        tiers_dir.mkdir(parents=True)
+        (tiers_dir / "t0.yaml").write_text(
+            "tier: t0\nname: Vanilla\ndescription: Test\n"
+            "uses_tools: false\nuses_delegation: false\nuses_hierarchy: false\n"
+        )
+
+        loader = ConfigLoader(base_path=tmp_path)
+        tier = loader.load_tier("t0")
+
+        assert tier.uses_tools is False
+        assert tier.uses_delegation is False
+        assert tier.uses_hierarchy is False
+
+    def test_load_tier_default_false_when_absent(self, tmp_path: Path) -> None:
+        """Absent capability fields in a tier YAML default to False."""
+        tiers_dir = tmp_path / "config" / "tiers"
+        tiers_dir.mkdir(parents=True)
+        (tiers_dir / "t0.yaml").write_text("tier: t0\nname: Vanilla\n")
+
+        loader = ConfigLoader(base_path=tmp_path)
+        tier = loader.load_tier("t0")
+
+        assert tier.uses_tools is False
+        assert tier.uses_delegation is False
+        assert tier.uses_hierarchy is False
+
     def test_load_all_tiers_skips_underscore_prefixed_fixtures(self, tmp_path: Path) -> None:
         """load_all_tiers() silently skips _-prefixed fixture files."""
         tiers_dir = tmp_path / "config" / "tiers"

--- a/tests/unit/config/test_json_schemas.py
+++ b/tests/unit/config/test_json_schemas.py
@@ -200,6 +200,34 @@ class TestTierSchema:
         """Only tier and name are required."""
         check_schema({"tier": "t3", "name": "Delegation"}, schema)
 
+    @pytest.mark.parametrize("field", ["uses_tools", "uses_delegation", "uses_hierarchy"])
+    def test_capability_field_explicit_false(self, schema: dict[str, Any], field: str) -> None:
+        """Schema accepts capability fields explicitly set to false."""
+        check_schema({"tier": "t0", "name": "Vanilla", field: False}, schema)
+
+    @pytest.mark.parametrize("field", ["uses_tools", "uses_delegation", "uses_hierarchy"])
+    def test_capability_field_explicit_true(self, schema: dict[str, Any], field: str) -> None:
+        """Schema accepts capability fields explicitly set to true."""
+        check_schema({"tier": "t4", "name": "Hierarchy", field: True}, schema)
+
+    def test_capability_fields_absent(self, schema: dict[str, Any]) -> None:
+        """Schema accepts tier when all capability fields are absent (default-false path)."""
+        check_schema({"tier": "t0", "name": "Vanilla"}, schema)
+
+    def test_capability_fields_all_explicit_false(self, schema: dict[str, Any]) -> None:
+        """Schema accepts t0/t1 fixture pattern: all three capability fields explicitly false."""
+        check_schema(
+            {
+                "tier": "t0",
+                "name": "Vanilla",
+                "description": "Base LLM with zero-shot prompting",
+                "uses_tools": False,
+                "uses_delegation": False,
+                "uses_hierarchy": False,
+            },
+            schema,
+        )
+
 
 # ---------------------------------------------------------------------------
 # model.schema.json


### PR DESCRIPTION
## Summary

- Add parametrized schema tests to `TestTierSchema` covering the explicit-false, explicit-true, and field-absent paths for `uses_tools`, `uses_delegation`, and `uses_hierarchy`
- Add loader tests to `TestConfigLoaderTier` verifying that t0/t1 fixtures with explicit `false` values load correctly, and that absent fields also default to `False`
- No production code changes required — t0.yaml and t1.yaml already have the fields explicitly set, and `TierConfig` already defines all three with `default=False`

## Test plan

- [x] `tests/unit/config/test_json_schemas.py::TestTierSchema::test_capability_field_explicit_false[uses_tools/uses_delegation/uses_hierarchy]`
- [x] `tests/unit/config/test_json_schemas.py::TestTierSchema::test_capability_field_explicit_true[uses_tools/uses_delegation/uses_hierarchy]`
- [x] `tests/unit/config/test_json_schemas.py::TestTierSchema::test_capability_fields_absent`
- [x] `tests/unit/config/test_json_schemas.py::TestTierSchema::test_capability_fields_all_explicit_false`
- [x] `tests/unit/config/test_config_loader.py::TestConfigLoaderTier::test_load_tier_capability_fields_explicit_false[t0/t1]`
- [x] `tests/unit/config/test_config_loader.py::TestConfigLoaderTier::test_load_tier_explicit_false_fields_via_tmp_path`
- [x] `tests/unit/config/test_config_loader.py::TestConfigLoaderTier::test_load_tier_default_false_when_absent`
- [x] All 4575 unit tests pass; coverage at 75.85%; pre-commit clean

Closes #1435

🤖 Generated with [Claude Code](https://claude.com/claude-code)