### PR TITLE
fix(docs): add CHANGELOG version link references and v0.1.0 tag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,3 +60,6 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 | v1.5.0  | `BaseExecutionInfo` deprecated; `DeprecationWarning` added at runtime |
 | v1.5.0  | `BaseRunMetrics` deprecated; `DeprecationWarning` added at runtime |
 | v2.0.0  | Both removed; only Pydantic hierarchy (`ExecutionInfoBase`, `RunMetricsBase`) remains |
+
+[Unreleased]: https://github.com/HomericIntelligence/ProjectScylla/compare/v0.1.0...HEAD
+[0.1.0]: https://github.com/HomericIntelligence/ProjectScylla/releases/tag/v0.1.0


### PR DESCRIPTION
## Summary
- Created annotated `v0.1.0` git tag pointing to commit `f924980` (the commit that introduced the 0.1.0 CHANGELOG entry)
- Created GitHub release for v0.1.0
- Added link reference definitions at the bottom of CHANGELOG.md so `[Unreleased]` and `[0.1.0]` render as working comparison links

## Test plan
- [x] `git ls-remote --tags origin v0.1.0` confirms tag exists on remote
- [x] GitHub release page exists at https://github.com/HomericIntelligence/ProjectScylla/releases/tag/v0.1.0
- [x] CHANGELOG.md link references are syntactically correct per Keep a Changelog spec
- [x] All pre-commit hooks pass (markdown lint, trailing whitespace, end-of-files, etc.)

Closes #1585

🤖 Generated with [Claude Code](https://claude.com/claude-code)