### PR TITLE
feat(scripts): add --dry-run flag to validate_config_schemas.py

### DIFF
--- a/scripts/validate_config_schemas.py
+++ b/scripts/validate_config_schemas.py
@@ -14,10 +14,12 @@ Usage:
     python scripts/validate_config_schemas.py config/defaults.yaml
     python scripts/validate_config_schemas.py config/models/claude-sonnet.yaml
     python scripts/validate_config_schemas.py --verbose config/defaults.yaml
+    python scripts/validate_config_schemas.py --dry-run config/defaults.yaml
 
 Exit codes:
     0: All files valid (or no matching schema found — warned, not failed)
-    1: One or more schema violations found
+    0: Violations found but --dry-run is set (errors printed, commit not blocked)
+    1: One or more schema violations found (without --dry-run)
 """
 
 import argparse
@@ -92,16 +94,23 @@ def validate_file(file_path: Path, schema: dict[str, object]) -> list[str]:
     return errors
 
 
-def check_files(files: list[Path], repo_root: Path, verbose: bool = False) -> int:
+def check_files(
+    files: list[Path],
+    repo_root: Path,
+    verbose: bool = False,
+    dry_run: bool = False,
+) -> int:
     """Validate each file against its matching schema.
 
     Args:
         files: List of file paths to check.
         repo_root: Repository root used for schema resolution.
         verbose: If True, print ``PASS:`` lines for valid files.
+        dry_run: If True, print all errors but return 0 (do not block commits).
 
     Returns:
-        0 if all files are valid, 1 if any violations are found.
+        0 if all files are valid or ``dry_run`` is True, 1 if any violations
+        are found and ``dry_run`` is False.
 
     """
     if not files:
@@ -139,6 +148,8 @@ def check_files(files: list[Path], repo_root: Path, verbose: bool = False) -> in
         elif verbose:
             print(f"PASS: {file_path}")
 
+    if any_failure and dry_run:
+        return 0
     return 1 if any_failure else 0
 
 
@@ -146,7 +157,7 @@ def main() -> int:
     """CLI entry point for config schema validation.
 
     Returns:
