### PR TITLE
docs(agents): update project structure in implementation-engineer agent

### DIFF
--- a/.claude/agents/implementation-engineer.md
+++ b/.claude/agents/implementation-engineer.md
@@ -104,30 +104,39 @@ def function_name(
 ### Project Structure
 
 ```text
-scylla/
-  metrics/
-    __init__.py
-    pass_rate.py
-    cost_of_pass.py
-    ...
-  e2e/
-    __init__.py
-    harness.py
-    tier_config.py
-    ...
-  analysis/
-    __init__.py
-    statistical.py
-    ...
+scylla/                          # Python source code
+  adapters/                      # CLI adapters
+  analysis/                      # Statistical analysis
+  automation/                    # Automation utilities
+  config/                        # Configuration
+  core/                          # Core types
+  discovery/                     # Resource discovery
+  e2e/                           # E2E testing framework
+  executor/                      # Execution engine
+  judge/                         # LLM judge system
+  metrics/                       # Metrics calculation
+  reporting/                     # Report generation
+  utils/                         # Utility functions
 tests/
-  unit/
-    metrics/
-    e2e/
+  unit/                          # Unit tests (mirrors scylla/ layout)
+    adapters/
     analysis/
-scripts/
-  automation/
-    run_benchmarks.py
-    collect_results.py
+    automation/
+    config/
+    core/
+    discovery/
+    e2e/
+    executor/
+    judge/
+    metrics/
+    reporting/
+    utils/
+  integration/                   # Integration tests
+  scripts/                       # Script tests
+scripts/                         # Python automation scripts
+config/                          # Configuration files
+  models/                        # Model configurations (YAML)
+schemas/                         # JSON schemas
 ```
 
 ## Examples


### PR DESCRIPTION
## Summary
- Updated the project structure diagram in `.claude/agents/implementation-engineer.md` to reflect the complete current repository layout
- Old diagram only showed 3 of 12 `scylla/` subpackages and an incomplete `tests/` layout
- New diagram lists all 12 `scylla/` subpackages, full `tests/unit/` mirror, and top-level directories (`scripts/`, `config/`, `schemas/`)
- Code example comment paths (`# scylla/metrics/pass_rate.py`, `# scylla/e2e/harness.py`) were already correct and unchanged

**Note**: The issue description suggested changing `scylla/` → `src/scylla/`, but `src/scylla/` does not exist — the project uses `scylla/` at the repo root. The actual fix is completing the incomplete structure diagram.

Closes #1578

## Test plan
- [x] Pre-commit hooks pass on changed file
- [x] Verified all directories listed in diagram exist on disk
- [x] Diagram aligns with canonical structure in CLAUDE.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)