### PR TITLE
feat(release): add release workflow and version consistency infrastructure

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,45 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
+        with:
+          fetch-depth: 0
+
+      - name: Validate tag matches package version
+        env:
+          TAG_NAME: ${{ github.ref_name }}
+        run: |
+          TAG_VERSION="${TAG_NAME#v}"
+          PKG_VERSION=$(python3 -c "
+          import re, pathlib
+          text = pathlib.Path('pyproject.toml').read_text()
+          m = re.search(r'^version\s*=\s*\"([^\"]+)\"', text, re.MULTILINE)
+          print(m.group(1) if m else '')
+          ")
+          if [ "$TAG_VERSION" != "$PKG_VERSION" ]; then
+            echo "::error::Tag version ($TAG_VERSION) does not match pyproject.toml version ($PKG_VERSION)"
+            exit 1
+          fi
+          echo "VERSION=$TAG_VERSION" >> "$GITHUB_ENV"
+
+      - name: Create GitHub Release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG_NAME: ${{ github.ref_name }}
+        run: |
+          gh release create "$TAG_NAME" \
+            --title "$TAG_NAME" \
+            --generate-notes

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -86,6 +86,9 @@ jobs:
       - name: Check Python version consistency (pyproject.toml vs Dockerfile)
         run: python3 scripts/check_python_version_consistency.py
 
+      - name: Check version consistency (pyproject.toml, pixi.toml, scylla/__init__.py)
+        run: python3 scripts/check_version_consistency.py
+
       - name: Install nats-server
         if: matrix.test-group.name == 'integration'
         run: |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,6 +7,7 @@ Thank you for your interest in contributing to ProjectScylla! This guide will he
 - [Quick Start](#quick-start)
 - [Development Setup](#development-setup)
 - [Development Workflow](#development-workflow)
+- [Versioning and Releases](#versioning-and-releases)
 - [Code Quality Standards](#code-quality-standards)
 - [Testing Requirements](#testing-requirements)
 - [Pull Request Process](#pull-request-process)
@@ -189,6 +190,49 @@ How you tested the changes
 - [x] Code formatted
 - [x] Documentation updated"
 ```
+
+## Versioning and Releases
+
+ProjectScylla follows [Semantic Versioning](https://semver.org/) (SemVer).
+
+### Version Declaration Sites
+
+The version is declared in three files that **must stay in sync**:
+
+| File | Field | Role |
+|------|-------|------|
+| `pyproject.toml` | `project.version` | Canonical source (used by hatchling for package metadata) |
+| `pixi.toml` | `workspace.version` | Pixi workspace version |
+| `scylla/__init__.py` | `__version__` | Runtime access; imported by the CLI |
+
+A CI check (`scripts/check_version_consistency.py`) verifies all three agree on every PR.
+
+### How to Bump the Version
+
+1. Update the version string in all three files listed above.
+2. Run `pixi install` to regenerate `pixi.lock` (the lock encodes the package SHA).
+3. Add a new section to `CHANGELOG.md` following [Keep a Changelog](https://keepachangelog.com/) format.
+4. Commit all changes (including `pixi.lock`).
+
+### Creating a Release
+
+Releases are created by pushing a version tag:
+
+```bash
+# After your version-bump PR is merged on main:
+git checkout main && git pull
+git tag v<VERSION>      # e.g. git tag v0.2.0
+git push origin v<VERSION>
+```
+
+The `.github/workflows/release.yml` workflow automatically creates a GitHub release
+with auto-generated release notes from conventional commits.
+
+### CHANGELOG Maintenance
+
+- Add entries under `## [Unreleased]` as you work.
+- When releasing, rename `[Unreleased]` to `[<version>] - <date>` and add a fresh `[Unreleased]` section.
+- Use Keep a Changelog categories: Added, Changed, Deprecated, Removed, Fixed, Security.
 
 ## Code Quality Standards
 

--- a/scripts/check_version_consistency.py
+++ b/scripts/check_version_consistency.py
@@ -1,0 +1,107 @@
+"""Check that the version string is consistent across all declaration sites.
+
+Reads the version from:
+  1. pyproject.toml  (project.version)
+  2. pixi.toml       (workspace.version)
+  3. scylla/__init__.py (__version__)
+
+Exits non-zero if any disagree.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+
+def _read_toml_version(path: Path, table_key: str) -> str | None:
+    """Read a version string from a TOML file without requiring a TOML library.
+
+    Looks for ``version = "..."`` under a ``[<table_key>]`` header.
+
+    Args:
+        path: Path to the TOML file.
+        table_key: The TOML table header to search under (e.g. "project" or "workspace").
+
+    Returns:
+        The version string, or None if not found.
+
+    """
+    if not path.exists():
+        return None
+
+    text = path.read_text()
+    in_table = False
+    for line in text.splitlines():
+        stripped = line.strip()
+        if stripped.startswith("[") and stripped.endswith("]"):
+            in_table = stripped == f"[{table_key}]"
+            continue
+        if in_table:
+            match = re.match(r'^version\s*=\s*"([^"]+)"', stripped)
+            if match:
+                return match.group(1)
+    return None
+
+
+def _read_init_version(path: Path) -> str | None:
+    """Read ``__version__`` from a Python file.
+
+    Args:
+        path: Path to the Python file (e.g. ``scylla/__init__.py``).
+
+    Returns:
+        The version string, or None if not found.
+
+    """
+    if not path.exists():
+        return None
+
+    text = path.read_text()
+    match = re.search(r'^__version__\s*=\s*"([^"]+)"', text, re.MULTILINE)
+    return match.group(1) if match else None
+
+
+def check_version_consistency(root: Path | None = None) -> int:
+    """Check version consistency across declaration sites.
+
+    Args:
+        root: Project root directory. Defaults to the repository root
+              (parent of the ``scripts/`` directory).
+
+    Returns:
+        0 if all versions match, 1 otherwise.
+
+    """
+    if root is None:
+        root = Path(__file__).resolve().parent.parent
+
+    sources: dict[str, str | None] = {
+        "pyproject.toml": _read_toml_version(root / "pyproject.toml", "project"),
+        "pixi.toml": _read_toml_version(root / "pixi.toml", "workspace"),
+        "scylla/__init__.py": _read_init_version(root / "scylla" / "__init__.py"),
+    }
+
+    missing = [name for name, ver in sources.items() if ver is None]
+    if missing:
+        for name in missing:
+            print(f"ERROR: could not read version from {name}")
+        return 1
+
+    versions = {name: ver for name, ver in sources.items() if ver is not None}
+    unique = set(versions.values())
+
+    if len(unique) == 1:
+        version = unique.pop()
+        print(f"OK: all version sources agree: {version}")
+        return 0
+
+    print("ERROR: version mismatch detected:")
+    for name, ver in versions.items():
+        print(f"  {name}: {ver}")
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(check_version_consistency())

--- a/tests/unit/scripts/test_check_version_consistency.py
+++ b/tests/unit/scripts/test_check_version_consistency.py
@@ -1,0 +1,113 @@
+"""Tests for version consistency across declaration sites."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from scylla import __version__
+
+# Repository root — three levels up from tests/unit/scripts/
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent.parent
+
+
+def _read_toml_version(path: Path, table_key: str) -> str | None:
+    """Read version from a TOML file without a TOML library."""
+    import re
+
+    text = path.read_text()
+    in_table = False
+    for line in text.splitlines():
+        stripped = line.strip()
+        if stripped.startswith("[") and stripped.endswith("]"):
+            in_table = stripped == f"[{table_key}]"
+            continue
+        if in_table:
+            match = re.match(r'^version\s*=\s*"([^"]+)"', stripped)
+            if match:
+                return match.group(1)
+    return None
+
+
+class TestVersionConsistency:
+    """Verify that all version declaration sites agree."""
+
+    def test_pyproject_matches_init(self) -> None:
+        """pyproject.toml version matches scylla.__version__."""
+        pyproject_version = _read_toml_version(REPO_ROOT / "pyproject.toml", "project")
+        assert pyproject_version == __version__
+
+    def test_pixi_matches_init(self) -> None:
+        """pixi.toml version matches scylla.__version__."""
+        pixi_version = _read_toml_version(REPO_ROOT / "pixi.toml", "workspace")
+        assert pixi_version == __version__
+
+    def test_all_three_agree(self) -> None:
+        """All three version sources report the same value."""
+        pyproject = _read_toml_version(REPO_ROOT / "pyproject.toml", "project")
+        pixi = _read_toml_version(REPO_ROOT / "pixi.toml", "workspace")
+        assert pyproject == pixi == __version__
+
+
+class TestCheckVersionConsistencyScript:
+    """Tests for the scripts/check_version_consistency.py module."""
+
+    def test_consistent_versions(self, tmp_path: Path) -> None:
+        """Script returns 0 when all versions match."""
+        (tmp_path / "pyproject.toml").write_text('[project]\nversion = "1.2.3"\n')
+        (tmp_path / "pixi.toml").write_text('[workspace]\nversion = "1.2.3"\n')
+        init_dir = tmp_path / "scylla"
+        init_dir.mkdir()
+        (init_dir / "__init__.py").write_text('__version__ = "1.2.3"\n')
+
+        from check_version_consistency import check_version_consistency
+
+        assert check_version_consistency(tmp_path) == 0
+
+    def test_inconsistent_versions(self, tmp_path: Path) -> None:
+        """Script returns 1 when versions differ."""
+        (tmp_path / "pyproject.toml").write_text('[project]\nversion = "1.2.3"\n')
+        (tmp_path / "pixi.toml").write_text('[workspace]\nversion = "9.9.9"\n')
+        init_dir = tmp_path / "scylla"
+        init_dir.mkdir()
+        (init_dir / "__init__.py").write_text('__version__ = "1.2.3"\n')
+
+        from check_version_consistency import check_version_consistency
+
+        assert check_version_consistency(tmp_path) == 1
+
+    def test_missing_file(self, tmp_path: Path) -> None:
+        """Script returns 1 when a version source file is missing."""
+        (tmp_path / "pyproject.toml").write_text('[project]\nversion = "1.0.0"\n')
+        # pixi.toml and scylla/__init__.py are missing
+
+        from check_version_consistency import check_version_consistency
+
+        assert check_version_consistency(tmp_path) == 1
+
+    @pytest.mark.parametrize(
+        "pyproject_ver,pixi_ver,init_ver",
+        [
+            ("0.1.0", "0.1.0", "0.2.0"),
+            ("0.1.0", "0.2.0", "0.1.0"),
+            ("0.2.0", "0.1.0", "0.1.0"),
+        ],
+    )
+    def test_single_mismatch_detected(
+        self,
+        tmp_path: Path,
+        pyproject_ver: str,
+        pixi_ver: str,
+        init_ver: str,
+    ) -> None:
+        """Script detects when exactly one source disagrees."""
+        (tmp_path / "pyproject.toml").write_text(f'[project]\nversion = "{pyproject_ver}"\n')
+        (tmp_path / "pixi.toml").write_text(f'[workspace]\nversion = "{pixi_ver}"\n')
+        init_dir = tmp_path / "scylla"
+        init_dir.mkdir()
+        (init_dir / "__init__.py").write_text(f'__version__ = "{init_ver}"\n')
+
+        from check_version_consistency import check_version_consistency
+
+        assert check_version_consistency(tmp_path) == 1


### PR DESCRIPTION
## Summary

Adds the release infrastructure required before creating the initial `v0.1.0` git tag and GitHub release:

- **`.github/workflows/release.yml`** — Tag-triggered workflow (`v*`) that validates the tag version matches `pyproject.toml` and creates a GitHub release with auto-generated notes. Actions pinned to commit SHAs per supply chain hardening convention.
- **`scripts/check_version_consistency.py`** — CI script verifying version agreement across `pyproject.toml`, `pixi.toml`, and `scylla/__init__.py`.
- **`.github/workflows/test.yml`** — Added version consistency check step to CI pipeline.
- **`CONTRIBUTING.md`** — Added "Versioning and Releases" section documenting version declaration sites, bump process, release creation, and changelog maintenance.
- **`tests/unit/scripts/test_check_version_consistency.py`** — 9 parametrized tests covering consistent, inconsistent, and missing version scenarios.

### Post-merge: Create v0.1.0 tag

After this PR merges, create the initial release:

```bash
git checkout main && git pull
git tag v0.1.0
git push origin v0.1.0
```

This triggers `release.yml` to create the GitHub release with auto-generated notes, establishing the baseline referenced in `CHANGELOG.md [0.1.0] - 2026-03-25`.

Closes #1579

## Test plan

- [x] `python3 scripts/check_version_consistency.py` exits 0 (all three sources agree on `0.1.0`)
- [x] All 9 version consistency tests pass
- [x] Full unit test suite passes (4841 passed, 2 skipped)
- [x] Pre-commit hooks pass (ruff, mypy, markdown-lint, yaml-lint, etc.)
- [ ] CI passes on this PR
- [ ] After merge: push `v0.1.0` tag and verify release workflow creates GitHub release

🤖 Generated with [Claude Code](https://claude.com/claude-code)