### PR TITLE
fix(e2e): replace broad except Exception in judge_runner with specific exception types

### DIFF
--- a/src/scylla/e2e/judge_runner.py
+++ b/src/scylla/e2e/judge_runner.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import json
 import logging
+import subprocess
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, cast
@@ -205,7 +206,14 @@ def _run_judge(
             # Rate limit errors must propagate immediately to trigger backoff
             raise
 
-        except Exception as e:
+        except (
+            RuntimeError,
+            ValueError,
+            subprocess.TimeoutExpired,
+            subprocess.SubprocessError,
+            OSError,
+            json.JSONDecodeError,
+        ) as e:
             # Log error with full context
             logger.error(
                 f"Judge {judge_num} failed with model {model}: {e}",

--- a/tests/unit/e2e/test_judge_runner.py
+++ b/tests/unit/e2e/test_judge_runner.py
@@ -322,14 +322,22 @@ class TestRunJudge:
         assert consensus["score"] == pytest.approx(0.9)
         assert consensus["passed"] is True
 
-    def test_judge_failure_records_zero_score(self, tmp_path: Path) -> None:
+    @pytest.mark.parametrize(
+        "exc",
+        [
+            RuntimeError("cli failed"),
+            ValueError("bad json"),
+            OSError("file error"),
+        ],
+    )
+    def test_judge_failure_records_zero_score(self, tmp_path: Path, exc: Exception) -> None:
         """Individual judge failure creates zero-score failed result instead of crashing."""
         judge_dir = tmp_path / "judge"
         judge_dir.mkdir()
 
         with patch(
             "scylla.e2e.judge_runner.run_llm_judge",
-            side_effect=Exception("judge error"),
+            side_effect=exc,
         ):
             _consensus, judges = _run_judge(
                 workspace=tmp_path,
@@ -351,7 +359,7 @@ class TestRunJudge:
 
         with patch(
             "scylla.e2e.judge_runner.run_llm_judge",
-            side_effect=Exception("judge error"),
+            side_effect=RuntimeError("cli failed"),
         ):
             consensus, judges = _run_judge(
                 workspace=tmp_path,


### PR DESCRIPTION
Replace the broad \`except Exception\` handler in \`judge_runner.py\`
with specific exception types, making error handling intentional and
preventing silent swallowing of unexpected exceptions.

The handler in `_run_judge()` now catches only:
- `RuntimeError` — Claude CLI subprocess failure (non-zero exit)
- `ValueError` — malformed/empty judge response JSON
- `subprocess.TimeoutExpired` — judge call exceeds 1200s timeout
- `subprocess.SubprocessError` — other subprocess failures
- `OSError` — file I/O errors writing timing/error artifacts
- `json.JSONDecodeError` — JSON parse errors in response handling

`RateLimitError` continues to propagate immediately via its own explicit re-raise. Tests updated to use concrete exception types and parametrized across `RuntimeError`, `ValueError`, and `OSError`.

Closes #1618