### PR TITLE
fix(e2e): make model validation mandatory, remove --skip-judge-validation

### DIFF
--- a/scripts/manage_experiment.py
+++ b/scripts/manage_experiment.py
@@ -128,11 +128,6 @@ def _add_run_args(parser: argparse.ArgumentParser) -> None:
         help="Add additional judge model (use multiple times)",
     )
     parser.add_argument(
-        "--skip-judge-validation",
-        action="store_true",
-        help="Skip model validation for judges",
-    )
-    parser.add_argument(
         "--thinking",
         choices=["None", "Low", "High", "UltraThink"],
         default="None",
@@ -578,6 +573,28 @@ def _run_batch(test_dirs: list[Path], args: argparse.Namespace) -> int:
             return 1
     # --- End early validation ---
 
+    # Validate all models upfront before spawning threads
+    from scylla.e2e.model_validation import validate_model
+
+    _batch_model_id = args.model
+    _batch_judge_model_id = args.judge_model
+    _batch_judge_models_list = [_batch_judge_model_id]
+    if args.add_judge:
+        for _extra_judge in args.add_judge:
+            if _extra_judge and _extra_judge not in _batch_judge_models_list:
+                _batch_judge_models_list.append(_extra_judge)
+
+    _all_models = [_batch_model_id, *_batch_judge_models_list]
+    _invalid_models = [
+        m for m in dict.fromkeys(_all_models) if not validate_model(m, max_retries=1, base_delay=5)
+    ]
+    if _invalid_models:
+        logger.error(
+            f"Invalid model(s): {', '.join(_invalid_models)}. "
+            f"Use full model IDs (e.g., 'claude-sonnet-4-6') or short aliases (e.g., 'sonnet')."
+        )
+        return 1
+
     _save_lock = threading.Lock()
 
     def save_result(result: dict[str, Any]) -> None:
@@ -988,19 +1005,18 @@ def cmd_run(args: argparse.Namespace) -> int:  # CLI dispatch with many command 
                 judge_models.append(extra_judge)
 
     # Validate all models upfront before starting any work
-    if not args.skip_judge_validation:
-        all_models_to_validate = [model_id, *judge_models]
-        invalid_models = [
-            m
-            for m in dict.fromkeys(all_models_to_validate)
-            if not validate_model(m, max_retries=1, base_delay=5)
-        ]
-        if invalid_models:
-            logger.error(
-                f"Invalid model(s): {', '.join(invalid_models)}. "
-                f"Use full model IDs (e.g., 'claude-sonnet-4-6')."
-            )
-            return 1
+    all_models_to_validate = [model_id, *judge_models]
+    invalid_models = [
+        m
+        for m in dict.fromkeys(all_models_to_validate)
+        if not validate_model(m, max_retries=1, base_delay=5)
+    ]
+    if invalid_models:
+        logger.error(
+            f"Invalid model(s): {', '.join(invalid_models)}. "
+            f"Use full model IDs (e.g., 'claude-sonnet-4-6') or short aliases (e.g., 'sonnet')."
+        )
+        return 1
 
     # Resolve tiers
     tier_ids = []

--- a/tests/unit/e2e/test_manage_experiment_cli.py
+++ b/tests/unit/e2e/test_manage_experiment_cli.py
@@ -335,7 +335,6 @@ class TestVerboseQuietLogging:
                 "--config",
                 str(config_dir),
                 "--verbose",
-                "--skip-judge-validation",
             ]
         )
 
@@ -365,7 +364,6 @@ class TestVerboseQuietLogging:
                 "--config",
                 str(config_dir),
                 "--quiet",
-                "--skip-judge-validation",
             ]
         )
 
@@ -430,7 +428,6 @@ class TestBatchModeDetection:
                 "run",
                 "--config",
                 str(tmp_path),
-                "--skip-judge-validation",
             ]
         )
 
@@ -504,7 +501,6 @@ class TestCmdRunUntilValidation:
                 str(tmp_path),
                 "--until",
                 "nonexistent_state_xyz",
-                "--skip-judge-validation",  # avoid API call
             ]
         )
 
@@ -529,7 +525,6 @@ class TestCmdRunUntilValidation:
                 str(tmp_path),
                 "--until-tier",
                 "invalid_tier_state",
-                "--skip-judge-validation",
             ]
         )
 
@@ -553,7 +548,6 @@ class TestCmdRunUntilValidation:
                 str(tmp_path),
                 "--until-experiment",
                 "invalid_experiment_state",
-                "--skip-judge-validation",
             ]
         )
 
@@ -573,7 +567,6 @@ class TestCmdRunUntilValidation:
                 "abc123",
                 "--config",
                 str(tmp_path),
-                "--skip-judge-validation",
             ]
         )
 
