### PR TITLE
feat(config): add MaestroConfig model and defaults.yaml example

### DIFF
--- a/schemas/defaults.schema.json
+++ b/schemas/defaults.schema.json
@@ -171,20 +171,38 @@
     },
     "maestro": {
       "type": "object",
-      "description": "Maestro orchestration settings",
+      "description": "AI Maestro REST API configuration for failure injection",
       "additionalProperties": false,
       "properties": {
-        "enabled": {
-          "type": "boolean",
-          "description": "Whether maestro orchestration is active"
+        "base_url": {
+          "type": "string",
+          "description": "Base URL for the Maestro REST API",
+          "format": "uri",
+          "examples": ["http://localhost:23000"]
         },
         "url": {
-          "description": "Maestro server URL",
-          "oneOf": [
-            {"type": "string"},
-            {"type": "null"}
-          ],
-          "examples": ["http://maestro:8080"]
+          "type": ["string", "null"],
+          "description": "Alias for base_url (used in defaults.yaml)",
+          "examples": ["http://localhost:23000"]
+        },
+        "enabled": {
+          "type": "boolean",
+          "description": "Whether to activate the Maestro integration",
+          "examples": [false]
+        },
+        "timeout_seconds": {
+          "type": "integer",
+          "description": "Timeout in seconds for mutation requests",
+          "minimum": 1,
+          "maximum": 300,
+          "examples": [10]
+        },
+        "health_check_timeout_seconds": {
+          "type": "integer",
+          "description": "Timeout in seconds for health-check requests",
+          "minimum": 1,
+          "maximum": 60,
+          "examples": [5]
         }
       }
     },
@@ -318,39 +336,6 @@
               "examples": [1200]
             }
           }
-        }
-      }
-    },
-    "maestro": {
-      "type": "object",
-      "description": "AI Maestro REST API configuration for failure injection",
-      "additionalProperties": false,
-      "properties": {
-        "base_url": {
-          "type": "string",
-          "description": "Base URL for the Maestro REST API",
-          "examples": ["http://localhost:23000"]
-        },
-        "url": {
-          "type": ["string", "null"],
-          "description": "Alias for base_url (used in defaults.yaml)",
-          "examples": ["http://localhost:23000"]
-        },
-        "enabled": {
-          "type": "boolean",
-          "description": "Whether to activate the Maestro integration"
-        },
-        "timeout_seconds": {
-          "type": "integer",
-          "description": "Timeout in seconds for mutation requests",
-          "minimum": 1,
-          "maximum": 300
-        },
-        "health_check_timeout_seconds": {
-          "type": "integer",
-          "description": "Timeout in seconds for health-check requests",
-          "minimum": 1,
-          "maximum": 60
         }
       }
     }

--- a/tests/unit/config/test_json_schemas.py
+++ b/tests/unit/config/test_json_schemas.py
@@ -155,6 +155,37 @@ class TestDefaultsSchema:
         """evaluation.seed can be an integer."""
         check_schema({"evaluation": {"seed": 42}}, schema)
 
+    def test_accepts_valid_maestro_block(self, schema: dict[str, Any]) -> None:
+        """Schema accepts a fully specified maestro configuration."""
+        check_schema(
+            {
+                "maestro": {
+                    "base_url": "http://localhost:23000",
+                    "enabled": False,
+                    "timeout_seconds": 10,
+                    "health_check_timeout_seconds": 5,
+                }
+            },
+            schema,
+        )
+
+    def test_rejects_maestro_additional_property(self, schema: dict[str, Any]) -> None:
+        """Maestro must reject unknown keys."""
+        with pytest.raises(jsonschema.ValidationError):
+            check_schema({"maestro": {"unknown_field": "value"}}, schema)
+
+    def test_rejects_maestro_timeout_out_of_range(self, schema: dict[str, Any]) -> None:
+        """maestro.timeout_seconds must be in [1, 300]."""
+        with pytest.raises(jsonschema.ValidationError):
+            check_schema({"maestro": {"timeout_seconds": 0}}, schema)
+
+    def test_rejects_maestro_health_check_timeout_out_of_range(
+        self, schema: dict[str, Any]
+    ) -> None:
+        """maestro.health_check_timeout_seconds must be in [1, 60]."""
+        with pytest.raises(jsonschema.ValidationError):
+            check_schema({"maestro": {"health_check_timeout_seconds": 61}}, schema)
+
 
 # ---------------------------------------------------------------------------
 # tier.schema.json

