### PR TITLE
fix(config): add model ID normalization for legacy and short aliases

### DIFF
--- a/scripts/manage_experiment.py
+++ b/scripts/manage_experiment.py
@@ -59,6 +59,7 @@ from pathlib import Path
 from typing import Any
 
 # Configure logging with thread-local context (tier/subtest/run)
+from scylla.config.constants import DEFAULT_AGENT_MODEL, DEFAULT_JUDGE_MODEL
 from scylla.e2e.log_context import ContextFilter
 
 logging.basicConfig(
@@ -117,13 +118,15 @@ def _add_run_args(parser: argparse.ArgumentParser) -> None:
         action="store_true",
         help="Run agents/judges in Docker containers",
     )
-    parser.add_argument("--model", type=str, default="sonnet", help="Primary model")
-    parser.add_argument("--judge-model", type=str, default="sonnet", help="Model for judging")
+    parser.add_argument("--model", type=str, default=DEFAULT_AGENT_MODEL, help="Primary model")
+    parser.add_argument(
+        "--judge-model", type=str, default=DEFAULT_JUDGE_MODEL, help="Model for judging"
+    )
     parser.add_argument(
         "--add-judge",
         action="append",
         nargs="?",
-        const="sonnet",
+        const=DEFAULT_JUDGE_MODEL,
         metavar="MODEL",
         help="Add additional judge model (use multiple times)",
     )
@@ -574,15 +577,17 @@ def _run_batch(test_dirs: list[Path], args: argparse.Namespace) -> int:
     # --- End early validation ---
 
     # Validate all models upfront before spawning threads
+    from scylla.config.constants import normalize_model_id
     from scylla.e2e.model_validation import validate_model
 
-    _batch_model_id = args.model
-    _batch_judge_model_id = args.judge_model
+    _batch_model_id = normalize_model_id(args.model)
+    _batch_judge_model_id = normalize_model_id(args.judge_model)
     _batch_judge_models_list = [_batch_judge_model_id]
     if args.add_judge:
         for _extra_judge in args.add_judge:
-            if _extra_judge and _extra_judge not in _batch_judge_models_list:
-                _batch_judge_models_list.append(_extra_judge)
+            _resolved = normalize_model_id(_extra_judge) if _extra_judge else _extra_judge
+            if _resolved and _resolved not in _batch_judge_models_list:
+                _batch_judge_models_list.append(_resolved)
 
     _all_models = [_batch_model_id, *_batch_judge_models_list]
     _invalid_models = [
@@ -658,13 +663,14 @@ def _run_batch(test_dirs: list[Path], args: argparse.Namespace) -> int:
                     "error": "Missing task_repo or task_commit",
                 }
 
-            model_id = args.model
-            judge_model_id = args.judge_model
+            model_id = normalize_model_id(args.model)
+            judge_model_id = normalize_model_id(args.judge_model)
             judge_models = [judge_model_id]
             if args.add_judge:
                 for extra_judge in args.add_judge:
-                    if extra_judge and extra_judge not in judge_models:
-                        judge_models.append(extra_judge)
+                    _resolved = normalize_model_id(extra_judge) if extra_judge else extra_judge
+                    if _resolved and _resolved not in judge_models:
+                        judge_models.append(_resolved)
 
             tier_ids = _batch_tier_ids
             until_run_state = _batch_until_run
@@ -993,16 +999,17 @@ def cmd_run(args: argparse.Namespace) -> int:  # CLI dispatch with many command 
         logger.error("--commit is required (or set in test.yaml)")
         return 1
 
-    # Resolve model IDs (pass through as-is — no alias resolution)
+    from scylla.config.constants import normalize_model_id
     from scylla.e2e.model_validation import validate_model
 
-    model_id = args.model
-    judge_model_id = args.judge_model
+    model_id = normalize_model_id(args.model)
+    judge_model_id = normalize_model_id(args.judge_model)
     judge_models = [judge_model_id]
     if args.add_judge:
         for extra_judge in args.add_judge:
