### PR TITLE
feat(ci): add non-blocking npm audit step to Docker validation

### DIFF
--- a/.github/workflows/docker-test.yml
+++ b/.github/workflows/docker-test.yml
@@ -72,6 +72,30 @@ jobs:
           severity: HIGH,CRITICAL
           version: v0.69.3
 
+      - name: Check npm audit (non-blocking)
+        id: npm_audit
+        continue-on-error: true
+        run: |
+          # Run npm audit inside the built container to check for high/critical vulnerabilities.
+          # This is non-blocking (continue-on-error: true) — findings are reported as warnings.
+          AUDIT_OUTPUT=$(docker run --rm scylla-experiment:trivy-scan \
+            npm audit --audit-level=high 2>&1) || AUDIT_EXIT=$?
+          AUDIT_EXIT=${AUDIT_EXIT:-0}
+
+          if [ "$AUDIT_EXIT" -ne 0 ]; then
+            VULN_COUNT=$(echo "$AUDIT_OUTPUT" | grep -c 'high\|critical' || true)
+            echo "::warning file=docker/Dockerfile::npm audit found ${VULN_COUNT} high/critical advisory line(s) in scylla-experiment image"
+            {
+              echo "## npm audit (high/critical)"
+              echo ""
+              echo '```'
+              echo "$AUDIT_OUTPUT"
+              echo '```'
+            } >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "::notice::npm audit passed — no high/critical vulnerabilities in npm dependencies"
+          fi
+
       - name: Apply trivial source-only change
         run: echo '# timing-probe' >> scylla/__init__.py
 

--- a/tests/unit/ci/test_npm_audit_step.py
+++ b/tests/unit/ci/test_npm_audit_step.py
@@ -1,0 +1,54 @@
+"""Regression tests for the npm audit CI step in docker-test.yml.
+
+Verifies that the Docker validation workflow contains a non-blocking npm audit
+step that checks for high/critical vulnerabilities and reports via annotations.
+Issue: #1592
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+_PROJECT_ROOT = Path(__file__).resolve().parents[3]
+_DOCKER_TEST_WORKFLOW = _PROJECT_ROOT / ".github" / "workflows" / "docker-test.yml"
+
+
+def test_npm_audit_step_exists() -> None:
+    """docker-test.yml must contain an npm audit step."""
+    content = _DOCKER_TEST_WORKFLOW.read_text()
+    assert "npm audit" in content, "docker-test.yml is missing the npm audit step (issue #1592)"
+
+
+def test_npm_audit_uses_high_level() -> None:
+    """Npm audit step must use --audit-level=high."""
+    content = _DOCKER_TEST_WORKFLOW.read_text()
+    assert "--audit-level=high" in content, (
+        "npm audit step must use --audit-level=high to filter noise"
+    )
+
+
+def test_npm_audit_is_non_blocking() -> None:
+    """Npm audit step must use continue-on-error: true."""
+    content = _DOCKER_TEST_WORKFLOW.read_text()
+    lines = content.splitlines()
+    in_audit_step = False
+    found_continue_on_error = False
+    for line in lines:
+        if "npm audit" in line and "name:" in line.lower():
+            in_audit_step = True
+        elif in_audit_step and "continue-on-error: true" in line:
+            found_continue_on_error = True
+            break
+        elif in_audit_step and line.strip().startswith("- name:"):
+            break
+    assert found_continue_on_error, (
+        "npm audit step must have continue-on-error: true to avoid blocking PRs"
+    )
+
+
+def test_npm_audit_emits_warning_annotation() -> None:
+    """Npm audit step must emit a ::warning:: annotation on findings."""
+    content = _DOCKER_TEST_WORKFLOW.read_text()
+    assert "::warning" in content and "npm audit" in content, (
+        "npm audit step must emit ::warning:: annotations for visibility"
+    )


### PR DESCRIPTION
## Summary
- Adds a non-blocking CI step that runs `npm audit --audit-level=high` inside the built Docker image after the Trivy scan
- Reports findings as GitHub warning annotations on `docker/Dockerfile` and detailed output in the job step summary
- Uses `continue-on-error: true` so audit failures never block PRs
- Includes 4 regression tests verifying the step configuration

## Test plan
- [x] 4 new regression tests in `tests/unit/ci/test_npm_audit_step.py` pass
- [x] All 40 existing CI regression tests still pass
- [x] YAML syntax validated
- [x] All pre-commit hooks pass
- [ ] Verify step appears in Docker Validation job log on next Docker-path PR

Closes #1592

🤖 Generated with [Claude Code](https://claude.ai/claude-code)