### PR TITLE
[Refactor] Deduplicate report format dispatch in CLI report command

### DIFF
--- a/scylla/cli/__init__.py
+++ b/scylla/cli/__init__.py
@@ -1,0 +1,1 @@
+"""CLI module for ProjectScylla."""

--- a/scylla/cli/main.py
+++ b/scylla/cli/main.py
@@ -1,0 +1,609 @@
+"""Command-line interface for ProjectScylla."""
+
+import json
+import statistics
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+import click
+
+from scylla.config import DEFAULT_JUDGE_MODEL, ConfigLoader
+from scylla.e2e.orchestrator import EvalOrchestrator, OrchestratorConfig
+from scylla.reporting import (
+    MarkdownReportGenerator,
+    ReportData,
+    SensitivityAnalysis,
+    TierMetrics,
+    TransitionAssessment,
+    create_tier_metrics,
+)
+from scylla.reporting.json_report import JsonReportGenerator
+
+# Dict-dispatch mapping format names to generator classes.
+# Adding a new format (e.g. HTML) requires only a new entry here
+# and a generator class with the same write_report(ReportData) -> Path interface.
+FORMAT_GENERATORS: dict[str, type[MarkdownReportGenerator] | type[JsonReportGenerator]] = {
+    "markdown": MarkdownReportGenerator,
+    "json": JsonReportGenerator,
+}
+
+
+@click.group()
+@click.version_option(version="0.1.0", prog_name="scylla")
+def cli() -> None:
+    """ProjectScylla - AI Agent Testing Framework.
+
+    Evaluate and benchmark AI agent architectures across multiple tiers.
+    """
+    pass
+
+
+@cli.command()
+@click.argument("test_id")
+@click.option(
+    "--tier",
+    "-t",
+    multiple=True,
+    help="Tier(s) to run (e.g., T0, T1). Can be specified multiple times.",
+)
+@click.option(
+    "--model",
+    "-m",
+    help="Run specific model only.",
+)
+@click.option(
+    "--runs",
+    "-r",
+    default=10,
+    type=int,
+    help="Number of runs per tier (default: 10).",
+)
+@click.option(
+    "--output-dir",
+    "-o",
+    type=click.Path(path_type=Path),
+    help="Override output directory.",
+)
+@click.option(
+    "--verbose",
+    "-v",
+    is_flag=True,
+    help="Verbose output.",
+)
+@click.option(
+    "--quiet",
+    "-q",
+    is_flag=True,
+    help="Minimal output (for CI).",
+)
+def run(
+    test_id: str,
+    tier: tuple[str, ...],
+    model: str | None,
+    runs: int,
+    output_dir: Path | None,
+    verbose: bool,
+    quiet: bool,
+) -> None:
+    """Run evaluation for a test case.
+
+    TEST_ID is the identifier of the test to run (e.g., 001-justfile-to-makefile).
+
+    Examples:
+        scylla run 001-justfile-to-makefile
+
+        scylla run 001-justfile-to-makefile --tier T0 --tier T1
+
+        scylla run 001-justfile-to-makefile --model claude-opus-4-6 --runs 1
+
+    """
+    if verbose and quiet:
+        raise click.UsageError("Cannot use --verbose and --quiet together.")
+
+    tiers = list(tier) if tier else None  # None means use test defaults
+    model_id = model or ConfigLoader().load_defaults().default_model
+
+    # Configure orchestrator
+    base_path = output_dir.parent if output_dir else Path(".")
+    config = OrchestratorConfig(
+        base_path=base_path,
+        runs_per_tier=runs,
+        tiers=tiers,
+        model=model_id,
+        quiet=quiet,
+        verbose=verbose,
+    )
+
+    orchestrator = EvalOrchestrator(config)
+
+    try:
+        if runs == 1 and tiers and len(tiers) == 1:
+            # Single run mode
+            result = orchestrator.run_single(
+                test_id=test_id,
+                model_id=model_id,
+                tier_id=tiers[0],
+            )
+            if not quiet:
+                click.echo(f"\nResult: {'PASS' if result.judgment.passed else 'FAIL'}")
+                click.echo(f"Grade: {result.judgment.letter_grade}")
+                click.echo(f"Cost: ${result.metrics.cost_usd:.4f}")
+        else:
+            # Multi-run mode
+            results = orchestrator.run_test(
+                test_id=test_id,
+                models=[model_id],
+                tiers=tiers,
+                runs_per_tier=runs,
+            )
+            if not quiet:
+                passed = sum(1 for r in results if r.judgment.passed)
+                click.echo(f"\nCompleted {len(results)} runs")
+                click.echo(f"Pass rate: {passed}/{len(results)}")
+
+    except Exception as e:
+        click.echo(f"Error: {e}", err=True)
+        sys.exit(1)
+
+
+def _load_results(test_id: str, base_path: Path = Path(".")) -> list[dict[str, Any]]:
+    """Load all result.json files for a test.
+
+    Args:
+        test_id: Test identifier
+        base_path: Base path for runs directory
+
+    Returns:
+        List of result dictionaries
+
+    """
+    runs_dir = base_path / "runs" / test_id
+    results: list[dict[str, Any]] = []
+
+    if not runs_dir.exists():
+        return results
+
+    for result_file in runs_dir.rglob("result.json"):
+        with open(result_file) as f:
+            results.append(json.load(f))
+
+    return results
+
+
+def _calculate_tier_metrics(
+    tier_id: str, results: list[dict[str, Any]], t0_pass_rate: float | None = None
+) -> TierMetrics:
+    """Calculate metrics for a tier from results.
+
+    Args:
+        tier_id: Tier identifier
+        results: List of result dictionaries for this tier
+        t0_pass_rate: T0 pass rate for uplift calculation
+
+    Returns:
+        TierMetrics for the tier
+
+    """
+    tier_names = {
+        "T0": "Vanilla",
+        "T1": "Prompted",
+        "T2": "Skills",
+        "T3": "Tooling",
+        "T4": "Delegation",
+        "T5": "Hierarchy",
+        "T6": "Hybrid",
+    }
+
+    pass_rates = [r["grading"]["pass_rate"] for r in results]
+    impl_rates = [r["judgment"]["impl_rate"] for r in results]
+    composites = [r["grading"]["composite_score"] for r in results]
+    costs = [r["grading"]["cost_of_pass"] for r in results]
+    # Filter out infinity for cost median
+    valid_costs = [c for c in costs if c != float("inf")]
+
+    pass_rate_median = statistics.median(pass_rates)
+    impl_rate_median = statistics.median(impl_rates)
+    composite_median = statistics.median(composites)
+    cost_median = statistics.median(valid_costs) if valid_costs else float("inf")
+    consistency_std = statistics.stdev(pass_rates) if len(pass_rates) > 1 else 0.0
+
+    # Calculate uplift vs T0
+    uplift = 0.0
+    if t0_pass_rate is not None and t0_pass_rate > 0:
+        uplift = ((pass_rate_median - t0_pass_rate) / t0_pass_rate) * 100
+
+    return create_tier_metrics(
+        tier_id=tier_id,
+        tier_name=tier_names.get(tier_id, tier_id),
+        pass_rate_median=pass_rate_median,
+        impl_rate_median=impl_rate_median,
+        composite_median=composite_median,
+        cost_of_pass_median=cost_median,
+        consistency_std_dev=consistency_std,
+        uplift=uplift,
+    )
+
+
+@cli.command()
+@click.argument("test_id")
+@click.option(
+    "--format",
+    "-f",
+    "output_format",
+    type=click.Choice(sorted(FORMAT_GENERATORS.keys())),
+    default="markdown",
+    help="Report format (default: markdown).",
+)
+@click.option(
+    "--output",
+    "-o",
+    type=click.Path(path_type=Path),
+    help="Output file path.",
+)
+def report(
+    test_id: str,
+    output_format: str,
+    output: Path | None,
+) -> None:
+    """Generate report for a completed test.
+
+    TEST_ID is the identifier of the test (e.g., 001-justfile-to-makefile).
+
+    Examples:
+        scylla report 001-justfile-to-makefile
+
+        scylla report 001-justfile-to-makefile --format json
+
+    """
+    click.echo(f"Generating {output_format} report for: {test_id}")
+
+    base_path = Path(".")
+    results = _load_results(test_id, base_path)
+
+    if not results:
+        click.echo(f"\nNo results found for test: {test_id}", err=True)
+        click.echo("Run 'scylla run {test_id}' first to generate results.", err=True)
+        sys.exit(1)
+
+    click.echo(f"  Found {len(results)} run results")
+
+    # Group results by tier
+    by_tier: dict[str, list[dict[str, Any]]] = {}
+    for r in results:
+        tier_id = r["tier_id"]
+        if tier_id not in by_tier:
+            by_tier[tier_id] = []
+        by_tier[tier_id].append(r)
+
+    # Sort tiers
+    sorted_tiers = sorted(by_tier.keys())
+
+    # Calculate T0 pass rate for uplift calculations
+    t0_pass_rate = None
+    if "T0" in by_tier:
+        t0_results = by_tier["T0"]
+        t0_pass_rates = [r["grading"]["pass_rate"] for r in t0_results]
+        t0_pass_rate = statistics.median(t0_pass_rates)
+
+    # Calculate metrics for each tier
+    tier_metrics = []
+    for tier_id in sorted_tiers:
+        metrics = _calculate_tier_metrics(tier_id, by_tier[tier_id], t0_pass_rate)
+        tier_metrics.append(metrics)
+        click.echo(
+            f"  {tier_id}: {len(by_tier[tier_id])} runs, pass rate: {metrics.pass_rate_median:.1%}"
+        )
+
+    # Calculate sensitivity analysis if multiple tiers
+    sensitivity = None
+    if len(tier_metrics) > 1:
+        pass_rates = [m.pass_rate_median for m in tier_metrics]
+        impl_rates = [m.impl_rate_median for m in tier_metrics]
+        costs = [
+            m.cost_of_pass_median for m in tier_metrics if m.cost_of_pass_median != float("inf")
+        ]
+
+        sensitivity = SensitivityAnalysis(
+            pass_rate_variance=statistics.variance(pass_rates) if len(pass_rates) > 1 else 0.0,
+            impl_rate_variance=statistics.variance(impl_rates) if len(impl_rates) > 1 else 0.0,
+            cost_variance=statistics.variance(costs) if len(costs) > 1 else 0.0,
+        )
+
+    # Calculate transitions
+    transitions = []
+    for i in range(len(tier_metrics) - 1):
+        from_tier = tier_metrics[i]
+        to_tier = tier_metrics[i + 1]
+
+        pass_delta = to_tier.pass_rate_median - from_tier.pass_rate_median
+        impl_delta = to_tier.impl_rate_median - from_tier.impl_rate_median
+        cost_delta = to_tier.cost_of_pass_median - from_tier.cost_of_pass_median
+
+        # Worth it if pass rate improves more than cost increases (relative)
+        worth_it = pass_delta > 0 and (cost_delta < 0 or pass_delta > cost_delta)
+
+        transitions.append(
+            TransitionAssessment(
+                from_tier=from_tier.tier_id,
+                to_tier=to_tier.tier_id,
+                pass_rate_delta=pass_delta,
+                impl_rate_delta=impl_delta,
+                cost_delta=cost_delta,
+                worth_it=worth_it,
+            )
+        )
+
+    # Determine runs per tier (from first tier's count)
+    runs_per_tier = len(by_tier[sorted_tiers[0]]) if sorted_tiers else 0
+
+    # Create report data
+    timestamp = datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+    report_data = ReportData(
+        test_id=test_id,
+        test_name=test_id.replace("-", " ").title(),
+        timestamp=timestamp,
+        runs_per_tier=runs_per_tier,
+        judge_model=DEFAULT_JUDGE_MODEL,
+        tiers=tier_metrics,
+        sensitivity=sensitivity,
+        transitions=transitions,
+        key_finding=f"Evaluated {len(results)} runs across {len(sorted_tiers)} tier(s).",
+        recommendations=[
+            "Review per-tier metrics to identify optimal configuration.",
+            "Consider cost-of-pass when selecting production tier.",
+        ],
+    )
+
+    # Generate report using dict-dispatch — single code path for all formats
+    generator_cls = FORMAT_GENERATORS[output_format]
+    report_dir = output.parent if output else base_path / "reports"
+    generator = generator_cls(report_dir)
+    report_path = generator.write_report(report_data)
+    click.echo(f"\nReport generated: {report_path}")
+
+
+@cli.command("list")
+@click.option(
+    "--verbose",
+    "-v",
+    is_flag=True,
+    help="Show detailed test information.",
+)
+def list_tests(verbose: bool) -> None:
+    """List available test cases.
+
+    Examples:
+        scylla list
+
+        scylla list --verbose
+
+    """
+    # Load from tests/fixtures/tests directory
+    tests_dir = Path("tests/fixtures/tests")
+    tests: list[tuple[str, str]] = []
+
+    if tests_dir.exists():
+        for test_path in sorted(tests_dir.iterdir()):
+            if test_path.is_dir():
+                test_yaml = test_path / "test.yaml"
+                if test_yaml.exists():
+                    import yaml
+
+                    try:
+                        with open(test_yaml) as f:
+                            test_data = yaml.safe_load(f)
+                        test_id = test_data.get("id", test_path.name)
+                        description = test_data.get("name", "No description")
+                        tests.append((test_id, description))
+                    except Exception:
+                        # Skip invalid test files
+                        continue
+
+    # Fallback to default list if no tests found (for backward compatibility)
+    if not tests:
+        tests = [
+            ("001-justfile-to-makefile", "Convert Justfile to Makefile"),
+        ]
+
+    click.echo("Available tests:\n")
+
+    for test_id, description in tests:
+        if verbose:
+            click.echo(f"  {test_id}")
+            click.echo(f"    Description: {description}")
+            click.echo()
+        else:
+            click.echo(f"  {test_id}: {description}")
+
+
+@cli.command("list-tiers")
+def list_tiers() -> None:
+    """List available evaluation tiers.
+
+    Examples:
+        scylla list-tiers
+
+    """
+    tiers = [
+        ("T0", "Vanilla", "Base LLM with zero-shot prompting"),
+        ("T1", "Prompted", "System prompts and chain-of-thought"),
+        ("T2", "Skills", "Prompt-encoded domain expertise"),
+        ("T3", "Tooling", "External function calling with JSON schemas"),
+        ("T4", "Delegation", "Flat multi-agent systems"),
+        ("T5", "Hierarchy", "Nested orchestration with self-correction"),
+        ("T6", "Hybrid", "Optimal combinations of proven components"),
+    ]
+
+    click.echo("Evaluation tiers:\n")
+
+    for tier_id, name, description in tiers:
+        click.echo(f"  {tier_id} ({name})")
+        click.echo(f"    {description}")
+        click.echo()
+
+
+@cli.command("list-models")
+def list_models() -> None:
+    """List configured models.
+
+    Examples:
+        scylla list-models
+
+    """
+    from scylla.config import ConfigurationError
+
+    loader = ConfigLoader()
+
+    try:
+        models = loader.load_all_models()
+    except ConfigurationError as e:
+        click.echo(f"Error loading model configurations: {e}", err=True)
+        sys.exit(1)
+
+    if not models:
+        click.echo("No model configurations found in config/models/")
+        click.echo("\nCreate YAML files in config/models/ to add models.")
+        return
+
+    click.echo("Configured models:\n")
+
+    for _model_key, model in models.items():
+        # Calculate pricing display
+        input_per_1m = model.cost_per_1k_input * 1000
+        output_per_1m = model.cost_per_1k_output * 1000
+        pricing = f"${input_per_1m:.2f}/${output_per_1m:.2f} per 1M tokens"
+
+        click.echo(f"  {model.model_id}")
+        if model.name:
+            click.echo(f"    Name: {model.name}")
+        if model.provider:
+            click.echo(f"    Provider: {model.provider}")
+        click.echo(f"    Pricing: {pricing}")
+        click.echo()
+
+
+@cli.group()
+def audit() -> None:
+    """Audit configuration files for consistency issues."""
+
+
+@audit.command("models")
+@click.option(
+    "--config-dir",
+    default=".",
+    show_default=True,
+    help="Project root directory (must contain config/models/).",
+)
+def audit_models(config_dir: str) -> None:
+    """Audit model config files for filename/model_id mismatches.
+
+    Exits non-zero if any mismatches are detected, making it suitable for
+    use in pre-commit hooks or CI pipelines.
+
+    Examples:
+        scylla audit models
+
+        scylla audit models --config-dir /path/to/project
+
+    """
+    from scylla.config.validation import validate_filename_model_id_consistency
+
+    loader = ConfigLoader(Path(config_dir))
+    models_dir = loader.base_path / "config" / "models"
+
+    if not models_dir.exists():
+        click.echo(f"ERROR: models directory not found: {models_dir}", err=True)
+        sys.exit(1)
+
+    mismatches: list[str] = []
+    for config_path in sorted(models_dir.glob("*.yaml")):
+        if config_path.stem.startswith("_"):
+            continue
+        try:
+            model_config = loader.load_model(config_path.stem)
+        except Exception:
+            continue
+        if model_config is None:
+            continue
+        warnings = validate_filename_model_id_consistency(config_path, model_config.model_id)
+        for warning in warnings:
+            mismatch_line = f"MISMATCH: {config_path.name} → {warning}"
+            mismatches.append(mismatch_line)
+            click.echo(mismatch_line)
+
+    if mismatches:
+        click.echo(f"\n{len(mismatches)} mismatch(es) detected.", err=True)
+        sys.exit(1)
+    else:
+        click.echo("OK: all model config filenames match their model_id.")
+
+
+@cli.command()
+@click.argument("test_id")
+def status(test_id: str) -> None:
+    """Show status of a test evaluation.
+
+    TEST_ID is the identifier of the test (e.g., 001-justfile-to-makefile).
+
+    Examples:
+        scylla status 001-justfile-to-makefile
+
+    """
+    click.echo(f"Status for: {test_id}\n")
+
+    # Load from runs directory
+    runs_dir = Path("runs")
+    results: list[dict[str, Any]] = []
+
+    if runs_dir.exists():
+        # Find all result.json files for this test_id
+        for result_file in runs_dir.glob(f"**/{test_id}/**/result.json"):
+            try:
+                with open(result_file) as f:
+                    result_data = json.load(f)
+                results.append(result_data)
+            except Exception:
+                # Skip invalid result files
+                continue
+
+    if not results:
+        click.echo("  No results found.")
+        click.echo(f"\n  Run 'scylla run {test_id}' to start evaluation.")
+        return
+
+    # Display summary by tier
+    tiers: dict[str, dict[str, Any]] = {}
+    for result in results:
+        tier_id = result.get("tier_id", "unknown")
+        if tier_id not in tiers:
+            tiers[tier_id] = {"total": 0, "passed": 0, "costs": []}
+
+        tiers[tier_id]["total"] += 1
+        if result.get("judgment", {}).get("passed", False):
+            tiers[tier_id]["passed"] += 1
+        cost = result.get("metrics", {}).get("cost_usd", 0.0)
+        tiers[tier_id]["costs"].append(cost)
+
+    click.echo(f"  Total runs: {len(results)}\n")
+
+    for tier_id in sorted(tiers.keys()):
+        tier_data = tiers[tier_id]
+        pass_rate = tier_data["passed"] / tier_data["total"] if tier_data["total"] > 0 else 0.0
+        avg_cost = statistics.mean(tier_data["costs"]) if tier_data["costs"] else 0.0
+
+        click.echo(f"  {tier_id}:")
+        click.echo(f"    Runs: {tier_data['total']}")
+        click.echo(f"    Pass Rate: {pass_rate:.1%}")
+        click.echo(f"    Avg Cost: ${avg_cost:.3f}")
+        click.echo()
+
+
+def main() -> None:
+    """Entry point for the CLI."""
+    cli()
+
+
+if __name__ == "__main__":
+    main()

