### PR TITLE
fix(markdownlint): properly allow Claude prompt XML tags instead of excluding .claude/plugins/

### DIFF
--- a/.claude/plugins/repo-analyzer/commands/repo-analyze-quick.md
+++ b/.claude/plugins/repo-analyzer/commands/repo-analyze-quick.md
@@ -211,15 +211,17 @@ Status: 🟢 A-B (healthy) | 🟡 C-D (needs attention) | 🔴 F (critical)
 
 **Bottom Line:** [One sentence: can this ship or not?]
 ```
+
 </output_format>
 
 <important_notes>
-  - **Speed over completeness:** This is a 5-minute check, not a 2-hour audit
-  - **Generous by default:** If you didn't find a problem, assume it's fine
-  - **Critical means critical:** Don't report style issues, minor gaps, or "nice-to-haves"
-  - **Security is non-negotiable:** This is the ONLY area where you should be thorough
-  - **No false alarms:** Only report things that genuinely block shipping or pose real risk
-  - **Give credit:** A partial README is better than none. A few tests are better than zero.
-  - **Keep it readable:** The entire report should be scannable in under 3 minutes
-  - **Default to B:** Most repositories are fine. Only downgrade when there's a real problem.
+
+- **Speed over completeness:** This is a 5-minute check, not a 2-hour audit
+- **Generous by default:** If you didn't find a problem, assume it's fine
+- **Critical means critical:** Don't report style issues, minor gaps, or "nice-to-haves"
+- **Security is non-negotiable:** This is the ONLY area where you should be thorough
+- **No false alarms:** Only report things that genuinely block shipping or pose real risk
+- **Give credit:** A partial README is better than none. A few tests are better than zero.
+- **Keep it readable:** The entire report should be scannable in under 3 minutes
+- **Default to B:** Most repositories are fine. Only downgrade when there's a real problem.
 </important_notes>

--- a/.claude/plugins/repo-analyzer/commands/repo-analyze-strict.md
+++ b/.claude/plugins/repo-analyzer/commands/repo-analyze-strict.md
@@ -81,18 +81,20 @@ Apply this rubric consistently across ALL sections. Every section starts at F an
 
 <anti_inflation_rules>
   MANDATORY — Enforce these to prevent grade inflation:
-  - DEFAULT IS F: Every section starts at F. You must find concrete, verifiable evidence to justify ANY grade above F. No evidence = F. Partial evidence = D range. Solid evidence with gaps = C range. Strong evidence = B range. Near-flawless evidence = A range.
-  - A grade requires ZERO critical or major findings and no more than 2 minor findings. If you have more, the grade is B or lower.
-  - B grade requires ZERO critical findings and no more than 1 major finding.
-  - "It exists" is not sufficient for a passing criterion. It must be CORRECT, COMPLETE, and MAINTAINED.
-  - Missing items are not nitpicks. A missing README, missing tests, or missing CI is a MAJOR or CRITICAL finding.
-  - Do NOT give credit for intent, plans, or TODO comments. Grade what EXISTS today.
-  - Do NOT round up. If the evidence puts a section at 74%, the grade is C, not C+ or B-.
-  - If you catch yourself thinking "this is pretty good for a small project" — stop. Grade against the criteria, not your expectations of the team.
-  - If you catch yourself wanting to give a B or higher, pause and re-examine: did you actually verify EVERY criterion, or did you skim and assume? Go back and check.
+
+- DEFAULT IS F: Every section starts at F. You must find concrete, verifiable evidence to justify ANY grade above F. No evidence = F. Partial evidence = D range. Solid evidence with gaps = C range. Strong evidence = B range. Near-flawless evidence = A range.
+- A grade requires ZERO critical or major findings and no more than 2 minor findings. If you have more, the grade is B or lower.
+- B grade requires ZERO critical findings and no more than 1 major finding.
+- "It exists" is not sufficient for a passing criterion. It must be CORRECT, COMPLETE, and MAINTAINED.
+- Missing items are not nitpicks. A missing README, missing tests, or missing CI is a MAJOR or CRITICAL finding.
+- Do NOT give credit for intent, plans, or TODO comments. Grade what EXISTS today.
+- Do NOT round up. If the evidence puts a section at 74%, the grade is C, not C+ or B-.
+- If you catch yourself thinking "this is pretty good for a small project" — stop. Grade against the criteria, not your expectations of the team.
+- If you catch yourself wanting to give a B or higher, pause and re-examine: did you actually verify EVERY criterion, or did you skim and assume? Go back and check.
 </anti_inflation_rules>
 
 For each section, output:
+
   1. Grade (letter with +/- modifier) and percentage
   2. An "Evidence Reviewed" note listing the specific files/directories you examined
   3. A "Strengths" list (what is done well — must cite specific files or code)
@@ -539,6 +541,7 @@ Status indicators: 🟢 A-B (healthy) | 🟡 C (needs attention) | 🔴 D-F (cri
 **Reality Check:**
 [If there are many A's or B's, add a note questioning whether the audit was truly strict enough]
 ```
+
 </output_format>
 
 <analysis_instructions>
@@ -614,13 +617,14 @@ Follow these steps when performing the STRICT audit:
 </analysis_instructions>
 
 <important_notes>
