### PR TITLE
chore(scripts): deprecate standalone nats_subscribe.py in favour of scylla subscribe

### DIFF
--- a/scripts/nats_subscribe.py
+++ b/scripts/nats_subscribe.py
@@ -1,6 +1,16 @@
 #!/usr/bin/env python3
 """Subscribe to NATS JetStream events from ProjectHermes.
 
+.. deprecated::
+    This script is deprecated. Use the ``scylla subscribe`` CLI subcommand instead::
+
+        scylla subscribe
+        scylla subscribe --config-dir /path/to/project
+        NATS_URL=nats://remote:4222 scylla subscribe
+
+    This standalone script duplicates functionality now provided by the
+    ``scylla subscribe`` subcommand and will be removed in a future release.
+
 Starts a long-running subscriber that listens for task events on the
 ``hi.tasks.*`` subject hierarchy. Press Ctrl+C to stop.
 
@@ -17,11 +27,17 @@ import logging
 import signal
 import sys
 import threading
+import warnings
 from pathlib import Path
 
 
 def main(argv: list[str] | None = None) -> int:
     """Run the NATS subscriber."""
+    warnings.warn(
+        "scripts/nats_subscribe.py is deprecated. Use 'scylla subscribe' instead.",
+        DeprecationWarning,
+        stacklevel=1,
+    )
     parser = argparse.ArgumentParser(
         description="Subscribe to NATS JetStream events from ProjectHermes.",
     )


### PR DESCRIPTION
Closes #1668