### PR TITLE
chore(deps): bump matplotlib, pytest, pre-commit lower bounds

### DIFF
--- a/pixi.lock
+++ b/pixi.lock
@@ -5259,21 +5259,21 @@ packages:
 - pypi: ./
   name: scylla
   version: 0.1.0
-  sha256: 2e6915a8913c6e4f76bb2aae2afd1a1422dc79804edf5adfd2f1030aaf055f00
+  sha256: 8bfcc1ea2da76c23a600cff9d54492f4c0e2d8a91cd935c276080b51cfd40d97
   requires_dist:
   - click>=8.0,<9
   - homericintelligence-hephaestus>=0.7.0,<1
   - httpx>=0.28.1,<1
   - pydantic>=2.12.5,<3
   - pyyaml>=6.0.3,<7
-  - pytest>=7.0,<10 ; extra == 'dev'
+  - pytest>=9.0.3,<10 ; extra == 'dev'
   - pytest-asyncio>=0.25,<2 ; extra == 'dev'
   - pytest-cov>=7.1.0,<8 ; extra == 'dev'
-  - pre-commit>=3.0,<5 ; extra == 'dev'
+  - pre-commit>=4.5.1,<5 ; extra == 'dev'
   - ruff>=0.1.0,<1 ; extra == 'dev'
   - defusedxml>=0.7,<1 ; extra == 'dev'
   - nats-py>=2.0,<3 ; extra == 'nats'
-  - matplotlib>=3.8,<4 ; extra == 'analysis'
+  - matplotlib>=3.10.8,<4 ; extra == 'analysis'
   - numpy>=1.24,<3 ; extra == 'analysis'
   - pandas>=2.0,<3 ; extra == 'analysis'
   - seaborn>=0.13.2,<1 ; extra == 'analysis'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,10 +34,10 @@ dependencies = [
 
 [project.optional-dependencies]
 dev = [
-    "pytest>=7.0,<10",
+    "pytest>=9.0.3,<10",
     "pytest-asyncio>=0.25,<2",
     "pytest-cov>=7.1.0,<8",
-    "pre-commit>=3.0,<5",
+    "pre-commit>=4.5.1,<5",
     "ruff>=0.1.0,<1",
     "defusedxml>=0.7,<1",
 ]
@@ -45,7 +45,7 @@ nats = [
     "nats-py>=2.0,<3",
 ]
 analysis = [
-    "matplotlib>=3.8,<4",
+    "matplotlib>=3.10.8,<4",
     "numpy>=1.24,<3",
     "pandas>=2.0,<3",
     "seaborn>=0.13.2,<1",


### PR DESCRIPTION
## Summary

- `matplotlib`: `>=3.8` → `>=3.10.8` (bugfix release)
- `pytest`: `>=7.0` → `>=9.0.3` (bugfix release)
- `pre-commit`: `>=3.0` → `>=4.5.1` (bugfix release)

Supersedes dependabot PRs #1817, #1819, #1820 — applied all three together to avoid lockfile conflicts.

## Test plan

- [ ] CI passes (pixi.lock regenerated locally)
- [ ] Existing test suite unaffected by version bumps

🤖 Generated with [Claude Code](https://claude.com/claude-code)