### PR TITLE
fix(e2e): detect rate limits in stream-json stdout, add WeeklyLimitError

### DIFF
--- a/src/scylla/e2e/judge_runner.py
+++ b/src/scylla/e2e/judge_runner.py
@@ -19,7 +19,7 @@ from typing import TYPE_CHECKING, Any, cast
 from scylla.e2e.llm_judge import run_llm_judge
 from scylla.e2e.models import JudgeResultSummary
 from scylla.e2e.paths import RESULT_FILE, get_judge_result_file
-from scylla.e2e.rate_limit import RateLimitError
+from scylla.e2e.rate_limit import RateLimitError, RateLimitInfo, _detect_rate_limit_from_stderr
 
 if TYPE_CHECKING:
     from scylla.e2e.llm_judge import BuildPipelineResult, JudgeResult
@@ -242,6 +242,16 @@ def _run_judge(
             error_file = judge_specific_dir / "error.log"
             error_file.write_text(f"Judge failed: {e}\n")
 
+            # Save raw stdout/stderr from the failed CLI call for post-hoc
+            # debugging (e.g. to detect rate-limit messages that slipped past
+            # the detection logic).
+            raw_stdout = getattr(e, "_judge_stdout", None)
+            raw_stderr = getattr(e, "_judge_stderr", None)
+            if raw_stdout is not None:
+                (judge_specific_dir / "stdout.log").write_text(raw_stdout)
+            if raw_stderr is not None:
+                (judge_specific_dir / "stderr.log").write_text(raw_stderr)
+
             # Record a zero-score failed result and continue to the next judge
             # rather than aborting the entire run. This handles cases like Haiku
             # returning conversational text instead of structured JSON.
@@ -260,9 +270,31 @@ def _run_judge(
     # Compute consensus from all judges (only valid ones contribute)
     consensus_score, consensus_passed, consensus_grade = _compute_judge_consensus(judges)
 
-    # If all judges failed (no valid results), return a zero-score result so the
-    # experiment can continue rather than crashing with an unhandled exception.
+    # If all judges failed (no valid results), check if the failures look like
+    # rate-limit errors.  If so, raise RateLimitError so the run enters
+    # RATE_LIMITED state instead of silently completing with score 0.0.
     if consensus_score is None:
+        all_errors = [j.reasoning for j in judges if not j.is_valid and j.reasoning]
+        rate_limit_errors = [e for e in all_errors if _detect_rate_limit_from_stderr(e)[0]]
+        if rate_limit_errors and len(rate_limit_errors) == len(judges):
+            # Every judge hit a rate limit — propagate so the run is retried
+            from datetime import datetime, timezone
+
+            logger.warning(
+                "All %d judges failed with rate-limit errors; propagating RateLimitError",
+                len(judges),
+            )
+            sample_error = rate_limit_errors[0]
+            _, retry_after = _detect_rate_limit_from_stderr(sample_error)
+            raise RateLimitError(
+                RateLimitInfo(
+                    source="judge",
+                    retry_after_seconds=retry_after,
+                    error_message=sample_error,
+                    detected_at=datetime.now(timezone.utc).isoformat(),
+                )
+            )
+
         logger.warning("All judges failed to produce valid results; returning zero-score consensus")
         return {
             "score": 0.0,

--- a/src/scylla/e2e/llm_judge.py
+++ b/src/scylla/e2e/llm_judge.py
@@ -645,7 +645,11 @@ def _extract_response_from_stream(stream_output: str) -> str:
 
 
 def _raise_if_rate_limit(stdout: str, stderr: str) -> None:
-    """Raise RateLimitError if stdout/stderr contain rate limit indicators."""
+    """Raise RateLimitError if stdout/stderr contain rate limit indicators.
+
+    Handles both single-object JSON (``--output-format json``) and
+    stream-json (``--output-format stream-json``) stdout formats.
+    """
     from scylla.e2e.rate_limit import RateLimitError, detect_rate_limit
 
     rate_limit_info = detect_rate_limit(stdout, stderr, source="judge")
@@ -763,7 +767,11 @@ def _call_claude_judge(
         error_msg = _extract_cli_error(result.stdout, result.stderr)
         _raise_if_rate_limit_in_error(error_msg)
         cb._record_failure()
-        raise RuntimeError(f"Claude CLI failed (exit {result.returncode}): {error_msg}")
+        exc = RuntimeError(f"Claude CLI failed (exit {result.returncode}): {error_msg}")
+        # Attach raw streams so judge_runner can save them for post-hoc debugging
+        exc._judge_stdout = result.stdout  # type: ignore[attr-defined]
+        exc._judge_stderr = result.stderr  # type: ignore[attr-defined]
+        raise exc
 
     # Check for rate limit in successful responses too
     rate_limit_info = detect_rate_limit(result.stdout, result.stderr, source="judge")

--- a/src/scylla/e2e/parallel_executor.py
+++ b/src/scylla/e2e/parallel_executor.py
@@ -24,7 +24,9 @@ from scylla.e2e.models import (
 from scylla.e2e.rate_limit import (
     RateLimitError,
     RateLimitInfo,
+    WeeklyLimitError,
     detect_rate_limit,
+    is_weekly_limit,
     wait_for_rate_limit,
 )
 
@@ -239,7 +241,19 @@ def run_tier_subtests_parallel(
                 f"{remaining} remaining, elapsed: {elapsed:.0f}s"
             )
         except RateLimitError as e:
-            # Handle rate limit in main thread
+            # Weekly/hard limits reset on a specific date — retrying after 60s
+            # will just fail again 120+ more times.  Stop immediately and let
+            # the operator resume after the reset time.
+            if is_weekly_limit(e.info):
+                logger.error(
+                    "Weekly usage limit detected from %s — stopping tier execution. "
+                    "Resume after: %s",
+                    e.info.source,
+                    e.info.error_message,
+                )
+                raise WeeklyLimitError(e.info) from e
+
+            # Transient rate limit: wait and retry once
             if checkpoint and checkpoint_path:
                 logger.info(f"Rate limit detected from {e.info.source}, waiting...")
                 wait_for_rate_limit(e.info.retry_after_seconds, checkpoint, checkpoint_path)

--- a/src/scylla/e2e/rate_limit.py
+++ b/src/scylla/e2e/rate_limit.py
@@ -72,6 +72,18 @@ class RateLimitError(Exception):
         super().__init__(f"Rate limit from {info.source}: {info.error_message}")
 
 
+class WeeklyLimitError(RateLimitError):
+    """Raised when a weekly/hard usage limit is hit (not a transient 429).
+
+    Weekly limits reset on a specific date/time, not after seconds.
+    Retrying after 60s will not help — the experiment must be paused
+    until the reset time.
+
+    Use this instead of ``RateLimitError`` when ``retry_after_seconds``
+    represents hours or days (i.e. a date-based reset, not a server backoff).
+    """
+
+
 def parse_retry_after(stderr: str) -> float | None:
     """Extract Retry-After value from stderr/headers with 10% buffer.
 
@@ -153,7 +165,24 @@ _STDERR_RATE_LIMIT_PATTERNS: list[tuple[str, bool, str]] = [
     ("ratelimit", True, "Rate limit detected in stderr"),
     ("hit your limit", True, "API limit hit"),
     ("overloaded", True, "API overloaded"),
+    # "resets <date>" appears in weekly usage limit messages, e.g.
+    # "You've hit your limit · resets Apr 3, 6am (America/Los_Angeles)"
+    ("resets ", True, "Usage limit with scheduled reset"),
 ]
+
+# Rate-limit keywords for JSON is_error result fields (used in JSON + stream-json detection)
+_JSON_RATE_LIMIT_KEYWORDS: tuple[str, ...] = (
+    "rate limit",
+    "rate_limit",
+    "ratelimit",
+    "overloaded",
+    "429",
+    "hit your limit",
+    "resets",
+    "weekly usage limit",
+    "upgrade to continue",
+    "failed to configure provider",
+)
 
 
 def _detect_rate_limit_from_stderr(stderr: str) -> tuple[str, float | None]:
@@ -177,12 +206,121 @@ def _detect_rate_limit_from_stderr(stderr: str) -> tuple[str, float | None]:
     return "", None
 
 
-def detect_rate_limit(stdout: str, stderr: str, source: str = "agent") -> RateLimitInfo | None:
-    """Detect rate limit from JSON output or stderr patterns.
+def _make_rate_limit_info(
+    source: str,
+    error_msg: str,
+    retry_after: float | None,
+    text_for_retry_parse: str = "",
+) -> RateLimitInfo:
+    """Build the appropriate RateLimitInfo (or WeeklyLimitError info) instance.
 
-    Detection order (requirement: JSON first, then stderr patterns):
-    1. Parse JSON `is_error` field (if stdout is JSON)
-    2. Scan stderr for patterns: 429, "rate limit", "overloaded"
+    If ``retry_after`` is more than 3600 seconds (1 hour) the limit is
+    considered a weekly/hard cap that cannot be resolved by a short wait.
+    We still return a ``RateLimitInfo``; the *caller* is responsible for
+    raising ``WeeklyLimitError`` when that distinction matters.
+
+    Args:
+        source: "agent" or "judge"
+        error_msg: Human-readable error message
+        retry_after: Seconds to wait, or None if unknown
+        text_for_retry_parse: Additional text to try parsing retry-after from
+
+    Returns:
+        RateLimitInfo populated with the supplied values
+
+    """
+    if retry_after is None and text_for_retry_parse:
+        retry_after = parse_retry_after(text_for_retry_parse)
+    return RateLimitInfo(
+        source=source,
+        retry_after_seconds=retry_after,
+        error_message=error_msg or "Rate limit detected",
+        detected_at=datetime.now(timezone.utc).isoformat(),
+    )
+
+
+def _detect_rate_limit_from_json_line(data: dict[str, object], source: str) -> RateLimitInfo | None:
+    """Check a single parsed JSON object for rate-limit indicators.
+
+    Handles both ``--output-format json`` (single object) and individual
+    lines from ``--output-format stream-json``.
+
+    Args:
+        data: Parsed JSON object
+        source: "agent" or "judge"
+
+    Returns:
+        RateLimitInfo if rate limit detected, None otherwise
+
+    """
+    if not data.get("is_error"):
+        return None
+
+    result = data.get("result", data.get("error", ""))
+    error_str = str(result).lower()
+
+    if any(keyword in error_str for keyword in _JSON_RATE_LIMIT_KEYWORDS):
+        retry_after = parse_retry_after(str(result))
+        return _make_rate_limit_info(source, str(result), retry_after)
+
+    return None
+
+
+def _detect_rate_limit_from_stdout(stdout: str, source: str) -> RateLimitInfo | None:
+    """Detect rate limit from stdout in JSON or stream-json format.
+
+    Tries single-object JSON first, then line-by-line stream-json, then
+    plain-text pattern matching.
+
+    Args:
+        stdout: Standard output from subprocess
+        source: "agent" or "judge"
+
+    Returns:
+        RateLimitInfo if rate limit detected, None otherwise
+
+    """
+    if not stdout.strip():
+        return None
+
+    # 1. Try single-object JSON (--output-format json)
+    try:
+        data = json.loads(stdout.strip())
+        info = _detect_rate_limit_from_json_line(data, source)
+        if info:
+            return info
+    except (json.JSONDecodeError, ValueError, TypeError):
+        pass
+
+    # 2. Try stream-json: one JSON object per line (--output-format stream-json)
+    for line in stdout.splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            data = json.loads(line)
+            info = _detect_rate_limit_from_json_line(data, source)
+            if info:
+                return info
+        except (json.JSONDecodeError, ValueError, TypeError):
+            continue
+
+    # 3. Plain-text pattern match (catches non-JSON error output in stdout)
+    rl_msg, retry_after = _detect_rate_limit_from_stderr(stdout)
+    if rl_msg:
+        return _make_rate_limit_info(source, rl_msg, retry_after)
+
+    return None
+
+
+def detect_rate_limit(stdout: str, stderr: str, source: str = "agent") -> RateLimitInfo | None:
+    """Detect rate limit from JSON or stream-json output, or stderr patterns.
+
+    Detection order:
+    1. Parse stdout as single JSON object (``--output-format json``)
+    2. Parse stdout line-by-line as stream-json (``--output-format stream-json``)
+    3. Scan stdout as plain text for rate-limit patterns
+    4. Scan stderr for rate-limit patterns
 
     Args:
         stdout: Standard output from subprocess
@@ -193,59 +331,40 @@ def detect_rate_limit(stdout: str, stderr: str, source: str = "agent") -> RateLi
         RateLimitInfo if rate limit detected, None otherwise
 
     """
-    # 1. Try JSON detection first (primary method)
-    try:
-        data = json.loads(stdout.strip())
+    info = _detect_rate_limit_from_stdout(stdout, source)
+    if info:
+        return info
 
-        # Check is_error field (from Claude Code JSON output)
-        # Rate-limited runs have is_error: true combined with rate-limit indicators
-        if data.get("is_error"):
-            result = data.get("result", data.get("error", ""))
-            error_str = str(result).lower()
-
-            # Check for rate limit keywords in error message
-            if any(
-                keyword in error_str
-                for keyword in [
-                    "rate limit",
-                    "rate_limit",
-                    "ratelimit",
-                    "overloaded",
-                    "429",
-                    "hit your limit",
-                    "resets",
-                    "weekly usage limit",
-                    "upgrade to continue",
-                    "failed to configure provider",
-                ]
-            ):
-                error_msg = str(result)
-                # Try parsing from error message first (JSON result field), then stderr
-                retry_after = parse_retry_after(error_msg) or parse_retry_after(stderr)
-
-                return RateLimitInfo(
-                    source=source,
-                    retry_after_seconds=retry_after,
-                    error_message=error_msg or "Rate limit detected (JSON is_error)",
-                    detected_at=datetime.now(timezone.utc).isoformat(),
-                )
-
-    except (json.JSONDecodeError, ValueError, TypeError):
-        # stdout is not JSON, try stderr patterns
-        pass
-
-    # 2. Scan stderr for rate limit patterns (fallback)
-    error_msg, retry_after = _detect_rate_limit_from_stderr(stderr)
-
-    if error_msg:
-        return RateLimitInfo(
-            source=source,
-            retry_after_seconds=retry_after,
-            error_message=error_msg,
-            detected_at=datetime.now(timezone.utc).isoformat(),
-        )
+    if stderr.strip():
+        error_msg, retry_after = _detect_rate_limit_from_stderr(stderr)
+        if error_msg:
+            return _make_rate_limit_info(source, error_msg, retry_after)
 
     return None
+
+
+def is_weekly_limit(info: RateLimitInfo) -> bool:
+    """Return True if this rate limit is a weekly/hard cap, not a transient 429.
+
+    Weekly limits reset on a specific date, typically hours or days away.
+    A retry-after value greater than 3600 seconds (1 hour) is considered
+    a weekly limit — short retries will not help.
+
+    Args:
+        info: RateLimitInfo to classify
+
+    Returns:
+        True if this is a weekly limit (long wait required)
+
+    """
+    if info.retry_after_seconds is not None and info.retry_after_seconds > 3600:
+        return True
+    # Also detect from error message keywords even if retry_after is unknown
+    msg_lower = info.error_message.lower()
+    return any(
+        kw in msg_lower
+        for kw in ("weekly usage limit", "hit your limit", "upgrade to continue", "resets ")
+    )
 
 
 def wait_for_rate_limit(

--- a/tests/unit/e2e/test_judge_runner.py
+++ b/tests/unit/e2e/test_judge_runner.py
@@ -18,6 +18,7 @@ from scylla.e2e.judge_runner import (
 )
 from scylla.e2e.models import JudgeResultSummary
 from scylla.e2e.paths import JUDGE_DIR, RESULT_FILE
+from scylla.e2e.rate_limit import RateLimitError, RateLimitInfo
 
 
 def _make_judge_result(
@@ -396,8 +397,6 @@ class TestRunJudge:
 
     def test_rate_limit_error_propagates(self, tmp_path: Path) -> None:
         """RateLimitError from judge propagates immediately (not caught)."""
-        from scylla.e2e.rate_limit import RateLimitError, RateLimitInfo
-
         judge_dir = tmp_path / "judge"
         judge_dir.mkdir()
         info = RateLimitInfo(
@@ -419,3 +418,66 @@ class TestRunJudge:
                     judge_dir=judge_dir,
                     judge_models=["claude-haiku-4-5"],
                 )
+
+    def test_all_judges_rate_limited_raises_rate_limit_error(self, tmp_path: Path) -> None:
+        """When all judges fail with rate-limit errors, _run_judge raises RateLimitError.
+
+        This is the test-001 failure mode: all three judges failed with
+        'You've hit your limit · resets Apr 3' but the error was silently
+        recorded as score=0.0 instead of raising RateLimitError.
+        """
+        judge_dir = tmp_path / "judge"
+        judge_dir.mkdir()
+
+        rate_limit_msg = (
+            "Claude CLI failed (exit 1): You've hit your limit"
+            " \u00b7 resets Apr 3, 6am (America/Los_Angeles)"
+        )
+
+        with patch(
+            "scylla.e2e.judge_runner.run_llm_judge",
+            side_effect=RuntimeError(rate_limit_msg),
+        ):
+            with pytest.raises(RateLimitError):
+                _run_judge(
+                    workspace=tmp_path,
+                    task_prompt="task",
+                    stdout="output",
+                    judge_dir=judge_dir,
+                    judge_models=["claude-opus-4-6", "claude-sonnet-4-6", "claude-haiku-4-5"],
+                )
+
+    def test_partial_rate_limit_does_not_raise(self, tmp_path: Path) -> None:
+        """When only some (not all) judges fail with rate-limit errors, return zero-score consensus.
+
+        If one judge succeeds, the experiment should continue with that result.
+        """
+        from unittest.mock import MagicMock
+
+        judge_dir = tmp_path / "judge"
+        judge_dir.mkdir()
+
+        rate_limit_msg = "Claude CLI failed (exit 1): You've hit your limit · resets Apr 3"
+        good_result = MagicMock()
+        good_result.score = 0.8
+        good_result.passed = True
+        good_result.grade = "B"
+        good_result.reasoning = "Good work"
+        good_result.is_valid = True
+        good_result.criteria_scores = {}
+
+        with patch(
+            "scylla.e2e.judge_runner.run_llm_judge",
+            side_effect=[RuntimeError(rate_limit_msg), good_result],
+        ):
+            consensus, judges = _run_judge(
+                workspace=tmp_path,
+                task_prompt="task",
+                stdout="output",
+                judge_dir=judge_dir,
+                judge_models=["claude-opus-4-6", "claude-sonnet-4-6"],
+            )
+
+        # Should not raise; valid judge contributes to consensus
+        assert consensus["score"] == pytest.approx(0.8)
+        assert len(judges) == 2

--- a/tests/unit/e2e/test_llm_judge.py
+++ b/tests/unit/e2e/test_llm_judge.py
@@ -834,6 +834,46 @@ class TestCallClaudeJudge:
             with pytest.raises(RateLimitError):
                 _call_claude_judge("Evaluate", "claude-opus-4-6", tmp_path)
 
+    def test_judge_call_exit1_rate_limit_stream_json_stdout(self, tmp_path: Path) -> None:
+        """Exit code 1 with rate limit in stream-json stdout raises RateLimitError.
+
+        This is the test-001 failure mode: --output-format stream-json emits
+        multiple JSON lines.  The old detect_rate_limit() tried json.loads()
+        on the whole stdout string, which fails for multi-line JSON.
+        """
+        stream_lines = [
+            json.dumps({"type": "system", "subtype": "init", "session_id": "abc"}),
+            json.dumps(
+                {
+                    "type": "result",
+                    "subtype": "error_during_execution",
+                    "is_error": True,
+                    "result": (
+                        "You've hit your limit \u00b7 resets Apr 3, 6am (America/Los_Angeles)"
+                    ),
+                }
+            ),
+        ]
+        mock_result = MagicMock()
+        mock_result.returncode = 1
+        mock_result.stdout = "\n".join(stream_lines)
+        mock_result.stderr = ""
+
+        with patch("subprocess.run", return_value=mock_result):
+            with pytest.raises(RateLimitError):
+                _call_claude_judge("Evaluate", "claude-opus-4-6", tmp_path)
+
+    def test_judge_call_exit1_rate_limit_resets_in_stderr(self, tmp_path: Path) -> None:
+        """'resets <date>' in stderr is detected as rate limit (the exact test-001 error)."""
+        mock_result = MagicMock()
+        mock_result.returncode = 1
+        mock_result.stdout = ""
+        mock_result.stderr = "You've hit your limit \u00b7 resets Apr 3, 6am (America/Los_Angeles)"
+
+        with patch("subprocess.run", return_value=mock_result):
+            with pytest.raises(RateLimitError):
+                _call_claude_judge("Evaluate", "claude-opus-4-6", tmp_path)
+
     def test_judge_call_with_rate_limit(self, tmp_path: Path) -> None:
         """Test rate limit detection."""
         mock_result = MagicMock()

--- a/tests/unit/e2e/test_rate_limit.py
+++ b/tests/unit/e2e/test_rate_limit.py
@@ -14,8 +14,10 @@ from scylla.e2e.checkpoint import E2ECheckpoint
 from scylla.e2e.rate_limit import (
     RateLimitError,
     RateLimitInfo,
+    WeeklyLimitError,
     check_api_rate_limit_status,
     detect_rate_limit,
+    is_weekly_limit,
     parse_retry_after,
     validate_run_result,
     wait_for_rate_limit,
@@ -402,6 +404,117 @@ class TestDetectRateLimit:
 
         assert info is not None
         assert "429" in info.error_message
+
+    def test_detect_stream_json_rate_limit_error(self) -> None:
+        """stream-json stdout (multi-line) with is_error rate limit is detected.
+
+        This is the exact failure mode from test-001: the judge uses
+        --output-format stream-json which emits multiple JSON lines.
+        The rate limit appeared in a stream-json event line, but the old
+        detect_rate_limit() tried json.loads(stdout) on the whole string,
+        which fails for multi-line JSON.
+        """
+        # Simulate stream-json: multiple lines, error in the last result event
+        stream_lines = [
+            json.dumps({"type": "system", "subtype": "init", "session_id": "abc"}),
+            json.dumps(
+                {
+                    "type": "result",
+                    "subtype": "error_during_execution",
+                    "is_error": True,
+                    "result": (
+                        "You've hit your limit \u00b7 resets Apr 3, 6am (America/Los_Angeles)"
+                    ),
+                }
+            ),
+        ]
+        stdout = "\n".join(stream_lines)
+        stderr = ""
+
+        info = detect_rate_limit(stdout, stderr, source="judge")
+
+        assert info is not None
+        assert info.source == "judge"
+        assert "hit your limit" in info.error_message.lower() or "resets" in info.error_message
+
+    def test_detect_stream_json_rate_limit_in_stdout_text(self) -> None:
+        """Rate limit message as plain text in stdout (not JSON) is detected."""
+        stdout = "You've hit your limit \u00b7 resets Apr 3, 6am (America/Los_Angeles)"
+        stderr = ""
+
+        info = detect_rate_limit(stdout, stderr, source="judge")
+
+        assert info is not None
+
+    def test_detect_resets_pattern_in_stderr(self) -> None:
+        """'resets <date>' in stderr is detected as rate limit."""
+        stderr = "You've hit your limit · resets Apr 3, 6am (America/Los_Angeles)"
+        info = detect_rate_limit("", stderr)
+        assert info is not None
+
+    def test_detect_resets_pattern_as_error_message(self) -> None:
+        """The exact error string from test-001 is detected."""
+        error_msg = "You've hit your limit \u00b7 resets Apr 3, 6am (America/Los_Angeles)"
+        # This is what _raise_if_rate_limit_in_error receives
+        from scylla.e2e.rate_limit import _detect_rate_limit_from_stderr
+
+        msg, _ = _detect_rate_limit_from_stderr(error_msg)
+        assert msg != ""
+
+
+class TestWeeklyLimitError:
+    """Tests for WeeklyLimitError and is_weekly_limit."""
+
+    def test_weekly_limit_error_is_rate_limit_error(self) -> None:
+        """WeeklyLimitError is a subclass of RateLimitError."""
+        info = RateLimitInfo(
+            source="judge",
+            retry_after_seconds=None,
+            error_message="Weekly usage limit reached",
+            detected_at="2026-01-01T00:00:00Z",
+        )
+        exc = WeeklyLimitError(info)
+        assert isinstance(exc, RateLimitError)
+
+    def test_is_weekly_limit_long_retry_after(self) -> None:
+        """retry_after_seconds > 3600 is classified as weekly."""
+        info = RateLimitInfo(
+            source="judge",
+            retry_after_seconds=86400.0,  # 24 hours
+            error_message="Some error",
+            detected_at="2026-01-01T00:00:00Z",
+        )
+        assert is_weekly_limit(info) is True
+
+    def test_is_weekly_limit_short_retry_after(self) -> None:
+        """retry_after_seconds <= 3600 is NOT classified as weekly."""
+        info = RateLimitInfo(
+            source="agent",
+            retry_after_seconds=30.0,
+            error_message="429 Too Many Requests",
+            detected_at="2026-01-01T00:00:00Z",
+        )
+        assert is_weekly_limit(info) is False
+
+    def test_is_weekly_limit_from_message_keywords(self) -> None:
+        """'hit your limit' in error message is classified as weekly even with None retry."""
+        info = RateLimitInfo(
+            source="judge",
+            retry_after_seconds=None,
+            error_message="You've hit your limit · resets Apr 3",
+            detected_at="2026-01-01T00:00:00Z",
+        )
+        assert is_weekly_limit(info) is True
+
+    def test_is_weekly_limit_none_retry_transient_message(self) -> None:
+        """None retry_after + generic 'overloaded' is NOT classified as weekly."""
+        info = RateLimitInfo(
+            source="agent",
+            retry_after_seconds=None,
+            error_message="API overloaded",
+            detected_at="2026-01-01T00:00:00Z",
+        )
+        assert is_weekly_limit(info) is False
 
 
 class TestWaitForRateLimit:


### PR DESCRIPTION
## Summary

- **Root cause of test-001 T4-T6 garbage data**: `detect_rate_limit()` called `json.loads(stdout)` on the whole stdout string, which fails for `--output-format stream-json` (multiple JSON lines). Rate-limit errors in stdout stream-json events went undetected, causing all judge failures to be recorded as `score: 0.0` valid-bad results instead of entering `RATE_LIMITED` state.
- The `_raise_if_rate_limit_in_error` fix that catches the error from extracted error messages was added 2026-04-03, four days after test-001 ran (2026-03-30).

## Changes

- **`rate_limit.py`**: Parse stdout line-by-line for stream-json format; add `"resets "` pattern; add `WeeklyLimitError` + `is_weekly_limit()`
- **`parallel_executor.py`**: Raise `WeeklyLimitError` immediately on weekly limits (not 60s wait + retry)  
- **`judge_runner.py`**: Propagate `RateLimitError` when ALL judges fail with rate-limit messages; save raw stdout/stderr for post-hoc debugging
- **`llm_judge.py`**: Attach raw streams to `RuntimeError` for the above

## Test plan
- [x] `test_rate_limit.py`: stream-json detection, `WeeklyLimitError`, `is_weekly_limit`, `"resets"` pattern
- [x] `test_judge_runner.py`: all-judges-rate-limited raises `RateLimitError`; partial failure still returns consensus
- [x] `test_llm_judge.py`: stream-json stdout raises `RateLimitError`; `"resets <date>"` in stderr raises `RateLimitError`
- [x] 237 tests pass, mypy clean, ruff clean

Closes #1821

🤖 Generated with [Claude Code](https://claude.com/claude-code)