### PR TITLE
feat(cli): add --output - (stdout) support for scylla report

### DIFF
--- a/scylla/cli/main.py
+++ b/scylla/cli/main.py
@@ -239,13 +239,13 @@ def _calculate_tier_metrics(
 @click.option(
     "--output",
     "-o",
-    type=click.Path(path_type=Path),
-    help="Output file path.",
+    default=None,
+    help="Output file path. Use '-' for stdout.",
 )
 def report(
     test_id: str,
     output_format: str,
-    output: Path | None,
+    output: str | None,
 ) -> None:
     """Generate report for a completed test.
 
@@ -256,18 +256,21 @@ def report(
 
         scylla report 001-justfile-to-makefile --format json
 
+        scylla report 001-justfile-to-makefile --format json --output -
+
     """
-    click.echo(f"Generating {output_format} report for: {test_id}")
+    stdout_mode = output == "-"
+    click.echo(f"Generating {output_format} report for: {test_id}", err=stdout_mode)
 
     base_path = Path(".")
     results = _load_results(test_id, base_path)
 
     if not results:
         click.echo(f"\nNo results found for test: {test_id}", err=True)
-        click.echo("Run 'scylla run {test_id}' first to generate results.", err=True)
+        click.echo(f"Run 'scylla run {test_id}' first to generate results.", err=True)
         sys.exit(1)
 
-    click.echo(f"  Found {len(results)} run results")
+    click.echo(f"  Found {len(results)} run results", err=stdout_mode)
 
     # Group results by tier
     by_tier: dict[str, list[dict[str, Any]]] = {}
@@ -293,7 +296,8 @@ def report(
         metrics = _calculate_tier_metrics(tier_id, by_tier[tier_id], t0_pass_rate)
         tier_metrics.append(metrics)
         click.echo(
-            f"  {tier_id}: {len(by_tier[tier_id])} runs, pass rate: {metrics.pass_rate_median:.1%}"
+            f"  {tier_id}: {len(by_tier[tier_id])} runs, pass rate: {metrics.pass_rate_median:.1%}",
+            err=stdout_mode,
         )
 
     # Calculate sensitivity analysis if multiple tiers
@@ -358,10 +362,16 @@ def report(
 
     # Generate report using dict-dispatch — single code path for all formats
     generator_cls = FORMAT_GENERATORS[output_format]
-    report_dir = output.parent if output else base_path / "reports"
-    generator = generator_cls(report_dir)
-    report_path = generator.write_report(report_data)
-    click.echo(f"\nReport generated: {report_path}")
+    if stdout_mode:
+        generator = generator_cls(Path("."))
+        content = generator.generate_report(report_data)
+        click.echo(content)
+    else:
+        output_path = Path(output) if output else None
+        report_dir = output_path.parent if output_path else base_path / "reports"
+        generator = generator_cls(report_dir)
+        report_path = generator.write_report(report_data)
+        click.echo(f"\nReport generated: {report_path}")
 
 
 @cli.command("list")

--- a/tests/unit/cli/test_cli_report_stdout.py
+++ b/tests/unit/cli/test_cli_report_stdout.py
@@ -1,0 +1,136 @@
+"""Tests for --output - (stdout) support in the report command."""
+
+import json
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from scylla.cli.main import cli
+
+
+def _create_mock_result(tier_id: str = "T0") -> dict[str, object]:
+    """Create a mock result.json dict."""
+    return {
+        "tier_id": tier_id,
+        "grading": {
+            "pass_rate": 0.8,
+            "composite_score": 0.75,
+            "cost_of_pass": 1.50,
+        },
+        "judgment": {
+            "impl_rate": 0.7,
+            "passed": True,
+            "letter_grade": "B",
+        },
+        "metrics": {
+            "cost_usd": 0.05,
+        },
+    }
+
+
+def _setup_mock_results(tier_id: str = "T0") -> None:
+    """Create mock result files in an isolated filesystem."""
+    result_dir = Path(f"runs/test-001/{tier_id}/run-1")
+    result_dir.mkdir(parents=True)
+    (result_dir / "result.json").write_text(json.dumps(_create_mock_result(tier_id)))
+
+
+class TestOutputStdout:
+    """Tests for --output - stdout mode."""
+
+    def test_json_output_to_stdout(self) -> None:
+        """--format json --output - prints valid JSON to stdout."""
+        runner = CliRunner()
+        with runner.isolated_filesystem():
+            _setup_mock_results()
+            result = runner.invoke(cli, ["report", "test-001", "--format", "json", "--output", "-"])
+            assert result.exit_code == 0
+            parsed = json.loads(result.stdout)
+            assert parsed["test_id"] == "test-001"
+
+    def test_markdown_output_to_stdout(self) -> None:
+        """--format markdown --output - prints markdown to stdout."""
+        runner = CliRunner()
+        with runner.isolated_filesystem():
+            _setup_mock_results()
+            result = runner.invoke(
+                cli, ["report", "test-001", "--format", "markdown", "--output", "-"]
+            )
+            assert result.exit_code == 0
+            assert "# Evaluation Report" in result.stdout
+
+    def test_stdout_mode_no_file_written(self) -> None:
+        """--output - does not create a report file on disk."""
+        runner = CliRunner()
+        with runner.isolated_filesystem():
+            _setup_mock_results()
+            result = runner.invoke(cli, ["report", "test-001", "--format", "json", "--output", "-"])
+            assert result.exit_code == 0
+            assert not Path("reports").exists()
+
+    def test_stdout_status_messages_on_stderr(self) -> None:
+        """Status messages go to stderr, not stdout, in stdout mode."""
+        runner = CliRunner()
+        with runner.isolated_filesystem():
+            _setup_mock_results()
+            result = runner.invoke(cli, ["report", "test-001", "--format", "json", "--output", "-"])
+            assert result.exit_code == 0
+            # stdout should be pure JSON — no status messages
+            json.loads(result.stdout)  # would raise if non-JSON content mixed in
+            # stderr should contain status messages
+            assert "Generating json report" in result.stderr
+            assert "Found 1 run results" in result.stderr
+
+    def test_stdout_json_sanitizes_special_floats(self) -> None:
+        """inf/nan values are sanitized to null in stdout JSON output."""
+        runner = CliRunner()
+        with runner.isolated_filesystem():
+            result_dir = Path("runs/test-001/T0/run-1")
+            result_dir.mkdir(parents=True)
+            mock = _create_mock_result()
+            assert isinstance(mock["grading"], dict)
+            mock["grading"]["cost_of_pass"] = float("inf")
+            (result_dir / "result.json").write_text(json.dumps(mock))
+
+            result = runner.invoke(cli, ["report", "test-001", "--format", "json", "--output", "-"])
+            assert result.exit_code == 0
+            parsed = json.loads(result.stdout)
+            # inf should be sanitized to None
+            for tier in parsed["tiers"]:
+                if tier["cost_of_pass_median"] is not None:
+                    assert tier["cost_of_pass_median"] != float("inf")
+
+
+class TestOutputFileRegression:
+    """Regression tests: existing --output <path> and default behavior still work."""
+
+    def test_no_output_flag_writes_default(self) -> None:
+        """No --output flag writes to reports/<test_id>/report.md."""
+        runner = CliRunner()
+        with runner.isolated_filesystem():
+            _setup_mock_results()
+            result = runner.invoke(cli, ["report", "test-001"])
+            assert result.exit_code == 0
+            assert Path("reports/test-001/report.md").exists()
+
+    def test_output_file_path_writes_file(self) -> None:
+        """--output <path> writes to the specified path's directory."""
+        runner = CliRunner()
+        with runner.isolated_filesystem():
+            _setup_mock_results()
+            result = runner.invoke(
+                cli, ["report", "test-001", "--format", "json", "--output", "custom/report.json"]
+            )
+            assert result.exit_code == 0
+            assert Path("custom/test-001/report.json").exists()
+
+    @pytest.mark.parametrize("fmt", ["json", "markdown"])
+    def test_default_format_dispatch(self, fmt: str) -> None:
+        """Both formats work without --output flag."""
+        runner = CliRunner()
+        with runner.isolated_filesystem():
+            _setup_mock_results()
+            result = runner.invoke(cli, ["report", "test-001", "--format", fmt])
+            assert result.exit_code == 0
+            assert "Report generated:" in result.output


### PR DESCRIPTION
## Summary
- Add `--output -` support to `scylla report` command for stdout output
- When `--output -` is specified, report content goes to stdout while status messages route to stderr
- Works with all formats (`--format json`, `--format markdown`)
- Fix missing f-string prefix on error message

## Example usage
```bash
# Pipe JSON report to jq for CI consumption
scylla report 001-test --format json --output - | jq '.tiers[].pass_rate_median'

# Redirect stderr to suppress status messages
scylla report 001-test --format json --output - 2>/dev/null | python -m json.tool
```

## Test plan
- [x] 5 new tests for stdout mode (valid JSON output, markdown output, no file written, stderr routing, NaN sanitization)
- [x] 4 regression tests (default behavior, file path output, format dispatch)
- [x] All 5130 existing tests pass
- [x] All pre-commit hooks pass (mypy, ruff, bandit)

Closes #1593

🤖 Generated with [Claude Code](https://claude.com/claude-code)