### PR TITLE
feat(cli): add --maestro-enabled and --maestro-url flags

### DIFF
--- a/config/defaults.yaml
+++ b/config/defaults.yaml
@@ -59,6 +59,11 @@ resilience:
 # Default model used when no --model flag is provided
 default_model: "claude-sonnet-4-6"
 
+# Maestro orchestration settings
+maestro:
+  enabled: false
+  url: null
+
 # NATS JetStream subscription settings
 nats:
   enabled: false

--- a/schemas/defaults.schema.json
+++ b/schemas/defaults.schema.json
@@ -169,6 +169,25 @@
         }
       }
     },
+    "maestro": {
+      "type": "object",
+      "description": "Maestro orchestration settings",
+      "additionalProperties": false,
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Whether maestro orchestration is active"
+        },
+        "url": {
+          "description": "Maestro server URL",
+          "oneOf": [
+            {"type": "string"},
+            {"type": "null"}
+          ],
+          "examples": ["http://maestro:8080"]
+        }
+      }
+    },
     "nats": {
       "type": "object",
       "description": "NATS JetStream subscription settings",

--- a/scripts/manage_experiment.py
+++ b/scripts/manage_experiment.py
@@ -118,6 +118,17 @@ def _add_run_args(parser: argparse.ArgumentParser) -> None:
         action="store_true",
         help="Run agents/judges in Docker containers",
     )
