### PR TITLE
feat(ci): add CHANGELOG version entry check

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -103,6 +103,10 @@ jobs:
         if: matrix.test-group.name == 'unit'
         run: pixi run python scripts/check_doc_config_consistency.py --verbose
 
+      - name: Check CHANGELOG version entry
+        if: matrix.test-group.name == 'unit'
+        run: pixi run python scripts/check_changelog_version.py --verbose
+
       - name: Enforce tests/unit/ structure conventions
         if: matrix.test-group.name == 'unit'
         run: pixi run python scripts/check_unit_test_structure.py

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -147,6 +147,13 @@ repos:
         language: system
         files: ^(CLAUDE\.md|README\.md|pyproject\.toml)$
         pass_filenames: false
+      - id: check-changelog-version
+        name: Check CHANGELOG Version Entry
+        description: Fails if CHANGELOG.md has no entry matching the version in pyproject.toml
+        entry: pixi run python scripts/check_changelog_version.py
+        language: system
+        files: ^(CHANGELOG\.md|pyproject\.toml)$
+        pass_filenames: false
       - id: validate-config-schemas
         name: Validate Config Files Against JSON Schemas
         description: >-

--- a/scripts/check_changelog_version.py
+++ b/scripts/check_changelog_version.py
@@ -1,0 +1,141 @@
+#!/usr/bin/env python3
+"""Verify CHANGELOG.md contains an entry matching the version in pyproject.toml.
+
+Checks that CHANGELOG.md has a ``## [X.Y.Z]`` or ``## X.Y.Z`` header matching
+the ``[project] version`` field in ``pyproject.toml``.  This prevents releasing
+without documenting changes.
+
+Usage:
+    python scripts/check_changelog_version.py
+    python scripts/check_changelog_version.py --repo-root /path/to/repo
+    python scripts/check_changelog_version.py --verbose
+
+Exit codes:
+    0: CHANGELOG.md contains a matching version entry
+    1: Version entry missing or files unreadable
+"""
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+import tomllib
+
+_REPO_ROOT = Path(__file__).parent.parent
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+
+def extract_version_from_pyproject(repo_root: Path) -> str:
+    """Read the ``[project] version`` field from ``pyproject.toml``.
+
+    Args:
+        repo_root: Path to the repository root containing ``pyproject.toml``.
+
+    Returns:
+        The version string (e.g. ``"0.1.0"``).
+
+    Raises:
+        SystemExit: If ``pyproject.toml`` is missing, unreadable, or lacks the key.
+
+    """
+    pyproject = repo_root / "pyproject.toml"
+    if not pyproject.exists():
+        print(f"ERROR: pyproject.toml not found at {pyproject}", file=sys.stderr)
+        sys.exit(1)
+
+    try:
+        with open(pyproject, "rb") as f:
+            data = tomllib.load(f)
+    except Exception as exc:
+        print(f"ERROR: Failed to parse pyproject.toml: {exc}", file=sys.stderr)
+        sys.exit(1)
+
+    try:
+        version: str = data["project"]["version"]
+    except KeyError:
+        print(
+            "ERROR: [project].version not found in pyproject.toml",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    return version
+
+
+def changelog_has_version(repo_root: Path, version: str) -> bool:
+    """Check whether CHANGELOG.md contains a header for *version*.
+
+    Scans for ``## [X.Y.Z]`` (Keep a Changelog format) or ``## X.Y.Z``
+    (without brackets) anywhere in the file.
+
+    Args:
+        repo_root: Path to the repository root containing ``CHANGELOG.md``.
+        version: The version string to search for (e.g. ``"0.1.0"``).
+
+    Returns:
+        ``True`` if a matching header is found, ``False`` otherwise.
+
+    Raises:
+        SystemExit: If ``CHANGELOG.md`` does not exist.
+
+    """
+    changelog = repo_root / "CHANGELOG.md"
+    if not changelog.exists():
+        print(f"ERROR: CHANGELOG.md not found at {changelog}", file=sys.stderr)
+        sys.exit(1)
+
+    text = changelog.read_text(encoding="utf-8")
+
+    # Match "## [0.1.0]" with optional trailing content (date, link, etc.)
+    # or "## 0.1.0" without brackets.
+    # Use (?:\s|$) instead of \b because \b after ']' requires a word char.
+    escaped = re.escape(version)
+    pattern = rf"^##\s+(?:\[{escaped}\]|{escaped})(?:\s|$)"
+    return bool(re.search(pattern, text, re.MULTILINE))
+
+
+def main() -> int:
+    """Run the CHANGELOG version entry check.
+
+    Returns:
+        Exit code: 0 if the check passes, 1 if it fails.
+
+    """
+    parser = argparse.ArgumentParser(
+        description="Verify CHANGELOG.md contains an entry for the pyproject.toml version",
+        epilog="Example: %(prog)s --repo-root /path/to/repo",
+    )
+    parser.add_argument(
+        "--repo-root",
+        type=Path,
+        default=_REPO_ROOT,
+        help="Path to repository root (default: parent of this script)",
+    )
+    parser.add_argument(
+        "--verbose",
+        "-v",
+        action="store_true",
+        help="Print passing check details",
+    )
+    args = parser.parse_args()
+    repo_root: Path = args.repo_root
+
+    version = extract_version_from_pyproject(repo_root)
+
+    if changelog_has_version(repo_root, version):
+        if args.verbose:
+            print(f"PASS: CHANGELOG.md contains entry for version {version}")
+        return 0
+
+    print(
+        f"CHANGELOG.md has no entry for version {version} "
+        f"(expected a '## [{version}]' or '## {version}' header)",
+        file=sys.stderr,
+    )
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/unit/scripts/test_check_changelog_version.py
+++ b/tests/unit/scripts/test_check_changelog_version.py
@@ -1,0 +1,198 @@
+"""Tests for scripts/check_changelog_version.py."""
+
+import sys
+import textwrap
+from pathlib import Path
+
+import pytest
+
+from scripts.check_changelog_version import (
+    changelog_has_version,
+    extract_version_from_pyproject,
+    main,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def write_pyproject(tmp_path: Path, content: str) -> Path:
+    """Write a pyproject.toml to *tmp_path* and return its path."""
+    path = tmp_path / "pyproject.toml"
+    path.write_text(textwrap.dedent(content), encoding="utf-8")
+    return path
+
+
+def write_changelog(tmp_path: Path, content: str) -> Path:
+    """Write a CHANGELOG.md to *tmp_path* and return its path."""
+    path = tmp_path / "CHANGELOG.md"
+    path.write_text(textwrap.dedent(content), encoding="utf-8")
+    return path
+
+
+PYPROJECT_VERSION_010 = """\
+    [project]
+    name = "scylla"
+    version = "0.1.0"
+"""
+
+PYPROJECT_VERSION_200 = """\
+    [project]
+    name = "scylla"
+    version = "2.0.0"
+"""
+
+PYPROJECT_NO_VERSION = """\
+    [project]
+    name = "scylla"
+"""
+
+CHANGELOG_WITH_010 = """\
+    # Changelog
+
+    ## [Unreleased]
+
+    ## [0.1.0] - 2026-03-25
+
+    ### Added
+    - Initial release
+"""
+
+CHANGELOG_BARE_010 = """\
+    # Changelog
+
+    ## 0.1.0
+
+    ### Added
+    - Initial release
+"""
+
+CHANGELOG_NO_MATCH = """\
+    # Changelog
+
+    ## [Unreleased]
+
+    ## [0.2.0] - 2026-04-01
+
+    ### Added
+    - Something else
+"""
+
+CHANGELOG_EMPTY = ""
+
+
+# ---------------------------------------------------------------------------
+# extract_version_from_pyproject
+# ---------------------------------------------------------------------------
+
+
+class TestExtractVersionFromPyproject:
+    """Tests for extract_version_from_pyproject()."""
+
+    def test_reads_version(self, tmp_path: Path) -> None:
+        """Should return the version string."""
+        write_pyproject(tmp_path, PYPROJECT_VERSION_010)
+        assert extract_version_from_pyproject(tmp_path) == "0.1.0"
+
+    def test_reads_different_version(self, tmp_path: Path) -> None:
+        """Should return a different version string."""
+        write_pyproject(tmp_path, PYPROJECT_VERSION_200)
+        assert extract_version_from_pyproject(tmp_path) == "2.0.0"
+
+    def test_missing_file_exits(self, tmp_path: Path) -> None:
+        """Should exit 1 when pyproject.toml is absent."""
+        with pytest.raises(SystemExit):
+            extract_version_from_pyproject(tmp_path)
+
+    def test_missing_key_exits(self, tmp_path: Path) -> None:
+        """Should exit 1 when [project].version is missing."""
+        write_pyproject(tmp_path, PYPROJECT_NO_VERSION)
+        with pytest.raises(SystemExit):
+            extract_version_from_pyproject(tmp_path)
+
+
+# ---------------------------------------------------------------------------
+# changelog_has_version
+# ---------------------------------------------------------------------------
+
+
+class TestChangelogHasVersion:
+    """Tests for changelog_has_version()."""
+
+    def test_bracketed_version_found(self, tmp_path: Path) -> None:
+        """Should return True for '## [0.1.0]' format."""
+        write_changelog(tmp_path, CHANGELOG_WITH_010)
+        assert changelog_has_version(tmp_path, "0.1.0") is True
+
+    def test_bare_version_found(self, tmp_path: Path) -> None:
+        """Should return True for '## 0.1.0' format (no brackets)."""
+        write_changelog(tmp_path, CHANGELOG_BARE_010)
+        assert changelog_has_version(tmp_path, "0.1.0") is True
+
+    def test_version_not_found(self, tmp_path: Path) -> None:
+        """Should return False when the version is not present."""
+        write_changelog(tmp_path, CHANGELOG_NO_MATCH)
+        assert changelog_has_version(tmp_path, "0.1.0") is False
+
+    def test_empty_changelog(self, tmp_path: Path) -> None:
+        """Should return False for an empty CHANGELOG.md."""
+        write_changelog(tmp_path, CHANGELOG_EMPTY)
+        assert changelog_has_version(tmp_path, "0.1.0") is False
+
+    def test_missing_changelog_exits(self, tmp_path: Path) -> None:
+        """Should exit 1 when CHANGELOG.md is absent."""
+        with pytest.raises(SystemExit):
+            changelog_has_version(tmp_path, "0.1.0")
+
+    def test_no_partial_match(self, tmp_path: Path) -> None:
+        """Should not match '0.1.0' inside '0.1.0-beta' or '10.1.0'."""
+        write_changelog(tmp_path, "## [0.1.0-beta]\n## [10.1.0]\n")
+        assert changelog_has_version(tmp_path, "0.1.0") is False
+
+
+# ---------------------------------------------------------------------------
+# main (integration via sys.argv)
+# ---------------------------------------------------------------------------
+
+
+class TestMain:
+    """Integration tests for main()."""
+
+    def test_happy_path_returns_zero(self, tmp_path: Path) -> None:
+        """Should return 0 when CHANGELOG has a matching entry."""
+        write_pyproject(tmp_path, PYPROJECT_VERSION_010)
+        write_changelog(tmp_path, CHANGELOG_WITH_010)
+        sys.argv = ["check_changelog_version.py", "--repo-root", str(tmp_path)]
+        assert main() == 0
+
+    def test_missing_entry_returns_one(self, tmp_path: Path) -> None:
+        """Should return 1 when CHANGELOG lacks the version."""
+        write_pyproject(tmp_path, PYPROJECT_VERSION_010)
+        write_changelog(tmp_path, CHANGELOG_NO_MATCH)
+        sys.argv = ["check_changelog_version.py", "--repo-root", str(tmp_path)]
+        assert main() == 1
+
+    def test_verbose_output(self, tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+        """Should print PASS message with --verbose."""
+        write_pyproject(tmp_path, PYPROJECT_VERSION_010)
+        write_changelog(tmp_path, CHANGELOG_WITH_010)
+        sys.argv = [
+            "check_changelog_version.py",
+            "--repo-root",
+            str(tmp_path),
+            "--verbose",
+        ]
+        assert main() == 0
+        captured = capsys.readouterr()
+        assert "PASS" in captured.out
+        assert "0.1.0" in captured.out
+
+    def test_repo_root_argument(self, tmp_path: Path) -> None:
+        """Should respect --repo-root for finding files."""
+        subdir = tmp_path / "nested"
+        subdir.mkdir()
+        write_pyproject(subdir, PYPROJECT_VERSION_010)
+        write_changelog(subdir, CHANGELOG_WITH_010)
+        sys.argv = ["check_changelog_version.py", "--repo-root", str(subdir)]
+        assert main() == 0


### PR DESCRIPTION
## Summary
- Add `scripts/check_changelog_version.py` that verifies `CHANGELOG.md` contains a `## [X.Y.Z]` header matching the version in `pyproject.toml`
- Wire as pre-commit hook (`check-changelog-version`) scoped to `CHANGELOG.md` and `pyproject.toml`
- Add CI step in `test.yml` (unit matrix only) after existing doc/config consistency check
- 14 unit tests covering version extraction, changelog matching, partial-match rejection, and CLI integration

## Test plan
- [x] 14/14 unit tests pass (`pixi run python -m pytest tests/unit/scripts/test_check_changelog_version.py -v`)
- [x] Script passes on current repo (`PASS: CHANGELOG.md contains entry for version 0.1.0`)
- [x] Pre-commit hook passes (`pre-commit run check-changelog-version --all-files`)
- [x] Full pre-commit suite passes (all hooks except pre-existing pixi env linking issue)

Closes #1586

🤖 Generated with [Claude Code](https://claude.com/claude-code)