### PR TITLE
fix(tier-manager): fall through to best_subtest.json when result.json…

### DIFF
--- a/scylla/e2e/tier_manager.py
+++ b/scylla/e2e/tier_manager.py
@@ -723,7 +723,8 @@ class TierManager:
                 with open(result_file) as f:
                     tier_result = json.load(f)
                 best_subtest_id = tier_result.get("best_subtest")
-            elif best_subtest_file.exists():
+
+            if not best_subtest_id and best_subtest_file.exists():
                 with open(best_subtest_file) as f:
                     selection = json.load(f)
                 best_subtest_id = selection.get("winning_subtest")

--- a/tests/unit/e2e/test_tier_manager.py
+++ b/tests/unit/e2e/test_tier_manager.py
@@ -976,6 +976,45 @@ class TestBuildMergedBaseline:
         merged = manager.build_merged_baseline([TierID.T0], experiment_dir)
         assert set(merged["tools"]["enabled"]) == {"bash", "read"}
 
+    def test_fallback_to_best_subtest_json_when_result_json_has_null_best_subtest(
+        self, tmp_path: Path
+    ) -> None:
+        """Test that build_merged_baseline falls back to best_subtest.json.
+
+        When result.json exists but best_subtest is null (e.g. tier report was
+        regenerated with empty data during a re-run).
+        """
+        import json
+
+        experiment_dir = tmp_path / "experiment"
+        t0_dir = experiment_dir / "T0"
+        t0_subtest_dir = t0_dir / "subtest-01"
+        t0_subtest_dir.mkdir(parents=True)
+
+        # result.json exists but best_subtest is null
+        (t0_dir / "result.json").write_text(json.dumps({"best_subtest": None, "scores": {}}))
+
+        # best_subtest.json has the winning subtest
+        (t0_dir / "best_subtest.json").write_text(
+            json.dumps({"winning_subtest": "subtest-01", "rationale": "Best pass rate"})
+        )
+
+        # Create config_manifest.json for the subtest
+        manifest = {
+            "resources": {
+                "tools": {"enabled": ["bash", "read"]},
+            }
+        }
+        (t0_subtest_dir / "config_manifest.json").write_text(json.dumps(manifest))
+
+        tiers_dir = tmp_path / "tiers"
+        tiers_dir.mkdir()
+        manager = TierManager(tiers_dir)
+
+        # Should succeed by falling through to best_subtest.json
+        merged = manager.build_merged_baseline([TierID.T0], experiment_dir)
+        assert set(merged["tools"]["enabled"]) == {"bash", "read"}
+
     def test_best_subtest_missing_manifest_falls_back_to_sibling(self, tmp_path: Path) -> None:
         """Test fallback when best subtest has no config_manifest.json but a sibling does."""
         import json


### PR DESCRIPTION
… has null best_subtest

When result.json exists but contains best_subtest=null (e.g. tier report was regenerated with empty data during a re-run), the previous elif prevented the fallback to best_subtest.json. Changed to a second if check so T5 subtests can find the best subtest from prior completed tiers even in this case.

Adds unit test covering the null best_subtest fallthrough scenario.

## Summary

<!-- Brief description of what this PR accomplishes -->

## Changes

<!-- List of key changes made -->

- Change 1
- Change 2

## Related Issues

<!-- Link related issues using keywords: Closes #123, Fixes #456, Related to #789 -->

Closes #

## Type of Change

<!-- Mark with an 'x' all that apply -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (code improvement without changing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] CI/CD or infrastructure change
- [ ] Test coverage improvement

## Testing

<!-- Describe the testing you've done -->

- [ ] All existing tests pass
- [ ] New tests added to cover changes
- [ ] Manual testing performed

## Checklist

<!-- Mark with an 'x' all that have been completed -->

- [ ] Code follows project style guidelines (ruff, mypy)
- [ ] Self-review of code completed
- [ ] Comments added in hard-to-understand areas
- [ ] Documentation updated (if needed)
- [ ] No new warnings introduced
- [ ] Conventional commit message format used
- [ ] Branch named following convention: `<issue-number>-<description>`

## Additional Notes

<!-- Any additional context, screenshots, or information -->

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
