### PR TITLE
feat(cli): implement JSON output format for scylla report

### DIFF
--- a/scylla/cli/main.py
+++ b/scylla/cli/main.py
@@ -223,7 +223,7 @@ def _calculate_tier_metrics(
     "--format",
     "-f",
     "output_format",
-    type=click.Choice(["markdown", "json", "html"]),
+    type=click.Choice(["markdown", "json"]),
     default="markdown",
     help="Report format (default: markdown).",
 )
@@ -353,9 +353,13 @@ def report(
         generator = MarkdownReportGenerator(report_dir)
         report_path = generator.write_report(report_data)
         click.echo(f"\nReport generated: {report_path}")
-    else:
-        click.echo(f"\n{output_format} format not yet implemented.", err=True)
-        sys.exit(1)
+    elif output_format == "json":
+        from scylla.reporting.json_report import JsonReportGenerator
+
+        report_dir = output.parent if output else base_path / "reports"
+        json_generator = JsonReportGenerator(report_dir)
+        report_path = json_generator.write_report(report_data)
+        click.echo(f"\nReport generated: {report_path}")
 
 
 @cli.command("list")

--- a/scylla/reporting/__init__.py
+++ b/scylla/reporting/__init__.py
@@ -3,6 +3,7 @@
 This module provides result writing and report generation capabilities.
 """
 
+from scylla.reporting.json_report import JsonReportGenerator
 from scylla.reporting.markdown import (
     MarkdownReportGenerator,
     ReportData,
@@ -39,15 +40,12 @@ from scylla.reporting.summary import (
 )
 
 __all__ = [
-    # Scorecard
     "EvalResult",
-    # Summary
     "EvaluationReport",
-    # Result
     "ExecutionInfo",
     "GradingInfo",
+    "JsonReportGenerator",
     "JudgmentInfo",
-    # Markdown
     "MarkdownReportGenerator",
     "MetricsInfo",
     "ModelScorecard",

--- a/scylla/reporting/json_report.py
+++ b/scylla/reporting/json_report.py
@@ -1,0 +1,91 @@
+"""JSON report generator for evaluation results."""
+
+import json
+import math
+from dataclasses import asdict
+from pathlib import Path
+from typing import Any
+
+from scylla.reporting.markdown import ReportData
+
+
+def _sanitize_for_json(obj: Any) -> Any:
+    """Recursively replace float('inf'), float('-inf'), and float('nan') with None.
+
+    JSON does not support these IEEE 754 special values, so they must be
+    converted before serialization.
+
+    Args:
+        obj: Any Python object (typically the output of dataclasses.asdict)
+
+    Returns:
+        Sanitized object safe for json.dumps
+
+    """
+    if isinstance(obj, float):
+        if math.isinf(obj) or math.isnan(obj):
+            return None
+        return obj
+    if isinstance(obj, dict):
+        return {k: _sanitize_for_json(v) for k, v in obj.items()}
+    if isinstance(obj, list):
+        return [_sanitize_for_json(item) for item in obj]
+    return obj
+
+
+class JsonReportGenerator:
+    """Generates JSON evaluation reports."""
+
+    def __init__(self, base_dir: Path) -> None:
+        """Initialize JSON report generator.
+
+        Args:
+            base_dir: Base directory for reports (e.g., 'reports/')
+
+        """
+        self.base_dir = base_dir
+
+    def get_report_dir(self, test_id: str) -> Path:
+        """Get the directory path for a test report.
+
+        Args:
+            test_id: Test identifier
+
+        Returns:
+            Path to report directory
+
+        """
+        return self.base_dir / test_id
+
+    def generate_report(self, data: ReportData) -> str:
+        """Generate a complete JSON report string.
+
+        Args:
+            data: Report data
+
+        Returns:
+            JSON string with indentation
+
+        """
+        raw = asdict(data)
+        sanitized = _sanitize_for_json(raw)
+        return json.dumps(sanitized, indent=2)
+
+    def write_report(self, data: ReportData) -> Path:
+        """Generate and write a JSON report to file.
+
+        Args:
+            data: Report data
+
+        Returns:
+            Path to written report.json
+
+        """
+        report_dir = self.get_report_dir(data.test_id)
+        report_dir.mkdir(parents=True, exist_ok=True)
+
+        report_path = report_dir / "report.json"
+        report_content = self.generate_report(data)
+        report_path.write_text(report_content)
+
+        return report_path

--- a/tests/unit/cli/test_cli.py
+++ b/tests/unit/cli/test_cli.py
@@ -123,6 +123,41 @@ class TestReportCommand:
         assert "Generating json report for: 001-test" in result.output
         assert "No results found" in result.output
 
+    def test_report_json_format_with_results(self, tmp_path: Path) -> None:
+        """Test report --format json generates JSON output when results exist."""
+        # Create a fake result.json
+        runs_dir = tmp_path / "runs" / "001-test" / "T0" / "run-1"
+        runs_dir.mkdir(parents=True)
+        result_data = {
+            "tier_id": "T0",
+            "grading": {"pass_rate": 0.8, "composite_score": 0.75, "cost_of_pass": 1.5},
+            "judgment": {"impl_rate": 0.7, "passed": True},
+            "metrics": {"cost_usd": 0.05},
+        }
+        import json as json_mod
+
+        (runs_dir / "result.json").write_text(json_mod.dumps(result_data))
+
+        runner = CliRunner()
+        with patch("scylla.cli.main._load_results", return_value=[result_data]):
+            result = runner.invoke(
+                cli, ["report", "001-test", "--format", "json"], catch_exceptions=False
+            )
+
+        assert result.exit_code == 0
+        assert "Generating json report for: 001-test" in result.output
+        assert "Report generated:" in result.output
+        assert "report.json" in result.output
+
+    def test_report_html_format_rejected(self) -> None:
+        """Test that html format is rejected by Click validation."""
+        runner = CliRunner()
+        result = runner.invoke(cli, ["report", "001-test", "--format", "html"])
+
+        # Click should reject 'html' since it's no longer in the choices
+        assert result.exit_code != 0
+        assert "Invalid value" in result.output or "invalid choice" in result.output.lower()
+
 
 class TestListCommand:
     """Tests for 'list' command."""

--- a/tests/unit/reporting/test_json_report.py
+++ b/tests/unit/reporting/test_json_report.py
@@ -1,0 +1,230 @@
+"""Tests for JSON report generator."""
+
+import json
+from pathlib import Path
+
+import pytest
+
+from scylla.reporting.json_report import JsonReportGenerator, _sanitize_for_json
+from scylla.reporting.markdown import (
+    SensitivityAnalysis,
+    TierMetrics,
+    TransitionAssessment,
+    create_report_data,
+)
+
+
+def _make_tier_metrics(
+    tier_id: str = "T0",
+    tier_name: str = "T0 (Vanilla)",
+    pass_rate_median: float = 0.8,
+    impl_rate_median: float = 0.75,
+    composite_median: float = 0.775,
+    cost_of_pass_median: float = 1.0,
+    consistency_std_dev: float = 0.1,
+    uplift: float = 0.0,
+) -> TierMetrics:
+    """Create test TierMetrics."""
+    return TierMetrics(
+        tier_id=tier_id,
+        tier_name=tier_name,
+        pass_rate_median=pass_rate_median,
+        impl_rate_median=impl_rate_median,
+        composite_median=composite_median,
+        cost_of_pass_median=cost_of_pass_median,
+        consistency_std_dev=consistency_std_dev,
+        uplift=uplift,
+    )
+
+
+class TestSanitizeForJson:
+    """Tests for the _sanitize_for_json helper."""
+
+    def test_normal_values_unchanged(self) -> None:
+        """Normal float, int, str, bool, None pass through unchanged."""
+        obj = {"a": 1.5, "b": 42, "c": "hello", "d": True, "e": None}
+        assert _sanitize_for_json(obj) == obj
+
+    def test_inf_replaced_with_none(self) -> None:
+        """float('inf') becomes None."""
+        assert _sanitize_for_json(float("inf")) is None
+
+    def test_negative_inf_replaced_with_none(self) -> None:
+        """float('-inf') becomes None."""
+        assert _sanitize_for_json(float("-inf")) is None
+
+    def test_nan_replaced_with_none(self) -> None:
+        """float('nan') becomes None."""
+        assert _sanitize_for_json(float("nan")) is None
+
+    def test_nested_dict(self) -> None:
+        """Sanitizes values inside nested dicts."""
+        obj = {"outer": {"inner": float("inf")}}
+        result = _sanitize_for_json(obj)
+        assert result == {"outer": {"inner": None}}
+
+    def test_list_of_floats(self) -> None:
+        """Sanitizes special floats inside lists."""
+        obj = [1.0, float("nan"), float("-inf"), 3.5]
+        result = _sanitize_for_json(obj)
+        assert result == [1.0, None, None, 3.5]
+
+    def test_mixed_nested_structure(self) -> None:
+        """Sanitizes deeply nested mixed structures."""
+        obj = {"tiers": [{"cost": float("inf")}, {"cost": 2.5}]}
+        result = _sanitize_for_json(obj)
+        assert result == {"tiers": [{"cost": None}, {"cost": 2.5}]}
+
+
+class TestJsonReportGenerator:
+    """Tests for JsonReportGenerator."""
+
+    def test_generate_report_basic(self) -> None:
+        """Basic ReportData serializes to valid JSON."""
+        generator = JsonReportGenerator(Path("/tmp"))
+        data = create_report_data(
+            test_id="001-test",
+            test_name="Test Name",
+            timestamp="2024-01-15T14:30:00Z",
+        )
+
+        output = generator.generate_report(data)
+        parsed = json.loads(output)
+
+        assert parsed["test_id"] == "001-test"
+        assert parsed["test_name"] == "Test Name"
+        assert parsed["timestamp"] == "2024-01-15T14:30:00Z"
+        assert parsed["tiers"] == []
+        assert parsed["recommendations"] == []
+
+    def test_generate_report_with_tiers(self) -> None:
+        """ReportData with tiers serializes correctly."""
+        generator = JsonReportGenerator(Path("/tmp"))
+        data = create_report_data(
+            test_id="001-test",
+            test_name="Test Name",
+            timestamp="2024-01-15T14:30:00Z",
+        )
+        data.tiers = [
+            _make_tier_metrics(tier_id="T0"),
+            _make_tier_metrics(tier_id="T1", tier_name="T1 (Prompted)", uplift=0.15),
+        ]
+
+        output = generator.generate_report(data)
+        parsed = json.loads(output)
+
+        assert len(parsed["tiers"]) == 2
+        assert parsed["tiers"][0]["tier_id"] == "T0"
+        assert parsed["tiers"][1]["tier_id"] == "T1"
+        assert parsed["tiers"][1]["uplift"] == pytest.approx(0.15)
+
+    def test_generate_report_sanitizes_inf(self) -> None:
+        """Infinity cost values are serialized as null."""
+        generator = JsonReportGenerator(Path("/tmp"))
+        data = create_report_data(
+            test_id="001-test",
+            test_name="Test Name",
+            timestamp="2024-01-15T14:30:00Z",
+        )
+        data.tiers = [_make_tier_metrics(cost_of_pass_median=float("inf"))]
+
+        output = generator.generate_report(data)
+        parsed = json.loads(output)
+
+        assert parsed["tiers"][0]["cost_of_pass_median"] is None
+
+    def test_generate_report_with_sensitivity(self) -> None:
+        """SensitivityAnalysis is serialized correctly."""
+        generator = JsonReportGenerator(Path("/tmp"))
+        data = create_report_data(
+            test_id="001-test",
+            test_name="Test Name",
+            timestamp="2024-01-15T14:30:00Z",
+        )
+        data.sensitivity = SensitivityAnalysis(0.05, 0.03, 0.10)
+
+        output = generator.generate_report(data)
+        parsed = json.loads(output)
+
+        assert parsed["sensitivity"]["pass_rate_variance"] == pytest.approx(0.05)
+        assert parsed["sensitivity"]["impl_rate_variance"] == pytest.approx(0.03)
+        assert parsed["sensitivity"]["cost_variance"] == pytest.approx(0.10)
+
+    def test_generate_report_with_transitions(self) -> None:
+        """TransitionAssessments are serialized correctly."""
+        generator = JsonReportGenerator(Path("/tmp"))
+        data = create_report_data(
+            test_id="001-test",
+            test_name="Test Name",
+            timestamp="2024-01-15T14:30:00Z",
+        )
+        data.transitions = [
+            TransitionAssessment("T0", "T1", 0.1, 0.15, 0.5, True),
+        ]
+
+        output = generator.generate_report(data)
+        parsed = json.loads(output)
+
+        assert len(parsed["transitions"]) == 1
+        assert parsed["transitions"][0]["from_tier"] == "T0"
+        assert parsed["transitions"][0]["worth_it"] is True
+
+    def test_write_report(self, tmp_path: Path) -> None:
+        """write_report creates report.json at expected path."""
+        generator = JsonReportGenerator(tmp_path)
+        data = create_report_data(
+            test_id="001-test",
+            test_name="Test Name",
+            timestamp="2024-01-15T14:30:00Z",
+        )
+        data.tiers = [_make_tier_metrics()]
+
+        output_path = generator.write_report(data)
+
+        assert output_path.exists()
+        assert output_path.name == "report.json"
+        assert output_path == tmp_path / "001-test" / "report.json"
+
+        # Verify content is valid JSON
+        content = output_path.read_text()
+        parsed = json.loads(content)
+        assert parsed["test_id"] == "001-test"
+
+    def test_write_report_creates_directories(self, tmp_path: Path) -> None:
+        """write_report creates intermediate directories."""
+        generator = JsonReportGenerator(tmp_path / "nested" / "reports")
+        data = create_report_data(
+            test_id="deep-test",
+            test_name="Deep Test",
+            timestamp="2024-01-15T14:30:00Z",
+        )
+
+        output_path = generator.write_report(data)
+
+        assert output_path.exists()
+        assert output_path.parent.name == "deep-test"
+
+    def test_get_report_dir(self) -> None:
+        """get_report_dir returns base_dir / test_id."""
+        generator = JsonReportGenerator(Path("/reports"))
+        assert generator.get_report_dir("001-test") == Path("/reports/001-test")
+
+    @pytest.mark.parametrize(
+        "special_value",
+        [float("inf"), float("-inf"), float("nan")],
+        ids=["inf", "neg_inf", "nan"],
+    )
+    def test_special_float_values_produce_valid_json(self, special_value: float) -> None:
+        """Special float values don't break JSON serialization."""
+        generator = JsonReportGenerator(Path("/tmp"))
+        data = create_report_data(
+            test_id="001-test",
+            test_name="Test Name",
+            timestamp="2024-01-15T14:30:00Z",
+        )
+        data.tiers = [_make_tier_metrics(cost_of_pass_median=special_value)]
+
+        output = generator.generate_report(data)
+        # Must be valid JSON (json.loads would raise on bare Infinity/NaN)
+        parsed = json.loads(output)
+        assert parsed["tiers"][0]["cost_of_pass_median"] is None


### PR DESCRIPTION
## Summary

- Add `JsonReportGenerator` class in `scylla/reporting/json_report.py` that serializes `ReportData` to indented JSON using `dataclasses.asdict()` with NaN/Inf sanitization
- Wire `--format json` in the `scylla report` CLI command to produce `report.json` output files
- Remove unimplemented `html` format from `click.Choice` to avoid misleading users with a `sys.exit(1)` stub

Closes #1510

## Test plan

- [x] 18 unit tests for `JsonReportGenerator` and `_sanitize_for_json` (100% coverage on new module)
- [x] 2 new CLI tests: JSON format with mock results + HTML rejection by Click validation
- [x] All 46 targeted tests pass (`tests/unit/reporting/test_json_report.py` + `tests/unit/cli/test_cli.py`)
- [x] Pre-commit hooks all pass (ruff, mypy, bandit, etc.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)