### PR TITLE
feat(scripts): extend schema validation to cover config/tiers/*.yaml

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -139,12 +139,13 @@ repos:
       - id: validate-config-schemas
         name: Validate Config Files Against JSON Schemas
         description: >-
-          Validates config/defaults.yaml, config/models/*.yaml, and
-          tests/fixtures/config/tiers/*.yaml against their JSON schemas in schemas/
+          Validates config/defaults.yaml, config/models/*.yaml,
+          config/tiers/*.yaml, and tests/fixtures/config/tiers/*.yaml
+          against their JSON schemas in schemas/
         entry: pixi run python scripts/validate_config_schemas.py
         language: system
         files: >-
-          ^(config/defaults\.yaml|config/models/.+\.yaml|
+          ^(config/defaults\.yaml|config/models/.+\.yaml|config/tiers/.+\.yaml|
           tests/fixtures/config/tiers/.+\.yaml)$
         pass_filenames: true
       - id: check-tier-label-consistency

--- a/scripts/validate_config_schemas.py
+++ b/scripts/validate_config_schemas.py
@@ -8,6 +8,7 @@ if any validation error is found, blocking the commit.
 Supported file patterns:
 - ``config/defaults.yaml`` → ``schemas/defaults.schema.json``
 - ``config/models/*.yaml`` → ``schemas/model.schema.json``
+- ``config/tiers/*.yaml`` → ``schemas/tier.schema.json``
 - ``tests/fixtures/config/tiers/*.yaml`` → ``schemas/tier.schema.json``
 
 Usage:
@@ -36,6 +37,7 @@ _REPO_ROOT = Path(__file__).parent.parent
 _SCHEMA_MAP: list[tuple[re.Pattern[str], Path]] = [
     (re.compile(r"^config/defaults\.yaml$"), Path("schemas/defaults.schema.json")),
     (re.compile(r"^config/models/.+\.yaml$"), Path("schemas/model.schema.json")),
+    (re.compile(r"^config/tiers/.+\.yaml$"), Path("schemas/tier.schema.json")),
     (
         re.compile(r"^tests/fixtures/config/tiers/.+\.yaml$"),
         Path("schemas/tier.schema.json"),

--- a/tests/unit/scripts/test_validate_config_schemas.py
+++ b/tests/unit/scripts/test_validate_config_schemas.py
@@ -80,11 +80,19 @@ class TestResolveSchema:
         path = _REPO_ROOT / "config" / "models" / "README.md"
         assert resolve_schema(path, _REPO_ROOT) is None
 
+    def test_production_tier_yaml_matches(self) -> None:
+        """config/tiers/*.yaml should match tier.schema.json."""
+        path = _REPO_ROOT / "config" / "tiers" / "t0.yaml"
+        result = resolve_schema(path, _REPO_ROOT)
+        assert result is not None
+        assert result.name == "tier.schema.json"
+
     @pytest.mark.parametrize(
         "rel_path",
         [
             "config/defaults.yaml",
             "config/models/claude-sonnet.yaml",
+            "config/tiers/t0.yaml",
             "tests/fixtures/config/tiers/t1.yaml",
         ],
     )
@@ -307,6 +315,23 @@ class TestMainIntegration:
         tier_files = list(tiers_dir.glob("*.yaml"))
         if not tier_files:
             pytest.skip("No tier fixture files found")
+        failures: list[str] = []
+        for tier_file in tier_files:
+            errors = validate_file(tier_file, schema)
+            if errors:
+                failures.append(f"{tier_file}: {errors}")
+        assert not failures, "\n".join(failures)
+
+    def test_production_tier_configs_validate(self) -> None:
+        """All production config/tiers/*.yaml files should pass schema validation."""
+        tiers_dir = _REPO_ROOT / "config" / "tiers"
+        if not tiers_dir.exists():
+            pytest.skip("config/tiers/ directory not present")
+        schema_path = _REPO_ROOT / "schemas" / "tier.schema.json"
+        schema = json.loads(schema_path.read_text())
+        tier_files = list(tiers_dir.glob("*.yaml"))
+        if not tier_files:
+            pytest.skip("No production tier config files found")
         failures: list[str] = []
         for tier_file in tier_files:
             errors = validate_file(tier_file, schema)


### PR DESCRIPTION
## Summary

- Added `^config/tiers/.+\.yaml$` as a third entry in `_SCHEMA_MAP` in `scripts/validate_config_schemas.py`, mapping production tier configs to `schemas/tier.schema.json`
- Updated the `files:` regex in `.pre-commit-config.yaml` to also trigger the hook on `config/tiers/*.yaml`
- Added unit test `test_production_tier_yaml_matches` and updated `test_all_supported_patterns_match` parametrization to cover the new pattern
- Added integration test `test_production_tier_configs_validate` that validates all real `config/tiers/*.yaml` files against the schema (skips gracefully when directory is absent)

## Test plan

- [x] All 4457 unit tests pass
- [x] New tests: `test_production_tier_yaml_matches`, `test_all_supported_patterns_match[config/tiers/t0.yaml]`, `test_production_tier_configs_validate` (skipped — no `config/tiers/` dir yet)
- [x] Pre-commit hooks pass on all changed files (ruff, mypy, yamllint, etc.)

Closes #1441

🤖 Generated with [Claude Code](https://claude.com/claude-code)