-            if extra_judge and extra_judge not in judge_models:
-                judge_models.append(extra_judge)
+            _resolved = normalize_model_id(extra_judge) if extra_judge else extra_judge
+            if _resolved and _resolved not in judge_models:
+                judge_models.append(_resolved)
 
     # Validate all models upfront before starting any work
     all_models_to_validate = [model_id, *judge_models]

--- a/scylla/config/__init__.py
+++ b/scylla/config/__init__.py
@@ -13,7 +13,7 @@ Example:
 
 """
 
-from .constants import DEFAULT_AGENT_MODEL, DEFAULT_JUDGE_MODEL
+from .constants import DEFAULT_AGENT_MODEL, DEFAULT_JUDGE_MODEL, normalize_model_id
 from .loader import ConfigLoader
 from .models import (
     AdaptersConfig,
@@ -71,6 +71,7 @@ __all__ = [
     "ValidationConfig",
     "calculate_cost",
     "get_model_pricing",
+    "normalize_model_id",
     # Validation
     "validate_defaults_filename",
 ]

--- a/scylla/config/constants.py
+++ b/scylla/config/constants.py
@@ -2,7 +2,41 @@
 
 This module is the single source of truth for default model IDs.
 Import from here rather than hardcoding model strings at call sites.
+
+No ``scylla.*`` imports allowed — this module must be safe to import
+from any layer without triggering circular dependencies.
 """
 
 DEFAULT_AGENT_MODEL: str = "claude-sonnet-4-6"
 DEFAULT_JUDGE_MODEL: str = "claude-opus-4-6"
+
+# Mapping of short aliases and legacy dot-notation IDs to canonical full IDs.
+MODEL_ID_ALIASES: dict[str, str] = {
+    # Short aliases
+    "opus": "claude-opus-4-6",
+    "sonnet": "claude-sonnet-4-6",
+    "haiku": "claude-haiku-4-5",
+    # Legacy dot-notation (pre-8717d9ba)
+    "opus-4.6": "claude-opus-4-6",
+    "sonnet-4.6": "claude-sonnet-4-6",
+    "haiku-4.5": "claude-haiku-4-5",
+    "opus-4.5": "claude-opus-4-5",
+    "sonnet-4.5": "claude-sonnet-4-5",
+}
+
+
+def normalize_model_id(model_id: str) -> str:
+    """Normalize a model ID to the canonical full form.
+
+    Handles short aliases (e.g., ``'sonnet'``), old dot-notation
+    (e.g., ``'opus-4.6'``), and passes through full IDs unchanged.
+
+    Args:
+        model_id: Raw model identifier from CLI or saved config.
+
+    Returns:
+        Canonical model ID (e.g., ``'claude-sonnet-4-6'``).
+
+    """
+    normalized = model_id.strip().lower()
+    return MODEL_ID_ALIASES.get(normalized, model_id)

--- a/scylla/e2e/models.py
+++ b/scylla/e2e/models.py
@@ -15,7 +15,11 @@ from typing import Any
 import yaml
 from pydantic import BaseModel, ConfigDict, Field, field_validator
 
-from scylla.config.constants import DEFAULT_AGENT_MODEL, DEFAULT_JUDGE_MODEL
+from scylla.config.constants import (
+    DEFAULT_AGENT_MODEL,
+    DEFAULT_JUDGE_MODEL,
+    normalize_model_id,
+)
 from scylla.core.results import RunResultBase
 
 # Grade ordering for min/max calculations (F=worst, S=best)
@@ -880,6 +884,16 @@ class ExperimentConfig(BaseModel):
     keep_failed_workspaces: bool = False  # Preserve workspaces for failed runs
     max_concurrent_workspaces: int | None = None  # Limit live workspaces (None = auto)
     max_concurrent_agents: int | None = None  # Limit concurrent claude CLI processes (None = auto)
