### PR TITLE
[Versioning] Add version consistency checks, release workflow, and docs

### DIFF
--- a/scylla/cli/main.py
+++ b/scylla/cli/main.py
@@ -9,6 +9,7 @@ from typing import Any
 
 import click
 
+from scylla import __version__
 from scylla.config import DEFAULT_JUDGE_MODEL, ConfigLoader
 from scylla.e2e.orchestrator import EvalOrchestrator, OrchestratorConfig
 from scylla.reporting import (
@@ -31,7 +32,7 @@ FORMAT_GENERATORS: dict[str, type[MarkdownReportGenerator] | type[JsonReportGene
 
 
 @click.group()
-@click.version_option(version="0.1.0", prog_name="scylla")
+@click.version_option(version=__version__, prog_name="scylla")
 def cli() -> None:
     """ProjectScylla - AI Agent Testing Framework.
 


### PR DESCRIPTION
## Summary

- Replace hardcoded CLI version (`"0.1.0"`) with dynamic `scylla.__version__` import
- Add `scripts/check_version_consistency.py` — verifies `pyproject.toml`, `pixi.toml`, and `scylla/__init__.py` all declare the same version string
- Add version-consistency CI step to `test.yml` to catch drift in PRs
- Create `release.yml` workflow triggered by `v*` tags that validates tag-vs-package version and creates a GitHub release
- Fix `CHANGELOG.md`: replace phantom `v1.5.0`/`v2.0.0` references with relative timeline language, add proper `[0.1.0]` release section
- Document versioning and release strategy in `CONTRIBUTING.md`
- Update CLI test to assert against `__version__` instead of hardcoded string

## Test plan

- [x] `scripts/check_version_consistency.py` exits 0 with matching versions
- [x] 9 new tests in `tests/unit/scripts/test_check_version_consistency.py` (consistent, inconsistent, missing file, parametrized single-mismatch)
- [x] Updated `test_version` in `test_cli.py` uses dynamic `__version__`
- [x] All 35 CLI + version tests pass
- [x] `pre-commit run --all-files` passes

Closes #1527

🤖 Generated with [Claude Code](https://claude.com/claude-code)