### PR TITLE
fix(e2e): work around CLI v2.1.83 empty result via stream-json

### DIFF
--- a/scylla/e2e/llm_judge.py
+++ b/scylla/e2e/llm_judge.py
@@ -563,6 +563,47 @@ def run_llm_judge(
     )
 
 
+def _extract_response_from_stream(stream_output: str) -> str:
+    """Extract assistant response text from stream-json output.
+
+    Parses newline-delimited JSON events and concatenates text blocks
+    from type:assistant message events. Falls back to the result field
+    if populated (for forward compatibility when CLI bug is fixed).
+
+    Args:
+        stream_output: Raw stream-json output from Claude CLI
+
+    Returns:
+        Extracted response text
+
+    """
+    text_parts: list[str] = []
+    result_text = ""
+
+    for line in stream_output.strip().splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            event = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+
+        if event.get("type") == "assistant":
+            message = event.get("message", {})
+            for block in message.get("content", []):
+                if block.get("type") == "text":
+                    text_parts.append(block["text"])
+        elif event.get("type") == "result":
+            result_text = event.get("result", "")
+
+    # Prefer result field if populated (CLI bug is fixed)
+    if result_text.strip():
+        return result_text
+
+    return "".join(text_parts)
+
+
 def _call_claude_judge(
     evaluation_context: str, model: str, workspace: Path | None = None
 ) -> tuple[str, str, str]:
@@ -587,13 +628,17 @@ def _call_claude_judge(
     # NOTE: --allowedTools takes variadic <tools...>, so any positional arg
     # placed after it gets consumed as a tool name instead of the prompt.
     # We pipe the evaluation context via stdin to avoid this and ARG_MAX limits.
+    # Use stream-json to work around Claude CLI v2.1.83 bug where --print
+    # mode returns empty result field despite the model generating tokens.
+    # Stream-json events contain the actual response in type:assistant messages.
     cmd = [
         "claude",
         "--model",
         model,
         "--print",
         "--output-format",
-        "text",
+        "stream-json",
+        "--verbose",
         "--dangerously-skip-permissions",
         "--allowedTools",
         "",  # No tools — all context is in the prompt
@@ -618,14 +663,14 @@ def _call_claude_judge(
 
         # Check stdout for JSON error response (Claude outputs errors as JSON)
         if result.stdout:
-            try:
-                data = json.loads(result.stdout.strip())
-                if data.get("is_error"):
-                    error_msg = data.get("result", data.get("error", "Unknown JSON error"))
-            except json.JSONDecodeError:
-                # Not JSON, check if stdout has useful text
-                if result.stdout.strip():
-                    error_msg = f"stdout: {result.stdout.strip()[:200]}"
+            for line in result.stdout.strip().splitlines():
+                try:
+                    data = json.loads(line.strip())
+                    if data.get("is_error"):
+                        error_msg = data.get("result", data.get("error", "Unknown JSON error"))
+                        break
+                except json.JSONDecodeError:
+                    continue
 
         # Fall back to stderr if no useful stdout
         if error_msg == "No error message" and result.stderr:
@@ -645,8 +690,9 @@ def _call_claude_judge(
     # Record success with circuit breaker
     cb._record_success()
 
-    # Return stdout, stderr, and raw response (stdout is the judge response)
-    return result.stdout, result.stderr, result.stdout
+    # Extract response text from stream-json events
+    response_text = _extract_response_from_stream(result.stdout)
+    return result.stdout, result.stderr, response_text
 
 
 def _parse_judge_response(response: str) -> JudgeResult:

--- a/tests/unit/e2e/test_llm_judge.py
+++ b/tests/unit/e2e/test_llm_judge.py
@@ -738,19 +738,27 @@ class TestCallClaudeJudge:
     """Tests for _call_claude_judge."""
 
     def test_successful_judge_call(self, tmp_path: Path) -> None:
-        """Test successful Claude judge call."""
+        """Test successful Claude judge call with stream-json output."""
+        judge_text = '{"score": 0.9, "passed": true, "reasoning": "Excellent"}'
+        # Simulate stream-json output: assistant event with content, then result event
+        stream_output = (
+            '{"type":"assistant","message":{"content":[{"type":"text","text":'
+            + json.dumps(judge_text)
+            + "}]}}\n"
+            + '{"type":"result","result":""}\n'
+        )
         mock_result = MagicMock()
         mock_result.returncode = 0
-        mock_result.stdout = '{"score": 0.9, "passed": true, "reasoning": "Excellent"}'
+        mock_result.stdout = stream_output
         mock_result.stderr = ""
 
         with patch("subprocess.run", return_value=mock_result):
-            stdout, _stderr, response = _call_claude_judge(
+            _stdout, _stderr, response = _call_claude_judge(
                 "Evaluate this task", "claude-opus-4-6", tmp_path
             )
 
-        assert '{"score": 0.9' in stdout
-        assert response == stdout
+        assert '{"score": 0.9' in response
+        assert response == judge_text
 
     def test_judge_call_with_json_error(self, tmp_path: Path) -> None:
         """Test handling of JSON error response."""


### PR DESCRIPTION
## Summary
- Work around Claude CLI v2.1.83 bug where `--print` mode returns empty `result` field (anthropics/claude-code#39028)
- Switch judge invocation from `--output-format text` to `--output-format stream-json --verbose`
- Add `_extract_response_from_stream()` to parse response from `type:assistant` message events
- Forward-compatible: falls back to `result` field when the CLI bug is fixed

## Root Cause
Claude CLI v2.1.83 `--print` mode discards model response content. The model generates tokens (confirmed via stream events, cost charged), but the `result` field used for stdout output is always empty. This caused all judge evaluations to fail with "Judge returned empty response."

## Test plan
- [x] All 1597 e2e unit tests pass
- [x] All 4901 tests pass (pre-push hook)
- [x] Manual verification: `_extract_response_from_stream()` correctly extracts 1070-char response from stream-json output
- [ ] Re-run Phase 3 judging on haiku-2 after cleanup

🤖 Generated with [Claude Code](https://claude.com/claude-code)