### PR TITLE
docs(contributing): add Code of Conduct reference

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,6 +14,7 @@ Thank you for your interest in contributing to ProjectScylla! This guide will he
 - [Issue Reporting Guidelines](#issue-reporting-guidelines)
 - [Documentation Expectations](#documentation-expectations)
 - [Code Review Process](#code-review-process)
+- [Code of Conduct](#code-of-conduct)
 - [Getting Help](#getting-help)
 
 ## Quick Start
@@ -587,6 +588,11 @@ ProjectScylla/
 ├── docs/                # Documentation
 └── .claude/             # AI agent configs
 ```
+
+## Code of Conduct
+
+This project follows the [Contributor Covenant Code of Conduct](CODE_OF_CONDUCT.md). By participating,
+you are expected to uphold this code. Please report unacceptable behavior to the project maintainers.
 
 ## License
 


### PR DESCRIPTION
## Summary

- Adds `[Code of Conduct](#code-of-conduct)` to CONTRIBUTING.md table of contents
- Adds `## Code of Conduct` section linking to `CODE_OF_CONDUCT.md`

`CODE_OF_CONDUCT.md` was already merged in a prior commit (4575af0f). This PR completes #1528 by wiring the reference into CONTRIBUTING.md so contributors are directed to it.

Closes #1528
Closes #1529

## Test plan

- [x] `CODE_OF_CONDUCT.md` exists and is committed
- [x] CONTRIBUTING.md TOC links to `#code-of-conduct` anchor
- [x] New section links to `CODE_OF_CONDUCT.md` file
- [x] No Python code changes — no pytest/mypy needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)