### PR TITLE
fix: update stale --cov=scylla refs to --cov=src/scylla after src-layout migration

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -354,7 +354,7 @@ pixi run pytest tests/unit/analysis/ -v
 pixi run pytest tests/unit/metrics/ -v
 
 # With coverage
-pixi run pytest tests/ --cov=scylla --cov-report=html
+pixi run pytest tests/ --cov=src/scylla --cov-report=html
 ```
 
 ### Writing Tests

--- a/scripts/quality_audit_feb_2026_issues.sh
+++ b/scripts/quality_audit_feb_2026_issues.sh
@@ -95,7 +95,7 @@ HIGH - Critical for maintaining code quality
 ## Verification
 ```bash
 # Run tests with coverage (should fail if <75%)
-pixi run python -m pytest tests/ --cov=scylla --cov-report=term-missing --cov-fail-under=75
+pixi run python -m pytest tests/ --cov=src/scylla --cov-report=term-missing --cov-fail-under=75
 ```
 
 ## Context

--- a/scripts/run_ci_local.sh
+++ b/scripts/run_ci_local.sh
@@ -135,7 +135,7 @@ run_test_unit() {
         pixi run pytest tests/unit \
             --override-ini="addopts=" \
             -v --strict-markers \
-            --cov=scylla --cov-report=term-missing \
+            --cov=src/scylla --cov-report=term-missing \
             --cov-fail-under=75
 }
 
@@ -143,7 +143,7 @@ run_test_integration() {
     log_step "Integration tests (pytest tests/integration)"
     run_in_container \
         pixi run pytest tests/integration \
-            -v --cov=scylla --cov-report=term-missing
+            -v --cov=src/scylla --cov-report=term-missing
 }
 
 run_security() {


### PR DESCRIPTION
Fix stale pytest coverage source references that still point to the old flat-layout
`scylla` package instead of `src/scylla` after the migration to src-layout.

Files updated:
- `scripts/run_ci_local.sh` (lines 138, 146)
- `CONTRIBUTING.md` (line 357)  
- `scripts/quality_audit_feb_2026_issues.sh` (line 98)

Closes #1671