### PR TITLE
perf(config): cache JSON schemas to avoid repeated file reads

### DIFF
--- a/scylla/config/loader.py
+++ b/scylla/config/loader.py
@@ -33,10 +33,14 @@ from .validation import (
 logger = logging.getLogger(__name__)
 
 _SCHEMAS_DIR = Path(__file__).parent.parent.parent / "schemas"
+_SCHEMA_CACHE: dict[str, dict[str, Any]] = {}
 
 
 def _validate_schema(data: dict[str, Any], schema_name: str, path: Path) -> None:
-    """Validate data against a JSON schema.
+    """Validate data against a JSON schema, with module-level caching.
+
+    Reads the schema file from disk on first call for a given schema_name;
+    subsequent calls reuse the cached schema dict.
 
     Args:
         data: Parsed YAML data to validate
@@ -47,11 +51,13 @@ def _validate_schema(data: dict[str, Any], schema_name: str, path: Path) -> None
         ConfigurationError: If validation fails
 
     """
-    schema_path = _SCHEMAS_DIR / f"{schema_name}.schema.json"
-    with open(schema_path) as f:
-        schema = json.load(f)
+    schema_file = f"{schema_name}.schema.json"
+    if schema_file not in _SCHEMA_CACHE:
+        schema_path = _SCHEMAS_DIR / schema_file
+        with open(schema_path) as f:
+            _SCHEMA_CACHE[schema_file] = json.load(f)
     try:
-        jsonschema.validate(data, schema)
+        jsonschema.validate(data, _SCHEMA_CACHE[schema_file])
     except jsonschema.ValidationError as e:
         raise ConfigurationError(
             f"Invalid {schema_name} configuration in {path}: {e.message}"

--- a/tests/unit/config/test_config_loader.py
+++ b/tests/unit/config/test_config_loader.py
@@ -12,6 +12,7 @@ Tests cover:
 
 import logging
 from pathlib import Path
+from unittest.mock import patch
 
 import pytest
 from pydantic import ValidationError
@@ -954,3 +955,112 @@ class TestSchemaValidation:
         loader = ConfigLoader(base_path=tmp_path)
         with pytest.raises(ConfigurationError, match="Invalid model configuration"):
             loader.load_model("bad-model")
+
+
+class TestValidateSchema:
+    """Tests for _validate_schema() module-level schema caching."""
+
+    def setup_method(self) -> None:
+        """Clear schema cache before each test to ensure isolation."""
+        from scylla.config import loader as loader_module
+
+        loader_module._SCHEMA_CACHE.clear()
+
+    def test_cache_miss_reads_schema_file(self) -> None:
+        """Schema file is read from disk on first call (cache miss)."""
+        from scylla.config.loader import _validate_schema
+
+        minimal_tier = {
+            "tier": "t0",
+            "name": "Prompts",
+        }
+        read_count = 0
+        original_open = open
+
+        def counting_open(path: object, *args: object, **kwargs: object) -> object:
+            nonlocal read_count
+            if "tier.schema.json" in str(path):
+                read_count += 1
+            return original_open(path, *args, **kwargs)  # type: ignore[call-overload]
+
+        with patch("builtins.open", side_effect=counting_open):
+            _validate_schema(minimal_tier, "tier", Path("t0.yaml"))
+
+        assert read_count == 1
+
+    def test_cache_hit_avoids_second_file_read(self) -> None:
+        """Schema file is read only once; second call uses the cache."""
+        from scylla.config.loader import _validate_schema
+
+        minimal_tier = {
+            "tier": "t0",
+            "name": "Prompts",
+        }
+        read_count = 0
+        original_open = open
+
+        def counting_open(path: object, *args: object, **kwargs: object) -> object:
+            nonlocal read_count
+            if "tier.schema.json" in str(path):
+                read_count += 1
+            return original_open(path, *args, **kwargs)  # type: ignore[call-overload]
+
+        with patch("builtins.open", side_effect=counting_open):
+            _validate_schema(minimal_tier, "tier", Path("t0.yaml"))
+            _validate_schema(minimal_tier, "tier", Path("t1.yaml"))
+
+        assert read_count == 1
+
+    def test_cache_populated_after_first_call(self) -> None:
+        """_SCHEMA_CACHE is populated after the first _validate_schema() call."""
+        from scylla.config import loader as loader_module
+        from scylla.config.loader import _validate_schema
+
+        minimal_tier = {
+            "tier": "t0",
+            "name": "Prompts",
+        }
+
+        assert "tier.schema.json" not in loader_module._SCHEMA_CACHE
+        _validate_schema(minimal_tier, "tier", Path("t0.yaml"))
+        assert "tier.schema.json" in loader_module._SCHEMA_CACHE
+        assert isinstance(loader_module._SCHEMA_CACHE["tier.schema.json"], dict)
+
+    def test_validation_failure_raises_configuration_error(self) -> None:
+        """ConfigurationError is raised when data does not match schema."""
+        from scylla.config.loader import _validate_schema
+
+        # tier schema requires "tier" and "name" — missing both triggers validation error
+        invalid_data: dict[str, str] = {"unknown_field": "bad"}
+        with pytest.raises(ConfigurationError, match="Invalid tier configuration"):
+            _validate_schema(invalid_data, "tier", Path("t0.yaml"))
+
+    def test_validation_success_does_not_raise(self) -> None:
+        """No exception raised for data that satisfies the schema."""
+        from scylla.config.loader import _validate_schema
+
+        valid_tier = {
+            "tier": "t0",
+            "name": "Prompts",
+        }
+        # Should not raise
+        _validate_schema(valid_tier, "tier", Path("t0.yaml"))
+
+    def test_different_schemas_cached_independently(self) -> None:
+        """Each schema_name gets its own cache entry."""
+        from scylla.config import loader as loader_module
+        from scylla.config.loader import _validate_schema
+
+        valid_tier = {
+            "tier": "t0",
+            "name": "Prompts",
+        }
+        valid_model = {
+            "model_id": "claude-3-5-haiku-20241022",
+        }
+
+        _validate_schema(valid_tier, "tier", Path("t0.yaml"))
+        _validate_schema(valid_model, "model", Path("model.yaml"))
+
+        assert "tier.schema.json" in loader_module._SCHEMA_CACHE
+        assert "model.schema.json" in loader_module._SCHEMA_CACHE


### PR DESCRIPTION
## Summary

- Add module-level `_SCHEMA_CACHE: dict[str, dict[str, Any]] = {}` to `scylla/config/loader.py`
- Update `_validate_schema()` to check the cache before doing any file I/O; reads schema from disk only on cache miss
- Each unique schema name (e.g. `tier.schema.json`) is read exactly once per process lifetime, eliminating N redundant reads in `load_all_tiers()` and `load_all_models()`

## Test plan

- [x] Added `TestValidateSchema` (6 tests) covering cache-miss file read, cache-hit deduplication, cache population, validation failure, validation success, and independent caching per schema name
- [x] All 4569 tests pass (293 config unit tests, no regressions)
- [x] Pre-commit hooks pass (ruff, mypy, all custom checks)
- [x] Combined coverage: 75.86% (above 9% floor and 75% unit threshold)

Closes #1437

🤖 Generated with [Claude Code](https://claude.com/claude-code)