### PR TITLE
[Docs] Update ecosystem description to include all 12 repos

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,11 +12,22 @@ Scylla represents the challenge of navigating trade-offs between capability gain
 studies across 120 YAML subtests with published results and 9%+ test coverage enforced in CI (combined
 scylla/ + scripts/ floor; scylla/ unit coverage is enforced at 75%+ separately in the unit CI step).
 
-**Ecosystem Context**: Part of a three-project ecosystem:
+**Ecosystem Context**: Part of a 12-repository ecosystem:
 
-- **ProjectOdyssey** - Training and capability development for agents
-- **ProjectKeystone** - Communication and distributed agent coordination
-- **ProjectScylla** - Testing, measurement, and optimization under constraints (this project)
+| Repository | Role |
+|------------|------|
+| **AchaeanFleet** | Container images for the agent mesh — base images, Dockerfiles, Compose |
+| **Myrmidons** | GitOps agent provisioning — agent definitions as code |
+| **Odysseus** | CLI and core platform for agent lifecycle management |
+| **ProjectArgus** | Observability — monitoring and metrics |
+| **ProjectHephaestus** | Shared Python utilities and foundational tools |
+| **ProjectHermes** | Webhook-to-NATS bridge — event ingestion |
+| **ProjectKeystone** | DAG execution engine |
+| **ProjectMnemosyne** | Skills marketplace — team knowledge sharing |
+| **ProjectOdyssey** | Training and capability development for agents |
+| **ProjectProteus** | CI/CD pipeline infrastructure |
+| **ProjectScylla** | Testing, measurement, and optimization under constraints (this project) |
+| **ProjectTelemachy** | Workflow engine |
 
 ## Critical Rules - Read First
 

--- a/README.md
+++ b/README.md
@@ -102,11 +102,22 @@ pixi run python scripts/generate_all_results.py \
 
 ## Ecosystem
 
-- **ProjectOdyssey** → Training and capability development
-- **ProjectKeystone** → Communication and distributed agent coordination
-- **ProjectScylla** → Testing, measurement, and optimization under trial
+Part of a 12-repository ecosystem:
 
-Together: cohesive ecosystem for building, connecting, and refining agent workflows.
+| Repository | Role |
+|------------|------|
+| **AchaeanFleet** | Container images for the agent mesh |
+| **Myrmidons** | GitOps agent provisioning |
+| **Odysseus** | CLI and core platform for agent lifecycle management |
+| **ProjectArgus** | Observability — monitoring and metrics |
+| **ProjectHephaestus** | Shared Python utilities and foundational tools |
+| **ProjectHermes** | Webhook-to-NATS bridge — event ingestion |
+| **ProjectKeystone** | DAG execution engine |
+| **ProjectMnemosyne** | Skills marketplace — team knowledge sharing |
+| **ProjectOdyssey** | Training and capability development for agents |
+| **ProjectProteus** | CI/CD pipeline infrastructure |
+| **ProjectScylla** | Testing, measurement, and optimization under constraints (this project) |
+| **ProjectTelemachy** | Workflow engine |
 
 ---
 

--- a/docs/design/architecture.md
+++ b/docs/design/architecture.md
@@ -16,13 +16,22 @@ ProjectScylla is an AI agent testing and optimization framework designed to meas
 
 ### Ecosystem Context
 
-ProjectScylla is part of a three-project ecosystem:
+ProjectScylla is part of a 12-repository ecosystem:
 
-| Project | Purpose |
-|---------|---------|
+| Repository | Role |
+|------------|------|
+| **AchaeanFleet** | Container images for the agent mesh |
+| **Myrmidons** | GitOps agent provisioning |
+| **Odysseus** | CLI and core platform for agent lifecycle management |
+| **ProjectArgus** | Observability — monitoring and metrics |
+| **ProjectHephaestus** | Shared Python utilities and foundational tools |
+| **ProjectHermes** | Webhook-to-NATS bridge — event ingestion |
+| **ProjectKeystone** | DAG execution engine |
+| **ProjectMnemosyne** | Skills marketplace — team knowledge sharing |
 | **ProjectOdyssey** | Training and capability development for agents |
-| **ProjectKeystone** | Communication and distributed agent coordination |
-| **ProjectScylla** | Testing, measurement, and optimization under constraints |
+| **ProjectProteus** | CI/CD pipeline infrastructure |
+| **ProjectScylla** | Testing, measurement, and optimization under constraints (this project) |
+| **ProjectTelemachy** | Workflow engine |
 
 ### Framework Characteristics
 


### PR DESCRIPTION
## Summary
- Replace stale 3-repo ecosystem listing with accurate 12-repo table across CLAUDE.md, README.md, and docs/design/architecture.md
- Fix incorrect ProjectKeystone description ("Communication and distributed agent coordination" → "DAG execution engine")
- Add 9 missing repos: AchaeanFleet, Myrmidons, Odysseus, ProjectArgus, ProjectHephaestus, ProjectHermes, ProjectMnemosyne, ProjectProteus, ProjectTelemachy

## Test plan
- [x] All repo names verified against `gh api orgs/HomericIntelligence/repos`
- [x] Pre-commit hooks pass (Markdown Lint, trailing whitespace, end-of-file, etc.)
- [x] Consistent table format across all three files
- [x] No Python code changes — documentation only

Closes #1507

🤖 Generated with [Claude Code](https://claude.ai/claude-code)