### PR TITLE
feat(e2e): reduce disk space by symlinking .pixi and shallow clones

### DIFF
--- a/scylla/e2e/experiment_setup_manager.py
+++ b/scylla/e2e/experiment_setup_manager.py
@@ -166,6 +166,8 @@ class ExperimentSetupManager:
         branch_name = f"baseline_{self.config.experiment_id[:8]}"
         try:
             workspace_manager.create_worktree(worktree_path)
+            # Seed shared .pixi before parallel worktrees start
+            workspace_manager.symlink_pixi(worktree_path)
             logger.info(f"Capturing experiment-level pipeline baseline at {worktree_path}")
             result = _run_build_pipeline(
                 workspace=worktree_path,

--- a/scylla/e2e/stages.py
+++ b/scylla/e2e/stages.py
@@ -299,6 +299,9 @@ def stage_apply_symlinks(ctx: RunContext) -> None:
         thinking_enabled=thinking_enabled,
     )
 
+    # Symlink .pixi to shared directory so worktrees reuse one pixi environment
+    ctx.workspace_manager.symlink_pixi(ctx.workspace)
+
 
 def stage_commit_config(ctx: RunContext) -> None:
     """SYMLINKS_APPLIED -> CONFIG_COMMITTED: Commit test config to workspace.

--- a/scylla/e2e/workspace_manager.py
+++ b/scylla/e2e/workspace_manager.py
@@ -94,15 +94,13 @@ class WorkspaceManager:
                 else:
                     logger.info(f"Cloning base repo to {self.base_repo}")
 
-                    # Determine clone depth based on layout
-                    # Centralized repos need full clone for commit availability
-                    # Per-experiment repos can use shallow clone
-                    use_shallow = self.repos_dir is None
-
-                    clone_cmd = ["git", "clone"]
-                    if use_shallow:
-                        clone_cmd.append("--depth=1")
-                    clone_cmd.extend([self.repo_url, str(self.base_repo)])
+                    clone_cmd = [
+                        "git",
+                        "clone",
+                        "--depth=1",
+                        self.repo_url,
+                        str(self.base_repo),
+                    ]
 
                     # Retry logic for transient network errors
                     max_retries = 3
@@ -220,8 +218,16 @@ class WorkspaceManager:
             logger.debug(f"Commit {self.commit} already available in object store")
             return  # Already available
 
-        # Fetch the specific commit
-        fetch_cmd = ["git", "-C", str(self.base_repo), "fetch", "origin", self.commit]
+        # Fetch the specific commit (shallow: only this commit's tree)
+        fetch_cmd = [
+            "git",
+            "-C",
+            str(self.base_repo),
+            "fetch",
+            "--depth=1",
+            "origin",
+            self.commit,
+        ]
         result = subprocess.run(fetch_cmd, capture_output=True, text=True)
         if result.returncode != 0:
             logger.debug(f"Fetch returned non-zero (may be ok): {result.stderr}")
@@ -359,6 +365,54 @@ class WorkspaceManager:
 
         subprocess.run(prune_cmd, capture_output=True, text=True)
         logger.debug("Pruned stale worktrees")
+
+    def get_shared_pixi_dir(self, subpath: str = "") -> Path:
+        """Return the path to the shared .pixi directory for worktrees.
+
+        All worktrees symlink their .pixi to this shared location so they
+        reuse a single pixi environment instead of duplicating it per worktree.
+
+        Args:
+            subpath: Optional sub-directory within the repo (e.g. "mojo" for
+                     modular repos with a nested pixi.toml).
+
+        Returns:
+            Path to the shared pixi directory.
+
+        """
+        suffix = f"_pixi_{subpath}" if subpath else "_pixi"
+        return self.base_repo.parent / f"{self.base_repo.name}{suffix}"
+
+    def symlink_pixi(self, workspace: Path) -> None:
+        """Symlink .pixi in workspace to a shared directory.
+
+        Detects pixi.toml at workspace root and/or workspace/mojo/ and
+        creates symlinks so all worktrees share a single pixi environment.
+
+        Idempotent: skips if .pixi already exists or is already a symlink.
+
+        Args:
+            workspace: Path to the worktree workspace.
+
+        """
+        # Root-level pixi.toml
+        if (workspace / "pixi.toml").exists():
+            pixi_dir = workspace / ".pixi"
+            if not pixi_dir.exists() and not pixi_dir.is_symlink():
+                shared = self.get_shared_pixi_dir()
+                shared.mkdir(parents=True, exist_ok=True)
+                pixi_dir.symlink_to(shared)
+                logger.debug(f"Symlinked {pixi_dir} -> {shared}")
+
+        # Modular repo: mojo/pixi.toml
+        mojo_dir = workspace / "mojo"
+        if (mojo_dir / "pixi.toml").exists():
+            pixi_dir = mojo_dir / ".pixi"
+            if not pixi_dir.exists() and not pixi_dir.is_symlink():
+                shared = self.get_shared_pixi_dir(subpath="mojo")
+                shared.mkdir(parents=True, exist_ok=True)
+                pixi_dir.symlink_to(shared)
+                logger.debug(f"Symlinked {pixi_dir} -> {shared}")
 
     @property
     def is_setup(self) -> bool:

--- a/tests/unit/e2e/test_workspace_manager.py
+++ b/tests/unit/e2e/test_workspace_manager.py
@@ -368,8 +368,8 @@ class TestCentralizedRepos:
         assert "cat-file" in str(mock_run.call_args_list[0])
         assert "fetch" in str(mock_run.call_args_list[1])
 
-    def test_full_clone_for_centralized(self, tmp_path: Path) -> None:
-        """Test that centralized repos use full clone (no --depth=1)."""
+    def test_shallow_clone_for_centralized(self, tmp_path: Path) -> None:
+        """Test that centralized repos use shallow clone (--depth=1)."""
         repos_dir = tmp_path / "repos"
         manager = WorkspaceManager(
             experiment_dir=tmp_path / "experiment",
@@ -385,10 +385,10 @@ class TestCentralizedRepos:
             with patch("fcntl.flock"):
                 manager.setup_base_repo()
 
-        # Check that clone command does NOT include --depth=1
+        # Check that clone command includes --depth=1
         clone_call = mock_run.call_args_list[0]
         clone_cmd = clone_call[0][0]
-        assert "--depth=1" not in clone_cmd
+        assert "--depth=1" in clone_cmd
         assert "clone" in clone_cmd
 
     def test_shallow_clone_for_legacy(self, tmp_path: Path) -> None:
@@ -539,3 +539,148 @@ class TestWorkspaceManagerGuards:
         with patch("subprocess.run", return_value=worktree_fail):
             with pytest.raises(RuntimeError, match="Failed to create worktree at"):
                 manager.create_worktree(workspace)
+
+
+class TestSymlinkPixi:
+    """Tests for .pixi symlink functionality."""
+
+    def test_symlink_pixi_standalone_repo(self, tmp_path: Path) -> None:
+        """Workspace with pixi.toml at root gets .pixi symlinked."""
+        manager = WorkspaceManager(
+            experiment_dir=tmp_path,
+            repo_url="https://github.com/test/repo.git",
+        )
+
+        workspace = tmp_path / "workspace"
+        workspace.mkdir()
+        (workspace / "pixi.toml").write_text("[project]\nname = 'test'\n")
+
+        manager.symlink_pixi(workspace)
+
+        pixi_link = workspace / ".pixi"
+        assert pixi_link.is_symlink()
+        assert pixi_link.resolve() == manager.get_shared_pixi_dir().resolve()
+
+    def test_symlink_pixi_modular_repo(self, tmp_path: Path) -> None:
+        """Workspace with mojo/pixi.toml gets mojo/.pixi symlinked."""
+        manager = WorkspaceManager(
+            experiment_dir=tmp_path,
+            repo_url="https://github.com/test/repo.git",
+        )
+
+        workspace = tmp_path / "workspace"
+        mojo_dir = workspace / "mojo"
+        mojo_dir.mkdir(parents=True)
+        (mojo_dir / "pixi.toml").write_text("[project]\nname = 'mojo'\n")
+
+        manager.symlink_pixi(workspace)
+
+        pixi_link = mojo_dir / ".pixi"
+        assert pixi_link.is_symlink()
+        assert pixi_link.resolve() == manager.get_shared_pixi_dir(subpath="mojo").resolve()
+
+    def test_symlink_pixi_no_pixi_toml(self, tmp_path: Path) -> None:
+        """No pixi.toml means no symlink created."""
+        manager = WorkspaceManager(
+            experiment_dir=tmp_path,
+            repo_url="https://github.com/test/repo.git",
+        )
+
+        workspace = tmp_path / "workspace"
+        workspace.mkdir()
+
+        manager.symlink_pixi(workspace)
+
+        assert not (workspace / ".pixi").exists()
+        assert not (workspace / ".pixi").is_symlink()
+
+    def test_symlink_pixi_idempotent(self, tmp_path: Path) -> None:
+        """Calling symlink_pixi twice does not raise."""
+        manager = WorkspaceManager(
+            experiment_dir=tmp_path,
+            repo_url="https://github.com/test/repo.git",
+        )
+
+        workspace = tmp_path / "workspace"
+        workspace.mkdir()
+        (workspace / "pixi.toml").write_text("[project]\nname = 'test'\n")
+
+        manager.symlink_pixi(workspace)
+        manager.symlink_pixi(workspace)  # Second call should be no-op
+
+        pixi_link = workspace / ".pixi"
+        assert pixi_link.is_symlink()
+
+    def test_symlink_pixi_existing_dir_skipped(self, tmp_path: Path) -> None:
+        """If .pixi already exists as a real directory, symlink is skipped."""
+        manager = WorkspaceManager(
+            experiment_dir=tmp_path,
+            repo_url="https://github.com/test/repo.git",
+        )
+
+        workspace = tmp_path / "workspace"
+        workspace.mkdir()
+        (workspace / "pixi.toml").write_text("[project]\nname = 'test'\n")
+        (workspace / ".pixi").mkdir()  # Real directory already exists
+
+        manager.symlink_pixi(workspace)
+
+        # Should remain a real directory, not a symlink
+        assert (workspace / ".pixi").is_dir()
+        assert not (workspace / ".pixi").is_symlink()
+
+    def test_get_shared_pixi_dir(self, tmp_path: Path) -> None:
+        """Verify path construction for root and mojo subpaths."""
+        manager = WorkspaceManager(
+            experiment_dir=tmp_path,
+            repo_url="https://github.com/test/repo.git",
+        )
+
+        root_shared = manager.get_shared_pixi_dir()
+        assert root_shared == manager.base_repo.parent / f"{manager.base_repo.name}_pixi"
+
+        mojo_shared = manager.get_shared_pixi_dir(subpath="mojo")
+        assert mojo_shared == manager.base_repo.parent / f"{manager.base_repo.name}_pixi_mojo"
+
+    def test_get_shared_pixi_dir_centralized(self, tmp_path: Path) -> None:
+        """Verify shared pixi dir for centralized repos."""
+        repos_dir = tmp_path / "repos"
+        manager = WorkspaceManager(
+            experiment_dir=tmp_path / "experiment",
+            repo_url="https://github.com/test/repo.git",
+            repos_dir=repos_dir,
+        )
+
+        shared = manager.get_shared_pixi_dir()
+        assert shared.parent == repos_dir
+        assert shared.name == f"{manager.base_repo.name}_pixi"
+
+
+class TestShallowClone:
+    """Tests for shallow clone behavior."""
+
+    def test_ensure_commit_available_depth_one(self, tmp_path: Path) -> None:
+        """Verify --depth=1 in fetch command for _ensure_commit_available."""
+        repos_dir = tmp_path / "repos"
+        manager = WorkspaceManager(
+            experiment_dir=tmp_path / "experiment",
+            repo_url="https://github.com/test/repo.git",
+            commit="abc123",
+            repos_dir=repos_dir,
+        )
+
+        # Mock that commit doesn't exist, then fetch succeeds
+        check_result = MagicMock()
+        check_result.returncode = 1  # Not found
+
+        fetch_result = MagicMock()
+        fetch_result.returncode = 0
+        fetch_result.stderr = ""
+
+        with patch("subprocess.run", side_effect=[check_result, fetch_result]) as mock_run:
+            manager._ensure_commit_available()
+
+        # Verify fetch includes --depth=1
+        fetch_cmd = mock_run.call_args_list[1][0][0]
+        assert "--depth=1" in fetch_cmd
+        assert "fetch" in fetch_cmd


### PR DESCRIPTION
## Summary
- Worktrees now symlink `.pixi` to a shared directory so all runs reuse one pixi environment (~500MB-2GB saved per worktree)
- All git clones (including centralized) now use `--depth=1`, and `_ensure_commit_available()` fetches shallowly
- Baseline capture seeds the shared `.pixi` before parallel worktrees start

## Test plan
- [x] 8 new unit tests for symlink and shallow clone behavior
- [x] All 4934 existing tests pass (0 failures)
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)