### PR TITLE
feat(maestro): add MaestroClient and AsyncMaestroClient for AI Maestro REST API

### DIFF
--- a/src/scylla/maestro/__init__.py
+++ b/src/scylla/maestro/__init__.py
@@ -1,0 +1,27 @@
+"""AI Maestro REST API integration.
+
+This module provides an HTTP client for communicating with the AI Maestro
+service to inject failures into agents during E2E evaluation runs.
+"""
+
+from scylla.maestro.async_client import AsyncMaestroClient as AsyncMaestroClient
+from scylla.maestro.client import MaestroClient as MaestroClient
+from scylla.maestro.errors import MaestroAPIError as MaestroAPIError
+from scylla.maestro.errors import MaestroConnectionError as MaestroConnectionError
+from scylla.maestro.errors import MaestroError as MaestroError
+from scylla.maestro.models import FailureSpec as FailureSpec
+from scylla.maestro.models import HealthResponse as HealthResponse
+from scylla.maestro.models import InjectionResult as InjectionResult
+from scylla.maestro.models import MaestroConfig as MaestroConfig
+
+__all__ = [
+    "AsyncMaestroClient",
+    "FailureSpec",
+    "HealthResponse",
+    "InjectionResult",
+    "MaestroAPIError",
+    "MaestroClient",
+    "MaestroConfig",
+    "MaestroConnectionError",
+    "MaestroError",
+]

