### PR TITLE
[Fix] Correct pyproject.toml repository URLs + add SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,55 @@
+# Security Policy
+
+## Supported Versions
+
+| Version | Supported          |
+| ------- | ------------------ |
+| 0.1.x   | :white_check_mark: |
+
+## Reporting a Vulnerability
+
+If you discover a security vulnerability in ProjectScylla, please report it responsibly.
+
+**Do NOT open a public GitHub issue for security vulnerabilities.**
+
+### How to Report
+
+1. **Email**: Send details to [research@villmow.us](mailto:research@villmow.us)
+2. **Subject line**: `[SECURITY] ProjectScylla - Brief description`
+3. **Include**:
+   - Description of the vulnerability
+   - Steps to reproduce
+   - Potential impact
+   - Suggested fix (if any)
+
+### What to Expect
+
+- **Acknowledgment**: Within 48 hours
+- **Assessment**: Within 1 week
+- **Resolution**: Depends on severity; critical issues targeted within 2 weeks
+
+### Scope
+
+The following are in scope for security reports:
+
+- API key exposure or credential leakage
+- Command injection in CLI or subprocess calls
+- Unsafe deserialization of experiment data
+- Docker container escape or privilege escalation
+- Dependencies with known CVEs not covered by pip-audit
+
+### Out of Scope
+
+- Vulnerabilities in third-party services (Anthropic API, OpenAI API)
+- Issues requiring physical access to the machine
+- Social engineering attacks
+
+## Security Practices
+
+ProjectScylla follows these security practices:
+
+- **No hardcoded secrets**: API keys read from environment variables
+- **No shell=True**: All subprocess calls use list-based arguments
+- **CVE scanning**: pip-audit runs in CI and pre-commit hooks
+- **Credential isolation**: Context-managed temporary credential mounts with restricted permissions
+- **Docker security**: Non-root user, SHA256-pinned base images, health checks

--- a/pixi.lock
+++ b/pixi.lock
@@ -3807,7 +3807,7 @@ packages:
 - pypi: ./
   name: scylla
   version: 0.1.0
-  sha256: 2b5ac04e10959723a78e7f5c17763301f8fdc1c4951f2f55071405ed02bb3fc7
+  sha256: a2df383b837cb0f83ea5f7779ca609b8a28692a55a553a22897570c835085bad
   requires_dist:
   - click>=8.0,<9
   - pydantic>=2.0,<3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,9 +53,9 @@ analysis = [
 ]
 
 [project.urls]
-Homepage = "https://github.com/mvillmow/ProjectScylla"
-Repository = "https://github.com/mvillmow/ProjectScylla"
-Issues = "https://github.com/mvillmow/ProjectScylla/issues"
+Homepage = "https://github.com/HomericIntelligence/ProjectScylla"
+Repository = "https://github.com/HomericIntelligence/ProjectScylla"
+Issues = "https://github.com/HomericIntelligence/ProjectScylla/issues"
 
 [tool.hatch.build.targets.wheel]
 packages = ["scylla"]


### PR DESCRIPTION
## Summary
- Fix `[project.urls]` in `pyproject.toml`: `mvillmow/ProjectScylla` → `HomericIntelligence/ProjectScylla` (3 URLs)
- Commit `SECURITY.md` (file existed but was untracked): vulnerability reporting policy, scope, and security practices

## Test plan
- [x] `grep HomericIntelligence pyproject.toml` confirms 3 matches
- [x] Pre-commit passes (all hooks green)

🤖 Generated with [Claude Code](https://claude.com/claude-code)