### PR TITLE
fix(nats): suppress asyncio.iscoroutinefunction DeprecationWarning from nats-py

### DIFF
--- a/pixi.lock
+++ b/pixi.lock
@@ -5255,7 +5255,7 @@ packages:
 - pypi: ./
   name: scylla
   version: 0.1.0
-  sha256: 19ea497b5aeafd29fdf1aca8a4f68ae8e84574a3f0d846656955ddd27502b5c3
+  sha256: 60c8d8eba3c4bde6918519f43369f022c89914fe3591a86c5af15915255303b5
   requires_dist:
   - click>=8.0,<9
   - homericintelligence-hephaestus>=0.6.0,<1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -125,6 +125,9 @@ addopts = [
 markers = [
     "integration: marks tests as integration tests (deselect with '-m \"not integration\"')",
 ]
+filterwarnings = [
+    "ignore::DeprecationWarning:nats",
+]
 
 [tool.bandit]
 # Bandit AST-based Python security scanner configuration.


### PR DESCRIPTION
All 5 NATS integration tests emit:
\`DeprecationWarning: 'asyncio.iscoroutinefunction' is deprecated\`
from the nats-py library.

Suppress this warning via pytest filterwarnings config since it originates
in a third-party library and is not actionable.

Closes #1656