+
+    @field_validator("models", mode="before")
+    @classmethod
+    def _normalize_models(cls, v: list[str]) -> list[str]:
+        return [normalize_model_id(m) for m in v]
+
+    @field_validator("judge_models", mode="before")
+    @classmethod
+    def _normalize_judge_models(cls, v: list[str]) -> list[str]:
+        return [normalize_model_id(m) for m in v]
 
     def to_dict(self) -> dict[str, Any]:
         """Convert to dictionary for JSON serialization."""

--- a/tests/unit/config/test_constants.py
+++ b/tests/unit/config/test_constants.py
@@ -1,7 +1,9 @@
 """Tests for scylla.config.constants module."""
 
+import pytest
+
 import scylla.config.constants as constants_module
-from scylla.config import DEFAULT_AGENT_MODEL, DEFAULT_JUDGE_MODEL
+from scylla.config import DEFAULT_AGENT_MODEL, DEFAULT_JUDGE_MODEL, normalize_model_id
 from scylla.config.constants import DEFAULT_AGENT_MODEL as AGENT_MODEL_DIRECT
 from scylla.config.constants import DEFAULT_JUDGE_MODEL as JUDGE_MODEL_DIRECT
 
@@ -71,3 +73,54 @@ class TestNoCircularImports:
             assert not stripped.startswith("import scylla"), (
                 f"constants.py must not import scylla.*: {line!r}"
             )
+
+
+class TestNormalizeModelId:
+    """Tests for normalize_model_id() alias resolution."""
+
+    @pytest.mark.parametrize(
+        ("raw", "expected"),
+        [
+            ("sonnet", "claude-sonnet-4-6"),
+            ("opus", "claude-opus-4-6"),
+            ("haiku", "claude-haiku-4-5"),
+        ],
+    )
+    def test_short_alias(self, raw: str, expected: str) -> None:
+        """Short aliases resolve to canonical full IDs."""
+        assert normalize_model_id(raw) == expected
+
+    @pytest.mark.parametrize(
+        ("raw", "expected"),
+        [
+            ("opus-4.6", "claude-opus-4-6"),
+            ("sonnet-4.6", "claude-sonnet-4-6"),
+            ("haiku-4.5", "claude-haiku-4-5"),
+            ("opus-4.5", "claude-opus-4-5"),
+            ("sonnet-4.5", "claude-sonnet-4-5"),
+        ],
+    )
+    def test_legacy_dot_notation(self, raw: str, expected: str) -> None:
+        """Legacy dot-notation IDs resolve to canonical full IDs."""
+        assert normalize_model_id(raw) == expected
+
+    @pytest.mark.parametrize(
+        "full_id",
+        ["claude-sonnet-4-6", "claude-opus-4-6", "claude-haiku-4-5"],
+    )
+    def test_full_id_passthrough(self, full_id: str) -> None:
+        """Full canonical IDs pass through unchanged."""
+        assert normalize_model_id(full_id) == full_id
+
+    def test_unknown_id_passthrough(self) -> None:
+        """Unknown model IDs pass through unchanged."""
+        assert normalize_model_id("some-future-model") == "some-future-model"
+
+    def test_case_insensitive(self) -> None:
+        """Alias lookup is case-insensitive."""
+        assert normalize_model_id("Sonnet") == "claude-sonnet-4-6"
+        assert normalize_model_id("OPUS") == "claude-opus-4-6"
+
+    def test_whitespace_stripped(self) -> None:
+        """Leading/trailing whitespace is stripped before lookup."""
+        assert normalize_model_id("  sonnet  ") == "claude-sonnet-4-6"

--- a/tests/unit/e2e/test_manage_experiment_cli.py
+++ b/tests/unit/e2e/test_manage_experiment_cli.py
@@ -76,8 +76,8 @@ class TestBuildParser:
             ]
         )
         assert args.runs == 10
-        assert args.model == "sonnet"
-        assert args.judge_model == "sonnet"
+        assert args.model == "claude-sonnet-4-6"
+        assert args.judge_model == "claude-opus-4-6"
         assert args.thinking == "None"
         assert args.until is None
         assert args.until_tier is None

--- a/tests/unit/e2e/test_manage_experiment_run.py
+++ b/tests/unit/e2e/test_manage_experiment_run.py
@@ -498,8 +498,8 @@ class TestAddJudgeDedup:
             cmd_run(args)
 
         assert len(captured_configs) == 1