--- a/tests/unit/config/test_models.py
+++ b/tests/unit/config/test_models.py
@@ -13,6 +13,7 @@ from scylla.config.models import (
     GradingConfig,
     JudgeConfig,
     LoggingConfig,
+    MaestroConfig,
     MetricsConfig,
     ModelConfig,
     OutputConfig,
@@ -480,6 +481,51 @@ class TestLoggingConfig:
         assert "%(asctime)s" in config.format
 
 
+class TestMaestroConfig:
+    """Tests for MaestroConfig model."""
+
+    def test_maestro_defaults(self) -> None:
+        """MaestroConfig should have sensible defaults."""
+        config = MaestroConfig()
+        assert config.base_url == "http://localhost:23000"
+        assert config.enabled is False
+        assert config.timeout_seconds == 10
+        assert config.health_check_timeout_seconds == 5
+
+    def test_maestro_custom_values(self) -> None:
+        """MaestroConfig should accept custom values."""
+        config = MaestroConfig(
+            base_url="http://maestro.example.com:8080",
+            enabled=True,
+            timeout_seconds=30,
+            health_check_timeout_seconds=15,
+        )
+        assert config.base_url == "http://maestro.example.com:8080"
+        assert config.enabled is True
+        assert config.timeout_seconds == 30
+        assert config.health_check_timeout_seconds == 15
+
+    def test_maestro_timeout_seconds_min(self) -> None:
+        """timeout_seconds must be >= 1."""
+        with pytest.raises(ValidationError):
+            MaestroConfig(timeout_seconds=0)
+
+    def test_maestro_timeout_seconds_max(self) -> None:
+        """timeout_seconds must be <= 300."""
+        with pytest.raises(ValidationError):
+            MaestroConfig(timeout_seconds=301)
+
+    def test_maestro_health_check_timeout_min(self) -> None:
+        """health_check_timeout_seconds must be >= 1."""
+        with pytest.raises(ValidationError):
+            MaestroConfig(health_check_timeout_seconds=0)
+
+    def test_maestro_health_check_timeout_max(self) -> None:
+        """health_check_timeout_seconds must be <= 60."""
+        with pytest.raises(ValidationError):
+            MaestroConfig(health_check_timeout_seconds=61)
+
+
 class TestDefaultsConfig:
     """Tests for DefaultsConfig model."""
 
@@ -493,6 +539,7 @@ class TestDefaultsConfig:
         assert isinstance(config.judge, JudgeConfig)
         assert isinstance(config.adapters, AdaptersConfig)
         assert isinstance(config.cleanup, CleanupConfig)
+        assert isinstance(config.maestro, MaestroConfig)
 
     def test_defaults_with_custom_values(self) -> None:
         """DefaultsConfig should accept custom values."""


### PR DESCRIPTION
## Summary
- Add `MaestroConfig` Pydantic model with `base_url`, `enabled`, `timeout_seconds`, and `health_check_timeout_seconds` fields
- Wire `MaestroConfig` into `DefaultsConfig` and `ScyllaConfig` as an optional field with sensible defaults
- Add `maestro` object definition to `schemas/defaults.schema.json` with constraint validation
- Add commented-out maestro example block to `config/defaults.yaml` for discoverability

## Test plan
- [x] Added 6 unit tests for `MaestroConfig` model (defaults, custom values, boundary validation)
- [x] Added 4 schema validation tests for the maestro JSON schema block
- [x] Updated `TestDefaultsConfig` to verify maestro field initialization
- [x] All 365 config tests pass
- [x] All pre-commit hooks pass (ruff, mypy, JSON schema validation, YAML lint)

Closes #1565

🤖 Generated with [Claude Code](https://claude.com/claude-code)