### PR TITLE
fix(coverage): raise combined floor from 9% to 75% and add test-unit task

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,8 +9,8 @@ the performance and cost-efficiency of agentic AI workflows. Named after the myt
 Scylla represents the challenge of navigating trade-offs between capability gains and operational costs.
 
 **Current Status**: Operational - active research with full evaluation infrastructure, running T0–T6 ablation
-studies across 120 YAML subtests with published results and 9%+ test coverage enforced in CI (combined
-scylla/ + scripts/ floor; scylla/ unit coverage is enforced at 75%+ separately in the unit CI step).
+studies across 120 YAML subtests with published results and 75%+ test coverage enforced locally and in CI
+(combined scylla/ + scripts/ floor; scylla/ unit coverage is also enforced at 75% in the CI unit step).
 
 **Ecosystem Context**: Part of a 12-repository ecosystem:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -321,11 +321,28 @@ pre-commit run --all-files
 - **Integration tests**: For multi-component features
 - **E2E tests**: For complete workflow changes
 
+### Coverage Thresholds
+
+ProjectScylla uses a dual-threshold coverage strategy:
+
+| Threshold | Scope | Where Enforced | Value |
+|-----------|-------|----------------|-------|
+| Combined floor | `scylla/` + `scripts/` | `pyproject.toml` (`fail_under`) — local runs | 75% |
+| Unit floor | `scylla/` only | CI `test.yml` unit step (`--cov-fail-under=75`) | 75% |
+| Integration floor | `scylla/` only | CI `test.yml` integration step (`--cov-fail-under=5`) | 5% |
+
+- **`pixi run test`** runs all tests with the combined 75% floor from `pyproject.toml`.
+- **`pixi run test-unit`** runs `tests/unit/` with the same 75% `scylla/` floor as CI, giving you local parity with the CI unit step.
+- **CI** uses `--override-ini="addopts="` to bypass `pyproject.toml` and apply its own per-step floors independently.
+
 ### Running Tests
 
 ```bash
-# All tests
-pixi run pytest tests/ --verbose
+# All tests (combined 75% coverage floor)
+pixi run test
+
+# Unit tests with CI-matching 75% scylla/ coverage floor
+pixi run test-unit
 
 # Specific categories
 pixi run pytest tests/unit/ -v          # Unit tests only

--- a/pixi.lock
+++ b/pixi.lock
@@ -4035,7 +4035,7 @@ packages:
 - pypi: ./
   name: scylla
   version: 0.1.0
-  sha256: 843e9c83c7e5643af9baab45a9c364aa463487254ef0c47619e85e34c3661496
+  sha256: 8c380062257028220f66eea9d7598e091e07e66038130a8f0a075f706bb71c65
   requires_dist:
   - click>=8.0,<9
   - httpx>=0.27,<1

--- a/pixi.toml
+++ b/pixi.toml
@@ -7,6 +7,7 @@ platforms = ["linux-64", "osx-arm64", "osx-64", "win-64"]
 
 [tasks]
 test = "pytest"
+test-unit = "pytest tests/unit --override-ini='addopts=' -v --strict-markers --cov=scylla --cov-report=term-missing --cov-fail-under=75"
 test-shell = "bats tests/shell/ --recursive --timing"
 lint = "ruff check scylla scripts tests"
 format = "ruff format scylla scripts tests"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -113,7 +113,6 @@ addopts = [
     "--cov=scripts",
     "--cov-report=term-missing",
     "--cov-report=html",
-    "--cov-fail-under=9",
 ]
 markers = [
     "integration: marks tests as integration tests (deselect with '-m \"not integration\"')",
@@ -156,11 +155,12 @@ omit = [
 
 [tool.coverage.report]
 # DUAL THRESHOLD DESIGN:
-# - This 9% floor: combined scylla/ + scripts/ floor (scripts/ has low coverage by design).
+# - This 75% floor: combined scylla/ + scripts/ floor for local runs.
 # - 75% floor: scylla/ unit tests only, enforced via --cov-fail-under=75 in test.yml unit step.
 # - 5% floor: integration tests, enforced via --cov-fail-under=5 in test.yml integration step.
-# Do not raise this value — the per-module floors in test.yml are the authoritative thresholds.
-fail_under = 9
+# CI uses --override-ini="addopts=" to bypass these addopts and apply its own per-step floors.
+# Locally, this floor gives developers immediate feedback on coverage regressions.
+fail_under = 75
 precision = 2
 show_missing = true
 skip_covered = false

--- a/scripts/check_doc_config_consistency.py
+++ b/scripts/check_doc_config_consistency.py
@@ -4,7 +4,9 @@
 Checks:
 1. Coverage threshold in CLAUDE.md matches ``fail_under`` in ``pyproject.toml``.
 2. ``--cov=<path>`` in README.md matches ``addopts`` in ``pyproject.toml``.
-3. ``--cov-fail-under=N`` in ``addopts`` matches ``fail_under`` in ``[tool.coverage.report]``.
+3. If ``--cov-fail-under=N`` is present in ``addopts``, it must match ``fail_under``
+   in ``[tool.coverage.report]``. Absent is OK — ``[tool.coverage.report].fail_under``
+   is the single source of truth.
 4. Test count in README.md is within 10% of actual pytest collect count.
 
 Usage:
@@ -217,10 +219,11 @@ def extract_cov_fail_under_from_addopts(repo_root: Path) -> int | None:
 
 
 def check_addopts_cov_fail_under(repo_root: Path, expected_threshold: int) -> list[str]:
-    """Check that ``--cov-fail-under`` in ``addopts`` matches ``fail_under`` in coverage report.
+    """Check that ``--cov-fail-under`` in ``addopts`` matches ``fail_under`` if present.
 
-    Reads ``--cov-fail-under=N`` from ``[tool.pytest.ini_options].addopts`` and compares it
-    to *expected_threshold* (from ``[tool.coverage.report].fail_under``).
+    If ``--cov-fail-under=N`` is present in ``[tool.pytest.ini_options].addopts``, it must
+    match *expected_threshold*. If absent, the check passes — ``[tool.coverage.report].fail_under``
+    is the single source of truth and pytest-cov reads it directly.
 
     Args:
         repo_root: Path to the repository root.
@@ -232,10 +235,9 @@ def check_addopts_cov_fail_under(repo_root: Path, expected_threshold: int) -> li
     """
     addopts_threshold = extract_cov_fail_under_from_addopts(repo_root)
 
+    # Absent is fine — [tool.coverage.report].fail_under is the single source of truth.
     if addopts_threshold is None:
-        return [
-            "pyproject.toml: No --cov-fail-under=N flag found in [tool.pytest.ini_options].addopts"
-        ]
+        return []
 
     if addopts_threshold != expected_threshold:
         return [
@@ -365,10 +367,18 @@ def main() -> int:  # CLI orchestration with many check paths
     if addopts_errors:
         all_errors.extend(addopts_errors)
     elif args.verbose:
-        print(
-            f"PASS: [tool.pytest.ini_options].addopts --cov-fail-under matches "
-            f"[tool.coverage.report].fail_under ({expected_threshold}%)"
-        )
+        addopts_val = extract_cov_fail_under_from_addopts(repo_root)
+        if addopts_val is not None:
+            print(
+                f"PASS: [tool.pytest.ini_options].addopts --cov-fail-under matches "
+                f"[tool.coverage.report].fail_under ({expected_threshold}%)"
+            )
+        else:
+            print(
+                f"PASS: No --cov-fail-under in addopts — "
+                f"[tool.coverage.report].fail_under "
+                f"({expected_threshold}%) is single source of truth"
+            )
 
     # --- Check 4: README.md test count ---
     actual_count = collect_actual_test_count(repo_root)

--- a/tests/unit/scripts/test_check_doc_config_consistency.py
+++ b/tests/unit/scripts/test_check_doc_config_consistency.py
@@ -357,15 +357,13 @@ class TestCheckAddoptsCovFailUnder:
         assert "80" in errors[0]
         assert "75" in errors[0]
 
-    def test_missing_flag_returns_error(self, tmp_path: Path) -> None:
-        """Should return an error when --cov-fail-under is absent from addopts."""
+    def test_missing_flag_returns_no_errors(self, tmp_path: Path) -> None:
+        """Should return no errors when --cov-fail-under is absent (single source of truth)."""
         write_pyproject(
             tmp_path,
             '[tool.pytest.ini_options]\naddopts = ["--cov=scylla"]\n',
         )
-        errors = check_addopts_cov_fail_under(tmp_path, 75)
-        assert len(errors) == 1
-        assert "--cov-fail-under" in errors[0]
+        assert check_addopts_cov_fail_under(tmp_path, 75) == []
 
 
 # ---------------------------------------------------------------------------
@@ -645,8 +643,8 @@ class TestMainIntegration:
             finally:
                 sys.argv = original_argv
 
-    def test_addopts_fail_under_absent_exits_one(self, tmp_path: Path) -> None:
-        """Missing --cov-fail-under in addopts should produce exit code 1."""
+    def test_addopts_fail_under_absent_exits_zero(self, tmp_path: Path) -> None:
+        """Missing --cov-fail-under in addopts should pass (single source of truth)."""
         import sys
 
         from scripts.check_doc_config_consistency import main
@@ -660,7 +658,7 @@ class TestMainIntegration:
         ):
             try:
                 result = main()
-                assert result == 1
+                assert result == 0
             finally:
                 sys.argv = original_argv
 


### PR DESCRIPTION
## Summary
- Raise the misleadingly low 9% combined coverage floor to 75% (2% below actual 77.42% baseline), giving developers real local regression protection
- Remove redundant `--cov-fail-under=9` from pytest addopts — `[tool.coverage.report].fail_under` is now the single source of truth
- Add `pixi run test-unit` task that mirrors CI's 75% scylla/ unit coverage enforcement locally
- Document the dual-threshold coverage strategy in CONTRIBUTING.md

## Test plan
- [x] `pixi run test` passes with new 75% combined floor (actual: 77.42%)
- [x] `pixi run test-unit` passes with 75% scylla/ floor (actual: 81.69%)
- [x] All 55 consistency check tests pass with updated expectations
- [x] `pre-commit run --all-files` passes all hooks
- [x] CI workflow unchanged (uses `--override-ini="addopts="` to bypass pyproject.toml)

Closes #1511

🤖 Generated with [Claude Code](https://claude.com/claude-code)