--- a/src/scylla/maestro/async_client.py
+++ b/src/scylla/maestro/async_client.py
@@ -1,0 +1,213 @@
+"""Asynchronous HTTP client for the AI Maestro REST API.
+
+Provides ``AsyncMaestroClient``, a thin wrapper around ``httpx.AsyncClient``
+that exposes health-checking, agent listing, failure injection, and diagnostics
+endpoints without blocking the event loop.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+import httpx
+
+from scylla.maestro.errors import MaestroAPIError, MaestroConnectionError, MaestroError
+from scylla.maestro.models import (
+    FailureSpec,
+    HealthResponse,
+    InjectionResult,
+    MaestroConfig,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class AsyncMaestroClient:
+    """Asynchronous HTTP client for the AI Maestro REST API.
+
+    Typical usage::
+
+        config = MaestroConfig(base_url="http://localhost:23000", enabled=True)
+        async with AsyncMaestroClient(config) as client:
+            if await client.health_check():
+                result = await client.inject_failure(spec)
+
+    The client can also be used without an async context manager; call
+    :meth:`close` explicitly when done.
+    """
+
+    def __init__(self, config: MaestroConfig) -> None:
+        """Initialize the async Maestro client.
+
+        Args:
+            config: Maestro configuration with base URL and timeouts.
+
+        """
+        self._config = config
+        self._base_url = config.base_url.rstrip("/")
+        self._client = httpx.AsyncClient(
+            base_url=self._base_url,
+            timeout=httpx.Timeout(config.timeout_seconds),
+        )
+
+    # -- Async context manager -----------------------------------------------
+
+    async def __aenter__(self) -> AsyncMaestroClient:
+        """Enter the async context manager."""
+        return self
+
+    async def __aexit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_val: BaseException | None,
+        exc_tb: Any,
+    ) -> None:
+        """Exit the async context manager and close the underlying HTTP client."""
+        await self.close()
+
+    async def close(self) -> None:
+        """Close the underlying HTTP connection pool."""
+        await self._client.aclose()
+
+    # -- Helpers -------------------------------------------------------------
+
+    async def _request(
+        self,
+        method: str,
+        path: str,
+        *,
+        json: dict[str, Any] | None = None,
+        timeout: float | None = None,
+    ) -> httpx.Response:
+        """Send an HTTP request and handle common error scenarios.
+
+        Args:
+            method: HTTP method (GET, POST, DELETE, etc.).
+            path: URL path relative to the base URL.
+            json: Optional JSON body for POST/PUT requests.
+            timeout: Optional per-request timeout override.
+
+        Returns:
+            The ``httpx.Response`` object.
+
+        Raises:
+            MaestroConnectionError: On network or timeout failures.
+            MaestroAPIError: On non-2xx status codes.
+
+        """
+        try:
+            response = await self._client.request(
+                method,
+                path,
+                json=json,
+                timeout=timeout,
+            )
+        except httpx.ConnectError as exc:
+            raise MaestroConnectionError(
+                f"Failed to connect to Maestro API at {self._base_url}: {exc}"
+            ) from exc
+        except httpx.TimeoutException as exc:
+            raise MaestroConnectionError(f"Request to Maestro API timed out: {exc}") from exc
+        except httpx.HTTPError as exc:
+            raise MaestroError(f"HTTP error communicating with Maestro API: {exc}") from exc
+
+        if not response.is_success:
+            raise MaestroAPIError(
+                f"Maestro API returned {response.status_code} for {method} {path}",
+                status_code=response.status_code,
+                response_body=response.text,
+            )
+
+        return response
+
+    # -- Public API ----------------------------------------------------------
+
+    async def health_check(self) -> HealthResponse | None:
+        """Check Maestro API health.
+
+        Returns:
+            A ``HealthResponse`` if the service is healthy, or ``None`` if the
+            service is unreachable.
+
+        """
+        try:
+            response = await self._request(
+                "GET",
+                "/api/v1/health",
+                timeout=self._config.health_check_timeout_seconds,
+            )
+            data: dict[str, Any] = response.json() or {}
+            return HealthResponse(**data)
+        except MaestroError:
+            logger.debug("Maestro health check failed", exc_info=True)
+            return None
+
+    async def list_agents(self) -> list[dict[str, Any]]:
+        """List all agents registered with Maestro.
+
+        Returns:
+            A list of agent dictionaries.
+
+        Raises:
+            MaestroConnectionError: On network failures.
+            MaestroAPIError: On non-2xx responses.
+
+        """
+        response = await self._request("GET", "/api/agents")
+        result: list[dict[str, Any]] = response.json() or []
+        return result
+
+    async def inject_failure(self, spec: FailureSpec) -> InjectionResult:
+        """Inject a failure into a target agent.
+
+        Args:
+            spec: The failure specification describing what to inject.
+
+        Returns:
+            An ``InjectionResult`` with the injection ID and status.
+
+        Raises:
+            MaestroConnectionError: On network failures.
+            MaestroAPIError: On non-2xx responses.
+
+        """
+        payload: dict[str, Any] = {
+            "agent_id": spec.agent_id,
+            "failure_type": spec.failure_type,
+            "parameters": spec.parameters or {},
+        }
+        if spec.duration_seconds is not None:
+            payload["duration_seconds"] = spec.duration_seconds
+
+        response = await self._request("POST", "/api/agents/inject", json=payload)
+        data: dict[str, Any] = response.json() or {}
+        return InjectionResult(**data)
+
+    async def clear_failure(self, injection_id: str) -> None:
+        """Remove a previously injected failure.
+
+        Args:
+            injection_id: The injection ID returned by :meth:`inject_failure`.
+
+        Raises:
+            MaestroConnectionError: On network failures.
+            MaestroAPIError: On non-2xx responses.
+
+        """
+        await self._request("DELETE", f"/api/agents/inject/{injection_id}")
+
+    async def get_diagnostics(self) -> dict[str, Any]:
+        """Retrieve Maestro diagnostic information.
+
+        Returns:
+            A dictionary of diagnostic data.
+
+        Raises:
+            MaestroConnectionError: On network failures.
+            MaestroAPIError: On non-2xx responses.
+
+        """
+        response = await self._request("GET", "/api/diagnostics")
+        result: dict[str, Any] = response.json() or {}
+        return result

--- a/src/scylla/maestro/client.py
+++ b/src/scylla/maestro/client.py
@@ -1,0 +1,274 @@
+"""HTTP client for the AI Maestro REST API.
+
+Provides ``MaestroClient``, a thin wrapper around ``httpx.Client`` that
+exposes health-checking, agent listing, failure injection, and diagnostics
+endpoints.  Transient failures are automatically retried with exponential
+backoff (configurable via ``MaestroConfig.max_retries``).
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from typing import Any
+
+import httpx
+
+from scylla.maestro.errors import MaestroAPIError, MaestroConnectionError, MaestroError
+from scylla.maestro.models import (
+    FailureSpec,
+    HealthResponse,
+    InjectionResult,
+    MaestroConfig,
+)
+
+logger = logging.getLogger(__name__)
+
+# Status codes that indicate transient server-side issues worth retrying.
+_RETRYABLE_STATUS_CODES: frozenset[int] = frozenset({502, 503, 504})
+
+# httpx exception types that represent transient network problems.
+_RETRYABLE_EXCEPTIONS: tuple[type[Exception], ...] = (
+    httpx.ConnectError,
+    httpx.TimeoutException,
+    httpx.RemoteProtocolError,
+)
+
+_BASE_RETRY_DELAY: float = 1.0
+_RETRY_BACKOFF_FACTOR: int = 2
+
+
+class MaestroClient:
+    """Synchronous HTTP client for the AI Maestro REST API.
+
+    Typical usage::
+
+        config = MaestroConfig(base_url="http://localhost:23000", enabled=True)
+        with MaestroClient(config) as client:
+            if client.health_check():
+                result = client.inject_failure(spec)
+
+    The client can also be used without a context manager; call :meth:`close`
+    explicitly when done.
+    """
+
+    def __init__(self, config: MaestroConfig) -> None:
+        """Initialize the Maestro client.
+
+        Args:
+            config: Maestro configuration with base URL and timeouts.
+
+        """
+        self._config = config
+        self._base_url = config.base_url.rstrip("/")
+        self._client = httpx.Client(
+            base_url=self._base_url,
+            timeout=httpx.Timeout(config.timeout_seconds),
+        )
+
+    # -- Context manager -----------------------------------------------------
+
+    def __enter__(self) -> MaestroClient:
+        """Enter the context manager."""
+        return self
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_val: BaseException | None,
+        exc_tb: Any,
+    ) -> None:
+        """Exit the context manager and close the underlying HTTP client."""
+        self.close()
+
+    def close(self) -> None:
+        """Close the underlying HTTP connection pool."""
+        self._client.close()
+
+    # -- Helpers -------------------------------------------------------------
+
+    def _request(
+        self,
+        method: str,
+        path: str,
+        *,
+        json: dict[str, Any] | None = None,
+        timeout: float | None = None,
+    ) -> httpx.Response:
+        """Send an HTTP request with automatic retry on transient failures.
+
+        Retries on connection errors, timeouts, remote protocol errors, and
+        HTTP 502/503/504 responses using exponential backoff (1s, 2s, 4s, ...).
+        Non-retryable errors (e.g. HTTP 400/401/403/404) raise immediately.
+
+        Args:
+            method: HTTP method (GET, POST, DELETE, etc.).
+            path: URL path relative to the base URL.
+            json: Optional JSON body for POST/PUT requests.
+            timeout: Optional per-request timeout override.
+
+        Returns:
+            The ``httpx.Response`` object.
+
+        Raises:
+            MaestroConnectionError: On network or timeout failures after retries.
+            MaestroAPIError: On non-2xx status codes (after retries for 502/503/504).
+
+        """
+        max_attempts = self._config.max_retries + 1
+        last_exception: Exception | None = None
+
+        for attempt in range(max_attempts):
+            try:
+                response = self._client.request(
+                    method,
+                    path,
+                    json=json,
+                    timeout=timeout,
+                )
+            except _RETRYABLE_EXCEPTIONS as exc:
+                last_exception = exc
+                if attempt < self._config.max_retries:
+                    delay = _BASE_RETRY_DELAY * (_RETRY_BACKOFF_FACTOR**attempt)
+                    logger.warning(
+                        "Maestro request %s %s failed (attempt %d/%d): %s — retrying in %.1fs",
+                        method,
+                        path,
+                        attempt + 1,
+                        max_attempts,
+                        exc,
+                        delay,
+                    )
+                    time.sleep(delay)
+                    continue
+                # Last attempt exhausted — raise as connection error
+                raise MaestroConnectionError(
+                    f"Failed to connect to Maestro API at {self._base_url} "
+                    f"after {max_attempts} attempts: {exc}"
+                ) from exc
+            except httpx.HTTPError as exc:
+                raise MaestroError(f"HTTP error communicating with Maestro API: {exc}") from exc
+
+            # Check for non-success status codes
+            if not response.is_success:
+                if (
+                    response.status_code in _RETRYABLE_STATUS_CODES
+                    and attempt < self._config.max_retries
+                ):
+                    delay = _BASE_RETRY_DELAY * (_RETRY_BACKOFF_FACTOR**attempt)
+                    logger.warning(
+                        "Maestro API returned %d for %s %s (attempt %d/%d) — retrying in %.1fs",
+                        response.status_code,
+                        method,
+                        path,
+                        attempt + 1,
+                        max_attempts,
+                        delay,
+                    )
+                    time.sleep(delay)
+                    continue
+                raise MaestroAPIError(
+                    f"Maestro API returned {response.status_code} for {method} {path}",
+                    status_code=response.status_code,
+                    response_body=response.text,
+                )
+
+            return response
+
+        # Should only be reached if max_retries > 0 and all attempts raised
+        # retryable exceptions (the last attempt re-raises above, so this is
+        # a safety net for the type checker).
+        raise MaestroConnectionError(  # pragma: no cover
+            f"All {max_attempts} attempts to {method} {path} failed: {last_exception}"
+        )
+
+    # -- Public API ----------------------------------------------------------
+
+    def health_check(self) -> HealthResponse | None:
+        """Check Maestro API health.
+
+        Returns:
+            A ``HealthResponse`` if the service is healthy, or ``None`` if the
+            service is unreachable.
+
+        """
+        try:
+            response = self._request(
+                "GET",
+                "/api/v1/health",
+                timeout=self._config.health_check_timeout_seconds,
+            )
+            data: dict[str, Any] = response.json() or {}
+            return HealthResponse(**data)
+        except MaestroError:
+            logger.debug("Maestro health check failed", exc_info=True)
+            return None
+
+    def list_agents(self) -> list[dict[str, Any]]:
+        """List all agents registered with Maestro.
+
+        Returns:
+            A list of agent dictionaries.
+
+        Raises:
+            MaestroConnectionError: On network failures.
+            MaestroAPIError: On non-2xx responses.
+
+        """
+        response = self._request("GET", "/api/agents")
+        result: list[dict[str, Any]] = response.json() or []
+        return result
+
+    def inject_failure(self, spec: FailureSpec) -> InjectionResult:
+        """Inject a failure into a target agent.
+
+        Args:
+            spec: The failure specification describing what to inject.
+
+        Returns:
+            An ``InjectionResult`` with the injection ID and status.
+
+        Raises:
+            MaestroConnectionError: On network failures.
+            MaestroAPIError: On non-2xx responses.
+
+        """
+        payload: dict[str, Any] = {
+            "agent_id": spec.agent_id,
+            "failure_type": spec.failure_type,
+            "parameters": spec.parameters or {},
+        }
+        if spec.duration_seconds is not None:
+            payload["duration_seconds"] = spec.duration_seconds
+
+        response = self._request("POST", "/api/agents/inject", json=payload)
+        data: dict[str, Any] = response.json() or {}
+        return InjectionResult(**data)
+
+    def clear_failure(self, injection_id: str) -> None:
+        """Remove a previously injected failure.
+
+        Args:
+            injection_id: The injection ID returned by :meth:`inject_failure`.
+
+        Raises:
+            MaestroConnectionError: On network failures.
+            MaestroAPIError: On non-2xx responses.
+
+        """
+        self._request("DELETE", f"/api/agents/inject/{injection_id}")
+
+    def get_diagnostics(self) -> dict[str, Any]:
+        """Retrieve Maestro diagnostic information.
+
+        Returns:
+            A dictionary of diagnostic data.
+
+        Raises:
+            MaestroConnectionError: On network failures.
+            MaestroAPIError: On non-2xx responses.
+
+        """
+        response = self._request("GET", "/api/diagnostics")
+        result: dict[str, Any] = response.json() or {}
+        return result

