### PR TITLE
feat(ci): add CI Containerfile for rootless Podman

### DIFF
--- a/ci/.containerignore
+++ b/ci/.containerignore
@@ -1,0 +1,44 @@
+# Files excluded from CI container build context
+# Modeled after docker/.dockerignore — CI container only needs source + config files
+
+# Version control
+.git/
+.gitignore
+
+# Build artifacts and caches
+build/
+.pixi/
+__pycache__/
+*.pyc
+*.pyo
+*.egg-info/
+*.egg/
+dist/
+.eggs/
+
+# Experiment results (large, not needed for CI)
+results/
+workspace/
+fullruns/
+
+# Documentation (not needed for running tests)
+docs/
+notes/
+
+# Docker-specific (CI container uses its own Containerfile)
+docker/
+
+# IDE and editor files
+.vscode/
+.idea/
+*.swp
+*.swo
+
+# OS files
+.DS_Store
+Thumbs.db
+
+# Temporary files
+*.tmp
+*.bak
+/tmp/

--- a/ci/Containerfile
+++ b/ci/Containerfile
@@ -1,0 +1,111 @@
+# Containerfile for scylla-ci:latest
+# CI container for running tests, linting, and security scans.
+#
+# This image provides:
+# - Python 3.12 environment (same base as docker/Dockerfile)
+# - pixi v0.63.2 with default + lint environments pre-installed
+# - pre-commit hook environments baked in (largest speedup)
+# - BATS for shell testing
+# - Non-root user 'ci' for rootless Podman compatibility
+#
+# Build (OCI-compliant — works with both podman and docker):
+#   podman build -f ci/Containerfile -t scylla-ci:local .
+#   docker build -f ci/Containerfile -t scylla-ci:local .
+#
+# Run:
+#   podman run --rm -v .:/workspace:Z scylla-ci:local pixi run pytest tests/unit
+#   podman run --rm -v .:/workspace:Z scylla-ci:local pixi run pre-commit run --all-files
+
+# ============================================================================
+# Stage 1: Builder — install pixi and Python environments
+# ============================================================================
+# Pinned to same SHA256 as docker/Dockerfile for consistency
+FROM python:3.12-slim@sha256:f3fa41d74a768c2fce8016b98c191ae8c1bacd8f1152870a3f9f87d350920b7c AS builder
+
+ENV DEBIAN_FRONTEND=noninteractive \
+    PIP_NO_CACHE_DIR=1 \
+    PIP_DISABLE_PIP_VERSION_CHECK=1 \
+    # Pixi install location
+    PIXI_HOME=/opt/pixi \
+    PATH="/opt/pixi/bin:$PATH"
+
+# Install build dependencies + git (required by pre-commit hooks)
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    git \
+    curl \
+    ca-certificates \
+    gcc \
+    g++ \
+    build-essential \
+    bats \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install pixi (pinned version matching CI workflows)
+# Using official installer — no root required after this point
+ARG PIXI_VERSION=v0.63.2
+RUN curl -fsSL https://pixi.sh/install.sh \
+    | PIXI_VERSION="${PIXI_VERSION}" PIXI_HOME=/opt/pixi bash
+
+# Layer 1: Dependency files — cache layer invalidated only when deps change
+# Copy in order of change frequency (least → most frequent)
+WORKDIR /opt/scylla-build
+COPY pixi.lock pixi.toml pyproject.toml .pre-commit-config.yaml ./
+
+# Layer 2: Install pixi environments (default + lint)
+# This bakes all Python packages into the image — no network needed at runtime
+RUN pixi install --manifest-path pixi.toml && \
+    pixi install --manifest-path pixi.toml --environment lint
+
+# Layer 3: Install pre-commit hook environments
+# Baking this in means 'pre-commit run --all-files' starts immediately,
+# without downloading hook repos or creating virtualenvs at CI time.
+# Hooks that use 'language: system' (pixi run ...) just need pixi available.
+RUN pixi run --manifest-path pixi.toml --environment lint \
+    pre-commit install-hooks
+
+# ============================================================================
+# Stage 2: Runtime — minimal image without build tools
+# ============================================================================
+FROM python:3.12-slim@sha256:f3fa41d74a768c2fce8016b98c191ae8c1bacd8f1152870a3f9f87d350920b7c
+
+LABEL org.opencontainers.image.title="scylla-ci"
+LABEL org.opencontainers.image.description="CI container for ProjectScylla — testing, linting, security scans"
+LABEL org.opencontainers.image.vendor="ProjectScylla"
+LABEL org.opencontainers.image.source="https://github.com/HomericIntelligence/ProjectScylla"
+
+ENV DEBIAN_FRONTEND=noninteractive \
+    PYTHONUNBUFFERED=1 \
+    PYTHONDONTWRITEBYTECODE=1 \
+    PIXI_HOME=/opt/pixi \
+    PATH="/opt/pixi/bin:$PATH"
+
+# Runtime-only system packages (no build tools)
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    git \
+    curl \
+    ca-certificates \
+    bats \
+    && rm -rf /var/lib/apt/lists/*
+
+# Copy pixi binary and pre-installed environments from builder
+COPY --from=builder /opt/pixi /opt/pixi
+
+# Copy pre-commit hook cache from builder (baked-in hook envs)
+COPY --from=builder /root/.cache/pre-commit /root/.cache/pre-commit
+
+# Create non-root user for rootless Podman compatibility
+# UID 1000 is the default first user on most Linux systems, matching typical
+# developer UIDs for smooth volume mount permissions without --userns=keep-id
+RUN groupadd -r ci && useradd -r -g ci -u 1000 -m -s /bin/bash ci
+
+# Copy pre-commit cache to ci user's home (pre-commit uses $HOME/.cache)
+RUN cp -r /root/.cache/pre-commit /home/ci/.cache/ 2>/dev/null || true && \
+    chown -R ci:ci /home/ci/.cache
+
+# Working directory is the mounted repo root at runtime
+WORKDIR /workspace
+
+# No ENTRYPOINT — commands are provided externally by CI or run_ci_local.sh
+# Example: podman run --rm -v .:/workspace:Z scylla-ci:local pixi run pytest
+
+USER ci

--- a/ci/README.md
+++ b/ci/README.md
@@ -1,0 +1,95 @@
+# CI Container
+
+The `ci/` directory contains the container image definition for running ProjectScylla's CI
+pipeline — tests, linting, security scans — in an isolated, reproducible environment.
+
+This is **separate** from the experiment container (`docker/Dockerfile`), which runs AI agent
+evaluations and includes Node.js and the Claude Code CLI. The CI container is lightweight:
+Python 3.12, pixi, pre-commit, bats — no experiment-specific tooling.
+
+## Building
+
+OCI-compliant — works with both Podman (rootless, no SU) and Docker:
+
+```bash
+# Podman (recommended — no root required)
+podman build -f ci/Containerfile -t scylla-ci:local .
+
+# Docker
+docker build -f ci/Containerfile -t scylla-ci:local .
+
+# Or use the pixi task
+pixi run ci-build
+```
+
+## Running CI locally
+
+Use `scripts/run_ci_local.sh` to run the full CI suite inside the container:
+
+```bash
+# All checks (pre-commit + tests + security + shell tests)
+./scripts/run_ci_local.sh
+
+# Specific subset
+./scripts/run_ci_local.sh pre-commit    # linting only
+./scripts/run_ci_local.sh test          # pytest unit + integration
+./scripts/run_ci_local.sh security      # pip-audit
+./scripts/run_ci_local.sh shell-test    # BATS shell tests
+```
+
+Or individual pixi tasks:
+
+```bash
+pixi run ci-lint   # pre-commit
+pixi run ci-test   # pytest
+pixi run ci-all    # everything
+```
+
+## Container engine
+
+The script auto-detects the container engine: Podman first, Docker as fallback.
+Override with the `CONTAINER_ENGINE` environment variable:
+
+```bash
+CONTAINER_ENGINE=docker ./scripts/run_ci_local.sh test
+```
+
+## Podman rootless notes
+
+The container runs as UID 1000 (user `ci`). When volume-mounting the repo:
+
+```bash
+# :Z flag handles SELinux relabeling on Podman
+podman run --rm \
+  --userns=keep-id \
+  --volume .:/workspace:Z \
+  scylla-ci:local \
+  pixi run pytest tests/unit
+```
+
+`--userns=keep-id` maps your host UID into the container so mounted files have
+correct ownership. No `sudo` or `--privileged` required.
+
+## What's baked in
+
+The CI image pre-installs:
+
+- **pixi v0.63.2** with `default` and `lint` environments from `pixi.lock`
+- **pre-commit hook environments** (the biggest speedup — no network calls at CI time)
+- **BATS** for shell testing
+
+Source code is **not** baked in — it is volume-mounted at runtime from the host. This means:
+
+- Container image only rebuilds when `pixi.lock`, `pixi.toml`, or `.pre-commit-config.yaml` change
+- Source changes do not require a container rebuild
+
+## Image registry
+
+In CI, the image is built and pushed to GHCR by `.github/workflows/ci-image.yml`:
+
+```
+ghcr.io/HomericIntelligence/scylla-ci:latest
+ghcr.io/HomericIntelligence/scylla-ci:<git-sha>
+```
+
+Workflows pull `scylla-ci:latest` and mount the current checkout as `/workspace`.


### PR DESCRIPTION
## Summary

- Adds `ci/Containerfile` — OCI-compliant multi-stage container image for CI (tests, linting, security scans)
- Separate from `docker/Dockerfile` (experiment execution / Claude Code CLI)
- Pre-installs pixi v0.63.2, both `default` and `lint` environments, and pre-commit hook environments
- Non-root user `ci` (UID 1000) for rootless Podman compatibility — no `sudo` required
- Works with both `podman build` and `docker build`

## Key design decisions

- Same `python:3.12-slim` SHA256 pin as `docker/Dockerfile` for consistency
- Pre-commit hook environments baked into image (biggest speedup — no network calls at CI time)
- Source code volume-mounted at runtime, not baked in (container only rebuilds when deps change)
- No `ENTRYPOINT` — commands provided externally

## Test plan

- [ ] `podman build -f ci/Containerfile -t scylla-ci:local .` succeeds (validated in PR 3 workflow)
- [ ] `docker build -f ci/Containerfile -t scylla-ci:local .` succeeds
- [ ] `podman run --rm -v .:/workspace:Z scylla-ci:local pixi run pytest tests/unit` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)