@@ -593,7 +586,6 @@ class TestCmdRunUntilValidation:
                 "https://github.com/test/repo",
                 "--config",
                 str(tmp_path),
-                "--skip-judge-validation",
             ]
         )
 
@@ -631,7 +623,6 @@ class TestCmdRunFromValidation:
                 str(tmp_path),
                 "--from",
                 "nonexistent_state_xyz",
-                "--skip-judge-validation",
             ]
         )
 
@@ -659,7 +650,6 @@ class TestCmdRunFromValidation:
                 str(tmp_path / "results"),
                 "--experiment-id",
                 "test-exp",
-                "--skip-judge-validation",
             ]
         )
 
@@ -683,7 +673,6 @@ class TestCmdRunFromValidation:
                 str(tmp_path),
                 "--from-tier",
                 "invalid_tier_xyz",
-                "--skip-judge-validation",
             ]
         )
 
@@ -707,7 +696,6 @@ class TestCmdRunFromValidation:
                 str(tmp_path),
                 "--from-experiment",
                 "invalid_experiment_xyz",
-                "--skip-judge-validation",
             ]
         )
 

--- a/tests/unit/e2e/test_manage_experiment_run.py
+++ b/tests/unit/e2e/test_manage_experiment_run.py
@@ -71,7 +71,6 @@ class TestCmdRunFromWithCheckpoint:
                 "replay_generated",
                 "--filter-tier",
                 "T0",
-                "--skip-judge-validation",
             ]
         )
 
@@ -144,7 +143,6 @@ class TestCmdRunFromWithCheckpoint:
                 str(results_dir),
                 "--from-tier",
                 "subtests_running",
-                "--skip-judge-validation",
             ]
         )
 
@@ -205,7 +203,6 @@ class TestCmdRunFromWithCheckpoint:
                 "subtests_running",
                 "--filter-tier",
                 "T0",
-                "--skip-judge-validation",
             ]
         )
 
@@ -258,7 +255,6 @@ class TestCmdRunFromWithCheckpoint:
                 str(results_dir),
                 "--from-experiment",
                 "tiers_running",
-                "--skip-judge-validation",
             ]
         )
 
@@ -352,7 +348,6 @@ class TestCmdRunFromInBatchMode:
                 "replay_generated",
                 "--results-dir",
                 str(results_dir),
-                "--skip-judge-validation",
             ]
         )
 
@@ -424,7 +419,6 @@ class TestCmdRunFromInBatchMode:
                 "not_a_valid_state",
                 "--results-dir",
                 str(results_dir),
-                "--skip-judge-validation",
             ]
         )
 
@@ -484,7 +478,6 @@ class TestAddJudgeDedup:
                 "sonnet",
                 "--add-judge",
                 "sonnet",
-                "--skip-judge-validation",
             ]
         )
 
@@ -523,7 +516,6 @@ class TestAddJudgeDedup:
                 "sonnet",
                 "--add-judge",
                 "opus",
-                "--skip-judge-validation",
             ]
         )
 
@@ -561,7 +553,6 @@ class TestAddJudgeDedup:
                 "--config",
                 str(config_dir),
                 "--add-judge",
-                "--skip-judge-validation",
             ]
         )
 
@@ -624,7 +615,6 @@ class TestYamlConfigFileMode:
                 "run",
                 "--config",
                 str(yaml_path),
-                "--skip-judge-validation",
             ]
         )
 
@@ -687,7 +677,6 @@ class TestYamlConfigFileMode:
                 "run",
                 "--config",
                 str(override_yaml),
-                "--skip-judge-validation",
             ]
         )
 
@@ -746,7 +735,6 @@ class TestTestConfigLoaderExclusion:
                 "run",
                 "--config",
                 str(tmp_path),
-                "--skip-judge-validation",
             ]
         )
 
@@ -826,7 +814,6 @@ class TestFilterJudgeSlotNoEffect:
                 "1",
                 "--filter-judge-slot",
                 "2",
-                "--skip-judge-validation",
             ]
         )
 
@@ -894,7 +881,6 @@ class TestNonExistentConfigPath:
                 "https://github.com/test/repo",
                 "--commit",
                 "abc123",
-                "--skip-judge-validation",
             ]
         )
 
@@ -950,7 +936,6 @@ class TestFreshFlag:
                 "--config",
                 str(config_dir),
                 "--fresh",
-                "--skip-judge-validation",
             ]
         )
 
@@ -985,7 +970,6 @@ class TestFreshFlag:
                 "run",
                 "--config",
                 str(config_dir),
-                "--skip-judge-validation",
             ]
         )
 
@@ -1053,7 +1037,6 @@ class TestUntilStateFlowsToConfig:
                 str(config_dir),
                 "--until",
                 "agent_complete",
-                "--skip-judge-validation",
             ]
         )
 