--- a/src/scylla/maestro/errors.py
+++ b/src/scylla/maestro/errors.py
@@ -1,0 +1,32 @@
+"""Exception hierarchy for AI Maestro REST API integration."""
+
+
+class MaestroError(Exception):
+    """Base exception for all Maestro API errors."""
+
+
+class MaestroConnectionError(MaestroError):
+    """Raised when the Maestro API is unreachable or a connection times out."""
+
+
+class MaestroAPIError(MaestroError):
+    """Raised when the Maestro API returns a non-2xx response.
+
+    Attributes:
+        status_code: HTTP status code from the response.
+        response_body: Raw response body text.
+
+    """
+
+    def __init__(self, message: str, status_code: int, response_body: str = "") -> None:
+        """Initialize MaestroAPIError.
+
+        Args:
+            message: Human-readable error description.
+            status_code: HTTP status code from the response.
+            response_body: Raw response body text.
+
+        """
+        super().__init__(message)
+        self.status_code = status_code
+        self.response_body = response_body

--- a/src/scylla/maestro/models.py
+++ b/src/scylla/maestro/models.py
@@ -1,0 +1,81 @@
+"""Pydantic models for AI Maestro REST API integration.
+
+Defines configuration, request, and response models used by MaestroClient.
+"""
+
+from typing import Any
+
+from pydantic import BaseModel, Field
+
+
+class MaestroConfig(BaseModel):
+    """Configuration for the AI Maestro REST API connection.
+
+    When ``enabled`` is ``False`` (the default), the client is not instantiated
+    and no HTTP calls are made.  This keeps the integration fully opt-in.
+    """
+
+    base_url: str = Field(
+        default="http://localhost:23000",
+        description="Base URL for the Maestro REST API",
+    )
+    enabled: bool = Field(
+        default=False,
+        description="Whether to activate the Maestro integration",
+    )
+    timeout_seconds: int = Field(
+        default=10,
+        ge=1,
+        le=300,
+        description="Timeout in seconds for mutation requests",
+    )
+    health_check_timeout_seconds: int = Field(
+        default=5,
+        ge=1,
+        le=60,
+        description="Timeout in seconds for health-check requests",
+    )
+    max_retries: int = Field(
+        default=3,
+        ge=0,
+        le=10,
+        description="Maximum retry attempts for transient network failures (0 disables retry)",
+    )
+
+
+class FailureSpec(BaseModel):
+    """Specification for a failure to inject via the Maestro API.
+
+    Attributes:
+        agent_id: Target agent identifier.
+        failure_type: Kind of failure (e.g. ``network_delay``, ``crash``, ``timeout``).
+        duration_seconds: Optional duration; ``None`` means permanent until cleared.
+        parameters: Arbitrary key-value parameters for the failure type.
+
+    """
+
+    agent_id: str = Field(..., description="Target agent identifier")
+    failure_type: str = Field(..., description="Kind of failure to inject")
+    duration_seconds: int | None = Field(
+        default=None,
+        ge=1,
+        description="Duration in seconds; None means permanent until cleared",
+    )
+    parameters: dict[str, Any] = Field(
+        default_factory=dict,
+        description="Extra parameters for the failure type",
+    )
+
+
+class HealthResponse(BaseModel):
+    """Response model for the Maestro health endpoint."""
+
+    status: str = Field(..., description="Health status string (e.g. 'ok')")
+    version: str | None = Field(default=None, description="API version string")
+
+
+class InjectionResult(BaseModel):
+    """Response model for a successful failure injection."""
+
+    injection_id: str = Field(..., description="Unique identifier for this injection")
+    status: str = Field(..., description="Injection status (e.g. 'active')")

--- a/tests/unit/maestro/__init__.py
+++ b/tests/unit/maestro/__init__.py
@@ -1,0 +1,1 @@
+"""Maestro module tests."""

--- a/tests/unit/maestro/conftest.py
+++ b/tests/unit/maestro/conftest.py
@@ -1,0 +1,16 @@
+"""Shared test fixtures for maestro tests."""
+
+import pytest
+
+from scylla.maestro.models import MaestroConfig
+
+
+@pytest.fixture
+def maestro_config() -> MaestroConfig:
+    """Create a test MaestroConfig with defaults."""
+    return MaestroConfig(
+        base_url="http://localhost:23000",
+        enabled=True,
+        timeout_seconds=5,
+        health_check_timeout_seconds=2,
+    )

