### PR TITLE
[Fix] Subscribe to all NATS subjects instead of only first

### DIFF
--- a/scylla/nats/subscriber.py
+++ b/scylla/nats/subscriber.py
@@ -108,44 +108,59 @@ class NATSSubscriberThread(threading.Thread):
         try:
             js = nc.jetstream()
 
-            sub = await js.subscribe(
-                subject=self._config.subjects[0] if self._config.subjects else "hi.tasks.>",
-                durable=self._config.durable_name,
-                stream=self._config.stream,
+            subjects = self._config.subjects or ["hi.tasks.>"]
+            subscriptions = []
+            for i, subject in enumerate(subjects):
+                durable = (
+                    self._config.durable_name
+                    if len(subjects) == 1
+                    else f"{self._config.durable_name}-{i}"
+                )
+                sub = await js.subscribe(
+                    subject=subject,
+                    durable=durable,
+                    stream=self._config.stream,
+                )
+                subscriptions.append(sub)
+
+            logger.info(
+                "Subscribed to %d NATS JetStream subject(s) on stream=%s: %s",
+                len(subscriptions),
+                self._config.stream,
+                subjects,
             )
 
-            logger.info("Subscribed to NATS JetStream (stream=%s)", self._config.stream)
-
             while not self._stop_event.is_set():
-                try:
-                    msg = await asyncio.wait_for(
-                        sub.next_msg(timeout=2.0),
-                        timeout=3.0,
-                    )
-                except (asyncio.TimeoutError, TimeoutError):
-                    continue
+                for sub in subscriptions:
+                    try:
+                        msg = await asyncio.wait_for(
+                            sub.next_msg(timeout=0.5),
+                            timeout=1.0,
+                        )
+                    except (asyncio.TimeoutError, TimeoutError):
+                        continue
 
-                # Parse and dispatch
-                try:
-                    data: dict[str, Any] = json.loads(msg.data.decode())
-                except (json.JSONDecodeError, UnicodeDecodeError):
-                    logger.warning(
-                        "Failed to decode message on %s (seq=%d)",
-                        msg.subject,
-                        msg.metadata.sequence.stream if msg.metadata else 0,
+                    # Parse and dispatch
+                    try:
+                        data: dict[str, Any] = json.loads(msg.data.decode())
+                    except (json.JSONDecodeError, UnicodeDecodeError):
+                        logger.warning(
+                            "Failed to decode message on %s (seq=%d)",
+                            msg.subject,
+                            msg.metadata.sequence.stream if msg.metadata else 0,
+                        )
+                        await msg.ack()
+                        continue
+
+                    event = NATSEvent(
+                        subject=msg.subject,
+                        data=data,
+                        timestamp=(msg.headers.get("Nats-Time-Stamp", "") if msg.headers else ""),
+                        sequence=msg.metadata.sequence.stream if msg.metadata else 0,
                     )
+
+                    self._handler(event)
                     await msg.ack()
-                    continue
-
-                event = NATSEvent(
-                    subject=msg.subject,
-                    data=data,
-                    timestamp=msg.headers.get("Nats-Time-Stamp", "") if msg.headers else "",
-                    sequence=msg.metadata.sequence.stream if msg.metadata else 0,
-                )
-
-                self._handler(event)
-                await msg.ack()
 
         finally:
             await nc.drain()

--- a/tests/unit/nats/test_subscribe_multi.py
+++ b/tests/unit/nats/test_subscribe_multi.py
@@ -1,0 +1,210 @@
+"""Tests for multi-subject subscription in NATSSubscriberThread."""
+
+import asyncio
+import json
+import logging
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from scylla.nats.config import NATSConfig
+from scylla.nats.subscriber import NATSSubscriberThread
+
+
+def _make_mock_msg(
+    subject: str = "hi.tasks.scylla.task1.created",
+    data: dict[str, object] | None = None,
+    sequence: int = 1,
+) -> AsyncMock:
+    """Create a mock NATS message with the given attributes."""
+    msg = AsyncMock()
+    payload = data or {"task_id": "task1"}
+    msg.data = json.dumps(payload).encode()
+    msg.subject = subject
+    msg.headers = {"Nats-Time-Stamp": "2024-01-01T00:00:00Z"}
+    msg.metadata = MagicMock()
+    msg.metadata.sequence.stream = sequence
+    msg.ack = AsyncMock()
+    return msg
+
+
+def _make_mocks() -> tuple[AsyncMock, MagicMock, AsyncMock]:
+    """Create mock NATS connection, JetStream context, and subscription."""
+    mock_nc = AsyncMock()
+    mock_js = MagicMock()
+    mock_nc.jetstream = MagicMock(return_value=mock_js)
+
+    mock_sub = AsyncMock()
+    mock_sub.next_msg = AsyncMock(side_effect=asyncio.TimeoutError)
+    mock_js.subscribe = AsyncMock(return_value=mock_sub)
+
+    return mock_nc, mock_js, mock_sub
+
+
+def _run_subscribe_loop(thread: NATSSubscriberThread, mock_nc: AsyncMock) -> None:
+    """Run _subscribe_loop in a new event loop with the nats module mocked."""
+    mock_nats = MagicMock()
+    mock_nats.connect = AsyncMock(return_value=mock_nc)
+
+    async def _run() -> None:
+        with patch.dict("sys.modules", {"nats": mock_nats}):
+            await thread._subscribe_loop()
+
+    asyncio.run(_run())
+
+
+class TestMultiSubjectSubscription:
+    """Test that _subscribe_loop subscribes to all configured subjects."""
+
+    def test_subscribes_to_all_subjects(self) -> None:
+        """js.subscribe is called once per subject in the config."""
+        config = NATSConfig(
+            enabled=True,
+            subjects=["events.created", "events.updated", "events.deleted"],
+        )
+        handler = MagicMock()
+        thread = NATSSubscriberThread(config=config, handler=handler)
+        thread._stop_event.set()
+
+        mock_nc, mock_js, _ = _make_mocks()
+        _run_subscribe_loop(thread, mock_nc)
+
+        assert mock_js.subscribe.call_count == 3
+        subscribed_subjects = [c.kwargs["subject"] for c in mock_js.subscribe.call_args_list]
+        assert subscribed_subjects == [
+            "events.created",
+            "events.updated",
+            "events.deleted",
+        ]
+
+    def test_single_subject(self) -> None:
+        """Single subject should call js.subscribe exactly once."""
+        config = NATSConfig(
+            enabled=True,
+            subjects=["events.>"],
+        )
+        handler = MagicMock()
+        thread = NATSSubscriberThread(config=config, handler=handler)
+        thread._stop_event.set()
+
+        mock_nc, mock_js, _ = _make_mocks()
+        _run_subscribe_loop(thread, mock_nc)
+
+        assert mock_js.subscribe.call_count == 1
+        assert mock_js.subscribe.call_args.kwargs["subject"] == "events.>"
+
+    def test_empty_subjects_falls_back_to_default(self) -> None:
+        """Empty subjects list falls back to 'hi.tasks.>'."""
+        config = NATSConfig(enabled=True, subjects=[])
+        handler = MagicMock()
+        thread = NATSSubscriberThread(config=config, handler=handler)
+        thread._stop_event.set()
+
+        mock_nc, mock_js, _ = _make_mocks()
+        _run_subscribe_loop(thread, mock_nc)
+
+        assert mock_js.subscribe.call_count == 1
+        assert mock_js.subscribe.call_args.kwargs["subject"] == "hi.tasks.>"
+
+    def test_durable_names_unique_per_subject(self) -> None:
+        """Each subscription gets a unique durable name when multiple subjects."""
+        config = NATSConfig(
+            enabled=True,
+            subjects=["events.created", "events.updated", "events.deleted"],
+            durable_name="scylla-subscriber",
+        )
+        handler = MagicMock()
+        thread = NATSSubscriberThread(config=config, handler=handler)
+        thread._stop_event.set()
+
+        mock_nc, mock_js, _ = _make_mocks()
+        _run_subscribe_loop(thread, mock_nc)
+
+        durable_names = [c.kwargs["durable"] for c in mock_js.subscribe.call_args_list]
+        assert durable_names == [
+            "scylla-subscriber-0",
+            "scylla-subscriber-1",
+            "scylla-subscriber-2",
+        ]
+        # All unique
+        assert len(set(durable_names)) == len(durable_names)
+
+    def test_single_subject_uses_unmodified_durable_name(self) -> None:
+        """Single subject preserves the original durable name (backward compat)."""
+        config = NATSConfig(
+            enabled=True,
+            subjects=["events.>"],
+            durable_name="scylla-subscriber",
+        )
+        handler = MagicMock()
+        thread = NATSSubscriberThread(config=config, handler=handler)
+        thread._stop_event.set()
+
+        mock_nc, mock_js, _ = _make_mocks()
+        _run_subscribe_loop(thread, mock_nc)
+
+        assert mock_js.subscribe.call_args.kwargs["durable"] == "scylla-subscriber"
+
+    def test_logs_all_subjects(self, caplog: pytest.LogCaptureFixture) -> None:
+        """Log message at startup includes all subscribed subjects."""
+        config = NATSConfig(
+            enabled=True,
+            subjects=["events.created", "events.updated"],
+        )
+        handler = MagicMock()
+        thread = NATSSubscriberThread(config=config, handler=handler)
+        thread._stop_event.set()
+
+        mock_nc, _mock_js, _ = _make_mocks()
+
+        with caplog.at_level(logging.INFO, logger="scylla.nats.subscriber"):
+            _run_subscribe_loop(thread, mock_nc)
+
+        log_text = caplog.text
+        assert "2 NATS JetStream subject(s)" in log_text
+        assert "events.created" in log_text
+        assert "events.updated" in log_text
+
+    def test_messages_from_all_subscriptions_dispatched(self) -> None:
+        """Messages from different subscriptions are all dispatched to handler."""
+        config = NATSConfig(
+            enabled=True,
+            subjects=["events.created", "events.updated"],
+        )
+        received: list[str] = []
+
+        def handler(event: object) -> None:
+            received.append(getattr(event, "subject", ""))
+
+        thread = NATSSubscriberThread(config=config, handler=handler)
+
+        mock_nc = AsyncMock()
+        mock_js = MagicMock()
+        mock_nc.jetstream = MagicMock(return_value=mock_js)
+
+        msg1 = _make_mock_msg(subject="events.created", sequence=1)
+        msg2 = _make_mock_msg(subject="events.updated", sequence=2)
+
+        # First sub returns msg1 then sets stop; second sub returns msg2
+        sub1 = AsyncMock()
+
+        async def sub1_next_msg(timeout: float = 0.5) -> AsyncMock:
+            return msg1
+
+        sub1.next_msg = sub1_next_msg
+
+        sub2 = AsyncMock()
+
+        async def sub2_next_msg(timeout: float = 0.5) -> AsyncMock:
+            # After delivering msg2, signal stop
+            thread._stop_event.set()
+            return msg2
+
+        sub2.next_msg = sub2_next_msg
+
+        mock_js.subscribe = AsyncMock(side_effect=[sub1, sub2])
+
+        _run_subscribe_loop(thread, mock_nc)
+
+        assert "events.created" in received
+        assert "events.updated" in received


### PR DESCRIPTION
## Summary
- Fixed `NATSSubscriberThread._subscribe_loop()` to subscribe to **all** subjects in `NATSConfig.subjects` instead of only `subjects[0]`
- Each subject gets its own JetStream subscription with a unique durable name (indexed suffix for multi-subject, unchanged for single-subject backward compatibility)
- Round-robin polling across all subscriptions in the message processing loop
- Improved startup log to show count and list of all subscribed subjects

## Test plan
- [x] 7 new tests in `tests/unit/nats/test_subscribe_multi.py` covering:
  - Multi-subject subscription (3 subjects → 3 `js.subscribe` calls)
  - Single subject regression guard
  - Empty subjects fallback to `hi.tasks.>`
  - Unique durable names per subject
  - Single subject preserves unmodified durable name
  - Log output includes all subjects
  - Messages from all subscriptions dispatched to handler
- [x] All 52 NATS unit tests pass
- [x] Full unit suite passes (4953 passed, 2 skipped)
- [x] All pre-commit hooks pass (ruff, mypy, bandit, etc.)

Closes #1572

🤖 Generated with [Claude Code](https://claude.com/claude-code)