### PR TITLE
[Feat] Add justfile for ecosystem task convention alignment

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -352,6 +352,20 @@ pre-commit run --all-files
 
 ## Common Commands
 
+### Quick Start (justfile)
+
+The justfile provides a convenient interface to all development tasks:
+
+```bash
+just              # List all available recipes
+just test         # Run pytest
+just lint         # Run ruff check
+just format       # Run ruff format
+just typecheck    # Run mypy
+just pre-commit   # Run all pre-commit hooks
+just ci-all       # Run full CI suite in container
+```
+
 ### Development Workflows
 
 **Pull Requests**: See [pr-workflow.md](/.claude/shared/pr-workflow.md)

--- a/justfile
+++ b/justfile
@@ -1,0 +1,50 @@
+# ProjectScylla task runner — delegates to pixi run
+# Ecosystem convention: justfile + pixi (invokable from Odysseus via just scylla-*)
+
+# List all available recipes
+default:
+    @just --list
+
+# Run pytest
+test:
+    pixi run test
+
+# Run BATS shell tests
+test-shell:
+    pixi run test-shell
+
+# Run ruff check
+lint:
+    pixi run lint
+
+# Run ruff format
+format:
+    pixi run format
+
+# Run mypy type checker
+typecheck:
+    pixi run mypy scylla scripts tests
+
+# Build CI container image
+ci-build:
+    pixi run ci-build
+
+# Run CI lint in container
+ci-lint:
+    pixi run ci-lint
+
+# Run CI tests in container
+ci-test:
+    pixi run ci-test
+
+# Run all CI in container
+ci-all:
+    pixi run ci-all
+
+# Run pip-audit security scan
+audit:
+    pixi run audit
+
+# Run all pre-commit hooks
+pre-commit:
+    pixi run pre-commit run --all-files

--- a/pixi.lock
+++ b/pixi.lock
@@ -24,6 +24,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/identify-1.2.2-py_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-8.7.0-pyhe01879c_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/iniconfig-2.3.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/just-1.48.0-hdab8a38_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ld_impl_linux-64-2.45.1-default_hbd61a6d_101.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libexpat-2.7.4-hecca717_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libffi-3.5.2-h3435931_0.conda
@@ -139,6 +140,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/identify-1.2.2-py_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-8.7.0-pyhe01879c_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/iniconfig-2.3.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/just-1.48.0-h009cd8f_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libexpat-2.7.4-h991f03e_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libffi-3.5.2-hd1f9c09_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/liblzma-5.8.2-h11316ed_0.conda
@@ -250,6 +252,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/identify-1.2.2-py_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-8.7.0-pyhe01879c_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/iniconfig-2.3.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/just-1.48.0-h748bcf4_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libexpat-2.7.4-hf6b4638_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libffi-3.5.2-hcf2aa1b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/liblzma-5.8.2-h8088a28_0.conda
@@ -361,6 +364,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/identify-2.6.17-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-8.7.0-pyhe01879c_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/iniconfig-2.3.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/just-1.48.0-h77a83cd_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libexpat-2.7.4-hac47afa_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libffi-3.5.2-h3d046cb_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/liblzma-5.8.2-hfd05255_0.conda
@@ -1676,6 +1680,51 @@ packages:
   requires_dist:
   - referencing>=0.31.0
   requires_python: '>=3.9'
+- conda: https://conda.anaconda.org/conda-forge/linux-64/just-1.48.0-hdab8a38_0.conda
+  sha256: c7cbf342d272d432547686631249a4a6fe12d74e853f2bccc39d0e54a19b1968
+  md5: 62497a2a8759e8ebb59874a6b47331c0
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  constrains:
+  - __glibc >=2.17
+  license: CC0-1.0
+  purls: []
+  size: 1496775
+  timestamp: 1774329506987
+- conda: https://conda.anaconda.org/conda-forge/osx-64/just-1.48.0-h009cd8f_0.conda
+  sha256: b6c341a207769f13745133ec9cbdde6608dc668b229d8568f4ca3c9076a7c361
+  md5: 848b1c694bb77110203f8c62cdc9d885
+  depends:
+  - __osx >=11.0
+  constrains:
+  - __osx >=10.13
+  license: CC0-1.0
+  purls: []
+  size: 1415107
+  timestamp: 1774330629078
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/just-1.48.0-h748bcf4_0.conda
+  sha256: 4682751015e8ed45faec67891f7e52a677b0800798552152b5cd25fd6710c4ad
+  md5: 365dd27b40595534b0775ca72c212ee9
+  depends:
+  - __osx >=11.0
+  constrains:
+  - __osx >=11.0
+  license: CC0-1.0
+  purls: []
+  size: 1298743
+  timestamp: 1774331112763
+- conda: https://conda.anaconda.org/conda-forge/win-64/just-1.48.0-h77a83cd_0.conda
+  sha256: 6fb91ac8505ecbaddc2dac45307fbab0ffc0c65af149a9324bd43308107d22b8
+  md5: 33ae64b1b4c283928a4ca7bcdce4c386
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  license: CC0-1.0
+  purls: []
+  size: 1450297
+  timestamp: 1774330560480
 - pypi: https://files.pythonhosted.org/packages/46/8a/b4ebe46ebaac6a303417fab10c2e165c557ddaff558f9699d302b256bc53/kiwisolver-1.5.0-cp314-cp314t-macosx_10_15_x86_64.whl
   name: kiwisolver
   version: 1.5.0

