### PR TITLE
fix(ci): restrict Trivy to vuln scanner and update base image SHA

### DIFF
--- a/.github/workflows/ci-image.yml
+++ b/.github/workflows/ci-image.yml
@@ -79,6 +79,7 @@ jobs:
         with:
           scan-type: image
           input: /tmp/scylla-ci.tar
+          scanners: vuln
           format: table
           exit-code: 1
           ignore-unfixed: true

--- a/ci/Containerfile
+++ b/ci/Containerfile
@@ -20,7 +20,7 @@
 # Stage 1: Builder — install pixi and Python environments
 # ============================================================================
 # Pinned to same SHA256 as docker/Dockerfile for consistency
-FROM python:3.12-slim@sha256:f3fa41d74a768c2fce8016b98c191ae8c1bacd8f1152870a3f9f87d350920b7c AS builder
+FROM python:3.12-slim@sha256:804ddf3251a60bbf9c92e73b7566c40428d54d0e79d3428194edf40da6521286 AS builder
 
 ENV DEBIAN_FRONTEND=noninteractive \
     PIP_NO_CACHE_DIR=1 \
@@ -73,7 +73,7 @@ RUN git init . && \
 # ============================================================================
 # Stage 2: Runtime — minimal image without build tools
 # ============================================================================
-FROM python:3.12-slim@sha256:f3fa41d74a768c2fce8016b98c191ae8c1bacd8f1152870a3f9f87d350920b7c
+FROM python:3.12-slim@sha256:804ddf3251a60bbf9c92e73b7566c40428d54d0e79d3428194edf40da6521286
 
 LABEL org.opencontainers.image.title="scylla-ci"
 LABEL org.opencontainers.image.description="CI container for ProjectScylla — testing, linting, security scans"


### PR DESCRIPTION
## Summary

Follow-up to #1771 (Trivy Podman fix). Two remaining issues found during the first successful scan run:

- **False-positive secrets**: The pre-commit cache baked into the CI image contains gitleaks' own test fixtures (fake Stripe, GitHub, HuggingFace, Slack tokens) and Go stdlib test certs — triggering hundreds of CRITICAL/HIGH findings. Fix: add `scanners: vuln` to restrict Trivy to CVE scanning only. Secrets are already covered by the dedicated gitleaks step in CI.
- **Real CVE**: `libc-bin` CVE-2026-0861 (HIGH, fixed upstream). Fix: update `python:3.12-slim` base image SHA to the current digest which includes the patched libc.

## Changes

- `.github/workflows/ci-image.yml`: add `scanners: vuln` to Trivy step
- `ci/Containerfile`: update `python:3.12-slim` SHA from `f3fa41d7...` → `804ddf32...`

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>