--- a/tests/unit/maestro/test_async_client.py
+++ b/tests/unit/maestro/test_async_client.py
@@ -1,0 +1,306 @@
+"""Tests for scylla.maestro.async_client."""
+
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import httpx
+import pytest
+
+from scylla.maestro.async_client import AsyncMaestroClient
+from scylla.maestro.errors import MaestroAPIError, MaestroConnectionError
+from scylla.maestro.models import (
+    FailureSpec,
+    HealthResponse,
+    InjectionResult,
+    MaestroConfig,
+)
+
+
+@pytest.fixture
+def config() -> MaestroConfig:
+    """Create a test MaestroConfig."""
+    return MaestroConfig(
+        base_url="http://localhost:23000",
+        enabled=True,
+        timeout_seconds=5,
+        health_check_timeout_seconds=2,
+    )
+
+
+def _mock_response(
+    status_code: int = 200,
+    json_data: dict[str, Any] | list[dict[str, Any]] | None = None,
+    text: str = "",
+) -> MagicMock:
+    """Build a mock httpx.Response."""
+    resp = MagicMock(spec=httpx.Response)
+    resp.status_code = status_code
+    resp.is_success = 200 <= status_code < 300
+    resp.json.return_value = json_data
+    resp.text = text
+    return resp
+
+
+def _async_client_mock() -> AsyncMock:
+    """Build an AsyncMock standing in for httpx.AsyncClient."""
+    mock = AsyncMock()
+    mock.aclose = AsyncMock()
+    return mock
+
+
+class TestAsyncMaestroClientContextManager:
+    """Tests for async context manager protocol."""
+
+    @pytest.mark.asyncio
+    async def test_aenter_returns_self(self, config: MaestroConfig) -> None:
+        """__aenter__ returns the client instance."""
+        client = AsyncMaestroClient(config)
+        result = await client.__aenter__()
+        assert result is client
+        await client.close()
+
+    @pytest.mark.asyncio
+    async def test_aexit_closes_client(self, config: MaestroConfig) -> None:
+        """__aexit__ closes the underlying httpx client."""
+        client = AsyncMaestroClient(config)
+        client._client = _async_client_mock()
+        await client.__aexit__(None, None, None)
+        client._client.aclose.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_async_with_statement(self, config: MaestroConfig) -> None:
+        """Client works as an async context manager."""
+        async with AsyncMaestroClient(config) as client:
+            assert isinstance(client, AsyncMaestroClient)
+
+
+class TestAsyncHealthCheck:
+    """Tests for AsyncMaestroClient.health_check."""
+
+    @pytest.mark.asyncio
+    async def test_success(self, config: MaestroConfig) -> None:
+        """Successful health check returns HealthResponse."""
+        mock_http = _async_client_mock()
+        mock_http.request.return_value = _mock_response(
+            json_data={"status": "ok", "version": "1.0.0"}
+        )
+
+        client = AsyncMaestroClient(config)
+        client._client = mock_http
+        result = await client.health_check()
+
+        assert isinstance(result, HealthResponse)
+        assert result.status == "ok"
+        assert result.version == "1.0.0"
+
+    @pytest.mark.asyncio
+    async def test_connection_error_returns_none(self, config: MaestroConfig) -> None:
+        """Connection failure returns None instead of raising."""
+        mock_http = _async_client_mock()
+        mock_http.request.side_effect = httpx.ConnectError("refused")
+
+        client = AsyncMaestroClient(config)
+        client._client = mock_http
+        result = await client.health_check()
+
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_timeout_returns_none(self, config: MaestroConfig) -> None:
+        """Timeout returns None instead of raising."""
+        mock_http = _async_client_mock()
+        mock_http.request.side_effect = httpx.ReadTimeout("timed out")
+
+        client = AsyncMaestroClient(config)
+        client._client = mock_http
+        result = await client.health_check()
+
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_non_2xx_returns_none(self, config: MaestroConfig) -> None:
+        """Non-2xx status returns None (API error caught internally)."""
+        mock_http = _async_client_mock()
+        mock_http.request.return_value = _mock_response(status_code=503, text="Service Unavailable")
+
+        client = AsyncMaestroClient(config)
+        client._client = mock_http
+        result = await client.health_check()
+
+        assert result is None
+
+
+class TestAsyncListAgents:
+    """Tests for AsyncMaestroClient.list_agents."""
+
+    @pytest.mark.asyncio
+    async def test_success(self, config: MaestroConfig) -> None:
+        """Successful list returns agent dicts."""
+        agents = [{"id": "agent-1", "name": "Test Agent"}]
+        mock_http = _async_client_mock()
+        mock_http.request.return_value = _mock_response(json_data=agents)
+
+        client = AsyncMaestroClient(config)
+        client._client = mock_http
+        result = await client.list_agents()
+
+        assert result == agents
+
+    @pytest.mark.asyncio
+    async def test_connection_error_raises(self, config: MaestroConfig) -> None:
+        """Connection failure raises MaestroConnectionError."""
+        mock_http = _async_client_mock()
+        mock_http.request.side_effect = httpx.ConnectError("refused")
+
+        client = AsyncMaestroClient(config)
+        client._client = mock_http
+
+        with pytest.raises(MaestroConnectionError):
+            await client.list_agents()
+
+    @pytest.mark.asyncio
+    async def test_non_2xx_raises_api_error(self, config: MaestroConfig) -> None:
+        """Non-2xx response raises MaestroAPIError."""
+        mock_http = _async_client_mock()
+        mock_http.request.return_value = _mock_response(
+            status_code=500, text="Internal Server Error"
+        )
+
+        client = AsyncMaestroClient(config)
+        client._client = mock_http
+
+        with pytest.raises(MaestroAPIError) as exc_info:
+            await client.list_agents()
+
+        assert exc_info.value.status_code == 500
+        assert exc_info.value.response_body == "Internal Server Error"
+
+
+class TestAsyncInjectFailure:
+    """Tests for AsyncMaestroClient.inject_failure."""
+
+    @pytest.mark.asyncio
+    async def test_success(self, config: MaestroConfig) -> None:
+        """Successful injection returns InjectionResult."""
+        mock_http = _async_client_mock()
+        mock_http.request.return_value = _mock_response(
+            json_data={"injection_id": "inj-001", "status": "active"}
+        )
+
+        client = AsyncMaestroClient(config)
+        client._client = mock_http
+
+        spec = FailureSpec(agent_id="agent-1", failure_type="crash")
+        result = await client.inject_failure(spec)
+
+        assert isinstance(result, InjectionResult)
+        assert result.injection_id == "inj-001"
+        assert result.status == "active"
+
+        # Verify the payload sent
+        call_args = mock_http.request.call_args
+        assert call_args[1]["json"] == {
+            "agent_id": "agent-1",
+            "failure_type": "crash",
+            "parameters": {},
+        }
+
+    @pytest.mark.asyncio
+    async def test_with_duration(self, config: MaestroConfig) -> None:
+        """Duration is included in payload when specified."""
+        mock_http = _async_client_mock()
+        mock_http.request.return_value = _mock_response(
+            json_data={"injection_id": "inj-002", "status": "active"}
+        )
+
+        client = AsyncMaestroClient(config)
+        client._client = mock_http
+
+        spec = FailureSpec(
+            agent_id="agent-1",
+            failure_type="network_delay",
+            duration_seconds=30,
+            parameters={"latency_ms": 200},
+        )
+        await client.inject_failure(spec)
+
+        call_args = mock_http.request.call_args
+        assert call_args[1]["json"] == {
+            "agent_id": "agent-1",
+            "failure_type": "network_delay",
+            "duration_seconds": 30,
+            "parameters": {"latency_ms": 200},
+        }
+
+    @pytest.mark.asyncio
+    async def test_timeout_raises(self, config: MaestroConfig) -> None:
+        """Timeout raises MaestroConnectionError."""
+        mock_http = _async_client_mock()
+        mock_http.request.side_effect = httpx.ReadTimeout("timed out")
+
+        client = AsyncMaestroClient(config)
+        client._client = mock_http
+
+        spec = FailureSpec(agent_id="agent-1", failure_type="crash")
+        with pytest.raises(MaestroConnectionError, match="timed out"):
+            await client.inject_failure(spec)
+
+
+class TestAsyncClearFailure:
+    """Tests for AsyncMaestroClient.clear_failure."""
+
+    @pytest.mark.asyncio
+    async def test_success(self, config: MaestroConfig) -> None:
+        """Successful clear does not raise."""
+        mock_http = _async_client_mock()
+        mock_http.request.return_value = _mock_response(json_data={})
+
+        client = AsyncMaestroClient(config)
+        client._client = mock_http
+        await client.clear_failure("inj-001")
+
+        call_args = mock_http.request.call_args
+        assert call_args[0] == ("DELETE", "/api/agents/inject/inj-001")
+
+    @pytest.mark.asyncio
+    async def test_not_found_raises(self, config: MaestroConfig) -> None:
+        """404 raises MaestroAPIError."""
+        mock_http = _async_client_mock()
+        mock_http.request.return_value = _mock_response(status_code=404, text="Not Found")
+
+        client = AsyncMaestroClient(config)
+        client._client = mock_http
+
+        with pytest.raises(MaestroAPIError) as exc_info:
+            await client.clear_failure("nonexistent")
+
+        assert exc_info.value.status_code == 404
+
+
+class TestAsyncGetDiagnostics:
+    """Tests for AsyncMaestroClient.get_diagnostics."""
+
+    @pytest.mark.asyncio
+    async def test_success(self, config: MaestroConfig) -> None:
+        """Successful diagnostics returns dict."""
+        diag = {"uptime": 3600, "agents_active": 5}
+        mock_http = _async_client_mock()
+        mock_http.request.return_value = _mock_response(json_data=diag)
+
+        client = AsyncMaestroClient(config)
+        client._client = mock_http
+        result = await client.get_diagnostics()
+
+        assert result == diag
+
+    @pytest.mark.asyncio
+    async def test_null_response_returns_empty_dict(self, config: MaestroConfig) -> None:
+        """Null JSON response is coerced to empty dict."""
+        mock_http = _async_client_mock()
+        mock_http.request.return_value = _mock_response(json_data=None)
+
+        client = AsyncMaestroClient(config)
+        client._client = mock_http
+        result = await client.get_diagnostics()
+
+        assert result == {}

