### PR TITLE
docs(contributing): update scylla/ path references to src/scylla/

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -107,7 +107,7 @@ git checkout -b 123-fix-judge-timeout
 
 ### 2. Make Your Changes
 
-- Follow existing code patterns in `scylla/`
+- Follow existing code patterns in `src/scylla/`
 - Add type hints to all function signatures
 - Write docstrings for public APIs
 - Keep changes focused and minimal
@@ -126,8 +126,8 @@ pixi run pytest tests/unit/your_test.py -v
 
 ```bash
 # Format and lint code
-pixi run ruff check scylla/ --fix
-pixi run ruff format scylla/
+pixi run ruff check src/scylla/ --fix
+pixi run ruff format src/scylla/
 
 # Run all tests
 pixi run pytest tests/ -v
@@ -503,7 +503,7 @@ pixi run pytest tests/ -v --pdb  # Drop into debugger on failure
 
 ```
 ProjectScylla/
-├── scylla/              # Python source code
+├── src/scylla/          # Python source code
 │   ├── analysis/        # Statistical analysis
 │   ├── adapters/        # CLI adapters
 │   ├── automation/      # Automation utilities


### PR DESCRIPTION
## Summary
- Update four residual `scylla/` path references in `CONTRIBUTING.md` to `src/scylla/` to align with the src-layout convention required by the ecosystem (#1523)
- Fixes prose reference (line 110), ruff check/format commands (lines 129-130), and project structure tree (line 506)

**Depends on:** #1523 (src-layout migration) — should not be merged before #1523 lands, otherwise paths will point to a directory that doesn't exist yet.

Closes #1576

## Test plan
- [x] `grep -n 'scylla/' CONTRIBUTING.md` shows only `src/scylla/` references
- [x] Pre-commit hooks pass (Markdown Lint, trailing whitespace, end-of-file)
- [x] No functional code changes — documentation only

🤖 Generated with [Claude Code](https://claude.com/claude-code)