### PR TITLE
fix(ci): update trivy-action to 0.35.0 and pin Trivy v0.69.3

### DIFF
--- a/.github/workflows/docker-test.yml
+++ b/.github/workflows/docker-test.yml
@@ -63,13 +63,14 @@ jobs:
           echo "duration=$((SECONDS - START))" >> "$GITHUB_OUTPUT"
 
       - name: Scan experiment image for vulnerabilities (Trivy)
-        uses: aquasecurity/trivy-action@0.30.0
+        uses: aquasecurity/trivy-action@0.35.0
         with:
           image-ref: scylla-experiment:trivy-scan
           format: table
           exit-code: 1
           ignore-unfixed: true
           severity: HIGH,CRITICAL
+          version: v0.69.3
 
       - name: Apply trivial source-only change
         run: echo '# timing-probe' >> scylla/__init__.py


### PR DESCRIPTION
## Summary
- Update `aquasecurity/trivy-action` from 0.30.0 to 0.35.0
- Pin Trivy binary version to v0.69.3 (current stable)

The old action (0.30.0) defaults to Trivy v0.60.0 whose `install.sh` fails to download in CI, causing `docker-build-timing` to fail on every push (including main).

## Test plan
- [x] CI `docker-build-timing` job should pass with the updated action and pinned version

🤖 Generated with [Claude Code](https://claude.com/claude-code)