### PR TITLE
feat(config): add schema validation to load_test() and load_rubric()

### DIFF
--- a/schemas/rubric.schema.json
+++ b/schemas/rubric.schema.json
@@ -4,16 +4,16 @@
   "title": "ProjectScylla Rubric Schema",
   "description": "Schema for rubric.yaml files that define scoring rubrics for LLM-as-Judge evaluation",
   "type": "object",
-  "required": ["requirements", "grading"],
+  "required": ["grading"],
   "additionalProperties": false,
   "properties": {
     "requirements": {
       "type": "array",
-      "description": "List of evaluation requirements",
+      "description": "List of evaluation requirements (requirements-based format)",
       "minItems": 1,
       "items": {
         "type": "object",
-        "required": ["id", "description", "weight", "evaluation"],
+        "required": ["id", "description", "weight"],
         "additionalProperties": false,
         "properties": {
           "id": {
@@ -25,8 +25,7 @@
           "description": {
             "type": "string",
             "description": "What this requirement measures",
-            "minLength": 10,
-            "maxLength": 200,
+            "minLength": 3,
             "examples": [
               "Makefile exists and is syntactically valid",
               "All justfile recipes have Makefile equivalents"
@@ -43,6 +42,75 @@
             "type": "string",
             "description": "Evaluation type: binary (pass/fail) or scaled (0.0-1.0)",
             "enum": ["binary", "scaled"]
+          },
+          "criteria": {
+            "type": "array",
+            "description": "Detailed evaluation criteria checklist",
+            "items": {
+              "type": "string",
+              "minLength": 1
+            }
+          },
+          "skill_validation": {
+            "type": "string",
+            "description": "Skill used to validate this requirement"
+          },
+          "skill_source": {
+            "type": "string",
+            "description": "Source URL for the validation skill"
+          }
+        }
+      }
+    },
+    "categories": {
+      "type": "object",
+      "description": "Category-based rubric (alternative to requirements-based format)",
+      "minProperties": 1,
+      "additionalProperties": {
+        "type": "object",
+        "required": ["weight", "scoring_type", "items"],
+        "additionalProperties": false,
+        "properties": {
+          "weight": {
+            "type": "number",
+            "description": "Category weight (0.0-1.0)",
+            "minimum": 0,
+            "maximum": 1
+          },
+          "scoring_type": {
+            "type": "string",
+            "description": "Scoring approach for this category",
+            "enum": ["checklist", "subjective"]
+          },
+          "items": {
+            "type": "array",
+            "description": "Checklist or subjective items in this category",
+            "minItems": 1,
+            "items": {
+              "type": "object",
+              "required": ["id", "check", "points"],
+              "additionalProperties": false,
+              "properties": {
+                "id": {
+                  "type": "string",
+                  "description": "Item identifier"
+                },
+                "check": {
+                  "type": "string",
+                  "description": "What to check or evaluate",
+                  "minLength": 1
+                },
+                "points": {
+                  "type": "number",
+                  "description": "Points awarded for this item",
+                  "minimum": 0
+                },
+                "na_condition": {
+                  "type": "string",
+                  "description": "Condition under which this item is not applicable"
+                }
+              }
+            }
           }
         }
       }

--- a/schemas/test.schema.json
+++ b/schemas/test.schema.json
@@ -4,14 +4,14 @@
   "title": "ProjectScylla Test Case Schema",
   "description": "Schema for test.yaml files that define test cases for AI agent evaluation",
   "type": "object",
-  "required": ["id", "name", "source", "task", "validation"],
+  "required": ["id", "name", "language", "source", "task", "validation"],
   "additionalProperties": false,
   "properties": {
     "id": {
       "type": "string",
-      "description": "Unique test identifier (e.g., '001-justfile-to-makefile')",
-      "pattern": "^[0-9]{3}-[a-z0-9]+(-[a-z0-9]+)*$",
-      "examples": ["001-justfile-to-makefile", "042-api-integration-test"]
+      "description": "Unique test identifier (e.g., 'test-001' or '001-justfile-to-makefile')",
+      "pattern": "^[a-z0-9][a-z0-9]*(-[a-z0-9]+)*$",
+      "examples": ["test-001", "001-justfile-to-makefile", "042-api-integration-test"]
     },
     "name": {
       "type": "string",
@@ -113,6 +113,22 @@
           }
         }
       }
+    },
+    "language": {
+      "type": "string",
+      "description": "Programming language for build pipeline",
+      "enum": ["python", "mojo"],
+      "examples": ["python", "mojo"]
+    },
+    "tiers": {
+      "type": "array",
+      "description": "Tiers this test participates in",
+      "default": [],
+      "items": {
+        "type": "string",
+        "enum": ["T0", "T1", "T2", "T3", "T4", "T5", "T6"]
+      },
+      "examples": [["T0", "T1", "T2"]]
     },
     "tags": {
       "type": "array",

--- a/scylla/config/loader.py
+++ b/scylla/config/loader.py
@@ -189,6 +189,9 @@ class ConfigLoader:
         test_path = self.base_path / "tests" / test_id / "test.yaml"
         data = self._load_yaml(test_path)
 
+        if not test_id.startswith("_"):
+            _validate_schema(data, "test", test_path)
+
         try:
             return EvalCase(**data)
         except Exception as e:
@@ -213,6 +216,9 @@ class ConfigLoader:
         """
         rubric_path = self.base_path / "tests" / test_id / "expected" / "rubric.yaml"
         data = self._load_yaml(rubric_path)
+
+        if not test_id.startswith("_"):
+            _validate_schema(data, "rubric", rubric_path)
 
         try:
             return Rubric(**data)

--- a/tests/unit/config/test_json_schemas.py
+++ b/tests/unit/config/test_json_schemas.py
@@ -58,7 +58,13 @@ class TestSchemaFiles:
 
     @pytest.mark.parametrize(
         "schema_name",
-        ["defaults.schema.json", "tier.schema.json", "model.schema.json"],
+        [
+            "defaults.schema.json",
+            "tier.schema.json",
+            "model.schema.json",
+            "test.schema.json",
+            "rubric.schema.json",
+        ],
     )
     def test_schema_file_exists(self, schema_name: str) -> None:
         """Schema file must exist."""
@@ -66,7 +72,13 @@ class TestSchemaFiles:
 
     @pytest.mark.parametrize(
         "schema_name",
-        ["defaults.schema.json", "tier.schema.json", "model.schema.json"],
+        [
+            "defaults.schema.json",
+            "tier.schema.json",
+            "model.schema.json",
+            "test.schema.json",
+            "rubric.schema.json",
+        ],
     )
     def test_schema_is_valid_json(self, schema_name: str) -> None:
         """Schema file must be valid JSON."""
@@ -75,7 +87,13 @@ class TestSchemaFiles:
 
     @pytest.mark.parametrize(
         "schema_name",
-        ["defaults.schema.json", "tier.schema.json", "model.schema.json"],
+        [
+            "defaults.schema.json",
+            "tier.schema.json",
+            "model.schema.json",
+            "test.schema.json",
+            "rubric.schema.json",
+        ],
     )
     def test_schema_has_required_keys(self, schema_name: str) -> None:
         """Each schema must have $schema, title, type, and additionalProperties."""
@@ -263,3 +281,183 @@ class TestModelSchema:
     def test_minimal_valid_model(self, schema: dict[str, Any]) -> None:
         """Only model_id is required."""
         check_schema({"model_id": "minimal-model"}, schema)
+
+
+# ---------------------------------------------------------------------------
+# test.schema.json
+# ---------------------------------------------------------------------------
+
+TESTS_FIXTURES_DIR = REPO_ROOT / "tests" / "fixtures" / "tests"
+
+_MINIMAL_TEST = {
+    "id": "test-001",
+    "name": "Hello World",
+    "language": "python",
+    "source": {
+        "repo": "https://github.com/mvillmow/Hello-World",
+        "hash": "7fd1a60b01f91b314f59955a4e4d4e80d8edf11d",
+    },
+    "task": {"prompt_file": "prompt.md"},
+    "validation": {
+        "criteria_file": "expected/criteria.md",
+        "rubric_file": "expected/rubric.yaml",
+    },
+}
+
+
+class TestTestSchema:
+    """Tests for test.schema.json against fixture test cases."""
+
+    @pytest.fixture
+    def schema(self) -> dict[str, Any]:
+        """Load test schema."""
+        return load_schema("test.schema.json")
+
+    @pytest.mark.parametrize(
+        "fixture_dir",
+        ["test-001", "test-002"],
+    )
+    def test_real_test_fixture_is_valid(self, schema: dict[str, Any], fixture_dir: str) -> None:
+        """Real test fixture files must conform to test.schema.json."""
+        data = load_yaml(TESTS_FIXTURES_DIR / fixture_dir / "test.yaml")
+        check_schema(data, schema)
+
+    def test_rejects_missing_required_id(self, schema: dict[str, Any]) -> None:
+        """Id is required."""
+        data = {k: v for k, v in _MINIMAL_TEST.items() if k != "id"}
+        with pytest.raises(jsonschema.ValidationError):
+            check_schema(data, schema)
+
+    def test_rejects_missing_required_name(self, schema: dict[str, Any]) -> None:
+        """Name is required."""
+        data = {k: v for k, v in _MINIMAL_TEST.items() if k != "name"}
+        with pytest.raises(jsonschema.ValidationError):
+            check_schema(data, schema)
+
+    def test_rejects_missing_required_language(self, schema: dict[str, Any]) -> None:
+        """Language is required."""
+        data = {k: v for k, v in _MINIMAL_TEST.items() if k != "language"}
+        with pytest.raises(jsonschema.ValidationError):
+            check_schema(data, schema)
+
+    def test_rejects_additional_property(self, schema: dict[str, Any]) -> None:
+        """Schema must reject unknown top-level keys."""
+        data = {**_MINIMAL_TEST, "unknown_key": "value"}
+        with pytest.raises(jsonschema.ValidationError):
+            check_schema(data, schema)
+
+    def test_rejects_invalid_language(self, schema: dict[str, Any]) -> None:
+        """Language must be python or mojo."""
+        data = {**_MINIMAL_TEST, "language": "javascript"}
+        with pytest.raises(jsonschema.ValidationError):
+            check_schema(data, schema)
+
+    def test_accepts_optional_tags(self, schema: dict[str, Any]) -> None:
+        """Tags array is accepted."""
+        data = {**_MINIMAL_TEST, "tags": ["build-system", "migration"]}
+        check_schema(data, schema)
+
+    def test_accepts_optional_tiers(self, schema: dict[str, Any]) -> None:
+        """Tiers array is accepted."""
+        data = {**_MINIMAL_TEST, "tiers": ["T0", "T1", "T2"]}
+        check_schema(data, schema)
+
+    def test_accepts_minimal_valid_test(self, schema: dict[str, Any]) -> None:
+        """All required fields present, no optional ones."""
+        check_schema(_MINIMAL_TEST, schema)
+
+
+# ---------------------------------------------------------------------------
+# rubric.schema.json
+# ---------------------------------------------------------------------------
+
+_MINIMAL_RUBRIC_REQUIREMENTS = {
+    "requirements": [
+        {
+            "id": "R001",
+            "description": "First requirement",
+            "weight": 1.0,
+            "evaluation": "binary",
+        }
+    ],
+    "grading": {"pass_threshold": 0.60},
+}
+
+_MINIMAL_RUBRIC_CATEGORIES = {
+    "categories": {
+        "functional": {
+            "weight": 1.0,
+            "scoring_type": "checklist",
+            "items": [{"id": "F1", "check": "File exists", "points": 1.0}],
+        }
+    },
+    "grading": {"pass_threshold": 0.60},
+}
+
+
+class TestRubricSchema:
+    """Tests for rubric.schema.json against fixture rubric files."""
+
+    @pytest.fixture
+    def schema(self) -> dict[str, Any]:
+        """Load rubric schema."""
+        return load_schema("rubric.schema.json")
+
+    @pytest.mark.parametrize(
+        "fixture_path",
+        [
+            "test-001/expected/rubric.yaml",
+            "test-002/expected/rubric.yaml",
+            "test-003/expected/rubric.yaml",
+        ],
+    )
+    def test_real_rubric_fixture_is_valid(self, schema: dict[str, Any], fixture_path: str) -> None:
+        """Real rubric fixture files must conform to rubric.schema.json."""
+        data = load_yaml(TESTS_FIXTURES_DIR / fixture_path)
+        check_schema(data, schema)
+
+    def test_rejects_missing_grading(self, schema: dict[str, Any]) -> None:
+        """Grading is required."""
+        data = {"requirements": _MINIMAL_RUBRIC_REQUIREMENTS["requirements"]}
+        with pytest.raises(jsonschema.ValidationError):
+            check_schema(data, schema)
+
+    def test_rejects_additional_top_level_property(self, schema: dict[str, Any]) -> None:
+        """Schema must reject unknown top-level keys."""
+        data = {**_MINIMAL_RUBRIC_REQUIREMENTS, "unknown_field": "value"}
+        with pytest.raises(jsonschema.ValidationError):
+            check_schema(data, schema)
+
+    def test_rejects_invalid_pass_threshold(self, schema: dict[str, Any]) -> None:
+        """pass_threshold must be in [0.0, 1.0]."""
+        data = {**_MINIMAL_RUBRIC_REQUIREMENTS, "grading": {"pass_threshold": 1.5}}
+        with pytest.raises(jsonschema.ValidationError):
+            check_schema(data, schema)
+
+    def test_accepts_requirements_format(self, schema: dict[str, Any]) -> None:
+        """Requirements-based rubric is accepted."""
+        check_schema(_MINIMAL_RUBRIC_REQUIREMENTS, schema)
+
+    def test_accepts_categories_format(self, schema: dict[str, Any]) -> None:
+        """Categories-based rubric is accepted."""
+        check_schema(_MINIMAL_RUBRIC_CATEGORIES, schema)
+
+    def test_accepts_requirement_with_criteria(self, schema: dict[str, Any]) -> None:
+        """Requirement items may include optional criteria array."""
+        data = {
+            "requirements": [
+                {
+                    "id": "R001",
+                    "description": "Check with criteria",
+                    "weight": 1.0,
+                    "evaluation": "scaled",
+                    "criteria": ["criterion one", "criterion two"],
+                }
+            ],
+            "grading": {"pass_threshold": 0.60},
+        }
+        check_schema(data, schema)
+
+    def test_accepts_minimal_valid_rubric(self, schema: dict[str, Any]) -> None:
+        """Only grading is required."""
+        check_schema({"grading": {"pass_threshold": 0.60}}, schema)


### PR DESCRIPTION
## Summary

- Wires JSON schema validation into `ConfigLoader.load_test()` and `ConfigLoader.load_rubric()` using the existing `_validate_schema()` module-level helper, consistent with `load_tier()`, `load_defaults()`, and `load_model()`
- Updates `schemas/test.schema.json` to add required `language` field, optional `tiers` array, and broadened `id` pattern matching real fixture formats
- Updates `schemas/rubric.schema.json` to support both `requirements`-based and `categories`-based rubric formats, plus optional `criteria`/`skill_validation`/`skill_source` fields in requirement items
- Adds `TestTestSchema` and `TestRubricSchema` test classes to `tests/unit/config/test_json_schemas.py` with real-fixture validation and rejection tests
- Adds `test.schema.json` and `rubric.schema.json` to `TestSchemaFiles` parametrize lists

## Test plan

- [x] All 69 schema tests pass (`tests/unit/config/test_json_schemas.py`)
- [x] All 313 config unit tests pass
- [x] All 4481 unit tests pass
- [x] All pre-commit hooks pass (ruff, mypy, yaml-lint, custom validators)
- [x] `load_test()` validates against `test.schema.json` (skips `_`-prefixed test IDs)
- [x] `load_rubric()` validates against `rubric.schema.json` (skips `_`-prefixed test IDs)

Closes #1438

🤖 Generated with [Claude Code](https://claude.com/claude-code)