### PR TITLE
fix(reporting): honor explicit output_path in write_report()

### DIFF
--- a/scylla/reporting/markdown.py
+++ b/scylla/reporting/markdown.py
@@ -291,20 +291,27 @@ class MarkdownReportGenerator:
 
         return "".join(sections)
 
-    def write_report(self, data: ReportData) -> Path:
+    def write_report(self, data: ReportData, output_path: Path | None = None) -> Path:
         """Generate and write a report to file.
 
         Args:
             data: Report data
+            output_path: Explicit file path to write the report to. When
+                provided, the report is written to this exact path instead of
+                the convention-based ``{base_dir}/{test_id}/report.md``.
 
         Returns:
-            Path to written report.md
+            Path to written report file.
 
         """
-        report_dir = self.get_report_dir(data.test_id)
-        report_dir.mkdir(parents=True, exist_ok=True)
+        if output_path is not None:
+            report_path = output_path
+        else:
+            report_dir = self.get_report_dir(data.test_id)
+            report_dir.mkdir(parents=True, exist_ok=True)
+            report_path = report_dir / "report.md"
 
-        report_path = report_dir / "report.md"
+        report_path.parent.mkdir(parents=True, exist_ok=True)
         report_content = self.generate_report(data)
         report_path.write_text(report_content)
 

--- a/tests/unit/reporting/test_markdown_output_path.py
+++ b/tests/unit/reporting/test_markdown_output_path.py
@@ -1,0 +1,103 @@
+"""Tests for MarkdownReportGenerator.write_report() output_path parameter."""
+
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from scylla.reporting.markdown import (
+    MarkdownReportGenerator,
+    ReportData,
+    create_report_data,
+)
+
+
+def _make_report_data() -> ReportData:
+    """Create minimal ReportData for testing."""
+    return create_report_data(
+        test_id="001-test",
+        test_name="Test Name",
+        timestamp="2024-01-15T14:30:00Z",
+    )
+
+
+class TestWriteReportOutputPath:
+    """Tests for the output_path parameter on write_report()."""
+
+    def test_write_report_with_explicit_output_path(self) -> None:
+        """When output_path is provided, write to that exact path."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            generator = MarkdownReportGenerator(Path(tmpdir))
+            data = _make_report_data()
+            target = Path(tmpdir) / "my-custom-report.md"
+
+            result = generator.write_report(data, output_path=target)
+
+            assert result == target
+            assert target.exists()
+            content = target.read_text()
+            assert "# Evaluation Report:" in content
+
+    def test_write_report_with_explicit_output_path_creates_parents(self) -> None:
+        """Parent directories are created when output_path has non-existent parents."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            generator = MarkdownReportGenerator(Path(tmpdir))
+            data = _make_report_data()
+            target = Path(tmpdir) / "deep" / "nested" / "dir" / "report.md"
+
+            result = generator.write_report(data, output_path=target)
+
+            assert result == target
+            assert target.exists()
+
+    def test_write_report_with_explicit_output_path_custom_filename(self) -> None:
+        """Custom filenames (not report.md) are honored."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            generator = MarkdownReportGenerator(Path(tmpdir))
+            data = _make_report_data()
+            target = Path(tmpdir) / "results-2024.md"
+
+            result = generator.write_report(data, output_path=target)
+
+            assert result.name == "results-2024.md"
+            assert result.exists()
+
+    def test_write_report_without_output_path_uses_convention(self) -> None:
+        """Default behavior (no output_path) writes to {base_dir}/{test_id}/report.md."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            generator = MarkdownReportGenerator(Path(tmpdir))
+            data = _make_report_data()
+
+            result = generator.write_report(data)
+
+            expected = Path(tmpdir) / "001-test" / "report.md"
+            assert result == expected
+            assert result.exists()
+
+    def test_write_report_output_path_none_uses_convention(self) -> None:
+        """Explicitly passing output_path=None falls back to convention."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            generator = MarkdownReportGenerator(Path(tmpdir))
+            data = _make_report_data()
+
+            result = generator.write_report(data, output_path=None)
+
+            expected = Path(tmpdir) / "001-test" / "report.md"
+            assert result == expected
+            assert result.exists()
+
+    @pytest.mark.parametrize(
+        "filename",
+        ["report.md", "custom.md", "evaluation-output.markdown", "results.txt"],
+    )
+    def test_write_report_various_filenames(self, filename: str) -> None:
+        """Various filenames are all honored when passed as output_path."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            generator = MarkdownReportGenerator(Path(tmpdir))
+            data = _make_report_data()
+            target = Path(tmpdir) / filename
+
+            result = generator.write_report(data, output_path=target)
+
+            assert result.name == filename
+            assert result.exists()


### PR DESCRIPTION
## Summary
- Add optional `output_path: Path | None` parameter to `MarkdownReportGenerator.write_report()` so callers can write the report to an exact file path instead of the convention-based `{base_dir}/{test_id}/report.md`
- When `output_path` is `None` (default), existing behavior is fully preserved — backward compatible
- Parent directories are created automatically for the explicit path

## Test plan
- [x] New parametrized tests in `tests/unit/reporting/test_markdown_output_path.py` (9 test cases)
- [x] Existing `test_markdown.py` tests still pass (no regressions)
- [x] Full test suite passes (4946 passed)
- [x] All pre-commit hooks pass (mypy, ruff, bandit, etc.)

Closes #1567

🤖 Generated with [Claude Code](https://claude.com/claude-code)