--- a/tests/unit/maestro/test_client.py
+++ b/tests/unit/maestro/test_client.py
@@ -1,0 +1,304 @@
+"""Tests for scylla.maestro.client."""
+
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import httpx
+import pytest
+
+from scylla.maestro.client import MaestroClient
+from scylla.maestro.errors import MaestroAPIError, MaestroConnectionError
+from scylla.maestro.models import (
+    FailureSpec,
+    HealthResponse,
+    InjectionResult,
+    MaestroConfig,
+)
+
+
+@pytest.fixture
+def config() -> MaestroConfig:
+    """Create a test MaestroConfig with retries disabled for basic tests."""
+    return MaestroConfig(
+        base_url="http://localhost:23000",
+        enabled=True,
+        timeout_seconds=5,
+        health_check_timeout_seconds=2,
+        max_retries=0,
+    )
+
+
+def _mock_response(
+    status_code: int = 200,
+    json_data: dict[str, Any] | list[dict[str, Any]] | None = None,
+    text: str = "",
+) -> MagicMock:
+    """Build a mock httpx.Response."""
+    resp = MagicMock(spec=httpx.Response)
+    resp.status_code = status_code
+    resp.is_success = 200 <= status_code < 300
+    resp.json.return_value = json_data
+    resp.text = text
+    return resp
+
+
+class TestMaestroClientContextManager:
+    """Tests for context manager protocol."""
+
+    def test_enter_returns_self(self, config: MaestroConfig) -> None:
+        """__enter__ returns the client instance."""
+        client = MaestroClient(config)
+        assert client.__enter__() is client
+        client.close()
+
+    def test_exit_closes_client(self, config: MaestroConfig) -> None:
+        """__exit__ closes the underlying httpx client."""
+        with patch.object(MaestroClient, "close") as mock_close:
+            client = MaestroClient(config)
+            client.__exit__(None, None, None)
+            mock_close.assert_called_once()
+
+    def test_with_statement(self, config: MaestroConfig) -> None:
+        """Client works as a context manager."""
+        with MaestroClient(config) as client:
+            assert isinstance(client, MaestroClient)
+
+
+class TestHealthCheck:
+    """Tests for MaestroClient.health_check."""
+
+    @patch("scylla.maestro.client.httpx.Client")
+    def test_success(self, mock_client_cls: MagicMock, config: MaestroConfig) -> None:
+        """Successful health check returns HealthResponse."""
+        mock_http = mock_client_cls.return_value
+        mock_http.request.return_value = _mock_response(
+            json_data={"status": "ok", "version": "1.0.0"}
+        )
+
+        client = MaestroClient(config)
+        client._client = mock_http
+        result = client.health_check()
+
+        assert isinstance(result, HealthResponse)
+        assert result.status == "ok"
+        assert result.version == "1.0.0"
+
+    @patch("scylla.maestro.client.httpx.Client")
+    def test_connection_error_returns_none(
+        self, mock_client_cls: MagicMock, config: MaestroConfig
+    ) -> None:
+        """Connection failure returns None instead of raising."""
+        mock_http = mock_client_cls.return_value
+        mock_http.request.side_effect = httpx.ConnectError("refused")
+
+        client = MaestroClient(config)
+        client._client = mock_http
+        result = client.health_check()
+
+        assert result is None
+
+    @patch("scylla.maestro.client.httpx.Client")
+    def test_timeout_returns_none(self, mock_client_cls: MagicMock, config: MaestroConfig) -> None:
+        """Timeout returns None instead of raising."""
+        mock_http = mock_client_cls.return_value
+        mock_http.request.side_effect = httpx.ReadTimeout("timed out")
+
+        client = MaestroClient(config)
+        client._client = mock_http
+        result = client.health_check()
+
+        assert result is None
+
+    @patch("scylla.maestro.client.httpx.Client")
+    def test_non_2xx_returns_none(self, mock_client_cls: MagicMock, config: MaestroConfig) -> None:
+        """Non-2xx status returns None (API error caught internally)."""
+        mock_http = mock_client_cls.return_value
+        mock_http.request.return_value = _mock_response(status_code=503, text="Service Unavailable")
+
+        client = MaestroClient(config)
+        client._client = mock_http
+        result = client.health_check()
+
+        assert result is None
+
+
+class TestListAgents:
+    """Tests for MaestroClient.list_agents."""
+
+    @patch("scylla.maestro.client.httpx.Client")
+    def test_success(self, mock_client_cls: MagicMock, config: MaestroConfig) -> None:
+        """Successful list returns agent dicts."""
+        agents: list[dict[str, Any]] = [{"id": "agent-1", "name": "Test Agent"}]
+        mock_http = mock_client_cls.return_value
+        mock_http.request.return_value = _mock_response(json_data=agents)
+
+        client = MaestroClient(config)
+        client._client = mock_http
+        result = client.list_agents()
+
+        assert result == agents
+
+    @patch("scylla.maestro.client.httpx.Client")
+    def test_connection_error_raises(
+        self, mock_client_cls: MagicMock, config: MaestroConfig
+    ) -> None:
+        """Connection failure raises MaestroConnectionError."""
+        mock_http = mock_client_cls.return_value
+        mock_http.request.side_effect = httpx.ConnectError("refused")
+
+        client = MaestroClient(config)
+        client._client = mock_http
+
+        with pytest.raises(MaestroConnectionError):
+            client.list_agents()
+
+    @patch("scylla.maestro.client.httpx.Client")
+    def test_non_2xx_raises_api_error(
+        self, mock_client_cls: MagicMock, config: MaestroConfig
+    ) -> None:
+        """Non-2xx response raises MaestroAPIError."""
+        mock_http = mock_client_cls.return_value
+        mock_http.request.return_value = _mock_response(
+            status_code=500, text="Internal Server Error"
+        )
+
+        client = MaestroClient(config)
+        client._client = mock_http
+
+        with pytest.raises(MaestroAPIError) as exc_info:
+            client.list_agents()
+
+        assert exc_info.value.status_code == 500
+        assert exc_info.value.response_body == "Internal Server Error"
+
+
+class TestInjectFailure:
+    """Tests for MaestroClient.inject_failure."""
+
+    @patch("scylla.maestro.client.httpx.Client")
+    def test_success(self, mock_client_cls: MagicMock, config: MaestroConfig) -> None:
+        """Successful injection returns InjectionResult."""
+        mock_http = mock_client_cls.return_value
+        mock_http.request.return_value = _mock_response(
+            json_data={"injection_id": "inj-001", "status": "active"}
+        )
+
+        client = MaestroClient(config)
+        client._client = mock_http
+
+        spec = FailureSpec(agent_id="agent-1", failure_type="crash")
+        result = client.inject_failure(spec)
+
+        assert isinstance(result, InjectionResult)
+        assert result.injection_id == "inj-001"
+        assert result.status == "active"
+
+        # Verify the payload sent
+        call_args = mock_http.request.call_args
+        assert call_args[1]["json"] == {
+            "agent_id": "agent-1",
+            "failure_type": "crash",
+            "parameters": {},
+        }
+
+    @patch("scylla.maestro.client.httpx.Client")
+    def test_with_duration(self, mock_client_cls: MagicMock, config: MaestroConfig) -> None:
+        """Duration is included in payload when specified."""
+        mock_http = mock_client_cls.return_value
+        mock_http.request.return_value = _mock_response(
+            json_data={"injection_id": "inj-002", "status": "active"}
+        )
+
+        client = MaestroClient(config)
+        client._client = mock_http
+
+        spec = FailureSpec(
+            agent_id="agent-1",
+            failure_type="network_delay",
+            duration_seconds=30,
+            parameters={"latency_ms": 200},
+        )
+        client.inject_failure(spec)
+
+        call_args = mock_http.request.call_args
+        assert call_args[1]["json"] == {
+            "agent_id": "agent-1",
+            "failure_type": "network_delay",
+            "duration_seconds": 30,
+            "parameters": {"latency_ms": 200},
+        }
+
+    @patch("scylla.maestro.client.httpx.Client")
+    def test_timeout_raises(self, mock_client_cls: MagicMock, config: MaestroConfig) -> None:
+        """Timeout raises MaestroConnectionError."""
+        mock_http = mock_client_cls.return_value
+        mock_http.request.side_effect = httpx.ReadTimeout("timed out")
+
+        client = MaestroClient(config)
+        client._client = mock_http
+
+        spec = FailureSpec(agent_id="agent-1", failure_type="crash")
+        with pytest.raises(MaestroConnectionError, match="timed out"):
+            client.inject_failure(spec)
+
+
+class TestClearFailure:
+    """Tests for MaestroClient.clear_failure."""
+
+    @patch("scylla.maestro.client.httpx.Client")
+    def test_success(self, mock_client_cls: MagicMock, config: MaestroConfig) -> None:
+        """Successful clear does not raise."""
+        mock_http = mock_client_cls.return_value
+        mock_http.request.return_value = _mock_response(json_data={})
+
+        client = MaestroClient(config)
+        client._client = mock_http
+        client.clear_failure("inj-001")
+
+        call_args = mock_http.request.call_args
+        assert call_args[0] == ("DELETE", "/api/agents/inject/inj-001")
+
+    @patch("scylla.maestro.client.httpx.Client")
+    def test_not_found_raises(self, mock_client_cls: MagicMock, config: MaestroConfig) -> None:
+        """404 raises MaestroAPIError."""
+        mock_http = mock_client_cls.return_value
+        mock_http.request.return_value = _mock_response(status_code=404, text="Not Found")
+
+        client = MaestroClient(config)
+        client._client = mock_http
+
+        with pytest.raises(MaestroAPIError) as exc_info:
+            client.clear_failure("nonexistent")
+
+        assert exc_info.value.status_code == 404
+
+
+class TestGetDiagnostics:
+    """Tests for MaestroClient.get_diagnostics."""
+
+    @patch("scylla.maestro.client.httpx.Client")
+    def test_success(self, mock_client_cls: MagicMock, config: MaestroConfig) -> None:
+        """Successful diagnostics returns dict."""
+        diag: dict[str, Any] = {"uptime": 3600, "agents_active": 5}
+        mock_http = mock_client_cls.return_value
+        mock_http.request.return_value = _mock_response(json_data=diag)
+
+        client = MaestroClient(config)
+        client._client = mock_http
+        result = client.get_diagnostics()
+
+        assert result == diag
+
+    @patch("scylla.maestro.client.httpx.Client")
+    def test_null_response_returns_empty_dict(
+        self, mock_client_cls: MagicMock, config: MaestroConfig
+    ) -> None:
+        """Null JSON response is coerced to empty dict."""
+        mock_http = mock_client_cls.return_value
+        mock_http.request.return_value = _mock_response(json_data=None)
+
+        client = MaestroClient(config)
+        client._client = mock_http
+        result = client.get_diagnostics()
+
+        assert result == {}

