### PR TITLE
feat(dx): add .editorconfig for cross-editor consistency

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,30 @@
+root = true
+
+[*]
+end_of_line = lf
+insert_final_newline = true
+charset = utf-8
+trim_trailing_whitespace = true
+
+[*.py]
+indent_style = space
+indent_size = 4
+
+[*.{yml,yaml}]
+indent_style = space
+indent_size = 2
+
+[*.md]
+trim_trailing_whitespace = false
+
+[*.{json,toml}]
+indent_style = space
+indent_size = 2
+
+[*.sh]
+indent_style = space
+indent_size = 2
+
+[Dockerfile*]
+indent_style = space
+indent_size = 4


### PR DESCRIPTION
## Summary
- Adds a root `.editorconfig` file with consistent settings for all file types in the repository
- Covers Python (4-space), YAML (2-space), JSON/TOML (2-space), shell scripts (2-space), Dockerfiles (4-space), and Markdown (trailing whitespace preserved)
- Ensures cross-editor formatting consistency for non-Python files not covered by ruff

## Test plan
- [x] `pre-commit run --files .editorconfig` passes cleanly
- [x] Settings align with existing ruff/yamllint configurations
- [x] `root = true` present to prevent inheritance from parent directories
- [ ] CI passes

Closes #1526

🤖 Generated with [Claude Code](https://claude.ai/claude-code)