### PR TITLE
fix(tier-manager): fall through to best_subtest.json when result.json has null best_subtest

### DIFF
--- a/scylla/e2e/tier_manager.py
+++ b/scylla/e2e/tier_manager.py
@@ -723,7 +723,8 @@ class TierManager:
                 with open(result_file) as f:
                     tier_result = json.load(f)
                 best_subtest_id = tier_result.get("best_subtest")
-            elif best_subtest_file.exists():
+
+            if not best_subtest_id and best_subtest_file.exists():
                 with open(best_subtest_file) as f:
                     selection = json.load(f)
                 best_subtest_id = selection.get("winning_subtest")

--- a/tests/unit/e2e/test_tier_manager.py
+++ b/tests/unit/e2e/test_tier_manager.py
@@ -976,6 +976,45 @@ class TestBuildMergedBaseline:
         merged = manager.build_merged_baseline([TierID.T0], experiment_dir)
         assert set(merged["tools"]["enabled"]) == {"bash", "read"}
 
+    def test_fallback_to_best_subtest_json_when_result_json_has_null_best_subtest(
+        self, tmp_path: Path
+    ) -> None:
+        """Test that build_merged_baseline falls back to best_subtest.json.
+
+        When result.json exists but best_subtest is null (e.g. tier report was
+        regenerated with empty data during a re-run).
+        """
+        import json
+
+        experiment_dir = tmp_path / "experiment"
+        t0_dir = experiment_dir / "T0"
+        t0_subtest_dir = t0_dir / "subtest-01"
+        t0_subtest_dir.mkdir(parents=True)
+
+        # result.json exists but best_subtest is null
+        (t0_dir / "result.json").write_text(json.dumps({"best_subtest": None, "scores": {}}))
+
+        # best_subtest.json has the winning subtest
+        (t0_dir / "best_subtest.json").write_text(
+            json.dumps({"winning_subtest": "subtest-01", "rationale": "Best pass rate"})
+        )
+
+        # Create config_manifest.json for the subtest
+        manifest = {
+            "resources": {
+                "tools": {"enabled": ["bash", "read"]},
+            }
+        }
+        (t0_subtest_dir / "config_manifest.json").write_text(json.dumps(manifest))
+
+        tiers_dir = tmp_path / "tiers"
+        tiers_dir.mkdir()
+        manager = TierManager(tiers_dir)
+
+        # Should succeed by falling through to best_subtest.json
+        merged = manager.build_merged_baseline([TierID.T0], experiment_dir)
+        assert set(merged["tools"]["enabled"]) == {"bash", "read"}
+
     def test_best_subtest_missing_manifest_falls_back_to_sibling(self, tmp_path: Path) -> None:
         """Test fallback when best subtest has no config_manifest.json but a sibling does."""
         import json


### PR DESCRIPTION
## Summary
- `build_merged_baseline` used `elif` for the `best_subtest.json` fallback, so it was never reached when `result.json` existed but contained `best_subtest: null`
- Changed to a sequential `if` check so the fallback fires whenever `best_subtest_id` is still None after reading `result.json`
- Adds a unit test for the null-best_subtest fallthrough case

## Root Cause
During re-runs of dryrun3, T5/02 was failing with "Cannot build merged baseline: all required tiers failed (T1)" even though T1 was complete. The tier's `result.json` had been regenerated with `best_subtest: null`, and the old `elif` prevented the code from reading `best_subtest.json` which had the correct `winning_subtest`.

## Test plan
- [x] `pixi run pytest tests/unit/e2e/test_tier_manager.py -v -k "merged_baseline or fallback"` — 4 passed
- [x] `pixi run pytest tests/unit/ -q` — 4681 passed, 76.58% coverage
- [x] `pre-commit run --all-files` — passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)