-        # judge_models should contain exactly one entry (deduped); no alias resolution
-        assert captured_configs[0].judge_models == ["sonnet"]
+        # judge_models should contain exactly one entry (deduped); aliases normalized
+        assert captured_configs[0].judge_models == ["claude-sonnet-4-6"]
 
     def test_add_judge_different_model_appended(self, tmp_path: Path) -> None:
         """--add-judge with a different model is appended to judge_models."""
@@ -536,17 +536,17 @@ class TestAddJudgeDedup:
             cmd_run(args)
 
         assert len(captured_configs) == 1
-        # No alias resolution — model names passed through as-is
-        assert captured_configs[0].judge_models == ["sonnet", "opus"]
+        # Short aliases normalized to full IDs
+        assert captured_configs[0].judge_models == ["claude-sonnet-4-6", "claude-opus-4-6"]
 
-    def test_add_judge_bare_flag_defaults_to_sonnet(self, tmp_path: Path) -> None:
-        """--add-judge with no value uses const='sonnet'; deduped against default judge-model."""
+    def test_add_judge_bare_flag_defaults_to_judge_model(self, tmp_path: Path) -> None:
+        """--add-judge with no value uses const=DEFAULT_JUDGE_MODEL; deduped against default."""
         config_dir = tmp_path / "test-dir"
         self._make_test_dir(config_dir)
 
         parser = build_parser()
-        # --add-judge with no value: argparse uses const="sonnet"
-        # --judge-model defaults to "sonnet", so the result deduplicates to one sonnet entry
+        # --add-judge with no value: argparse uses const=DEFAULT_JUDGE_MODEL
+        # --judge-model also defaults to DEFAULT_JUDGE_MODEL, so it deduplicates
         args = parser.parse_args(
             [
                 "run",
@@ -573,8 +573,8 @@ class TestAddJudgeDedup:
             cmd_run(args)
 
         assert len(captured_configs) == 1
-        # No alias resolution — model names passed through as-is
-        assert captured_configs[0].judge_models == ["sonnet"]
+        # Default judge model deduped to single entry
+        assert captured_configs[0].judge_models == ["claude-opus-4-6"]
 
 
 # ---------------------------------------------------------------------------
@@ -2386,9 +2386,9 @@ class TestAddJudgeBatchMode:
 
         assert result == 0
         assert len(captured_configs) == 2
-        # No alias resolution — model names passed through as-is
+        # Short aliases normalized to full IDs
         for config in captured_configs:
-            assert config.judge_models == ["sonnet", "opus"]
+            assert config.judge_models == ["claude-sonnet-4-6", "claude-opus-4-6"]
 
 
 # ---------------------------------------------------------------------------
@@ -2558,11 +2558,11 @@ class TestModelAliasResolution:
         ):
             cmd_run(args)
 
-        # No alias resolution — model name passed through as-is
-        assert captured[0].models == ["opus"]
+        # Short alias "opus" normalized to full ID
+        assert captured[0].models == ["claude-opus-4-6"]
 
-    def test_judge_model_haiku_passed_through(self, tmp_path: Path) -> None:
-        """--judge-model haiku is passed through as-is in ExperimentConfig.judge_models."""
+    def test_judge_model_haiku_normalized(self, tmp_path: Path) -> None:
+        """--judge-model haiku is normalized to full ID in ExperimentConfig.judge_models."""
         config_dir = tmp_path / "test-dir"
         self._make_test_dir(config_dir)
 
@@ -2593,8 +2593,8 @@ class TestModelAliasResolution:
         ):
             cmd_run(args)
 
-        # No alias resolution — model name passed through as-is
-        assert "haiku" in captured[0].judge_models
+        # Short alias "haiku" normalized to full ID
+        assert "claude-haiku-4-5" in captured[0].judge_models
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/e2e/test_models.py
+++ b/tests/unit/e2e/test_models.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import tempfile
 from pathlib import Path
