### PR TITLE
chore(audit): fix dead link, update Docker CLI, add version upper bounds

### DIFF
--- a/.claude/agents/chief-evaluator.md
+++ b/.claude/agents/chief-evaluator.md
@@ -123,4 +123,4 @@ Chief Evaluator:
 - [Evaluation Guidelines](/.claude/shared/evaluation-guidelines.md)
 - [Metrics Definitions](/.claude/shared/metrics-definitions.md)
 - [Research Methodology](/docs/research.md)
-- [Agent Hierarchy](/agents/hierarchy.md)
+- [Agent Hierarchy](/.claude/agents/)

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -127,9 +127,9 @@ RUN curl -fsSL https://deb.nodesource.com/setup_20.x | bash - \
 
 # Install Claude Code CLI (pinned to specific version for reproducibility)
 # This is the primary tool for agent-based test execution
-# Version 2.1.42 verified working in #601
+# Version 2.1.74 verified working
 # See: https://github.com/mvillmow/ProjectScylla/issues/650
-RUN npm install -g @anthropic-ai/claude-code@2.1.42
+RUN npm install -g @anthropic-ai/claude-code@2.1.74
 
 # Create non-root user for security
 RUN groupadd -r scylla && useradd -r -g scylla -m -s /bin/bash scylla

--- a/pixi.lock
+++ b/pixi.lock
@@ -3807,24 +3807,24 @@ packages:
 - pypi: ./
   name: scylla
   version: 0.1.0
-  sha256: d5726766cf8c25837f0974d7b4d5af78352b528acc2d65931542c690bfd89053
+  sha256: 2b5ac04e10959723a78e7f5c17763301f8fdc1c4951f2f55071405ed02bb3fc7
   requires_dist:
-  - click>=8.0
-  - pydantic>=2.0
-  - pyyaml>=6.0
-  - pytest>=7.0 ; extra == 'dev'
-  - pytest-cov>=4.0 ; extra == 'dev'
-  - pre-commit>=3.0 ; extra == 'dev'
-  - ruff>=0.1.0 ; extra == 'dev'
-  - defusedxml>=0.7 ; extra == 'dev'
-  - matplotlib>=3.8 ; extra == 'analysis'
-  - numpy>=1.24 ; extra == 'analysis'
-  - pandas>=2.0 ; extra == 'analysis'
-  - seaborn>=0.13 ; extra == 'analysis'
-  - scipy>=1.11 ; extra == 'analysis'
-  - altair>=5.0 ; extra == 'analysis'
-  - vl-convert-python>=1.0 ; extra == 'analysis'
-  - krippendorff>=0.6.0 ; extra == 'analysis'
+  - click>=8.0,<9
+  - pydantic>=2.0,<3
+  - pyyaml>=6.0,<7
+  - pytest>=7.0,<9 ; extra == 'dev'
+  - pytest-cov>=4.0,<7 ; extra == 'dev'
+  - pre-commit>=3.0,<5 ; extra == 'dev'
+  - ruff>=0.1.0,<1 ; extra == 'dev'
+  - defusedxml>=0.7,<1 ; extra == 'dev'
+  - matplotlib>=3.8,<4 ; extra == 'analysis'
+  - numpy>=1.24,<3 ; extra == 'analysis'
+  - pandas>=2.0,<3 ; extra == 'analysis'
+  - seaborn>=0.13,<1 ; extra == 'analysis'
+  - scipy>=1.11,<2 ; extra == 'analysis'
+  - altair>=5.0,<7 ; extra == 'analysis'
+  - vl-convert-python>=1.0,<2 ; extra == 'analysis'
+  - krippendorff>=0.6.0,<1 ; extra == 'analysis'
   requires_python: '>=3.10'
 - pypi: https://files.pythonhosted.org/packages/83/11/00d3c3dfc25ad54e731d91449895a79e4bf2384dc3ac01809010ba88f6d5/seaborn-0.13.2-py3-none-any.whl
   name: seaborn

--- a/pixi.toml
+++ b/pixi.toml
@@ -37,21 +37,21 @@ jsonschema = ">=4.0,<5"
 defusedxml = ">=0.7,<1"
 
 [feature.dev.dependencies]
-pre-commit = ">=3.0"
-ruff = ">=0.1.0"
-mypy = ">=1.8.0"
-yamllint = ">=1.35.0"
-bats-core = ">=1.11.0"
+pre-commit = ">=3.0,<5"
+ruff = ">=0.1.0,<1"
+mypy = ">=1.8.0,<2"
+yamllint = ">=1.35.0,<2"
+bats-core = ">=1.11.0,<2"
 
 [feature.dev.pypi-dependencies]
 pip-audit = ">=2.7,<3"
 
 [feature.lint.dependencies]
 # Minimal dependencies for CI pre-commit checks only
-ruff = ">=0.1.0"
-mypy = ">=1.8.0"
-yamllint = ">=1.35.0"
-pre-commit = ">=3.0"
+ruff = ">=0.1.0,<1"
+mypy = ">=1.8.0,<2"
+yamllint = ">=1.35.0,<2"
+pre-commit = ">=3.0,<5"
 
 [feature.lint.pypi-dependencies]
 pip-audit = ">=2.7,<3"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,9 +25,9 @@ classifiers = [
 ]
 keywords = ["ai", "agents", "benchmarking", "evaluation", "testing"]
 dependencies = [
-    "click>=8.0",
-    "pydantic>=2.0",
-    "pyyaml>=6.0",
+    "click>=8.0,<9",
+    "pydantic>=2.0,<3",
+    "pyyaml>=6.0,<7",
 ]
 
 [project.scripts]
@@ -35,21 +35,21 @@ scylla = "scylla.cli.main:main"
 
 [project.optional-dependencies]
 dev = [
-    "pytest>=7.0",
-    "pytest-cov>=4.0",
-    "pre-commit>=3.0",
-    "ruff>=0.1.0",
-    "defusedxml>=0.7",
+    "pytest>=7.0,<9",
+    "pytest-cov>=4.0,<7",
+    "pre-commit>=3.0,<5",
+    "ruff>=0.1.0,<1",
+    "defusedxml>=0.7,<1",
 ]
 analysis = [
-    "matplotlib>=3.8",
-    "numpy>=1.24",
-    "pandas>=2.0",
-    "seaborn>=0.13",
-    "scipy>=1.11",
-    "altair>=5.0",
-    "vl-convert-python>=1.0",
-    "krippendorff>=0.6.0",
+    "matplotlib>=3.8,<4",
+    "numpy>=1.24,<3",
+    "pandas>=2.0,<3",
+    "seaborn>=0.13,<1",
+    "scipy>=1.11,<2",
+    "altair>=5.0,<7",
+    "vl-convert-python>=1.0,<2",
+    "krippendorff>=0.6.0,<1",
 ]
 
 [project.urls]


### PR DESCRIPTION
## Summary
- Fix dead `hierarchy.md` link in `.claude/agents/chief-evaluator.md` → points to `/.claude/agents/`
- Update Docker Claude CLI pin from 2.1.42 to 2.1.74
- Add upper-bound version pins to all dependencies in `pyproject.toml` and `pixi.toml`
- Regenerate `pixi.lock`

Closes #1446

## Test plan
- [x] `pixi install` succeeds
- [x] `pixi run test` — 4788 passed
- [x] `pre-commit run --all-files` — all passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)