### PR TITLE
feat(scripts): add --tag flag to bump_version.py for git tag creation

### DIFF
--- a/scripts/bump_version.py
+++ b/scripts/bump_version.py
@@ -221,6 +221,7 @@ def bump_version(
     part: str,
     dry_run: bool = False,
     verbose: bool = False,
+    tag: bool = False,
 ) -> int:
     """Bump the project version atomically across pyproject.toml and pixi.toml.
 
@@ -229,6 +230,7 @@ def bump_version(
         part: Which part to bump — ``"major"``, ``"minor"``, or ``"patch"``.
         dry_run: If True, print what would change without writing.
         verbose: If True, print additional details.
+        tag: If True, create a git tag ``v<new_version>`` after bumping.
 
     Returns:
         0 on success, 1 on failure.
@@ -264,10 +266,11 @@ def bump_version(
         )
         return 1
 
-    # Create git tag for the new version
-    tag_result = create_git_tag(new_str, repo_root, verbose=verbose)
-    if tag_result != 0:
-        return 1
+    # Optionally create a git tag for the new version
+    if tag:
+        tag_result = create_git_tag(new_str, repo_root, verbose=verbose)
+        if tag_result != 0:
+            return 1
 
     print(f"Version bumped: {old_str} -> {new_str}")
     print()
@@ -312,6 +315,11 @@ def main() -> int:
         action="store_true",
         help="Print additional details",
     )
+    parser.add_argument(
+        "--tag",
+        action="store_true",
+        help="Create a git tag v<new_version> after bumping",
+    )
 
     args = parser.parse_args()
     return bump_version(
@@ -319,6 +327,7 @@ def main() -> int:
         part=args.part,
         dry_run=args.dry_run,
         verbose=args.verbose,
+        tag=args.tag,
     )
 
 

--- a/tests/unit/scripts/test_bump_version.py
+++ b/tests/unit/scripts/test_bump_version.py
@@ -347,11 +347,30 @@ class TestBumpVersion:
         assert 'version = "2.0.0"' in (tmp_path / "pyproject.toml").read_text()
         assert 'version = "2.0.0"' in (tmp_path / "pixi.toml").read_text()
 
-    def test_creates_git_tag_after_bump(self, tmp_path: Path) -> None:
-        """Should create a git tag v{new_version} after a successful bump."""
+    def test_no_git_tag_by_default(self, tmp_path: Path) -> None:
+        """Should not create a git tag when --tag is not passed."""
         setup_repo(tmp_path, "0.1.0")
         init_git_repo(tmp_path)
         result = bump_version(tmp_path, "patch")
+        assert result == 0
+        tags = (
+            subprocess.run(
+                ["git", "tag"],
+                cwd=tmp_path,
+                capture_output=True,
+                text=True,
+                check=True,
+            )
+            .stdout.strip()
+            .splitlines()
+        )
+        assert "v0.1.1" not in tags
+
+    def test_creates_git_tag_when_flag_passed(self, tmp_path: Path) -> None:
+        """Should create a git tag v{new_version} when tag=True is passed."""
+        setup_repo(tmp_path, "0.1.0")
+        init_git_repo(tmp_path)
+        result = bump_version(tmp_path, "patch", tag=True)
         assert result == 0
         tags = (
             subprocess.run(


### PR DESCRIPTION
Add optional \`--tag\` flag to \`scripts/bump_version.py\` that creates a
\`v<new_version>\` git tag after bumping version files.

Previously, `bump_version()` always created a git tag. This changes
the behaviour so tagging is opt-in via `--tag`.

Usage:
\`\`\`
python scripts/bump_version.py patch --tag
python scripts/bump_version.py minor --tag
\`\`\`

If the tag already exists, a helpful error is printed and the script
exits with code 1.

Closes #1702