@@ -1092,7 +1075,6 @@ class TestUntilStateFlowsToConfig:
                 str(config_dir),
                 "--until-tier",
                 "subtests_complete",
-                "--skip-judge-validation",
             ]
         )
 
@@ -1131,7 +1113,6 @@ class TestUntilStateFlowsToConfig:
                 str(config_dir),
                 "--until-experiment",
                 "tiers_running",
-                "--skip-judge-validation",
             ]
         )
 
@@ -1204,7 +1185,6 @@ class TestBatchFromMissingCheckpoint:
                 str(results_dir),
                 "--threads",
                 "1",
-                "--skip-judge-validation",
             ]
         )
 
@@ -1281,7 +1261,6 @@ class TestBatchTestsFilter:
                 str(results_dir),
                 "--threads",
                 "1",
-                "--skip-judge-validation",
             ]
         )
 
@@ -1365,7 +1344,6 @@ class TestRetryInfraFailuresInBatch:
                 str(results_dir),
                 "--threads",
                 "1",
-                "--skip-judge-validation",
             ]
         )
 
@@ -1425,7 +1403,6 @@ class TestRetryInfraFailuresInBatch:
                 str(results_dir),
                 "--threads",
                 "1",
-                "--skip-judge-validation",
             ]
         )
 
@@ -1519,7 +1496,6 @@ class TestRetryInfraFailuresInBatch:
                 str(results_dir),
                 "--threads",
                 "1",
-                "--skip-judge-validation",
             ]
         )
 
@@ -1601,7 +1577,6 @@ class TestRetryInfraFailuresInBatch:
                 str(results_dir),
                 "--threads",
                 "1",
-                "--skip-judge-validation",
             ]
         )
 
@@ -2390,7 +2365,6 @@ class TestAddJudgeBatchMode:
                 str(results_dir),
                 "--threads",
                 "1",
-                "--skip-judge-validation",
             ]
         )
 
@@ -2565,7 +2539,6 @@ class TestModelAliasResolution:
                 str(config_dir),
                 "--model",
                 "opus",
-                "--skip-judge-validation",
             ]
         )
 
@@ -2601,7 +2574,6 @@ class TestModelAliasResolution:
                 str(config_dir),
                 "--judge-model",
                 "haiku",
-                "--skip-judge-validation",
             ]
         )
 
@@ -2666,7 +2638,6 @@ class TestUnknownTierReturnsError:
                 str(config_dir),
                 "--tiers",
                 "TX",
-                "--skip-judge-validation",
             ]
         )
 
@@ -2689,7 +2660,7 @@ class TestUnknownTierReturnsError:
 
 
 class TestJudgeValidationBehavior:
-    """Tests for --skip-judge-validation flag behavior."""
+    """Tests for mandatory model validation behavior."""
 
     def _make_test_dir(self, path: Path) -> None:
         """Create a minimal test directory with test.yaml and prompt.md."""
@@ -2706,33 +2677,8 @@ class TestJudgeValidationBehavior:
         (path / "test.yaml").write_text(yaml.dump(test_yaml))
         (path / "prompt.md").write_text("test prompt")
 
-    def test_skip_judge_validation_skips_validate_model(self, tmp_path: Path) -> None:
-        """With --skip-judge-validation, validate_model is never called."""
-        config_dir = tmp_path / "test-dir"
-        self._make_test_dir(config_dir)
-
-        parser = build_parser()
-        args = parser.parse_args(
-            [
-                "run",
-                "--config",
-                str(config_dir),
-                "--skip-judge-validation",
-            ]
-        )
-
-        from manage_experiment import cmd_run
-
-        with (
-            patch("scylla.e2e.model_validation.validate_model", return_value=True) as mock_validate,
-            patch("scylla.e2e.runner.run_experiment", return_value={"T0": {}}),
-        ):
-            cmd_run(args)
-
-        mock_validate.assert_not_called()
-
-    def test_without_skip_validation_calls_validate_model(self, tmp_path: Path) -> None:
-        """Without --skip-judge-validation, validate_model is called for each judge model."""
+    def test_validation_always_calls_validate_model(self, tmp_path: Path) -> None:
+        """Model validation is always called for all models."""
         config_dir = tmp_path / "test-dir"
         self._make_test_dir(config_dir)
 
@@ -2754,6 +2700,29 @@ class TestJudgeValidationBehavior:
             cmd_run(args)
 
         mock_validate.assert_called()
+
+    def test_invalid_model_aborts_with_error(self, tmp_path: Path) -> None:
+        """Invalid models cause cmd_run to abort with exit code 1."""
+        config_dir = tmp_path / "test-dir"
+        self._make_test_dir(config_dir)
+
+        parser = build_parser()
+        args = parser.parse_args(
+            [
+                "run",
+                "--config",
+                str(config_dir),
+                "--judge-model",
+                "invalid-model",
+            ]
+        )
+
+        from manage_experiment import cmd_run
+
+        with patch("scylla.e2e.model_validation.validate_model", return_value=False):
+            result = cmd_run(args)
+
+        assert result == 1
 
 
 # ---------------------------------------------------------------------------
