### PR TITLE
[Fix] Use sample variance (N-1) instead of population variance in statistics.py

### DIFF
--- a/scylla/metrics/statistics.py
+++ b/scylla/metrics/statistics.py
@@ -127,13 +127,17 @@ def calculate_range(values: list[float]) -> tuple[float, float]:
 
 
 def calculate_variance(values: list[float]) -> float:
-    """Calculate the population variance.
+    """Calculate the sample variance using Bessel's correction.
+
+    Uses N-1 denominator (Bessel's correction) to provide an unbiased
+    estimate of the population variance from a sample. This is the
+    standard choice for small-N ablation runs (typically 9-10 per tier).
 
     Args:
         values: List of numeric values.
 
     Returns:
-        Variance, or 0.0 if empty or single value.
+        Sample variance, or 0.0 if fewer than 2 values.
 
     """
     if len(values) < 2:
@@ -141,17 +145,19 @@ def calculate_variance(values: list[float]) -> float:
 
     mean = calculate_mean(values)
     squared_diffs = [(v - mean) ** 2 for v in values]
-    return sum(squared_diffs) / len(values)
+    return sum(squared_diffs) / (len(values) - 1)
 
 
 def calculate_std_dev(values: list[float]) -> float:
-    """Calculate the population standard deviation.
+    """Calculate the sample standard deviation.
+
+    Uses Bessel's correction (N-1) via calculate_variance().
 
     Args:
         values: List of numeric values.
 
     Returns:
-        Standard deviation, or 0.0 if empty or single value.
+        Sample standard deviation, or 0.0 if fewer than 2 values.
 
     """
     variance = calculate_variance(values)

--- a/tests/unit/metrics/test_statistics.py
+++ b/tests/unit/metrics/test_statistics.py
@@ -135,11 +135,30 @@ class TestCalculateVariance:
         assert calculate_variance(values) == 0.0
 
     def test_known_variance(self) -> None:
-        """Test Known variance."""
+        """Test Known sample variance with Bessel's correction."""
         # Values: 2, 4, 6, mean = 4
-        # Variance = ((2-4)^2 + (4-4)^2 + (6-4)^2) / 3 = (4+0+4)/3 = 8/3
+        # Sample variance = ((2-4)^2 + (4-4)^2 + (6-4)^2) / (3-1) = (4+0+4)/2 = 4.0
         values = [2.0, 4.0, 6.0]
-        assert calculate_variance(values) == pytest.approx(8.0 / 3)
+        assert calculate_variance(values) == pytest.approx(4.0)
+
+    def test_two_values(self) -> None:
+        """Test Bessel's correction with minimum sample size."""
+        # Values: 0, 2, mean = 1
+        # Sample variance = ((0-1)^2 + (2-1)^2) / (2-1) = 2/1 = 2.0
+        values = [0.0, 2.0]
+        assert calculate_variance(values) == pytest.approx(2.0)
+
+    @pytest.mark.parametrize(
+        ("values", "expected"),
+        [
+            ([1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0], 7.5),
+            ([1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0], 9.166666666666666),
+        ],
+        ids=["nine-runs", "ten-runs"],
+    )
+    def test_typical_ablation_sizes(self, values: list[float], expected: float) -> None:
+        """Test with typical 9-10 run ablation sizes."""
+        assert calculate_variance(values) == pytest.approx(expected)
 
 
 class TestCalculateStdDev:
@@ -159,10 +178,10 @@ class TestCalculateStdDev:
         assert calculate_std_dev(values) == 0.0
 
     def test_known_std_dev(self) -> None:
-        """Test Known std dev."""
-        # Variance = 8/3, std_dev = sqrt(8/3)
+        """Test Known sample std dev with Bessel's correction."""
+        # Sample variance = 4.0, std_dev = sqrt(4.0) = 2.0
         values = [2.0, 4.0, 6.0]
-        expected = math.sqrt(8.0 / 3)
+        expected = math.sqrt(4.0)
         assert calculate_std_dev(values) == pytest.approx(expected)
 
 


### PR DESCRIPTION
## Summary
- Switched `calculate_variance()` from population variance (÷N) to sample variance (÷N-1, Bessel's correction)
- `calculate_std_dev()` inherits the fix automatically
- Updated tests to assert correct sample variance values and added parametrized tests for typical 9-10 run ablation sizes

## Why
For ablation studies with 9-10 runs per tier, dividing by N instead of N-1 underestimates variability by ~11-12.5%, inflating consistency scores and potentially producing false positives in tier comparisons.

## Test plan
- [x] Updated `test_known_variance` and `test_known_std_dev` to assert sample (N-1) values
- [x] Added `test_two_values` for minimum sample size edge case
- [x] Added parametrized `test_typical_ablation_sizes` for 9 and 10 run scenarios
- [x] All 4785 unit tests pass (0 failures)
- [x] Pre-commit hooks pass (ruff, mypy, bandit, etc.)

Closes #1508

🤖 Generated with [Claude Code](https://claude.com/claude-code)