### PR TITLE
fix(retry-errors): save checkpoint for intermediate-state runs

### DIFF
--- a/scripts/manage_experiment.py
+++ b/scripts/manage_experiment.py
@@ -334,7 +334,7 @@ def _reset_non_completed_runs(checkpoint: Any) -> int:
         checkpoint: Loaded E2ECheckpoint to mutate in-place.
 
     Returns:
-        Number of runs reset to pending (failed/rate_limited only).
+        Number of non-completed runs found (terminal resets + intermediate).
 
     """
     terminal_states = ("failed", "rate_limited")
@@ -350,11 +350,11 @@ def _reset_non_completed_runs(checkpoint: Any) -> int:
                 # All non-completed runs trigger the tier/subtest cascade
                 affected_tiers.add(tier_id)
                 affected_subtests.add((tier_id, subtest_id))
+                reset_count += 1  # Count ALL non-completed runs
                 if state in terminal_states:
                     # Terminal runs restart from scratch
                     runs[run_num_str] = "pending"
                     checkpoint.unmark_run_completed(tier_id, subtest_id, int(run_num_str))
-                    reset_count += 1
                 # else: intermediate state — leave run state as-is; cascade handles re-entry
 
     for tier_id, subtest_id in affected_subtests:

--- a/tests/unit/e2e/test_manage_experiment_run.py
+++ b/tests/unit/e2e/test_manage_experiment_run.py
@@ -1670,8 +1670,8 @@ class TestRetryErrorsInBatch:
 
         reset_count = _reset_non_completed_runs(checkpoint)
 
-        # Only failed and rate_limited runs are reset to pending (2 total)
-        assert reset_count == 2
+        # All non-completed runs counted (failed + rate_limited + intermediate = 4)
+        assert reset_count == 4
         assert checkpoint.run_states["T0"]["00"]["1"] == "pending"
         assert checkpoint.run_states["T1"]["01"]["1"] == "pending"
         # Intermediate runs keep their state (resume where they left off)
@@ -1721,8 +1721,8 @@ class TestRetryErrorsInBatch:
 
         reset_count = _reset_non_completed_runs(checkpoint)
 
-        # No failed/rate_limited runs → reset_count is 0
-        assert reset_count == 0
+        # 4 intermediate non-completed runs found
+        assert reset_count == 4
         # Intermediate run states are preserved (resume where they left off)
         assert checkpoint.run_states["T0"]["00"]["2"] == "judge_prompt_built"
         assert checkpoint.run_states["T0"]["00"]["3"] == "dir_structure_created"


### PR DESCRIPTION
## Summary
- `_reset_non_completed_runs()` now counts ALL non-completed runs (intermediate + terminal), not just terminal resets
- Fixes `--retry-errors` not saving checkpoint when only intermediate-state runs exist (e.g., `judge_prompt_built`, `replay_generated`)
- Both batch-mode (line 649) and single-mode (line 1038) save guards now trigger correctly

## Test plan
- [x] All 12 retry-related tests pass
- [x] 4774 tests pass, 76.45% unit coverage
- [ ] Manual: run `--retry-errors` against dryrun3 test-002 (0 terminal failures, 22 intermediate) and confirm checkpoint saved

🤖 Generated with [Claude Code](https://claude.com/claude-code)