### PR TITLE
docs: fix stale coverage threshold references (73%/80% → 75%)

### DIFF
--- a/docs/analysis-prompt.md
+++ b/docs/analysis-prompt.md
@@ -77,8 +77,8 @@ Analyze ProjectScylla for completeness, quality, and maturity across six dimensi
 
 **Success Criteria:**
 
-- `pytest --cov` meets or exceeds the 73% `--cov-fail-under` threshold
-- Unit tests cover all `src/scylla/` sub-packages (adapters, analysis, e2e, executor, judge, metrics, reporting)
+- `pytest --cov` meets or exceeds the 75% `--cov-fail-under` threshold
+- Unit tests cover all `scylla/` sub-packages (adapters, analysis, e2e, executor, judge, metrics, reporting)
 - 47 test fixtures (test-001 to test-047) have complete `test.yaml`, `prompt.md`, `expected/criteria.md`, `expected/rubric.yaml`
 - Sub-test YAML configs in `tests/claude-code/shared/subtests/t0/`–`t6/` are all valid per `schemas/`
 - Tests use proper mocking for external calls (Docker, GitHub API, Claude API)

--- a/scripts/quality_audit_feb_2026_issues.sh
+++ b/scripts/quality_audit_feb_2026_issues.sh
@@ -69,7 +69,7 @@ echo "  Created issue #${issue_num}"
 # HIGH-2: Configure test coverage thresholds
 echo "Creating issue: Configure test coverage thresholds in CI..."
 issue_url=$(gh issue create \
-  --title "HIGH: Configure test coverage thresholds in CI (80%)" \
+  --title "HIGH: Configure test coverage thresholds in CI (75%)" \
   --label "testing" \
   --body "$(cat <<'EOF'
 ## Objective
@@ -77,12 +77,12 @@ Enforce minimum test coverage thresholds to prevent coverage regression.
 
 ## Deliverables
 - [ ] Create pytest.ini with coverage configuration
-- [ ] Set line coverage threshold to 80%
+- [ ] Set line coverage threshold to 75%
 - [ ] Configure coverage report formats (term-missing, html)
 - [ ] Add coverage configuration to pyproject.toml
 
 ## Success Criteria
-- CI fails if coverage drops below 80%
+- CI fails if coverage drops below 75%
 - Coverage reports show missing lines
 - HTML coverage report generated for detailed analysis
 
@@ -94,8 +94,8 @@ HIGH - Critical for maintaining code quality
 
 ## Verification
 ```bash
-# Run tests with coverage (should fail if <80%)
-pixi run python -m pytest tests/ --cov=scylla --cov-report=term-missing --cov-fail-under=80
+# Run tests with coverage (should fail if <75%)
+pixi run python -m pytest tests/ --cov=scylla --cov-report=term-missing --cov-fail-under=75
 ```
 
 ## Context
@@ -497,7 +497,7 @@ Created 10 tracking issues for code quality audit findings:
 
 ### HIGH Priority
 - #${issue_numbers[0]} - Resolve 4 skipped tests and clean up .orig artifacts
-- #${issue_numbers[1]} - Configure test coverage thresholds in CI (80%)
+- #${issue_numbers[1]} - Configure test coverage thresholds in CI (75%)
 - #${issue_numbers[2]} - Add mypy type checking to pre-commit hooks
 - #${issue_numbers[3]} - Fix duplicate model config names (same model_id)
 


### PR DESCRIPTION
Fix stale coverage threshold references in documentation and scripts:

- `docs/analysis-prompt.md`: 73% → 75% (current threshold)
- `scripts/quality_audit_feb_2026_issues.sh`: 80% → 75% (current threshold)

Closes #1608
Closes #1609