--- a/scylla/reporting/__init__.py
+++ b/scylla/reporting/__init__.py
@@ -3,6 +3,7 @@
 This module provides result writing and report generation capabilities.
 """
 
+from scylla.reporting.json_report import JsonReportGenerator
 from scylla.reporting.markdown import (
     MarkdownReportGenerator,
     ReportData,
@@ -39,15 +40,12 @@ from scylla.reporting.summary import (
 )
 
 __all__ = [
-    # Scorecard
     "EvalResult",
-    # Summary
     "EvaluationReport",
-    # Result
     "ExecutionInfo",
     "GradingInfo",
+    "JsonReportGenerator",
     "JudgmentInfo",
-    # Markdown
     "MarkdownReportGenerator",
     "MetricsInfo",
     "ModelScorecard",

--- a/scylla/reporting/json_report.py
+++ b/scylla/reporting/json_report.py
@@ -1,0 +1,91 @@
+"""JSON report generator for evaluation results."""
+
+import json
+import math
+from dataclasses import asdict
+from pathlib import Path
+from typing import Any
+
+from scylla.reporting.markdown import ReportData
+
+
+def _sanitize_for_json(obj: Any) -> Any:
+    """Recursively replace float('inf'), float('-inf'), and float('nan') with None.
+
+    JSON does not support these IEEE 754 special values, so they must be
+    converted before serialization.
+
+    Args:
+        obj: Any Python object (typically the output of dataclasses.asdict)
+
+    Returns:
+        Sanitized object safe for json.dumps
+
+    """
+    if isinstance(obj, float):
+        if math.isinf(obj) or math.isnan(obj):
+            return None
+        return obj
+    if isinstance(obj, dict):
+        return {k: _sanitize_for_json(v) for k, v in obj.items()}
+    if isinstance(obj, list):
+        return [_sanitize_for_json(item) for item in obj]
+    return obj
+
+
+class JsonReportGenerator:
+    """Generates JSON evaluation reports."""
+
+    def __init__(self, base_dir: Path) -> None:
+        """Initialize JSON report generator.
+
+        Args:
+            base_dir: Base directory for reports (e.g., 'reports/')
+
+        """
+        self.base_dir = base_dir
+
+    def get_report_dir(self, test_id: str) -> Path:
+        """Get the directory path for a test report.
+
+        Args:
+            test_id: Test identifier
+
+        Returns:
+            Path to report directory
+
+        """
+        return self.base_dir / test_id
+
+    def generate_report(self, data: ReportData) -> str:
+        """Generate a complete JSON report string.
+
+        Args:
+            data: Report data
+
+        Returns:
+            JSON string with indentation
+
+        """
+        raw = asdict(data)
+        sanitized = _sanitize_for_json(raw)
+        return json.dumps(sanitized, indent=2)
+
+    def write_report(self, data: ReportData) -> Path:
+        """Generate and write a JSON report to file.
+
+        Args:
+            data: Report data
+
+        Returns:
+            Path to written report.json
+
+        """
+        report_dir = self.get_report_dir(data.test_id)
+        report_dir.mkdir(parents=True, exist_ok=True)
+
+        report_path = report_dir / "report.json"
+        report_content = self.generate_report(data)
+        report_path.write_text(report_content)
+
+        return report_path

--- a/tests/unit/cli/__init__.py
+++ b/tests/unit/cli/__init__.py
@@ -1,0 +1,1 @@
+"""CLI unit tests."""

--- a/tests/unit/cli/test_cli_report.py
+++ b/tests/unit/cli/test_cli_report.py
@@ -1,0 +1,133 @@
+"""Tests for CLI report command format dispatch."""
+
+import json
+from pathlib import Path
+
+from click.testing import CliRunner
+
+from scylla.cli.main import FORMAT_GENERATORS, cli
+from scylla.reporting.json_report import JsonReportGenerator
+from scylla.reporting.markdown import MarkdownReportGenerator
+
+
+class TestFormatGenerators:
+    """Tests for the FORMAT_GENERATORS dispatch dict."""
+
+    def test_contains_markdown(self) -> None:
+        """Markdown format is registered."""
+        assert "markdown" in FORMAT_GENERATORS
+
+    def test_contains_json(self) -> None:
+        """JSON format is registered."""
+        assert "json" in FORMAT_GENERATORS
+
+    def test_markdown_maps_to_correct_class(self) -> None:
+        """Markdown key maps to MarkdownReportGenerator."""
+        assert FORMAT_GENERATORS["markdown"] is MarkdownReportGenerator
+
+    def test_json_maps_to_correct_class(self) -> None:
+        """JSON key maps to JsonReportGenerator."""
+        assert FORMAT_GENERATORS["json"] is JsonReportGenerator
+
+    def test_all_generators_have_write_report(self) -> None:
+        """All registered generators have a write_report method."""
+        for fmt, cls in FORMAT_GENERATORS.items():
+            assert hasattr(cls, "write_report"), f"{fmt} generator missing write_report"
+
+
+def _create_mock_result(tier_id: str = "T0") -> dict[str, object]:
+    """Create a mock result.json dict."""
+    return {
+        "tier_id": tier_id,
+        "grading": {
+            "pass_rate": 0.8,
+            "composite_score": 0.75,
+            "cost_of_pass": 1.50,
+        },
+        "judgment": {
+            "impl_rate": 0.7,
+            "passed": True,
+            "letter_grade": "B",
+        },
+        "metrics": {
+            "cost_usd": 0.05,
+        },
+    }
+
+
+class TestReportCommand:
+    """Tests for the report CLI command."""
+
+    def test_report_no_results_exits_error(self) -> None:
+        """Report command exits with error when no results found."""
+        runner = CliRunner()
+        with runner.isolated_filesystem():
+            result = runner.invoke(cli, ["report", "nonexistent-test"])
+            assert result.exit_code != 0
+            assert "No results found" in result.output
+
+    def test_report_markdown_format(self) -> None:
+        """Report command generates markdown report via dict dispatch."""
+        runner = CliRunner()
+        with runner.isolated_filesystem():
+            # Create mock result files
+            result_dir = Path("runs/test-001/T0/run-1")
+            result_dir.mkdir(parents=True)
+            (result_dir / "result.json").write_text(json.dumps(_create_mock_result()))
+
+            result = runner.invoke(cli, ["report", "test-001", "--format", "markdown"])
+            assert result.exit_code == 0
+            assert "Report generated:" in result.output
+            assert Path("reports/test-001/report.md").exists()
+
+    def test_report_json_format(self) -> None:
+        """Report command generates JSON report via dict dispatch."""
+        runner = CliRunner()
+        with runner.isolated_filesystem():
+            # Create mock result files
+            result_dir = Path("runs/test-001/T0/run-1")
+            result_dir.mkdir(parents=True)
+            (result_dir / "result.json").write_text(json.dumps(_create_mock_result()))
+
+            result = runner.invoke(cli, ["report", "test-001", "--format", "json"])
+            assert result.exit_code == 0
+            assert "Report generated:" in result.output
+            assert Path("reports/test-001/report.json").exists()
+
+            # Verify it's valid JSON
+            content = json.loads(Path("reports/test-001/report.json").read_text())
+            assert content["test_id"] == "test-001"
+
+    def test_report_default_format_is_markdown(self) -> None:
+        """Default format is markdown when --format is not specified."""
+        runner = CliRunner()
+        with runner.isolated_filesystem():
+            result_dir = Path("runs/test-001/T0/run-1")
+            result_dir.mkdir(parents=True)
+            (result_dir / "result.json").write_text(json.dumps(_create_mock_result()))
+
+            result = runner.invoke(cli, ["report", "test-001"])
+            assert result.exit_code == 0
+            assert Path("reports/test-001/report.md").exists()
+
+    def test_report_invalid_format_rejected(self) -> None:
+        """Invalid format is rejected by Click's Choice validator."""
+        runner = CliRunner()
+        result = runner.invoke(cli, ["report", "test-001", "--format", "html"])
+        assert result.exit_code != 0
+
+    def test_report_multiple_tiers(self) -> None:
+        """Report handles results across multiple tiers."""
+        runner = CliRunner()
+        with runner.isolated_filesystem():
+            for tier in ["T0", "T1"]:
+                result_dir = Path(f"runs/test-001/{tier}/run-1")
+                result_dir.mkdir(parents=True)
+                (result_dir / "result.json").write_text(
+                    json.dumps(_create_mock_result(tier_id=tier))
+                )
+
+            result = runner.invoke(cli, ["report", "test-001"])
+            assert result.exit_code == 0
+            assert "T0:" in result.output
+            assert "T1:" in result.output