+    parser.add_argument(
+        "--maestro-enabled",
+        action="store_true",
+        help="Enable maestro orchestration",
+    )
+    parser.add_argument(
+        "--maestro-url",
+        type=str,
+        default=None,
+        help="Maestro server URL (required when --maestro-enabled is set)",
+    )
     parser.add_argument("--model", type=str, default=DEFAULT_AGENT_MODEL, help="Primary model")
     parser.add_argument(
         "--judge-model", type=str, default=DEFAULT_JUDGE_MODEL, help="Model for judging"
@@ -699,6 +710,8 @@ def _run_batch(test_dirs: list[Path], args: argparse.Namespace) -> int:
                 max_subtests=args.max_subtests,
                 skip_agent_teams=args.skip_agent_teams,
                 use_containers=args.use_containers,
+                maestro_enabled=args.maestro_enabled,
+                maestro_url=args.maestro_url,
                 thinking_mode=args.thinking or "None",
                 tiers_to_run=tier_ids,
                 until_run_state=until_run_state,
@@ -999,6 +1012,10 @@ def cmd_run(args: argparse.Namespace) -> int:  # CLI dispatch with many command 
         logger.error("--commit is required (or set in test.yaml)")
         return 1
 
+    if args.maestro_enabled and not args.maestro_url:
+        logger.error("--maestro-url is required when --maestro-enabled is set")
+        return 1
+
     from scylla.config.constants import normalize_model_id
     from scylla.e2e.model_validation import validate_model
 
@@ -1121,6 +1138,8 @@ def cmd_run(args: argparse.Namespace) -> int:  # CLI dispatch with many command 
         max_subtests=args.max_subtests,
         skip_agent_teams=args.skip_agent_teams,
         use_containers=args.use_containers,
+        maestro_enabled=args.maestro_enabled,
+        maestro_url=args.maestro_url,
         thinking_mode=args.thinking or "None",
         tiers_to_run=tier_ids,
         until_run_state=until_run_state,

--- a/scylla/e2e/models.py
+++ b/scylla/e2e/models.py
@@ -842,6 +842,8 @@ class ExperimentConfig(BaseModel):
             (default: tiers_dir/../expected/criteria.md)
         rubric_file: Optional path to rubric.yaml
             (default: tiers_dir/../expected/rubric.yaml)
+        maestro_enabled: Enable maestro orchestration (default: False)
+        maestro_url: Maestro server URL (default: None)
 
     """
 
@@ -866,6 +868,8 @@ class ExperimentConfig(BaseModel):
     )
     criteria_file: Path | None = None  # Optional explicit path to criteria.md
     rubric_file: Path | None = None  # Optional explicit path to rubric.yaml
+    maestro_enabled: bool = False  # Enable maestro orchestration
+    maestro_url: str | None = None  # Maestro server URL
     # Ephemeral --until controls (not saved to experiment.json / not in config_hash)
     until_run_state: RunState | None = None
     until_tier_state: TierState | None = None
@@ -913,6 +917,8 @@ class ExperimentConfig(BaseModel):
             "skip_agent_teams": self.skip_agent_teams,
             "thinking_mode": self.thinking_mode,
             "use_containers": self.use_containers,
+            "maestro_enabled": self.maestro_enabled,
+            "maestro_url": self.maestro_url,
         }
 
     def save(self, path: Path) -> None:
@@ -949,6 +955,8 @@ class ExperimentConfig(BaseModel):
             skip_agent_teams=data.get("skip_agent_teams", False),
             thinking_mode=data.get("thinking_mode", "None"),
             use_containers=data.get("use_containers", False),
+            maestro_enabled=data.get("maestro_enabled", False),
+            maestro_url=data.get("maestro_url"),
         )
 
 

--- a/tests/unit/e2e/test_manage_experiment_cli.py
+++ b/tests/unit/e2e/test_manage_experiment_cli.py
@@ -92,6 +92,8 @@ class TestBuildParser:
         assert args.filter_judge_slot is None
         assert args.threads == 4
         assert args.tests is None
+        assert args.maestro_enabled is False
+        assert args.maestro_url is None
 
     def test_repair_subcommand_requires_checkpoint_path(self) -> None:
         """'repair' subcommand requires a positional checkpoint_path argument."""
@@ -704,6 +706,117 @@ class TestCmdRunFromValidation:
         with patch("scylla.e2e.model_validation.validate_model", return_value=True):
             result = cmd_run(args)
         assert result == 1
+
+
+# ---------------------------------------------------------------------------
+# --maestro-enabled / --maestro-url flags
+# ---------------------------------------------------------------------------
+
+
+class TestMaestroFlags:
+    """Tests for --maestro-enabled and --maestro-url CLI flags."""
+
+    def test_run_accepts_maestro_enabled_flag(self) -> None:
+        """'run' subcommand accepts --maestro-enabled flag."""
+        parser = build_parser()
+        args = parser.parse_args(
+            [
+                "run",
+                "--repo",
+                "https://github.com/test/repo",
+                "--commit",
+                "abc123",
+                "--maestro-enabled",
+            ]
+        )
+        assert args.maestro_enabled is True
+
+    def test_run_accepts_maestro_url_flag(self) -> None:
+        """'run' subcommand accepts --maestro-url flag."""
+        parser = build_parser()
+        args = parser.parse_args(
+            [
+                "run",
+                "--repo",
+                "https://github.com/test/repo",
+                "--commit",
+                "abc123",
+                "--maestro-url",
+                "http://maestro:8080",
+            ]
+        )
+        assert args.maestro_url == "http://maestro:8080"
+
+    def test_maestro_enabled_without_url_returns_1(self, tmp_path: Path) -> None:
+        """cmd_run returns exit code 1 when --maestro-enabled is set without --maestro-url."""
+        config_dir = tmp_path / "test-dir"
+        config_dir.mkdir()
+
+        import yaml
+
+        test_yaml = {
+            "task_repo": "https://github.com/test/repo",
+            "task_commit": "abc123",
+            "experiment_id": "test-exp",
+            "timeout_seconds": 3600,
+            "language": "python",
+        }
+        (config_dir / "test.yaml").write_text(yaml.dump(test_yaml))
+        (config_dir / "prompt.md").write_text("test prompt")
+
+        parser = build_parser()
+        args = parser.parse_args(
+            [
+                "run",
+                "--config",
+                str(config_dir),
+                "--maestro-enabled",
+            ]
+        )
+
+        from manage_experiment import cmd_run
+
+        with patch("scylla.e2e.model_validation.validate_model", return_value=True):
+            result = cmd_run(args)
+        assert result == 1
+
+    def test_maestro_enabled_with_url_passes_validation(self, tmp_path: Path) -> None:
+        """cmd_run does not fail validation when both --maestro-enabled and --maestro-url set."""
+        config_dir = tmp_path / "test-dir"
+        config_dir.mkdir()
+
+        import yaml
+
+        test_yaml = {
+            "task_repo": "https://github.com/test/repo",
+            "task_commit": "abc123",
+            "experiment_id": "test-exp",
+            "timeout_seconds": 3600,
+            "language": "python",
+        }
+        (config_dir / "test.yaml").write_text(yaml.dump(test_yaml))
+        (config_dir / "prompt.md").write_text("test prompt")
+
+        parser = build_parser()
+        args = parser.parse_args(
+            [
+                "run",
+                "--config",
+                str(config_dir),
+                "--maestro-enabled",
+                "--maestro-url",
+                "http://maestro:8080",
+            ]
+        )
+
+        from manage_experiment import cmd_run
+
+        with (
+            patch("scylla.e2e.model_validation.validate_model", return_value=True),
+            patch("scylla.e2e.runner.run_experiment", return_value={"T0": {}}),
+        ):
+            result = cmd_run(args)
+        assert result == 0
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/e2e/test_models.py
+++ b/tests/unit/e2e/test_models.py
@@ -435,6 +435,79 @@ class TestExperimentConfig:
             assert loaded.runs_per_subtest == 5
             assert loaded.tiers_to_run == [TierID.T0, TierID.T1, TierID.T2]
 
+    def test_to_dict_includes_maestro_fields(self) -> None:
+        """Test that to_dict() includes maestro_enabled and maestro_url."""
+        config = ExperimentConfig(
+            experiment_id="test-maestro",
+            task_repo="https://github.com/test/repo",
+            task_commit="abc123",
+            task_prompt_file=Path("prompt.md"),
+            language="python",
+            maestro_enabled=True,
+            maestro_url="http://maestro:8080",
+        )
+
+        d = config.to_dict()
+
+        assert d["maestro_enabled"] is True
+        assert d["maestro_url"] == "http://maestro:8080"
+
+    def test_save_and_load_maestro_fields(self) -> None:
+        """Test that maestro fields round-trip through save/load."""
+        config = ExperimentConfig(
+            experiment_id="test-maestro-rt",
+            task_repo="https://github.com/test/repo",
+            task_commit="abc123",
+            task_prompt_file=Path("prompt.md"),
+            language="python",
+            maestro_enabled=True,
+            maestro_url="http://maestro:8080",
+        )
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = Path(tmpdir) / "config.json"
+            config.save(path)
+
+            loaded = ExperimentConfig.load(path)
+
+            assert loaded.maestro_enabled is True
+            assert loaded.maestro_url == "http://maestro:8080"
+
+    def test_load_backward_compat_missing_maestro_fields(self) -> None:
+        """Test that load() handles missing maestro fields (backward compatibility)."""
+        import json
+
+        config_data = {
+            "experiment_id": "test-old",
+            "task_repo": "https://github.com/test/repo",
+            "task_commit": "abc123",
+            "task_prompt_file": "prompt.md",
+            "language": "python",
+        }
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = Path(tmpdir) / "config.json"
+            with open(path, "w") as f:
+                json.dump(config_data, f)
+
+            loaded = ExperimentConfig.load(path)
+
+            assert loaded.maestro_enabled is False
+            assert loaded.maestro_url is None
+
+    def test_default_maestro_fields(self) -> None:
+        """Test that maestro fields default correctly."""
+        config = ExperimentConfig(
+            experiment_id="test-defaults",
+            task_repo="https://github.com/test/repo",
+            task_commit="abc123",
+            task_prompt_file=Path("prompt.md"),
+            language="python",
+        )
+
+        assert config.maestro_enabled is False
+        assert config.maestro_url is None
+
 
 class TestExperimentConfigDefaults:
     """Tests verifying ExperimentConfig defaults use the published constants."""


### PR DESCRIPTION
## Summary
- Add `--maestro-enabled` (boolean) and `--maestro-url` (string) CLI flags to `manage_experiment.py run` subcommand
- Wire through `ExperimentConfig` with persistence via `to_dict()`/`load()` and backward-compatible defaults
- Validate that `--maestro-url` is required when `--maestro-enabled` is set (returns exit code 1 otherwise)
- Add maestro section to `config/defaults.yaml` and `schemas/defaults.schema.json`

Closes #1597

## Test plan
- [x] Parser tests: `--maestro-enabled` and `--maestro-url` flags accepted with correct defaults
- [x] Validation test: `--maestro-enabled` without `--maestro-url` returns exit code 1
- [x] Validation test: both flags together passes validation
- [x] Model tests: `to_dict()` includes maestro fields
- [x] Model tests: `save()`/`load()` round-trip preserves maestro fields
- [x] Model tests: backward compatibility when maestro fields missing from JSON
- [x] Model tests: default values (False/None)
- [x] Pre-commit hooks pass
- [x] All 75 existing + new tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)