--- a/tests/unit/maestro/test_models.py
+++ b/tests/unit/maestro/test_models.py
@@ -1,0 +1,119 @@
+"""Tests for scylla.maestro.models."""
+
+import pytest
+from pydantic import ValidationError
+
+from scylla.maestro.models import (
+    FailureSpec,
+    HealthResponse,
+    InjectionResult,
+    MaestroConfig,
+)
+
+
+class TestMaestroConfig:
+    """Tests for MaestroConfig defaults and validation."""
+
+    def test_defaults(self) -> None:
+        """Default config is disabled with localhost URL."""
+        config = MaestroConfig()
+        assert config.base_url == "http://localhost:23000"
+        assert config.enabled is False
+        assert config.timeout_seconds == 10
+        assert config.health_check_timeout_seconds == 5
+
+    def test_custom_values(self) -> None:
+        """Custom values override defaults."""
+        config = MaestroConfig(
+            base_url="http://maestro.example.com:8080",
+            enabled=True,
+            timeout_seconds=30,
+            health_check_timeout_seconds=3,
+        )
+        assert config.base_url == "http://maestro.example.com:8080"
+        assert config.enabled is True
+        assert config.timeout_seconds == 30
+        assert config.health_check_timeout_seconds == 3
+
+    def test_timeout_minimum(self) -> None:
+        """Timeout must be >= 1."""
+        with pytest.raises(ValidationError):
+            MaestroConfig(timeout_seconds=0)
+
+    def test_timeout_maximum(self) -> None:
+        """Timeout must be <= 300."""
+        with pytest.raises(ValidationError):
+            MaestroConfig(timeout_seconds=301)
+
+    def test_health_check_timeout_maximum(self) -> None:
+        """Health check timeout must be <= 60."""
+        with pytest.raises(ValidationError):
+            MaestroConfig(health_check_timeout_seconds=61)
+
+
+class TestFailureSpec:
+    """Tests for FailureSpec model."""
+
+    def test_required_fields(self) -> None:
+        """agent_id and failure_type are required."""
+        spec = FailureSpec(agent_id="agent-1", failure_type="crash")
+        assert spec.agent_id == "agent-1"
+        assert spec.failure_type == "crash"
+        assert spec.duration_seconds is None
+        assert spec.parameters == {}
+
+    def test_with_optional_fields(self) -> None:
+        """All fields populated correctly."""
+        spec = FailureSpec(
+            agent_id="agent-2",
+            failure_type="network_delay",
+            duration_seconds=60,
+            parameters={"latency_ms": 500},
+        )
+        assert spec.duration_seconds == 60
+        assert spec.parameters == {"latency_ms": 500}
+
+    def test_missing_required_raises(self) -> None:
+        """Missing required fields raise ValidationError."""
+        with pytest.raises(ValidationError):
+            FailureSpec()  # type: ignore[call-arg]
+
+    def test_duration_minimum(self) -> None:
+        """Duration must be >= 1 when provided."""
+        with pytest.raises(ValidationError):
+            FailureSpec(agent_id="a", failure_type="x", duration_seconds=0)
+
+
+class TestHealthResponse:
+    """Tests for HealthResponse model."""
+
+    def test_from_dict(self) -> None:
+        """Parse a health response from a dictionary."""
+        resp = HealthResponse(status="ok", version="1.2.3")
+        assert resp.status == "ok"
+        assert resp.version == "1.2.3"
+
+    def test_version_optional(self) -> None:
+        """Version is optional and defaults to None."""
+        resp = HealthResponse(status="ok")
+        assert resp.version is None
+
+    def test_missing_status_raises(self) -> None:
+        """Missing status raises ValidationError."""
+        with pytest.raises(ValidationError):
+            HealthResponse()  # type: ignore[call-arg]
+
+
+class TestInjectionResult:
+    """Tests for InjectionResult model."""
+
+    def test_from_dict(self) -> None:
+        """Parse an injection result from a dictionary."""
+        result = InjectionResult(injection_id="inj-001", status="active")
+        assert result.injection_id == "inj-001"
+        assert result.status == "active"
+
+    def test_missing_fields_raises(self) -> None:
+        """Missing required fields raise ValidationError."""
+        with pytest.raises(ValidationError):
+            InjectionResult()  # type: ignore[call-arg]