--- a/tests/unit/reporting/test_json_report.py
+++ b/tests/unit/reporting/test_json_report.py
@@ -1,0 +1,119 @@
+"""Tests for JSON report generator."""
+
+import json
+import tempfile
+from pathlib import Path
+
+from scylla.reporting.json_report import JsonReportGenerator, _sanitize_for_json
+from scylla.reporting.markdown import ReportData, TierMetrics
+
+
+def _make_report_data(test_id: str = "test-001") -> ReportData:
+    """Create minimal ReportData for testing."""
+    return ReportData(
+        test_id=test_id,
+        test_name="Test 001",
+        timestamp="2025-01-01T00:00:00Z",
+        runs_per_tier=10,
+        judge_model="claude-opus-4-6",
+    )
+
+
+class TestSanitizeForJson:
+    """Tests for _sanitize_for_json helper."""
+
+    def test_sanitize_inf(self) -> None:
+        """Positive infinity is replaced with None."""
+        assert _sanitize_for_json(float("inf")) is None
+
+    def test_sanitize_negative_inf(self) -> None:
+        """Negative infinity is replaced with None."""
+        assert _sanitize_for_json(float("-inf")) is None
+
+    def test_sanitize_nan(self) -> None:
+        """NaN is replaced with None."""
+        assert _sanitize_for_json(float("nan")) is None
+
+    def test_sanitize_normal_float(self) -> None:
+        """Normal floats are preserved."""
+        assert _sanitize_for_json(1.5) == 1.5
+
+    def test_sanitize_dict(self) -> None:
+        """Dict values are recursively sanitized."""
+        result = _sanitize_for_json({"a": float("inf"), "b": 1.0})
+        assert result == {"a": None, "b": 1.0}
+
+    def test_sanitize_list(self) -> None:
+        """List values are recursively sanitized."""
+        result = _sanitize_for_json([float("nan"), 2.0])
+        assert result == [None, 2.0]
+
+    def test_sanitize_nested(self) -> None:
+        """Nested structures are recursively sanitized."""
+        result = _sanitize_for_json({"items": [{"cost": float("inf")}]})
+        assert result == {"items": [{"cost": None}]}
+
+    def test_sanitize_non_float(self) -> None:
+        """Non-float values are passed through."""
+        assert _sanitize_for_json("hello") == "hello"
+        assert _sanitize_for_json(42) == 42
+
+
+class TestJsonReportGenerator:
+    """Tests for JsonReportGenerator."""
+
+    def test_get_report_dir(self) -> None:
+        """Report dir is base_dir / test_id."""
+        gen = JsonReportGenerator(Path("/reports"))
+        assert gen.get_report_dir("test-001") == Path("/reports/test-001")
+
+    def test_generate_report_returns_valid_json(self) -> None:
+        """generate_report returns parseable JSON."""
+        gen = JsonReportGenerator(Path("/tmp"))
+        data = _make_report_data()
+        result = gen.generate_report(data)
+        parsed = json.loads(result)
+        assert parsed["test_id"] == "test-001"
+        assert parsed["test_name"] == "Test 001"
+
+    def test_generate_report_sanitizes_inf(self) -> None:
+        """Infinity values in tier metrics are sanitized to null."""
+        gen = JsonReportGenerator(Path("/tmp"))
+        data = _make_report_data()
+        data.tiers = [
+            TierMetrics(
+                tier_id="T0",
+                tier_name="Vanilla",
+                pass_rate_median=0.5,
+                impl_rate_median=0.5,
+                composite_median=0.5,
+                cost_of_pass_median=float("inf"),
+                consistency_std_dev=0.1,
+                uplift=0.0,
+            )
+        ]
+        result = gen.generate_report(data)
+        parsed = json.loads(result)
+        assert parsed["tiers"][0]["cost_of_pass_median"] is None
+
+    def test_write_report_creates_file(self) -> None:
+        """write_report creates report.json in the correct directory."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            gen = JsonReportGenerator(Path(tmpdir))
+            data = _make_report_data()
+            path = gen.write_report(data)
+
+            assert path.exists()
+            assert path.name == "report.json"
+            assert path.parent.name == "test-001"
+
+            content = json.loads(path.read_text())
+            assert content["test_id"] == "test-001"
+
+    def test_write_report_creates_directories(self) -> None:
+        """write_report creates missing directories."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            gen = JsonReportGenerator(Path(tmpdir) / "nested" / "reports")
+            data = _make_report_data()
+            path = gen.write_report(data)
+            assert path.exists()


