### PR TITLE
fix(ci): add apt-get upgrade and trivyignore for remaining CVEs

### DIFF
--- a/.github/workflows/ci-image.yml
+++ b/.github/workflows/ci-image.yml
@@ -80,6 +80,7 @@ jobs:
           scan-type: image
           input: /tmp/scylla-ci.tar
           scanners: vuln
+          trivyignores: .trivyignore
           format: table
           exit-code: 1
           ignore-unfixed: true

--- a/.trivyignore
+++ b/.trivyignore
@@ -1,0 +1,9 @@
+# Trivy vulnerability ignore file
+# Entries here suppress known false-positives or accepted risks in the CI image.
+# Each entry should document WHY it is ignored.
+
+# CVE-2026-33671: picomatch ReDoS — present in markdownlint-cli2's Node dependency tree
+# baked into the pre-commit cache (/root/.cache/pre-commit/ and /home/ci/.cache/).
+# Not runtime code; not reachable from untrusted input in CI. Unfixable without bumping
+# the markdownlint-cli2 pre-commit hook version (which is pinned for reproducibility).
+CVE-2026-33671

--- a/ci/Containerfile
+++ b/ci/Containerfile
@@ -30,7 +30,8 @@ ENV DEBIAN_FRONTEND=noninteractive \
     PATH="/opt/pixi/bin:$PATH"
 
 # Install build dependencies + git (required by pre-commit hooks)
-RUN apt-get update && apt-get install -y --no-install-recommends \
+# apt-get upgrade picks up any security patches released after the base image was pinned
+RUN apt-get update && apt-get upgrade -y && apt-get install -y --no-install-recommends \
     git \
     curl \
     ca-certificates \
@@ -87,7 +88,8 @@ ENV DEBIAN_FRONTEND=noninteractive \
     PATH="/opt/pixi/bin:$PATH"
 
 # Runtime-only system packages (no build tools)
-RUN apt-get update && apt-get install -y --no-install-recommends \
+# apt-get upgrade picks up any security patches released after the base image was pinned
+RUN apt-get update && apt-get upgrade -y && apt-get install -y --no-install-recommends \
     git \
     curl \
     ca-certificates \


### PR DESCRIPTION
## Summary

Follow-up to #1771 and #1772. Two Trivy findings remain after the base image SHA update:

- **CVE-2026-28390** (libssl3t64/openssl, HIGH): Fixed version in apt but not yet in the pinned SHA. Add `apt-get upgrade -y` to both Containerfile stages so security patches are always applied at build time regardless of pin staleness.
- **CVE-2026-33671** (picomatch, HIGH): In markdownlint-cli2 Node deps inside the pre-commit cache baked into the image. Not runtime code, not reachable from untrusted input in CI. Suppressed via `.trivyignore` with documented rationale.

## Changes

- `ci/Containerfile`: add `apt-get upgrade -y` to builder and runtime stages
- `.trivyignore`: new file, suppresses CVE-2026-33671 with rationale comment
- `.github/workflows/ci-image.yml`: wire `trivyignores: .trivyignore` into Trivy step

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>