### PR TITLE
fix(ci): fix release.yml version regex to handle dotted pyproject.toml headers

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,12 +24,13 @@ jobs:
         run: |
           TAG_VERSION="${TAG_NAME#v}"
           PKG_VERSION=$(python3 -c "
-          import re, pathlib
-          text = pathlib.Path('pyproject.toml').read_text()
-          project_section = re.search(r'^\[project\](.*?)^(?=\[)', text, re.MULTILINE | re.DOTALL)
-          section_text = project_section.group(1) if project_section else text
-          m = re.search(r'^version\s*=\s*\"([^\"]+)\"', section_text, re.MULTILINE)
-          print(m.group(1) if m else '')
+          try:
+              import tomllib
+          except ImportError:
+              import tomli as tomllib
+          with open('pyproject.toml', 'rb') as f:
+              data = tomllib.load(f)
+          print(data['project']['version'])
           ")
           if [ "$TAG_VERSION" != "$PKG_VERSION" ]; then
             echo "::error::Tag version ($TAG_VERSION) does not match pyproject.toml version ($PKG_VERSION)"


### PR DESCRIPTION
## Summary

- The regex in `release.yml` for extracting version from `pyproject.toml` used a fragile `re.search` pattern that could match `version = "..."` lines in dotted table headers like `[tool.hatch.version]` instead of the `[project]` section
- Replaced with Python's `tomllib` (stdlib in Python 3.11+, with fallback to `tomli` for 3.10) for reliable TOML parsing that correctly navigates the `data['project']['version']` path

## Test plan
- [ ] Verify the release workflow correctly reads `version = "0.1.0"` from `[project]` section
- [ ] Confirm no false matches from other TOML sections containing `version`

Closes #1615