-        Exit code (0 if clean, 1 if violations found).
+        Exit code (0 if clean or --dry-run, 1 if violations found without --dry-run).
 
     """
     parser = argparse.ArgumentParser(
@@ -171,9 +182,14 @@ def main() -> int:
         default=_REPO_ROOT,
         help="Repository root for resolving schema paths (default: parent of this script)",
     )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Print all errors but exit 0 — useful for previewing violations without blocking commits",  # noqa: E501
+    )
 
     args = parser.parse_args()
-    return check_files(args.files, args.repo_root, verbose=args.verbose)
+    return check_files(args.files, args.repo_root, verbose=args.verbose, dry_run=args.dry_run)
 
 
 if __name__ == "__main__":

--- a/tests/unit/scripts/test_validate_config_schemas.py
+++ b/tests/unit/scripts/test_validate_config_schemas.py
@@ -6,7 +6,7 @@ from pathlib import Path
 
 import pytest
 
-from scripts.validate_config_schemas import check_files, resolve_schema, validate_file
+from scripts.validate_config_schemas import check_files, main, resolve_schema, validate_file
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -260,6 +260,103 @@ class TestCheckFiles:
         good = _write_yaml(cfg_dir, "good.yaml", 'name: "ok"\n')
         bad = _write_yaml(cfg_dir, "bad.yaml", "extra: true\n")
         assert check_files([good, bad], repo_root) == 1
+
+
+# ---------------------------------------------------------------------------
+# TestDryRun
+# ---------------------------------------------------------------------------
+
+
+class TestDryRun:
+    """Tests for --dry-run behaviour in check_files() and main()."""
+
+    def _make_schema_root(self, tmp_path: Path) -> Path:
+        """Create a fake repo root with schemas/ directory."""
+        schemas_dir = tmp_path / "schemas"
+        schemas_dir.mkdir()
+        (schemas_dir / "defaults.schema.json").write_text(json.dumps(_SIMPLE_SCHEMA))
+        (schemas_dir / "model.schema.json").write_text(json.dumps(_SIMPLE_SCHEMA))
+        (schemas_dir / "tier.schema.json").write_text(json.dumps(_SIMPLE_SCHEMA))
+        return tmp_path
+
+    def test_dry_run_with_violations_returns_zero(self, tmp_path: Path) -> None:
+        """dry_run=True should return 0 even when there are violations."""
+        repo_root = self._make_schema_root(tmp_path)
+        cfg_dir = tmp_path / "config" / "models"
+        cfg_dir.mkdir(parents=True)
+        bad = _write_yaml(cfg_dir, "bad.yaml", "extra_field: true\n")
+        assert check_files([bad], repo_root, dry_run=True) == 0
+
+    def test_dry_run_false_with_violations_returns_one(self, tmp_path: Path) -> None:
+        """dry_run=False should return 1 when there are violations."""
+        repo_root = self._make_schema_root(tmp_path)
+        cfg_dir = tmp_path / "config" / "models"
+        cfg_dir.mkdir(parents=True)
+        bad = _write_yaml(cfg_dir, "bad.yaml", "extra_field: true\n")
+        assert check_files([bad], repo_root, dry_run=False) == 1
+
+    def test_dry_run_prints_errors(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """dry_run=True should still print errors to stderr."""
+        repo_root = self._make_schema_root(tmp_path)
+        cfg_dir = tmp_path / "config" / "models"
+        cfg_dir.mkdir(parents=True)
+        bad = _write_yaml(cfg_dir, "bad.yaml", "extra_field: true\n")
+        check_files([bad], repo_root, dry_run=True)
+        captured = capsys.readouterr()
+        assert "FAIL" in captured.err
+
+    def test_dry_run_no_violations_returns_zero(self, tmp_path: Path) -> None:
+        """dry_run=True with a valid file should still return 0."""
+        repo_root = self._make_schema_root(tmp_path)
+        cfg_dir = tmp_path / "config" / "models"
+        cfg_dir.mkdir(parents=True)
+        good = _write_yaml(cfg_dir, "good.yaml", 'name: "ok"\n')
+        assert check_files([good], repo_root, dry_run=True) == 0
+
+    def test_dry_run_multiple_bad_files_all_reported(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """dry_run=True should report all invalid files, not just the first."""
+        repo_root = self._make_schema_root(tmp_path)
+        cfg_dir = tmp_path / "config" / "models"
+        cfg_dir.mkdir(parents=True)
+        bad_a = _write_yaml(cfg_dir, "bad_a.yaml", "extra_a: 1\n")
+        bad_b = _write_yaml(cfg_dir, "bad_b.yaml", "extra_b: 2\n")
+        result = check_files([bad_a, bad_b], repo_root, dry_run=True)
+        assert result == 0
+        captured = capsys.readouterr()
+        assert "bad_a.yaml" in captured.err
+        assert "bad_b.yaml" in captured.err
+
+    def test_main_dry_run_flag_with_violations_exits_zero(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str], monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """main() with --dry-run should exit 0 even when violations are found."""
+        repo_root = self._make_schema_root(tmp_path)
+        cfg_dir = tmp_path / "config" / "models"
+        cfg_dir.mkdir(parents=True)
+        bad = _write_yaml(cfg_dir, "bad.yaml", "extra_field: true\n")
+        monkeypatch.setattr(
+            "sys.argv",
+            ["validate_config_schemas.py", "--dry-run", "--repo-root", str(repo_root), str(bad)],
+        )
+        assert main() == 0
+
+    def test_main_no_dry_run_with_violations_exits_one(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """main() without --dry-run should exit 1 when violations are found."""
+        repo_root = self._make_schema_root(tmp_path)
+        cfg_dir = tmp_path / "config" / "models"
+        cfg_dir.mkdir(parents=True)
+        bad = _write_yaml(cfg_dir, "bad.yaml", "extra_field: true\n")
+        monkeypatch.setattr(
+            "sys.argv",
+            ["validate_config_schemas.py", "--repo-root", str(repo_root), str(bad)],
+        )
+        assert main() == 1
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Added `--dry-run` flag to `scripts/validate_config_schemas.py`
- When `--dry-run` is set, all schema validation errors are printed but the script exits with code `0`, allowing bulk config updates to be previewed without blocking pre-commit hooks
- Added `dry_run` parameter to `check_files()` with full type hints and updated docstrings
- Added `TestDryRun` test class with 7 tests covering all flag combinations

## Changes

- `scripts/validate_config_schemas.py`: Added `--dry-run` argparse flag, `dry_run` parameter to `check_files()`, updated module docstring
- `tests/unit/scripts/test_validate_config_schemas.py`: Added `TestDryRun` class with 7 tests

## Test plan

- [x] 33 tests pass in `tests/unit/scripts/test_validate_config_schemas.py` (26 existing + 7 new)
- [x] All pre-commit hooks pass (ruff format, ruff check, mypy, all others)
- [x] `--dry-run` exits 0 with violations
- [x] Without `--dry-run`, exits 1 with violations (unchanged behaviour)

Closes #1442

🤖 Generated with [Claude Code](https://claude.com/claude-code)