### PR TITLE
fix(ci): add README.md to Containerfile COPY

### DIFF
--- a/ci/Containerfile
+++ b/ci/Containerfile
@@ -49,7 +49,7 @@ RUN curl -fsSL https://pixi.sh/install.sh \
 # Layer 1: Dependency files — cache layer invalidated only when deps change
 # Copy in order of change frequency (least → most frequent)
 WORKDIR /opt/scylla-build
-COPY pixi.lock pixi.toml pyproject.toml .pre-commit-config.yaml ./
+COPY pixi.lock pixi.toml pyproject.toml .pre-commit-config.yaml README.md ./
 
 # Layer 2: Install pixi environments (default + lint)
 # This bakes all Python packages into the image — no network needed at runtime


### PR DESCRIPTION
## Summary

- Fixes `OSError: Readme file does not exist: README.md` in `ci/Containerfile` builder stage
- The `ci-image.yml` workflow fails when building the CI container because `pyproject.toml` references `README.md` as its readme, but it was not copied into the builder stage

## Root Cause

`ci/Containerfile` Layer 1 COPY only included `pixi.lock pixi.toml pyproject.toml .pre-commit-config.yaml`.
When `pixi install` runs `hatchling` to build the package metadata, hatchling tries to read `README.md` and fails.

## Fix

Add `README.md` to the COPY instruction so hatchling can locate it during package metadata validation.

## Test plan

- [ ] `ci-image.yml` build step completes without `OSError: Readme file does not exist`
- [ ] `docker build -f ci/Containerfile .` succeeds locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)