+from typing import ClassVar
 
 import pytest
 
@@ -463,3 +464,67 @@ class TestExperimentConfigDefaults:
             language="python",
         )
         assert config.judge_models == [DEFAULT_JUDGE_MODEL]
+
+
+class TestExperimentConfigModelNormalization:
+    """Tests for model ID normalization in ExperimentConfig."""
+
+    _BASE_KWARGS: ClassVar[dict[str, object]] = {
+        "experiment_id": "test-norm",
+        "task_repo": "https://github.com/test/repo",
+        "task_commit": "abc123",
+        "task_prompt_file": Path("prompt.md"),
+        "language": "python",
+    }
+
+    def test_models_normalized_from_short_alias(self) -> None:
+        """Short aliases in models are expanded to full IDs."""
+        config = ExperimentConfig(**self._BASE_KWARGS, models=["sonnet"])  # type: ignore[arg-type]
+        assert config.models == ["claude-sonnet-4-6"]
+
+    def test_judge_models_normalized_from_dot_notation(self) -> None:
+        """Legacy dot-notation judge_models are expanded to full IDs."""
+        config = ExperimentConfig(
+            **self._BASE_KWARGS,  # type: ignore[arg-type]
+            judge_models=["opus-4.6", "sonnet-4.6", "haiku-4.5"],
+        )
+        assert config.judge_models == [
+            "claude-opus-4-6",
+            "claude-sonnet-4-6",
+            "claude-haiku-4-5",
+        ]
+
+    def test_full_ids_unchanged(self) -> None:
+        """Already-canonical IDs pass through unchanged."""
+        config = ExperimentConfig(
+            **self._BASE_KWARGS,  # type: ignore[arg-type]
+            models=["claude-sonnet-4-6"],
+            judge_models=["claude-opus-4-6"],
+        )
+        assert config.models == ["claude-sonnet-4-6"]
+        assert config.judge_models == ["claude-opus-4-6"]
+
+    def test_load_normalizes_legacy_ids(self, tmp_path: Path) -> None:
+        """ExperimentConfig.load() normalizes legacy model IDs from saved JSON."""
+        import json
+
+        config_data = {
+            "experiment_id": "test-norm",
+            "task_repo": "https://github.com/test/repo",
+            "task_commit": "abc123",
+            "task_prompt_file": "prompt.md",
+            "language": "python",
+            "models": ["haiku-4.5"],
+            "judge_models": ["opus-4.6", "sonnet-4.6", "haiku-4.5"],
+        }
+        config_path = tmp_path / "experiment.json"
+        config_path.write_text(json.dumps(config_data))
+
+        loaded = ExperimentConfig.load(config_path)
+
+        assert loaded.models == ["claude-haiku-4-5"]
+        assert loaded.judge_models == [
+            "claude-opus-4-6",
+            "claude-sonnet-4-6",
+            "claude-haiku-4-5",
+        ]


### PR DESCRIPTION
## Summary
- Add `normalize_model_id()` in `scylla/config/constants.py` that maps short aliases (`sonnet`, `opus`, `haiku`) and legacy dot-notation (`opus-4.6`, `sonnet-4.6`, `haiku-4.5`) to canonical full IDs (`claude-opus-4-6`, etc.)
- Add Pydantic `field_validator` on `ExperimentConfig.models` and `judge_models` so normalization happens automatically for both fresh and resumed experiments
- Update CLI defaults from bare `"sonnet"` to centralized `DEFAULT_AGENT_MODEL`/`DEFAULT_JUDGE_MODEL` constants

## Test plan
- [x] 11 new parametrized tests for `normalize_model_id()` (short aliases, dot notation, passthrough, case insensitivity)
- [x] 4 new tests for `ExperimentConfig` model normalization (construction + `load()` from saved JSON)
- [x] Updated 7 existing test assertions for normalized model IDs
- [x] Full unit suite: 4800 passed, 81.71% coverage
- [x] Pre-commit hooks all pass
- [x] Data fix applied to 1660 JSON files under `~/fullruns/haiku-2/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)