### PR TITLE
refactor(scripts): consolidate pyproject.toml parsing into shared helper

### DIFF
--- a/scripts/check_doc_config_consistency.py
+++ b/scripts/check_doc_config_consistency.py
@@ -25,11 +25,11 @@ import subprocess
 import sys
 from pathlib import Path
 
-import tomllib
-
 _REPO_ROOT = Path(__file__).parent.parent
 if str(_REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(_REPO_ROOT))
+
+from common import load_pyproject  # noqa: E402
 
 
 def load_pyproject_coverage_threshold(repo_root: Path) -> int:
@@ -45,17 +45,7 @@ def load_pyproject_coverage_threshold(repo_root: Path) -> int:
         SystemExit: If ``pyproject.toml`` is missing, unreadable, or lacks the key.
 
     """
-    pyproject = repo_root / "pyproject.toml"
-    if not pyproject.exists():
-        print(f"ERROR: pyproject.toml not found at {pyproject}", file=sys.stderr)
-        sys.exit(1)
-
-    try:
-        with open(pyproject, "rb") as f:
-            data = tomllib.load(f)
-    except Exception as exc:
-        print(f"ERROR: Failed to parse pyproject.toml: {exc}", file=sys.stderr)
-        sys.exit(1)
+    data = load_pyproject(repo_root)
 
     try:
         threshold = data["tool"]["coverage"]["report"]["fail_under"]
@@ -82,13 +72,7 @@ def extract_cov_path_from_pyproject(repo_root: Path) -> str:
         SystemExit: If the key is missing or no ``--cov=`` flag is found.
 
     """
-    pyproject = repo_root / "pyproject.toml"
-    try:
-        with open(pyproject, "rb") as f:
-            data = tomllib.load(f)
-    except Exception as exc:
-        print(f"ERROR: Failed to parse pyproject.toml: {exc}", file=sys.stderr)
-        sys.exit(1)
+    data = load_pyproject(repo_root)
 
     addopts = data.get("tool", {}).get("pytest", {}).get("ini_options", {}).get("addopts", [])
 
@@ -195,13 +179,7 @@ def extract_cov_fail_under_from_addopts(repo_root: Path) -> int | None:
         SystemExit: If ``pyproject.toml`` is missing or unreadable.
 
     """
-    pyproject = repo_root / "pyproject.toml"
-    try:
-        with open(pyproject, "rb") as f:
-            data = tomllib.load(f)
-    except Exception as exc:
-        print(f"ERROR: Failed to parse pyproject.toml: {exc}", file=sys.stderr)
-        sys.exit(1)
+    data = load_pyproject(repo_root)
 
     addopts = data.get("tool", {}).get("pytest", {}).get("ini_options", {}).get("addopts", [])
 

--- a/scripts/common.py
+++ b/scripts/common.py
@@ -10,8 +10,11 @@ Centralized Utilities:
 - Colors: ANSI terminal colors with disable() method
 """
 
+import sys
 from pathlib import Path
+from typing import Any
 
+import tomllib
 from hephaestus.utils.helpers import get_repo_root
 
 # Label colors for GitHub issues (evaluation workflow)
@@ -23,6 +26,33 @@ LABEL_COLORS = {
     "analysis": "c2e0c6",  # Light green
     "documentation": "0075ca",  # Blue
 }
+
+
+def load_pyproject(repo_root: Path) -> dict[str, Any]:
+    """Load and parse ``pyproject.toml`` from *repo_root*.
+
+    Args:
+        repo_root: Path to the repository root containing ``pyproject.toml``.
+
+    Returns:
+        Parsed TOML data as a dictionary.
+
+    Raises:
+        SystemExit: If ``pyproject.toml`` is missing or cannot be parsed.
+
+    """
+    pyproject = repo_root / "pyproject.toml"
+    if not pyproject.exists():
+        print(f"ERROR: pyproject.toml not found at {pyproject}", file=sys.stderr)
+        sys.exit(1)
+
+    try:
+        with open(pyproject, "rb") as f:
+            data: dict[str, Any] = tomllib.load(f)
+            return data
+    except Exception as exc:
+        print(f"ERROR: Failed to parse pyproject.toml: {exc}", file=sys.stderr)
+        sys.exit(1)
 
 
 def get_agents_dir() -> Path:


### PR DESCRIPTION
## Summary
- Add `load_pyproject(repo_root: Path) -> dict[str, Any]` helper to `scripts/common.py`
- Update `scripts/check_doc_config_consistency.py` to call `load_pyproject()` in the three places that previously had inline `tomllib.load()` calls
- Remove `import tomllib` from `check_doc_config_consistency.py` (now handled by `common.py`)

## Test plan
- [ ] `SKIP=gitleaks,yamllint pixi run python -m pytest tests/unit/scripts/ -v -k "consistency or changelog"` — 304 tests pass
- [ ] `SKIP=gitleaks,yamllint pixi run pre-commit run --files scripts/common.py scripts/check_doc_config_consistency.py scripts/check_changelog_version.py` — all hooks pass

Closes #1699

🤖 Generated with [Claude Code](https://claude.com/claude-code)