### PR TITLE
ci(test): add Validate config schemas step to CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -98,6 +98,10 @@ jobs:
         if: matrix.test-group.name == 'unit'
         run: pixi run python scripts/check_unit_test_structure.py
 
+      - name: Validate config schemas
+        if: matrix.test-group.name == 'unit'
+        run: pixi run python scripts/validate_config_schemas.py config/defaults.yaml config/models/*.yaml tests/fixtures/config/tiers/*.yaml
+
       - name: Run ${{ matrix.test-group.name }} tests
         env:
           TEST_PATH: ${{ matrix.test-group.path }}


### PR DESCRIPTION
## Summary

- Adds a `Validate config schemas` step to `.github/workflows/test.yml` that runs `scripts/validate_config_schemas.py config/defaults.yaml config/models/*.yaml tests/fixtures/config/tiers/*.yaml` on every PR
- The step is gated with `if: matrix.test-group.name == 'unit'` — same pattern as `Check doc/config consistency` and `Enforce tests/unit/ structure conventions`
- The step runs after pixi setup but before the test run, reusing the existing pixi environment
- The script (`scripts/validate_config_schemas.py`), its tests (`tests/unit/scripts/test_validate_config_schemas.py`), and the pre-commit hook (`.pre-commit-config.yaml`) were already in place from #1382

## Test plan
- [x] `pixi run python scripts/validate_config_schemas.py --verbose config/defaults.yaml config/models/*.yaml tests/fixtures/config/tiers/*.yaml` exits 0 — all 15 files PASS
- [x] `pixi run pytest tests/unit/scripts/test_validate_config_schemas.py -v` — 26 tests pass
- [x] `pre-commit run --files .github/workflows/test.yml` — YAML Lint and all other applicable hooks pass
- [x] Full test suite: 4563 passed, 1 skipped, coverage 75.85%

Closes #1443

🤖 Generated with [Claude Code](https://claude.com/claude-code)