### PR TITLE
fix(scripts): scope pixi.toml version regex to [workspace] section

### DIFF
--- a/scripts/check_version_consistency.py
+++ b/scripts/check_version_consistency.py
@@ -24,9 +24,14 @@ try:
 except ImportError:
     import tomli as tomllib
 
-# Regex to match version = "X.Y.Z" in pixi.toml [workspace] section.
+# Regex to match version = "X.Y.Z" in the [workspace] section of pixi.toml.
+# Anchors to the [workspace] header and captures the first version field that
+# follows it (before any subsequent section header).  Using re.DOTALL so that
+# [^\[]* can span newlines.
 # We use regex instead of a TOML parser to avoid reformatting the file.
-_PIXI_VERSION_RE = re.compile(r'^version\s*=\s*"([^"]+)"', re.MULTILINE)
+_PIXI_VERSION_RE = re.compile(
+    r'(?s)\[workspace\][^\[]*?version\s*=\s*"([^"]+)"',
+)
 
 
 def get_pyproject_version(repo_root: Path) -> str:

--- a/tests/unit/scripts/test_check_version_consistency.py
+++ b/tests/unit/scripts/test_check_version_consistency.py
@@ -124,6 +124,35 @@ class TestGetPixiVersion:
         path.write_text('[workspace]\nversion  =  "2.0.0"\n')
         assert get_pixi_version(tmp_path) == "2.0.0"
 
+    def test_ignores_dependency_version_outside_workspace(self, tmp_path: Path) -> None:
+        """Should not pick up a version field that appears outside [workspace]."""
+        content = textwrap.dedent("""\
+            [workspace]
+            name = "test-project"
+            version = "1.2.3"
+
+            [dependencies]
+            some-dep = "9.9.9"
+            another = { version = "8.8.8" }
+        """)
+        path = tmp_path / "pixi.toml"
+        path.write_text(content)
+        assert get_pixi_version(tmp_path) == "1.2.3"
+
+    def test_version_field_before_workspace_not_matched(self, tmp_path: Path) -> None:
+        """Should not match a version = line that appears before [workspace]."""
+        content = textwrap.dedent("""\
+            [other]
+            version = "0.0.1"
+
+            [workspace]
+            name = "test-project"
+            version = "1.0.0"
+        """)
+        path = tmp_path / "pixi.toml"
+        path.write_text(content)
+        assert get_pixi_version(tmp_path) == "1.0.0"
+
 
 # ---------------------------------------------------------------------------
 # TestCheckVersionConsistency


### PR DESCRIPTION
\`_PIXI_VERSION_RE\` in \`check_version_consistency.py\` previously matched the
first \`version = "..."\` occurrence anywhere in \`pixi.toml\`, which could
accidentally match a dependency version rather than the project's own
version in the \`[workspace]\` section.

Updated the regex to use DOTALL and anchor to the \`[workspace]\` section
header, consistent with the approach already used in \`bump_version.py\`.

Two new tests added to \`test_check_version_consistency.py\`:
- \`test_ignores_dependency_version_outside_workspace\`: verifies dependency versions after \`[workspace]\` are not matched
- \`test_version_field_before_workspace_not_matched\`: verifies a version field in a section before \`[workspace]\` is not matched

Closes #1703