### PR TITLE
fix(docker): resolve HIGH Trivy CVEs (glibc, cross-spawn, glob, minimatch)

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -122,7 +122,8 @@ ENV DEBIAN_FRONTEND=noninteractive \
     CLAUDE_CONFIG_DIR=/home/scylla/.claude
 
 # Install ONLY runtime dependencies (no build tools, no curl — Node.js copied from source stage)
-RUN apt-get update && apt-get install -y --no-install-recommends \
+# apt-get upgrade resolves OS-level CVEs (e.g. CVE-2026-0861 glibc heap corruption)
+RUN apt-get update && apt-get upgrade -y && apt-get install -y --no-install-recommends \
     git \
     ca-certificates \
     && rm -rf /var/lib/apt/lists/*
@@ -139,8 +140,12 @@ RUN ln -sf /usr/local/lib/node_modules/npm/bin/npm-cli.js /usr/local/bin/npm \
 # This is the primary tool for agent-based test execution
 # Version 2.1.84 verified working — upgraded from 2.1.74 to resolve Trivy HIGH CVEs
 # in transitive deps (cross-spawn, glob, minimatch, tar). See #650, #1542.
-RUN npm install -g @anthropic-ai/claude-code@2.1.84 \
-    && npm audit fix --global --audit-level=high 2>/dev/null || true
+RUN npm install -g @anthropic-ai/claude-code@2.1.84
+# Apply security patches for HIGH CVEs in Node.js transitive dependencies:
+#   CVE-2024-21538 (cross-spawn ReDoS), CVE-2025-64756 (glob command injection),
+#   CVE-2026-26996/27903/27904 (minimatch DoS via catastrophic backtracking)
+# --force allows semver-breaking upgrades needed to reach safe versions
+RUN npm audit fix --force 2>/dev/null || true
 
 # Create non-root user for security
 RUN groupadd -r scylla && useradd -r -g scylla -m -s /bin/bash scylla


### PR DESCRIPTION
## Summary

Fixes HIGH-severity CVEs causing Trivy scan failures in `docker-build-timing` and `Build, scan, and push CI image` checks on all branches.

### CVEs Fixed

**OS-level (glibc):**
- **CVE-2026-0861**: libc-bin/libc6 heap corruption in memalign — fixed by adding `apt-get upgrade -y` to the runtime stage's apt install step

**Node.js transitive dependencies (Claude Code CLI):**
- **CVE-2024-21538**: cross-spawn 7.0.3 → 7.0.5 (ReDoS vulnerability)
- **CVE-2025-64756**: glob 10.4.2 → 10.5.0 (command injection via filenames)
- **CVE-2026-26996**: minimatch 9.0.5 → 9.0.6+ (DoS via glob patterns)
- **CVE-2026-27903**: minimatch → 9.0.7+ (DoS via recursive backtracking)
- **CVE-2026-27904**: minimatch → 9.0.7+ (catastrophic backtracking)

### Changes

- `docker/Dockerfile`: Added `apt-get upgrade -y` alongside the existing `apt-get install` to pick up OS-level security patches
- `docker/Dockerfile`: Separated `npm install` and `npm audit fix` into distinct `RUN` layers; switched from `--global --audit-level=high` to `--force` to allow semver-breaking upgrades required to reach the safe versions listed above

## Test plan

- [ ] `docker-build-timing` CI check passes with no Trivy HIGH findings
- [ ] `Build, scan, and push CI image` CI check passes
- [ ] Existing unit and integration tests unaffected (no Python code changes)