### PR TITLE
fix(docker): pin node:20-slim digest to 2026-03-26 build

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -90,8 +90,8 @@ RUN pip install --user --no-cache-dir --no-deps /opt/scylla/
 # Pinned to node:20-slim SHA256 for reproducibility.
 # Using multi-stage copy avoids the NodeSource curl|bash pattern which
 # introduces an external dependency and pipe-to-shell security risk.
-# Digest pinned 2026-03-15: node:20-slim
-FROM node:20-slim@sha256:eef3816042c0f522a2ca9655c1947ca6f97c908b0c227aa50e19432646342ab7 AS node-source
+# Digest pinned 2026-03-26: node:20-slim (see #1591; may rotate — re-pin if CI breaks)
+FROM node:20-slim@sha256:1e85773c98c31d4fe5b545e4cb17379e617b348832fb3738b22a08f68dec30f3 AS node-source
 
 # ============================================================================
 # Stage 2: Runtime - Minimal production image

--- a/tests/unit/scripts/test_dockerfile_constraints.py
+++ b/tests/unit/scripts/test_dockerfile_constraints.py
@@ -237,6 +237,95 @@ class TestDockerfileBaseImageDigestConsistency:
         )
 
 
+def _parse_node_base_digest(dockerfile_content: str) -> str | None:
+    """Extract SHA256 digest from the node base image FROM line.
+
+    Matches ``node:XX-slim@sha256:<64 hex>`` on FROM lines.
+
+    Args:
+        dockerfile_content: Raw text content of the Dockerfile.
+
+    Returns:
+        The digest string (e.g. ``sha256:abc...``), or ``None`` if not found.
+
+    """
+    for line in dockerfile_content.splitlines():
+        stripped = line.strip()
+        if not stripped.upper().startswith("FROM"):
+            continue
+        if not re.search(r"node:", stripped, re.IGNORECASE):
+            continue
+        match = re.search(r"@(sha256:[a-f0-9]{64})", stripped, re.IGNORECASE)
+        if match:
+            return match.group(1)
+    return None
+
+
+class TestDockerfileNodeImageDigestPin:
+    """Assert the node:20-slim FROM line carries a SHA256 digest pin."""
+
+    def test_node_from_line_has_sha256_digest(self) -> None:
+        """The node-source stage must carry a SHA256 digest pin.
+
+        Without a digest pin, the node stage can silently drift to a
+        different upstream image.  See issues #1542 and #1591.
+        """
+        content = DOCKERFILE_PATH.read_text()
+        digest = _parse_node_base_digest(content)
+        assert digest is not None, (
+            "No SHA256 digest found on the node:*-slim FROM line in docker/Dockerfile. "
+            "The node-source stage must include a @sha256:<64-hex> pin for reproducibility. "
+            "See issue #1591."
+        )
+
+    def test_node_digest_is_64_hex_chars(self) -> None:
+        """The node digest must be a valid 64-character hex string."""
+        content = DOCKERFILE_PATH.read_text()
+        digest = _parse_node_base_digest(content)
+        assert digest is not None, "No node digest found"
+        assert re.fullmatch(r"sha256:[a-f0-9]{64}", digest), (
+            f"Node digest '{digest}' is not a valid sha256:<64-hex> string."
+        )
+
+
+class TestParseNodeBaseDigest:
+    """Unit tests for _parse_node_base_digest helper."""
+
+    _DIGEST = "sha256:" + "a" * 64
+
+    def test_node_from_line_with_digest(self) -> None:
+        """Should extract digest from a node FROM line."""
+        content = f"FROM node:20-slim@{self._DIGEST} AS node-source"
+        assert _parse_node_base_digest(content) == self._DIGEST
+
+    def test_node_from_line_without_digest(self) -> None:
+        """Node FROM line without @sha256 should return None."""
+        content = "FROM node:20-slim AS node-source"
+        assert _parse_node_base_digest(content) is None
+
+    def test_ignores_python_from_lines(self) -> None:
+        """FROM lines referencing python images should be ignored."""
+        content = f"FROM python:3.12-slim@{self._DIGEST}\nFROM node:20-slim AS node-source"
+        assert _parse_node_base_digest(content) is None
+
+    def test_ignores_comment_lines(self) -> None:
+        """Comment lines containing node digest should be ignored."""
+        content = (
+            f"# FROM node:20-slim@{self._DIGEST}\nFROM node:20-slim@{self._DIGEST} AS node-source"
+        )
+        assert _parse_node_base_digest(content) == self._DIGEST
+
+    def test_empty_dockerfile(self) -> None:
+        """Empty Dockerfile should return None."""
+        assert _parse_node_base_digest("") is None
+
+    def test_short_hash_not_matched(self) -> None:
+        """A hash shorter than 64 hex chars must not be matched."""
+        short = "sha256:" + "f" * 63
+        content = f"FROM node:20-slim@{short} AS node-source"
+        assert _parse_node_base_digest(content) is None
+
+
 class TestParsePythonBaseDigests:
     """Unit tests for _parse_python_base_digests helper."""
 


### PR DESCRIPTION
## Summary
- Updated the `node:20-slim` SHA256 digest in `docker/Dockerfile` from the 2026-03-15 pin (`eef3816...`) to the latest 2026-03-26 build (`1e85773...`), picking up upstream Node.js runtime and npm security patches
- Added `_parse_node_base_digest()` helper and `TestDockerfileNodeImageDigestPin` regression tests to guard against accidental digest pin removal
- Added `TestParseNodeBaseDigest` unit tests (6 cases) for the new helper function

Closes #1591

## Test plan
- [x] All 33 dockerfile constraint tests pass (including 8 new tests)
- [x] Full test suite passes (4945 passed, 2 skipped)
- [x] Pre-commit hooks all pass
- [x] Old digest `eef3816` no longer present in `docker/`
- [x] Coverage at 77.60% (above 9% threshold)

🤖 Generated with [Claude Code](https://claude.com/claude-code)