### PR TITLE
feat(cli): add subscribe subcommand to manage_experiment.py

### DIFF
--- a/scripts/manage_experiment.py
+++ b/scripts/manage_experiment.py
@@ -1691,6 +1691,96 @@ def cmd_visualize(args: argparse.Namespace) -> int:  # CLI dispatch with many vi
 
 
 # ---------------------------------------------------------------------------
+# Subcommand: subscribe
+# ---------------------------------------------------------------------------
+
+
+def _add_subscribe_args(parser: argparse.ArgumentParser) -> None:
+    """Add arguments for the 'subscribe' subcommand."""
+    parser.add_argument(
+        "--config-dir",
+        type=Path,
+        default=Path("."),
+        help="Project root directory containing config/defaults.yaml (default: .)",
+    )
+
+
+def cmd_subscribe(args: argparse.Namespace) -> int:
+    """Execute the 'subscribe' subcommand.
+
+    Starts a long-running NATS JetStream subscriber that listens for task
+    events on the ``hi.tasks.*`` subject hierarchy.  Press Ctrl+C to stop.
+    """
+    import signal
+    import threading
+
+    from scylla.config import ConfigLoader, ConfigurationError
+
+    loader = ConfigLoader(args.config_dir)
+
+    try:
+        defaults = loader.load_defaults()
+    except ConfigurationError as exc:
+        logger.error("Error loading configuration: %s", exc)
+        return 1
+
+    # Guard: DefaultsConfig must expose a .nats field (added by #1505).
+    if not hasattr(defaults, "nats"):
+        logger.error(
+            "DefaultsConfig has no 'nats' field — "
+            "NATS support requires the infrastructure from issue #1505."
+        )
+        return 1
+
+    nats_config = defaults.nats
+
+    if not nats_config.enabled:
+        logger.error(
+            "NATS subscription is disabled in config/defaults.yaml "
+            "(nats.enabled=false). Set nats.enabled to true or use "
+            "NATS_URL env var to enable."
+        )
+        return 1
+
+    try:
+        from scylla.nats import NATSSubscriberThread, create_default_router
+    except (ImportError, ModuleNotFoundError):
+        logger.error("nats-py is not installed. Install with: pip install 'scylla[nats]'")
+        return 1
+
+    # Configure logging from defaults
+    log_level = getattr(logging, defaults.logging.level, logging.INFO)
+    logging.getLogger().setLevel(log_level)
+
+    router = create_default_router()
+    subscriber = NATSSubscriberThread(config=nats_config, handler=router.dispatch)
+
+    stop_event = threading.Event()
+
+    def _signal_handler(signum: int, frame: object) -> None:
+        logger.info("Shutdown requested (signal %s)", signum)
+        stop_event.set()
+
+    signal.signal(signal.SIGINT, _signal_handler)
+    signal.signal(signal.SIGTERM, _signal_handler)
+
+    logger.info(
+        "Subscribing to NATS at %s (stream=%s)",
+        nats_config.url,
+        nats_config.stream,
+    )
+    subscriber.start()
+
+    # Block until shutdown signal
+    stop_event.wait()
+
+    logger.info("Stopping subscriber...")
+    subscriber.stop()
+    logger.info("Subscriber stopped.")
+    return 0
+
+
+# ---------------------------------------------------------------------------
 # Main entry point
 # ---------------------------------------------------------------------------
 
@@ -1706,6 +1796,7 @@ Subcommands:
   run        Run single or batch experiments with optional --from re-execution
   repair     Repair corrupt checkpoint (rebuilds from run_result.json files)
   visualize  Show experiment state from checkpoint
+  subscribe  Subscribe to NATS JetStream events from ProjectHermes
 
 Use 'manage_experiment.py <subcommand> --help' for subcommand-specific options.
 
@@ -1755,6 +1846,17 @@ Equivalence mapping (old → new):
     )
     _add_visualize_args(visualize_parser)
 
+    # subscribe subcommand
+    subscribe_parser = subparsers.add_parser(
+        "subscribe",
+        help="Subscribe to NATS JetStream events from ProjectHermes",
+        description=(
+            "Start a long-running subscriber that listens for task events "
+            "on the hi.tasks.* subject hierarchy. Press Ctrl+C to stop."
+        ),
+    )
+    _add_subscribe_args(subscribe_parser)
+
     return parser
 
 
