### PR TITLE
feat(ci): robustness, security hardening, and testing improvements

### DIFF
--- a/.github/workflows/ci-image.yml
+++ b/.github/workflows/ci-image.yml
@@ -23,6 +23,10 @@ on:
     - cron: "0 6 * * 1"
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.sha }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
   packages: write

--- a/.github/workflows/docker-test.yml
+++ b/.github/workflows/docker-test.yml
@@ -15,6 +15,13 @@ on:
       - 'tests/shell/**'
       - '.github/workflows/docker-test.yml'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.sha }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
 jobs:
   docker-validation:
     runs-on: ubuntu-latest
@@ -50,9 +57,19 @@ jobs:
         id: cold_build
         run: |
           START=$SECONDS
-          docker build -f docker/Dockerfile . --progress=plain --no-cache \
+          docker build -f docker/Dockerfile -t scylla-experiment:trivy-scan . \
+            --progress=plain --no-cache \
             2>&1 | tee /tmp/build_cold.log
           echo "duration=$((SECONDS - START))" >> "$GITHUB_OUTPUT"
+
+      - name: Scan experiment image for vulnerabilities (Trivy)
+        uses: aquasecurity/trivy-action@0.30.0
+        with:
+          image-ref: scylla-experiment:trivy-scan
+          format: table
+          exit-code: 1
+          ignore-unfixed: true
+          severity: HIGH,CRITICAL
 
       - name: Apply trivial source-only change
         run: echo '# timing-probe' >> scylla/__init__.py

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -5,9 +5,17 @@ on:
   push:
     branches: [main]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.sha }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
 jobs:
   pre-commit:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v6
         with:

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -12,6 +12,13 @@ on:
     - cron: "0 8 * * 1"
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.sha }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
 jobs:
   pip-audit:
     name: Dependency vulnerability scan

--- a/.github/workflows/shell-test.yml
+++ b/.github/workflows/shell-test.yml
@@ -10,6 +10,13 @@ on:
   push:
     branches: [main]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.sha }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
 jobs:
   bats:
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,6 +5,13 @@ on:
   push:
     branches: [main]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.sha }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest
@@ -113,12 +120,19 @@ jobs:
           TEST_PATH: ${{ matrix.test-group.path }}
         run: |
           # Install package in dev mode for unit tests
+          JUNITXML="junit-${{ matrix.test-group.name }}.xml"
           if [[ "$TEST_PATH" == "tests/unit" ]]; then
             pixi run pip install -e .
-            pixi run pytest "$TEST_PATH" --override-ini="addopts=" -v --strict-markers --cov=scylla --cov-report=term-missing --cov-report=xml --cov-fail-under=75
+            pixi run pytest "$TEST_PATH" --override-ini="addopts=" -v --strict-markers \
+              --cov=scylla --cov-report=term-missing --cov-report=xml --cov-fail-under=75 \
+              --junitxml="$JUNITXML"
           else
             # Integration tests: 5% floor prevents regression without blocking new work
-            pixi run pytest "$TEST_PATH" -v --cov=scylla --cov-report=term-missing --cov-report=xml --cov-fail-under=5
+            # --reruns 2: retry flaky integration tests (network/API calls) up to 2 times
+            pixi run pytest "$TEST_PATH" -v \
+              --cov=scylla --cov-report=term-missing --cov-report=xml --cov-fail-under=5 \
+              --reruns 2 --reruns-delay 5 \
+              --junitxml="$JUNITXML"
           fi
 
       - name: Upload coverage
@@ -135,5 +149,7 @@ jobs:
         uses: actions/upload-artifact@v7
         with:
           name: test-results-${{ matrix.test-group.name }}
-          path: coverage.xml
+          path: |
+            coverage.xml
+            junit-${{ matrix.test-group.name }}.xml
           retention-days: 7

--- a/README.md
+++ b/README.md
@@ -339,7 +339,7 @@ Schema: `scylla/analysis/schemas/run_result.schema.json`
 
 ### 🧪 Testing
 