### PR DESCRIPTION
## Summary
- Restore `JsonReportGenerator` and CLI module (removed in prior audit sweep)
- Replace the `if/elif` format dispatch chain in the `report` command with a `FORMAT_GENERATORS` dict mapping format names to generator classes
- Adding a new output format now requires only one dict entry and a generator class

## Changes
| File | Description |
|------|-------------|
| `scylla/reporting/json_report.py` | Restored `JsonReportGenerator` with `_sanitize_for_json` helper |
| `scylla/reporting/__init__.py` | Added `JsonReportGenerator` to exports |
| `scylla/cli/__init__.py` | New CLI module init |
| `scylla/cli/main.py` | Full CLI with `FORMAT_GENERATORS` dict-dispatch pattern |
| `tests/unit/reporting/test_json_report.py` | 13 tests for JSON report generation and sanitization |
| `tests/unit/cli/test_cli_report.py` | 11 tests for format dispatch dict and report command |

## Test plan
- [x] 24 new tests all pass
- [x] Full test suite (4961 tests) passes with 77% coverage
- [x] All pre-commit hooks pass (ruff, mypy, bandit, etc.)
- [x] `FORMAT_GENERATORS` dict verified to contain both `markdown` and `json` keys
- [x] Invalid format (`html`) correctly rejected by Click's `Choice` validator

Closes #1569

🤖 Generated with [Claude Code](https://claude.com/claude-code)