### PR TITLE
fix(automation): probe for base branch instead of hardcoding origin/main

### DIFF
--- a/scylla/automation/worktree_manager.py
+++ b/scylla/automation/worktree_manager.py
@@ -47,9 +47,22 @@ class WorktreeManager:
                 base_branch = result.stdout.strip()
                 logger.debug(f"Auto-detected base branch: {base_branch}")
             except Exception:
-                # Fallback to origin/main if auto-detection fails
-                base_branch = "origin/main"
-                logger.warning("Could not auto-detect base branch, using origin/main")
+                # Fallback: probe which branch actually exists
+                for candidate in ("origin/main", "origin/master"):
+                    try:
+                        run(
+                            ["git", "rev-parse", "--verify", candidate],
+                            cwd=self.repo_root,
+                            capture_output=True,
+                        )
+                        base_branch = candidate
+                        logger.warning(f"Could not auto-detect base branch, found {candidate}")
+                        break
+                    except Exception:
+                        continue
+                if base_branch is None:
+                    base_branch = "origin/main"
+                    logger.warning("Could not auto-detect base branch, defaulting to origin/main")
 
         self.base_branch = base_branch
         self.worktrees: dict[int, Path] = {}


### PR DESCRIPTION
## Summary

- WorktreeManager fallback now probes for `origin/main` then `origin/master` instead of blindly hardcoding `origin/main`
- Prevents worktree creation failures when `refs/remotes/origin/HEAD` symref is not set

## Context

`work_all_repos.sh` failed across all repos because:
1. `git symbolic-ref refs/remotes/origin/HEAD` was not set on several repos
2. Fallback hardcoded `origin/main`, but some stale local clones only had `origin/master`
3. Every `git worktree add` call failed with exit 128

## Test plan

- [x] Pre-commit hooks pass (ruff, mypy, bandit, etc.)
- [ ] Run `~/repo_worker.sh --dry-run` in a repo without `origin/HEAD` set
- [ ] Verify fallback correctly detects `origin/main` via `git rev-parse --verify`

🤖 Generated with [Claude Code](https://claude.com/claude-code)