@@ -1767,6 +1869,7 @@ def main() -> int:
         "run": cmd_run,
         "repair": cmd_repair,
         "visualize": cmd_visualize,
+        "subscribe": cmd_subscribe,
     }
 
     handler = subcommand_map.get(args.subcommand)

--- a/tests/unit/e2e/test_manage_experiment_subscribe.py
+++ b/tests/unit/e2e/test_manage_experiment_subscribe.py
@@ -1,0 +1,192 @@
+"""cmd_subscribe tests for scripts/manage_experiment.py."""
+
+from __future__ import annotations
+
+import signal
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from manage_experiment import build_parser
+
+# ---------------------------------------------------------------------------
+# Parser construction
+# ---------------------------------------------------------------------------
+
+
+class TestBuildParserSubscribe:
+    """Tests for subscribe subcommand registration in build_parser()."""
+
+    def test_subscribe_subcommand_registered(self) -> None:
+        """'subscribe' is registered as a subcommand in build_parser()."""
+        parser = build_parser()
+        subparsers_action = next(
+            action for action in parser._actions if hasattr(action, "choices") and action.choices
+        )
+        assert "subscribe" in subparsers_action.choices
+
+
+# ---------------------------------------------------------------------------
+# Argument parsing
+# ---------------------------------------------------------------------------
+
+
+class TestSubscribeArgs:
+    """Tests for subscribe subcommand argument parsing."""
+
+    def test_config_dir_default(self) -> None:
+        """--config-dir defaults to current directory."""
+        parser = build_parser()
+        args = parser.parse_args(["subscribe"])
+        assert args.config_dir == Path(".")
+        assert args.subcommand == "subscribe"
+
+    def test_config_dir_custom(self) -> None:
+        """--config-dir accepts a custom path."""
+        parser = build_parser()
+        args = parser.parse_args(["subscribe", "--config-dir", "/custom/path"])
+        assert args.config_dir == Path("/custom/path")
+
+
+# ---------------------------------------------------------------------------
+# cmd_subscribe — error paths
+# ---------------------------------------------------------------------------
+
+
+class TestCmdSubscribeErrors:
+    """Tests for cmd_subscribe() error handling."""
+
+    def test_nats_disabled_returns_1(self, tmp_path: Path) -> None:
+        """Returns 1 when NATS is disabled in config."""
+        from manage_experiment import cmd_subscribe
+
+        mock_defaults = MagicMock()
+        mock_defaults.nats.enabled = False
+
+        mock_loader = MagicMock()
+        mock_loader.load_defaults.return_value = mock_defaults
+
+        parser = build_parser()
+        args = parser.parse_args(["subscribe", "--config-dir", str(tmp_path)])
+
+        with patch("scylla.config.ConfigLoader", return_value=mock_loader):
+            result = cmd_subscribe(args)
+
+        assert result == 1
+
+    def test_missing_config_returns_1(self, tmp_path: Path) -> None:
+        """Returns 1 when ConfigLoader raises ConfigurationError."""
+        from manage_experiment import cmd_subscribe
+
+        from scylla.config import ConfigurationError
+
+        mock_loader = MagicMock()
+        mock_loader.load_defaults.side_effect = ConfigurationError("defaults.yaml not found")
+
+        parser = build_parser()
+        args = parser.parse_args(["subscribe", "--config-dir", str(tmp_path)])
+
+        with patch("scylla.config.ConfigLoader", return_value=mock_loader):
+            result = cmd_subscribe(args)
+
+        assert result == 1
+
+    def test_nats_import_error_returns_1(self, tmp_path: Path) -> None:
+        """Returns 1 when scylla.nats cannot be imported."""
+        from manage_experiment import cmd_subscribe
+
+        mock_defaults = MagicMock()
+        mock_defaults.nats.enabled = True
+
+        mock_loader = MagicMock()
+        mock_loader.load_defaults.return_value = mock_defaults
+
+        parser = build_parser()
+        args = parser.parse_args(["subscribe", "--config-dir", str(tmp_path)])
+
+        with (
+            patch("scylla.config.ConfigLoader", return_value=mock_loader),
+            patch.dict("sys.modules", {"scylla.nats": None}),
+        ):
+            result = cmd_subscribe(args)
+
+        assert result == 1
+
+    def test_missing_nats_attribute_returns_1(self, tmp_path: Path) -> None:
+        """Returns 1 when DefaultsConfig has no .nats attribute."""
+        from manage_experiment import cmd_subscribe
+
+        mock_defaults = MagicMock(spec=[])  # empty spec — no attributes
+
+        mock_loader = MagicMock()
+        mock_loader.load_defaults.return_value = mock_defaults
+
+        parser = build_parser()
+        args = parser.parse_args(["subscribe", "--config-dir", str(tmp_path)])
+
+        with patch("scylla.config.ConfigLoader", return_value=mock_loader):
+            result = cmd_subscribe(args)
+
+        assert result == 1
+
+
+# ---------------------------------------------------------------------------
+# cmd_subscribe — happy path
+# ---------------------------------------------------------------------------
+
+
+class TestCmdSubscribeStartStop:
+    """Tests for cmd_subscribe() subscriber lifecycle."""
+
+    def test_subscriber_started_and_stopped(self, tmp_path: Path) -> None:
+        """Subscriber is started and cleanly stopped on shutdown signal."""
+        from manage_experiment import cmd_subscribe
+
+        mock_defaults = MagicMock()
+        mock_defaults.nats.enabled = True
+        mock_defaults.nats.url = "nats://localhost:4222"
+        mock_defaults.nats.stream = "TASKS"
+        mock_defaults.logging.level = "INFO"
+        mock_defaults.logging.format = "%(message)s"
+
+        mock_loader = MagicMock()
+        mock_loader.load_defaults.return_value = mock_defaults
+
+        mock_subscriber = MagicMock()
+        mock_router = MagicMock()
+
+        # Make the subscriber thread module mock
+        mock_nats_module = MagicMock()
+        mock_nats_module.NATSSubscriberThread.return_value = mock_subscriber
+        mock_nats_module.create_default_router.return_value = mock_router
+
+        parser = build_parser()
+        args = parser.parse_args(["subscribe", "--config-dir", str(tmp_path)])
+
+        original_signal = signal.getsignal(signal.SIGINT)
+
+        # Simulate: after subscriber.start(), immediately fire the stop event
+        def _start_side_effect() -> None:
+            # Find the signal handler that was registered and invoke it
+            # to simulate Ctrl+C
+            handler = signal.getsignal(signal.SIGINT)
+            if callable(handler):
+                handler(signal.SIGINT, None)
+
+        mock_subscriber.start.side_effect = _start_side_effect
+
+        try:
+            with (
+                patch("scylla.config.ConfigLoader", return_value=mock_loader),
+                patch.dict("sys.modules", {"scylla.nats": mock_nats_module}),
+            ):
+                result = cmd_subscribe(args)
+        finally:
+            signal.signal(signal.SIGINT, original_signal)
+
+        assert result == 0
+        mock_nats_module.NATSSubscriberThread.assert_called_once_with(
+            config=mock_defaults.nats,
+            handler=mock_router.dispatch,
+        )
+        mock_subscriber.start.assert_called_once()
+        mock_subscriber.stop.assert_called_once()


### PR DESCRIPTION
## Summary
- Adds a `subscribe` subcommand to `scripts/manage_experiment.py` that wraps the NATS JetStream subscriber logic
- Consolidates all experiment-management operations (`run`, `repair`, `visualize`, `subscribe`) into a single CLI entry point for discoverability
- Gracefully handles missing NATS infrastructure from #1505 (returns exit code 1 with descriptive errors)

## Changes
- **`scripts/manage_experiment.py`**: Added `_add_subscribe_args()`, `cmd_subscribe()`, registered `subscribe` in `build_parser()` and `main()` subcommand map
- **`tests/unit/e2e/test_manage_experiment_subscribe.py`**: 8 new unit tests covering parser registration, argument parsing, all error paths (NATS disabled, config missing, import error, missing nats attribute), and subscriber start/stop lifecycle

## Test plan
- [x] All 8 new subscribe tests pass
- [x] All 64 existing manage_experiment tests pass (no regressions)
- [x] ruff check + format clean
- [x] mypy clean (no type errors)
- [x] All pre-commit hooks pass

Closes #1574

🤖 Generated with [Claude Code](https://claude.com/claude-code)