--- a/pixi.toml
+++ b/pixi.toml
@@ -44,6 +44,7 @@ jsonschema = ">=4.0,<5"
 defusedxml = ">=0.7,<1"
 
 [feature.dev.dependencies]
+just = ">=1.25.0,<2"
 pre-commit = ">=3.0,<5"
 ruff = ">=0.1.0,<1"
 mypy = ">=1.8.0,<2"

--- a/tests/shell/justfile/test_justfile.bats
+++ b/tests/shell/justfile/test_justfile.bats
@@ -1,0 +1,100 @@
+#!/usr/bin/env bats
+# Tests for the project justfile — verifies recipes exist and stay in sync
+
+REPO_ROOT="$(git -C "$(dirname "$BATS_TEST_FILENAME")" rev-parse --show-toplevel)"
+JUSTFILE="${REPO_ROOT}/justfile"
+
+# ---------------------------------------------------------------------------
+# Existence
+# ---------------------------------------------------------------------------
+
+@test "justfile exists at project root" {
+    [ -f "$JUSTFILE" ]
+}
+
+# ---------------------------------------------------------------------------
+# just --list succeeds
+# ---------------------------------------------------------------------------
+
+@test "just --list succeeds" {
+    run just --justfile "$JUSTFILE" --list
+    [ "$status" -eq 0 ]
+}
+
+# ---------------------------------------------------------------------------
+# Expected recipes are present
+# ---------------------------------------------------------------------------
+
+@test "justfile contains 'test' recipe" {
+    run just --justfile "$JUSTFILE" --list
+    [[ "$output" == *"test "* ]] || [[ "$output" == *"test"$'\n'* ]]
+}
+
+@test "justfile contains 'lint' recipe" {
+    run just --justfile "$JUSTFILE" --list
+    [[ "$output" == *"lint "* ]] || [[ "$output" == *"lint"$'\n'* ]]
+}
+
+@test "justfile contains 'format' recipe" {
+    run just --justfile "$JUSTFILE" --list
+    [[ "$output" == *"format "* ]] || [[ "$output" == *"format"$'\n'* ]]
+}
+
+@test "justfile contains 'typecheck' recipe" {
+    run just --justfile "$JUSTFILE" --list
+    [[ "$output" == *"typecheck"* ]]
+}
+
+@test "justfile contains 'pre-commit' recipe" {
+    run just --justfile "$JUSTFILE" --list
+    [[ "$output" == *"pre-commit"* ]]
+}
+
+@test "justfile contains 'audit' recipe" {
+    run just --justfile "$JUSTFILE" --list
+    [[ "$output" == *"audit"* ]]
+}
+
+@test "justfile contains 'ci-all' recipe" {
+    run just --justfile "$JUSTFILE" --list
+    [[ "$output" == *"ci-all"* ]]
+}
+
+# ---------------------------------------------------------------------------
+# No heredocs (regression guard — known pitfall with just)
+# ---------------------------------------------------------------------------
+
+@test "justfile contains no heredocs" {
+    run grep -cE '<<\s*[A-Z_"'"'"']' "$JUSTFILE"
+    # grep -c returns 1 (failure) when count is 0 — that is the success case
+    [ "$status" -eq 1 ] || [ "$output" = "0" ]
+}
+
+# ---------------------------------------------------------------------------
+# Every pixi [tasks] key has a matching justfile recipe
+# ---------------------------------------------------------------------------
+
+@test "all pixi tasks have a corresponding just recipe" {
+    # Extract task names from [tasks] section of pixi.toml
+    local pixi_toml="${REPO_ROOT}/pixi.toml"
+    [ -f "$pixi_toml" ] || skip "pixi.toml not found"
+
+    # Get just recipe names
+    local just_recipes
+    just_recipes="$(just --justfile "$JUSTFILE" --list 2>/dev/null | tail -n +2 | awk '{print $1}')"
+
+    # Parse [tasks] keys (lines matching key = "..." under [tasks], skip comments)
+    local missing=""
+    while IFS= read -r task; do
+        # typecheck is not a pixi task but a just-only recipe — skip plan-issues
+        # since it's a script utility, not a developer workflow
+        case "$task" in
+            plan-issues) continue ;;
+        esac
+        if ! echo "$just_recipes" | grep -qx "$task"; then
+            missing="${missing} ${task}"
+        fi
+    done < <(sed -n '/^\[tasks\]/,/^\[/{ /^\[/d; /^#/d; /^$/d; s/ *=.*//p; }' "$pixi_toml")
+
+    [ -z "$missing" ] || fail "pixi tasks missing from justfile:${missing}"
+}


### PR DESCRIPTION
## Summary
- Add `justfile` wrapping all pixi tasks (`test`, `lint`, `format`, `typecheck`, `ci-*`, `audit`, `pre-commit`)
- Add `just` as a dev dependency in `pixi.toml` (conda-forge, `>=1.25.0,<2`)
- Add BATS tests verifying recipe coverage, no heredocs, and pixi task sync
- Document justfile in CLAUDE.md Common Commands section

Closes #1506

## Test plan
- [x] `just --list` shows all 12 recipes with descriptions
- [x] All 11 new BATS tests pass (`pixi run test-shell`)
- [x] All 80 BATS tests pass (including existing tests)
- [x] All pre-commit hooks pass
- [x] `pixi.lock` regenerated and committed

🤖 Generated with [Claude Code](https://claude.ai/claude-code)