### PR TITLE
feat(dx): add .editorconfig for cross-editor consistency

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,25 +1,22 @@
+# EditorConfig — https://editorconfig.org
 root = true
 
 [*]
+charset = utf-8
 end_of_line = lf
 insert_final_newline = true
-charset = utf-8
 trim_trailing_whitespace = true
-
-[*.py]
 indent_style = space
 indent_size = 4
 
-[*.{yml,yaml}]
-indent_style = space
+[*.py]
+indent_size = 4
+
+[*.{yml,yaml,json,toml}]
 indent_size = 2
 
 [*.md]
 trim_trailing_whitespace = false
-
-[*.{json,toml}]
-indent_style = space
-indent_size = 2
 
 [*.sh]
 indent_style = space
@@ -28,3 +25,6 @@ indent_size = 2
 [Dockerfile*]
 indent_style = space
 indent_size = 4
+
+[Makefile]
+indent_style = tab


### PR DESCRIPTION
Add `.editorconfig` to ensure consistent formatting rules across editors and IDEs.

Closes #1526