-ProjectScylla has a comprehensive test suite covering all functionality. To see the current test count:
+ProjectScylla has a comprehensive test suite of 4870 tests covering all functionality. To see the current test count:
 
 ```bash
 pixi run pytest tests/ --collect-only -q | tail -1

--- a/pixi.lock
+++ b/pixi.lock
@@ -50,6 +50,8 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.19.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-9.0.2-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-cov-7.0.0-pyhcf101f3_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-rerunfailures-14.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-timeout-2.4.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/python-3.14.3-he1279bd_1_cp314t.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python-discovery-1.1.3-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/python-librt-0.8.1-py314h3f2afee_0.conda
@@ -158,6 +160,8 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.19.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-9.0.2-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-cov-7.0.0-pyhcf101f3_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-rerunfailures-14.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-timeout-2.4.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/python-3.14.3-h994187b_1_cp314t.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python-discovery-1.1.3-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/python-librt-0.8.1-py314hef6ada0_0.conda
@@ -267,6 +271,8 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.19.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-9.0.2-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-cov-7.0.0-pyhcf101f3_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-rerunfailures-14.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-timeout-2.4.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/python-3.14.3-h6c44a53_1_cp314t.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python-discovery-1.1.3-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/python-librt-0.8.1-py314h8dbd3ad_0.conda
@@ -376,6 +382,8 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.19.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-9.0.2-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-cov-7.0.0-pyhcf101f3_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-rerunfailures-14.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-timeout-2.4.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/python-3.14.3-h4b44e0e_101_cp314.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python-discovery-1.1.3-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/python-librt-0.8.1-py314hc5dbbe4_0.conda
@@ -502,6 +510,8 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.19.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-9.0.2-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-cov-7.0.0-pyhcf101f3_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-rerunfailures-14.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-timeout-2.4.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/python-3.14.3-he1279bd_1_cp314t.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python-discovery-1.1.3-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/python-librt-0.8.1-py314h3f2afee_0.conda
@@ -609,6 +619,8 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.19.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-9.0.2-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-cov-7.0.0-pyhcf101f3_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-rerunfailures-14.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-timeout-2.4.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/python-3.14.3-h994187b_1_cp314t.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python-discovery-1.1.3-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/python-librt-0.8.1-py314hef6ada0_0.conda
@@ -717,6 +729,8 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.19.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-9.0.2-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-cov-7.0.0-pyhcf101f3_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-rerunfailures-14.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-timeout-2.4.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/python-3.14.3-h6c44a53_1_cp314t.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python-discovery-1.1.3-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/python-librt-0.8.1-py314h8dbd3ad_0.conda
@@ -825,6 +839,8 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.19.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-9.0.2-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-cov-7.0.0-pyhcf101f3_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-rerunfailures-14.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-timeout-2.4.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/python-3.14.3-h4b44e0e_101_cp314.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python-discovery-1.1.3-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/python-librt-0.8.1-py314hc5dbbe4_0.conda
@@ -3194,6 +3210,33 @@ packages:
   - pkg:pypi/pytest-cov?source=hash-mapping
   size: 29016
   timestamp: 1757612051022
+- conda: https://conda.anaconda.org/conda-forge/noarch/pytest-rerunfailures-14.0-pyhd8ed1ab_0.conda
+  sha256: 08fb77f313c5739a3526a07c865671f6e36d1458d073c1b23b4f0b66501138bd
+  md5: 0696324a8c882d182485f20368d21583
+  depends:
+  - importlib-metadata >=1
+  - packaging >=17.1
+  - pytest >=7.2
+  - python >=3.8
+  - setuptools
+  license: MPL-2.0
+  license_family: OTHER
+  purls:
+  - pkg:pypi/pytest-rerunfailures?source=hash-mapping
+  size: 17835
+  timestamp: 1710357496750
+- conda: https://conda.anaconda.org/conda-forge/noarch/pytest-timeout-2.4.0-pyhd8ed1ab_0.conda
+  sha256: 25afa7d9387f2aa151b45eb6adf05f9e9e3f58c8de2bc09be7e85c114118eeb9
+  md5: 52a50ca8ea1b3496fbd3261bea8c5722
+  depends:
+  - pytest >=7.0.0
+  - python >=3.9
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/pytest-timeout?source=hash-mapping
+  size: 20137
+  timestamp: 1746533140824
 - conda: https://conda.anaconda.org/conda-forge/linux-64/python-3.14.3-he1279bd_1_cp314t.conda
   build_number: 1
   sha256: 4212a85ccc69264eaf9e68b77ff9b504e78935a53d0923fa409900084418edce
@@ -3808,7 +3851,7 @@ packages:
 - pypi: ./
   name: scylla
   version: 0.1.0
-  sha256: 8e5a010aa2c765440aa03f6f7adda5b90b3594e21a65e054cb3620a0545bc396
+  sha256: 7b2e456d82d8a26476aad10af093aebe2c69c324de801e953ecd56ee1a9abbad
   requires_dist:
   - click>=8.0,<9
   - pydantic>=2.0,<3

--- a/pixi.toml
+++ b/pixi.toml
@@ -24,6 +24,8 @@ pip = "*"
 pre-commit = ">=4.5.1,<5"
 pytest = ">=9.0.2,<10"
 pytest-cov = ">=7.0.0,<8"
+pytest-timeout = ">=2.0,<3"
+pytest-rerunfailures = ">=14.0,<15"
 types-pyyaml = ">=6.0.12.20250915,<7"
 types-jsonschema = ">=4.26.0.20260202,<5"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -103,6 +103,7 @@ testpaths = ["tests"]
 #             `from export_data import …`, `from manage_experiment import …`).
 #             Audited in #1193: no collection errors; all scripts importable.
 pythonpath = [".", "scripts"]
+timeout = 120
 addopts = [
     "-v",
     "--strict-markers",

--- a/scripts/docker_common.sh
+++ b/scripts/docker_common.sh
@@ -132,9 +132,9 @@ prepare_credential_mount() {
         TEMP_CREDS_DIR="${PROJECT_DIR}/.tmp-container-creds"
         mkdir -p "${TEMP_CREDS_DIR}"
 
-        # Copy credentials file with world-readable permissions
+        # Copy credentials file with owner-only permissions
         cp "${creds_file}" "${TEMP_CREDS_DIR}/.credentials.json"
-        chmod 644 "${TEMP_CREDS_DIR}/.credentials.json"
+        chmod 600 "${TEMP_CREDS_DIR}/.credentials.json"
 
         # Mount the temp directory into container
         VOLUMES+=("-v" "${TEMP_CREDS_DIR}:/tmp/host-creds:ro")


### PR DESCRIPTION
## Summary

- Add concurrency controls to all 6 workflows (cancel stale runs on new pushes)
- Add `permissions: contents: read` to 5 workflows that were missing least-privilege settings
- Add `timeout-minutes: 30` to `pre-commit.yml` (was uncapped at 6-hour default)
- Fix credential file permissions: `chmod 644` → `chmod 600` in `scripts/docker_common.sh`
- Add Trivy vulnerability scanning for `docker/Dockerfile` in `docker-test.yml`
- Add `pytest-timeout` (120s per test) and `pytest-rerunfailures` to `pixi.toml`
- Add `--reruns 2 --reruns-delay 5` for integration tests (flaky network/API tolerance)
- Add `--junitxml` output for all test runs (enables PR test annotations)
- Update README.md test count to 4870 (required by `check-doc-config-consistency`)

## Test plan

- [ ] Pre-commit passes locally (`pre-commit run --all-files`)
- [ ] All 6 workflows have `concurrency:` and `permissions:` blocks
- [ ] `pre-commit.yml` has `timeout-minutes: 30`
- [ ] `scripts/docker_common.sh` uses `chmod 600`
- [ ] `docker-test.yml` has Trivy scan step
- [ ] `pixi.toml` has `pytest-timeout` and `pytest-rerunfailures`
- [ ] `pyproject.toml` has `timeout = 120` in pytest config
- [ ] Integration tests use `--reruns 2 --reruns-delay 5`
- [ ] All test runs produce JUnit XML artifacts

🤖 Generated with [Claude Code](https://claude.com/claude-code)