@@ -2793,7 +2762,6 @@ class TestTimeoutOverride:
                 str(config_dir),
                 "--timeout",
                 "7200",
-                "--skip-judge-validation",
             ]
         )
 
@@ -2853,7 +2821,6 @@ class TestThinkingModeFlowsToConfig:
                 str(config_dir),
                 "--thinking",
                 "High",
-                "--skip-judge-validation",
             ]
         )
 
@@ -2912,7 +2879,6 @@ class TestTimeoutFallbackToTestYaml:
                 "run",
                 "--config",
                 str(config_dir),
-                "--skip-judge-validation",
             ]
         )
         assert args.timeout is None  # verify default is None
@@ -2986,7 +2952,6 @@ class TestBatchEarlyValidation:
                 "TX",
                 "--results-dir",
                 str(results_dir),
-                "--skip-judge-validation",
             ]
         )
 
@@ -3017,7 +2982,6 @@ class TestBatchEarlyValidation:
                 "bogus_state_xyz",
                 "--results-dir",
                 str(results_dir),
-                "--skip-judge-validation",
             ]
         )
 
@@ -3057,7 +3021,6 @@ class TestConfigPathExistence:
                 "https://github.com/test/repo",
                 "--commit",
                 "abc123",
-                "--skip-judge-validation",
             ]
         )
 
@@ -3118,7 +3081,6 @@ class TestSingleModeExceptionHandling:
                 "run",
                 "--config",
                 str(config_dir),
-                "--skip-judge-validation",
             ]
         )
 
@@ -3205,7 +3167,6 @@ class TestBatchMissingTaskRepo:
                 str(results_dir),
                 "--threads",
                 "1",
-                "--skip-judge-validation",
             ]
         )
 
@@ -3288,7 +3249,6 @@ class TestFilterSubtestAndRunWiring:
                 "replay_generated",
                 "--filter-subtest",
                 "00",
-                "--skip-judge-validation",
             ]
         )
 
@@ -3333,7 +3293,6 @@ class TestFilterSubtestAndRunWiring:
                 "replay_generated",
                 "--filter-run",
                 "1",
-                "--skip-judge-validation",
             ]
         )
 
@@ -3403,7 +3362,6 @@ class TestPromptOverride:
                 str(config_dir),
                 "--prompt",
                 str(custom_prompt),
-                "--skip-judge-validation",
             ]
         )
 
@@ -3494,7 +3452,6 @@ class TestAlwaysRetryInSingleMode:
                 str(config_dir),
                 "--results-dir",
                 str(results_dir),
-                "--skip-judge-validation",
             ]
         )
 
@@ -3528,7 +3485,6 @@ class TestAlwaysRetryInSingleMode:
                 str(config_dir),
                 "--results-dir",
                 str(results_dir),
-                "--skip-judge-validation",
             ]
         )
 
@@ -3583,7 +3539,6 @@ class TestAlwaysRetryInSingleMode:
                 str(config_dir),
                 "--results-dir",
                 str(results_dir),
-                "--skip-judge-validation",
             ]
         )
 
@@ -3638,7 +3593,6 @@ class TestAlwaysRetryInSingleMode:
                 str(config_dir),
                 "--results-dir",
                 str(results_dir),
-                "--skip-judge-validation",
             ]
         )
 
@@ -3871,7 +3825,6 @@ class TestCmdRunTiersAndMaxSubtests:
                 "--tiers",
                 "T0",
                 "T2",
-                "--skip-judge-validation",
             ]
         )
 
@@ -3908,7 +3861,6 @@ class TestCmdRunTiersAndMaxSubtests:
                 str(config_dir),
                 "--max-subtests",
                 "3",
-                "--skip-judge-validation",
             ]
         )
 
@@ -3943,7 +3895,6 @@ class TestCmdRunTiersAndMaxSubtests:
                 "run",
                 "--config",
                 str(config_dir),
-                "--skip-judge-validation",
             ]
         )
 


### PR DESCRIPTION
## Summary
- Make model validation mandatory in both batch and single-run code paths so invalid model names (e.g., `opus-4.6`, `sonnet-4.6`) are caught immediately at startup instead of failing hundreds of runs later at judge execution time
- Remove the `--skip-judge-validation` CLI flag — validation now always runs
- Add model validation to the batch early-validation block (was completely missing)

## Test plan
- [x] All 110 tests in `test_manage_experiment_run.py` and `test_manage_experiment_cli.py` pass
- [x] New test `test_invalid_model_aborts_with_error` verifies invalid models cause exit code 1
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)