--- a/tests/unit/maestro/test_retry.py
+++ b/tests/unit/maestro/test_retry.py
@@ -1,0 +1,449 @@
+"""Tests for MaestroClient retry logic.
+
+Verifies that transient failures (connection errors, timeouts, HTTP 502/503/504)
+are retried with exponential backoff, while permanent errors (4xx) raise immediately.
+"""
+
+from typing import Any
+from unittest.mock import MagicMock, call, patch
+
+import httpx
+import pytest
+
+from scylla.maestro.client import MaestroClient
+from scylla.maestro.errors import MaestroAPIError, MaestroConnectionError
+from scylla.maestro.models import FailureSpec, MaestroConfig
+
+
+@pytest.fixture
+def retry_config() -> MaestroConfig:
+    """Config with 3 retries for retry tests."""
+    return MaestroConfig(
+        base_url="http://localhost:23000",
+        enabled=True,
+        timeout_seconds=5,
+        health_check_timeout_seconds=2,
+        max_retries=3,
+    )
+
+
+def _mock_response(
+    status_code: int = 200,
+    json_data: dict[str, Any] | list[dict[str, Any]] | None = None,
+    text: str = "",
+) -> MagicMock:
+    """Build a mock httpx.Response."""
+    resp = MagicMock(spec=httpx.Response)
+    resp.status_code = status_code
+    resp.is_success = 200 <= status_code < 300
+    resp.json.return_value = json_data
+    resp.text = text
+    return resp
+
+
+class TestRetryOnTransientErrors:
+    """Verify that transient exceptions trigger retries then succeed."""
+
+    @patch("scylla.maestro.client.time.sleep")
+    @patch("scylla.maestro.client.httpx.Client")
+    def test_retry_connect_error_then_succeed(
+        self,
+        mock_client_cls: MagicMock,
+        mock_sleep: MagicMock,
+        retry_config: MaestroConfig,
+    ) -> None:
+        """ConnectError on first attempt, success on second."""
+        mock_http = mock_client_cls.return_value
+        mock_http.request.side_effect = [
+            httpx.ConnectError("refused"),
+            _mock_response(json_data=[]),
+        ]
+
+        client = MaestroClient(retry_config)
+        client._client = mock_http
+        result = client.list_agents()
+
+        assert result == []
+        assert mock_http.request.call_count == 2
+        mock_sleep.assert_called_once_with(1.0)
+
+    @patch("scylla.maestro.client.time.sleep")
+    @patch("scylla.maestro.client.httpx.Client")
+    def test_retry_timeout_then_succeed(
+        self,
+        mock_client_cls: MagicMock,
+        mock_sleep: MagicMock,
+        retry_config: MaestroConfig,
+    ) -> None:
+        """TimeoutException on first attempt, success on second."""
+        mock_http = mock_client_cls.return_value
+        mock_http.request.side_effect = [
+            httpx.ReadTimeout("timed out"),
+            _mock_response(json_data=[]),
+        ]
+
+        client = MaestroClient(retry_config)
+        client._client = mock_http
+        result = client.list_agents()
+
+        assert result == []
+        assert mock_http.request.call_count == 2
+
+    @patch("scylla.maestro.client.time.sleep")
+    @patch("scylla.maestro.client.httpx.Client")
+    def test_retry_remote_protocol_error_then_succeed(
+        self,
+        mock_client_cls: MagicMock,
+        mock_sleep: MagicMock,
+        retry_config: MaestroConfig,
+    ) -> None:
+        """RemoteProtocolError on first attempt, success on second."""
+        mock_http = mock_client_cls.return_value
+        mock_http.request.side_effect = [
+            httpx.RemoteProtocolError("server disconnected"),
+            _mock_response(json_data=[]),
+        ]
+
+        client = MaestroClient(retry_config)
+        client._client = mock_http
+        result = client.list_agents()
+
+        assert result == []
+        assert mock_http.request.call_count == 2
+
+    @pytest.mark.parametrize("status_code", [502, 503, 504])
+    @patch("scylla.maestro.client.time.sleep")
+    @patch("scylla.maestro.client.httpx.Client")
+    def test_retry_retryable_status_then_succeed(
+        self,
+        mock_client_cls: MagicMock,
+        mock_sleep: MagicMock,
+        retry_config: MaestroConfig,
+        status_code: int,
+    ) -> None:
+        """HTTP 502/503/504 on first attempt, success on second."""
+        mock_http = mock_client_cls.return_value
+        mock_http.request.side_effect = [
+            _mock_response(status_code=status_code, text="Server Error"),
+            _mock_response(json_data=[]),
+        ]
+
+        client = MaestroClient(retry_config)
+        client._client = mock_http
+        result = client.list_agents()
+
+        assert result == []
+        assert mock_http.request.call_count == 2
+        mock_sleep.assert_called_once_with(1.0)
+
+
+class TestRetryExhaustion:
+    """Verify that exhausting all retries raises the appropriate error."""
+
+    @patch("scylla.maestro.client.time.sleep")
+    @patch("scylla.maestro.client.httpx.Client")
+    def test_all_retries_exhausted_connection_error(
+        self,
+        mock_client_cls: MagicMock,
+        mock_sleep: MagicMock,
+        retry_config: MaestroConfig,
+    ) -> None:
+        """Raises MaestroConnectionError after max_retries+1 ConnectErrors."""
+        mock_http = mock_client_cls.return_value
+        mock_http.request.side_effect = httpx.ConnectError("refused")
+
+        client = MaestroClient(retry_config)
+        client._client = mock_http
+
+        with pytest.raises(MaestroConnectionError, match="after 4 attempts"):
+            client.list_agents()
+
+        assert mock_http.request.call_count == 4  # 1 initial + 3 retries
+        assert mock_sleep.call_count == 3
+
+    @patch("scylla.maestro.client.time.sleep")
+    @patch("scylla.maestro.client.httpx.Client")
+    def test_all_retries_exhausted_502(
+        self,
+        mock_client_cls: MagicMock,
+        mock_sleep: MagicMock,
+        retry_config: MaestroConfig,
+    ) -> None:
+        """Raises MaestroAPIError after max_retries+1 502s."""
+        mock_http = mock_client_cls.return_value
+        mock_http.request.return_value = _mock_response(status_code=502, text="Bad Gateway")
+
+        client = MaestroClient(retry_config)
+        client._client = mock_http
+
+        with pytest.raises(MaestroAPIError) as exc_info:
+            client.list_agents()
+
+        assert exc_info.value.status_code == 502
+        assert mock_http.request.call_count == 4
+
+
+class TestNoRetryOnPermanentErrors:
+    """Verify that permanent client errors are not retried."""
+
+    @pytest.mark.parametrize("status_code", [400, 401, 403, 404, 422])
+    @patch("scylla.maestro.client.time.sleep")
+    @patch("scylla.maestro.client.httpx.Client")
+    def test_no_retry_on_client_error(
+        self,
+        mock_client_cls: MagicMock,
+        mock_sleep: MagicMock,
+        retry_config: MaestroConfig,
+        status_code: int,
+    ) -> None:
+        """4xx errors raise immediately without retry."""
+        mock_http = mock_client_cls.return_value
+        mock_http.request.return_value = _mock_response(
+            status_code=status_code, text="Client Error"
+        )
+
+        client = MaestroClient(retry_config)
+        client._client = mock_http
+
+        with pytest.raises(MaestroAPIError) as exc_info:
+            client.list_agents()
+
+        assert exc_info.value.status_code == status_code
+        assert mock_http.request.call_count == 1  # No retries
+        mock_sleep.assert_not_called()
+
+    @patch("scylla.maestro.client.time.sleep")
+    @patch("scylla.maestro.client.httpx.Client")
+    def test_no_retry_on_500(
+        self,
+        mock_client_cls: MagicMock,
+        mock_sleep: MagicMock,
+        retry_config: MaestroConfig,
+    ) -> None:
+        """HTTP 500 is not in the retryable set — raises immediately."""
+        mock_http = mock_client_cls.return_value
+        mock_http.request.return_value = _mock_response(
+            status_code=500, text="Internal Server Error"
+        )
+
+        client = MaestroClient(retry_config)
+        client._client = mock_http
+
+        with pytest.raises(MaestroAPIError) as exc_info:
+            client.list_agents()
+
+        assert exc_info.value.status_code == 500
+        assert mock_http.request.call_count == 1
+        mock_sleep.assert_not_called()
+
+
+class TestRetryBackoff:
+    """Verify exponential backoff timing."""
+
+    @patch("scylla.maestro.client.time.sleep")
+    @patch("scylla.maestro.client.httpx.Client")
+    def test_backoff_delays(
+        self,
+        mock_client_cls: MagicMock,
+        mock_sleep: MagicMock,
+        retry_config: MaestroConfig,
+    ) -> None:
+        """Delays follow 1s, 2s, 4s exponential pattern."""
+        mock_http = mock_client_cls.return_value
+        mock_http.request.side_effect = httpx.ConnectError("refused")
+
+        client = MaestroClient(retry_config)
+        client._client = mock_http
+
+        with pytest.raises(MaestroConnectionError):
+            client.list_agents()
+
+        assert mock_sleep.call_args_list == [
+            call(1.0),
+            call(2.0),
+            call(4.0),
+        ]
+
+
+class TestRetryLogging:
+    """Verify that retry attempts are logged."""
+
+    @patch("scylla.maestro.client.time.sleep")
+    @patch("scylla.maestro.client.httpx.Client")
+    def test_retry_logs_warning(
+        self,
+        mock_client_cls: MagicMock,
+        mock_sleep: MagicMock,
+        retry_config: MaestroConfig,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """Each retry attempt logs a WARNING with attempt info."""
+        mock_http = mock_client_cls.return_value
+        mock_http.request.side_effect = [
+            httpx.ConnectError("refused"),
+            _mock_response(json_data=[]),
+        ]
+
+        client = MaestroClient(retry_config)
+        client._client = mock_http
+
+        import logging
+
+        with caplog.at_level(logging.WARNING, logger="scylla.maestro.client"):
+            client.list_agents()
+
+        assert len(caplog.records) == 1
+        record = caplog.records[0]
+        assert "attempt 1/4" in record.message
+        assert "retrying in 1.0s" in record.message
+
+    @patch("scylla.maestro.client.time.sleep")
+    @patch("scylla.maestro.client.httpx.Client")
+    def test_retry_502_logs_warning(
+        self,
+        mock_client_cls: MagicMock,
+        mock_sleep: MagicMock,
+        retry_config: MaestroConfig,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """HTTP 502 retry logs a WARNING with status code."""
+        mock_http = mock_client_cls.return_value
+        mock_http.request.side_effect = [
+            _mock_response(status_code=502, text="Bad Gateway"),
+            _mock_response(json_data=[]),
+        ]
+
+        client = MaestroClient(retry_config)
+        client._client = mock_http
+
+        import logging
+
+        with caplog.at_level(logging.WARNING, logger="scylla.maestro.client"):
+            client.list_agents()
+
+        assert len(caplog.records) == 1
+        assert "502" in caplog.records[0].message
+
+
+class TestRetryConfig:
+    """Verify configurable retry behavior."""
+
+    @patch("scylla.maestro.client.time.sleep")
+    @patch("scylla.maestro.client.httpx.Client")
+    def test_max_retries_zero_disables_retry(
+        self,
+        mock_client_cls: MagicMock,
+        mock_sleep: MagicMock,
+    ) -> None:
+        """With max_retries=0, errors raise immediately."""
+        config = MaestroConfig(
+            base_url="http://localhost:23000",
+            enabled=True,
+            max_retries=0,
+        )
+        mock_http = mock_client_cls.return_value
+        mock_http.request.side_effect = httpx.ConnectError("refused")
+
+        client = MaestroClient(config)
+        client._client = mock_http
+
+        with pytest.raises(MaestroConnectionError):
+            client.list_agents()
+
+        assert mock_http.request.call_count == 1
+        mock_sleep.assert_not_called()
+
+    @patch("scylla.maestro.client.time.sleep")
+    @patch("scylla.maestro.client.httpx.Client")
+    def test_max_retries_custom_value(
+        self,
+        mock_client_cls: MagicMock,
+        mock_sleep: MagicMock,
+    ) -> None:
+        """With max_retries=1, only 1 retry is attempted."""
+        config = MaestroConfig(
+            base_url="http://localhost:23000",
+            enabled=True,
+            max_retries=1,
+        )
+        mock_http = mock_client_cls.return_value
+        mock_http.request.side_effect = httpx.ConnectError("refused")
+
+        client = MaestroClient(config)
+        client._client = mock_http
+
+        with pytest.raises(MaestroConnectionError):
+            client.list_agents()
+
+        assert mock_http.request.call_count == 2  # 1 initial + 1 retry
+        mock_sleep.assert_called_once_with(1.0)
+
+
+class TestRetryWithPublicMethods:
+    """Verify that public methods benefit from retry logic."""
+
+    @patch("scylla.maestro.client.time.sleep")
+    @patch("scylla.maestro.client.httpx.Client")
+    def test_inject_failure_retries_on_transient(
+        self,
+        mock_client_cls: MagicMock,
+        mock_sleep: MagicMock,
+        retry_config: MaestroConfig,
+    ) -> None:
+        """inject_failure retries on transient errors."""
+        mock_http = mock_client_cls.return_value
+        mock_http.request.side_effect = [
+            httpx.ConnectError("refused"),
+            _mock_response(json_data={"injection_id": "inj-001", "status": "active"}),
+        ]
+
+        client = MaestroClient(retry_config)
+        client._client = mock_http
+
+        spec = FailureSpec(agent_id="agent-1", failure_type="crash")
+        result = client.inject_failure(spec)
+
+        assert result.injection_id == "inj-001"
+        assert mock_http.request.call_count == 2
+
+    @patch("scylla.maestro.client.time.sleep")
+    @patch("scylla.maestro.client.httpx.Client")
+    def test_clear_failure_retries_on_transient(
+        self,
+        mock_client_cls: MagicMock,
+        mock_sleep: MagicMock,
+        retry_config: MaestroConfig,
+    ) -> None:
+        """clear_failure retries on transient errors."""
+        mock_http = mock_client_cls.return_value
+        mock_http.request.side_effect = [
+            httpx.ReadTimeout("timed out"),
+            _mock_response(json_data={}),
+        ]
+
+        client = MaestroClient(retry_config)
+        client._client = mock_http
+
+        client.clear_failure("inj-001")
+        assert mock_http.request.call_count == 2
+
+    @patch("scylla.maestro.client.time.sleep")
+    @patch("scylla.maestro.client.httpx.Client")
+    def test_health_check_retries_before_returning_none(
+        self,
+        mock_client_cls: MagicMock,
+        mock_sleep: MagicMock,
+        retry_config: MaestroConfig,
+    ) -> None:
+        """health_check retries internally before returning None."""
+        mock_http = mock_client_cls.return_value
+        mock_http.request.side_effect = httpx.ConnectError("refused")
+
+        client = MaestroClient(retry_config)
+        client._client = mock_http
+
+        result = client.health_check()
+
+        assert result is None
+        # All retries exhausted, then health_check catches the error
+        assert mock_http.request.call_count == 4  # 1 + 3 retries


### PR DESCRIPTION
Add httpx-based sync and async HTTP clients for the AI Maestro REST API with health checking, agent listing, failure injection, and diagnostics endpoints. `AsyncMaestroClient` enables non-blocking I/O when multiple tiers run concurrently in the parallel executor.

- New `src/scylla/maestro/` module: `MaestroClient`, `AsyncMaestroClient`, models, error hierarchy
- 48 unit tests covering sync client, async client, models, and retry logic

Closes #1564
Closes #1504