### PR TITLE
fix(e2e): pipe judge prompt via stdin instead of positional arg

### DIFF
--- a/scylla/e2e/llm_judge.py
+++ b/scylla/e2e/llm_judge.py
@@ -582,6 +582,10 @@ def _call_claude_judge(
     # Judge evaluates from provided context only (workspace state, git diff,
     # pipeline results are all included in the prompt). No tool access needed,
     # which reduces memory overhead and avoids dependency on workspace existence.
+    #
+    # NOTE: --allowedTools takes variadic <tools...>, so any positional arg
+    # placed after it gets consumed as a tool name instead of the prompt.
+    # We pipe the evaluation context via stdin to avoid this and ARG_MAX limits.
     cmd = [
         "claude",
         "--model",
@@ -596,22 +600,13 @@ def _call_claude_judge(
         str(JUDGE_SYSTEM_PROMPT_FILE),
     ]
 
-    # Pass evaluation context as the prompt. For very large prompts (T5/T6),
-    # pipe via stdin to avoid OS ARG_MAX limits (~2MB on Linux).
-    max_arg_length = 1_000_000
-    stdin_input: str | None = None
-    if len(evaluation_context) < max_arg_length:
-        cmd.append(evaluation_context)
-    else:
-        stdin_input = evaluation_context
-
     result = subprocess.run(
         cmd,
         capture_output=True,
         text=True,
         timeout=1200,  # 20 minutes - judging can take time with Opus
         env={k: v for k, v in os.environ.items() if k != "CLAUDECODE"},
-        input=stdin_input,
+        input=evaluation_context,
     )
 
     if result.returncode != 0:


### PR DESCRIPTION
## Summary

- **Root cause confirmed**: `--allowedTools` takes variadic `<tools...>`, consuming the positional prompt argument. The evaluation context was eaten as a tool name, not delivered as the prompt.
- **Fix**: Always pipe evaluation context via `stdin` (`input=` parameter), avoiding both the variadic flag issue and OS `ARG_MAX` limits.
- **User-confirmed**: All 3 CLI test commands showed positional args fail after `--allowedTools ""` (exit 1: "Input must be provided either through stdin or as a prompt argument")

Builds on PR #1543 which identified the temp-file-path issue but missed that the positional arg replacement was also consumed by the variadic `--allowedTools` flag.

## Test plan

- [x] 142 unit tests pass (test_llm_judge + test_stage_finalization)
- [x] All pre-commit hooks pass
- [ ] User confirms judge returns non-empty response on resumed fullrun

🤖 Generated with [Claude Code](https://claude.com/claude-code)