-  - **Evidence is EVERYTHING:** Every grade claim must cite specific files, line numbers, and concrete examples
-  - **Be ruthlessly honest:** Your job is accuracy, not encouragement
-  - **Default to F:** Every section starts at F. Prove otherwise with evidence.
-  - **No assumptions:** If you didn't read the file, you can't grade that criterion
-  - **"Exists" ≠ "Good":** A README that exists but is outdated/wrong is worse than none
-  - **Missing = Major/Critical:** Not having tests is not a nitpick. It's a MAJOR or CRITICAL finding.
-  - **Context doesn't excuse poor quality:** "It's a small project" is not a reason to inflate grades
-  - **Count your files:** You must examine at least 20 source files. List every one.
-  - **Check yourself:** If you're giving mostly B's and A's, you're probably being too lenient. Re-audit.
+
+- **Evidence is EVERYTHING:** Every grade claim must cite specific files, line numbers, and concrete examples
+- **Be ruthlessly honest:** Your job is accuracy, not encouragement
+- **Default to F:** Every section starts at F. Prove otherwise with evidence.
+- **No assumptions:** If you didn't read the file, you can't grade that criterion
+- **"Exists" ≠ "Good":** A README that exists but is outdated/wrong is worse than none
+- **Missing = Major/Critical:** Not having tests is not a nitpick. It's a MAJOR or CRITICAL finding.
+- **Context doesn't excuse poor quality:** "It's a small project" is not a reason to inflate grades
+- **Count your files:** You must examine at least 20 source files. List every one.
+- **Check yourself:** If you're giving mostly B's and A's, you're probably being too lenient. Re-audit.
 </important_notes>

--- a/.claude/plugins/repo-analyzer/commands/repo-analyze.md
+++ b/.claude/plugins/repo-analyzer/commands/repo-analyze.md
@@ -67,6 +67,7 @@ Apply this rubric consistently across ALL sections:
   N/A          — Not applicable to this project type (must justify why).
 
 For each section, output:
+
   1. Grade and percentage
   2. A "Strengths" list (what is done well)
   3. A "Findings" list (issues, graded as CRITICAL / MAJOR / MINOR / NITPICK)
@@ -490,6 +491,7 @@ Status indicators: 🟢 A-B (healthy) | 🟡 C (needs attention) | 🔴 D-F (cri
 2. [Second priority action]
 3. [Third priority action]
 ```
+
 </output_format>
 
 <analysis_instructions>
@@ -542,10 +544,11 @@ Follow these steps when performing the audit:
 </analysis_instructions>
 
 <important_notes>
-  - Be specific: always cite file paths, function names, line numbers, and concrete examples.
-  - Be fair: acknowledge good work. Not everything needs to be criticized.
-  - Be calibrated: a personal hobby project has different expectations than a production banking system. Consider the project's context and stated goals.
-  - Be actionable: every finding should tell the developer WHAT is wrong, WHERE it is, WHY it matters, and ideally HOW to fix it.
-  - Mark sections N/A only when truly not applicable, with justification.
-  - If you cannot determine something due to insufficient information (e.g., private CI configuration), state what you could not assess and why.
+
+- Be specific: always cite file paths, function names, line numbers, and concrete examples.
+- Be fair: acknowledge good work. Not everything needs to be criticized.
+- Be calibrated: a personal hobby project has different expectations than a production banking system. Consider the project's context and stated goals.
+- Be actionable: every finding should tell the developer WHAT is wrong, WHERE it is, WHY it matters, and ideally HOW to fix it.
+- Mark sections N/A only when truly not applicable, with justification.
+- If you cannot determine something due to insufficient information (e.g., private CI configuration), state what you could not assess and why.
 </important_notes>

--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -16,13 +16,20 @@
       "sup",
       "issue-number",
       "number",
-      "role"
+      "role",
+      "system",
+      "task",
+      "principle",
+      "section",
+      "sections",
+      "step"
     ]
   },
   "MD036": false,
   "MD040": false,
   "MD041": false,
   "MD042": false,
+  "MD046": false,
   "MD051": false,
   "MD060": false
 }

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -181,7 +181,7 @@ repos:
       - id: markdownlint-cli2
         name: Markdown Lint
         description: Lint markdown files for consistency
-        exclude: ^(notes/(plan|issues|review|blog)/|build/|docs/template\.md|docs/arxiv/|docs/design/figures/|\.claude/plugins/)
+        exclude: ^(notes/(plan|issues|review|blog)/|build/|docs/template\.md|docs/arxiv/|docs/design/figures/)
         args: ['--config', '.markdownlint.json', '--fix']
 
   # YAML linting


### PR DESCRIPTION
## Summary

- Replaces the `.claude/plugins/` directory exclusion workaround (from #1481) with the correct fix
- Adds `system`, `task`, `principle`, `section`, `sections`, `step` to MD033 `allowed_elements` in `.markdownlint.json`
- Disables MD046 (code-block-style) since fenced blocks are the project standard
- Removes `.claude/plugins/` from the pre-commit markdownlint exclusion list
- Fixes MD007/MD031/MD032 formatting in the repo-analyzer plugin command files

## Test plan
- [ ] `pre-commit run markdownlint-cli2 --all-files` passes with 0 errors
- [ ] CI pre-commit check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)