### PR TITLE
feat(maestro): add retry logic to MaestroClient for transient failures

### DIFF
--- a/src/scylla/maestro/__init__.py
+++ b/src/scylla/maestro/__init__.py
@@ -1,0 +1,27 @@
+"""AI Maestro REST API integration.
+
+This module provides an HTTP client for communicating with the AI Maestro
+service to inject failures into agents during E2E evaluation runs.
+"""
+
+from scylla.maestro.async_client import AsyncMaestroClient as AsyncMaestroClient
+from scylla.maestro.client import MaestroClient as MaestroClient
+from scylla.maestro.errors import MaestroAPIError as MaestroAPIError
+from scylla.maestro.errors import MaestroConnectionError as MaestroConnectionError
+from scylla.maestro.errors import MaestroError as MaestroError
+from scylla.maestro.models import FailureSpec as FailureSpec
+from scylla.maestro.models import HealthResponse as HealthResponse
+from scylla.maestro.models import InjectionResult as InjectionResult
+from scylla.maestro.models import MaestroConfig as MaestroConfig
+
+__all__ = [
+    "AsyncMaestroClient",
+    "FailureSpec",
+    "HealthResponse",
+    "InjectionResult",
+    "MaestroAPIError",
+    "MaestroClient",
+    "MaestroConfig",
+    "MaestroConnectionError",
+    "MaestroError",
+]

--- a/src/scylla/maestro/async_client.py
+++ b/src/scylla/maestro/async_client.py
@@ -1,0 +1,213 @@
+"""Asynchronous HTTP client for the AI Maestro REST API.
+
+Provides ``AsyncMaestroClient``, a thin wrapper around ``httpx.AsyncClient``
+that exposes health-checking, agent listing, failure injection, and diagnostics
+endpoints without blocking the event loop.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+import httpx
+
+from scylla.maestro.errors import MaestroAPIError, MaestroConnectionError, MaestroError
+from scylla.maestro.models import (
+    FailureSpec,
+    HealthResponse,
+    InjectionResult,
+    MaestroConfig,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class AsyncMaestroClient:
+    """Asynchronous HTTP client for the AI Maestro REST API.
+
+    Typical usage::
+
+        config = MaestroConfig(base_url="http://localhost:23000", enabled=True)
+        async with AsyncMaestroClient(config) as client:
+            if await client.health_check():
+                result = await client.inject_failure(spec)
+
+    The client can also be used without an async context manager; call
+    :meth:`close` explicitly when done.
+    """
+
+    def __init__(self, config: MaestroConfig) -> None:
+        """Initialize the async Maestro client.
+
+        Args:
+            config: Maestro configuration with base URL and timeouts.
+
+        """
+        self._config = config
+        self._base_url = config.base_url.rstrip("/")
+        self._client = httpx.AsyncClient(
+            base_url=self._base_url,
+            timeout=httpx.Timeout(config.timeout_seconds),
+        )
+
+    # -- Async context manager -----------------------------------------------
+
+    async def __aenter__(self) -> AsyncMaestroClient:
+        """Enter the async context manager."""
+        return self
+
+    async def __aexit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_val: BaseException | None,
+        exc_tb: Any,
+    ) -> None:
+        """Exit the async context manager and close the underlying HTTP client."""
+        await self.close()
+
+    async def close(self) -> None:
+        """Close the underlying HTTP connection pool."""
+        await self._client.aclose()
+
+    # -- Helpers -------------------------------------------------------------
+
+    async def _request(
+        self,
+        method: str,
+        path: str,
+        *,
+        json: dict[str, Any] | None = None,
+        timeout: float | None = None,
+    ) -> httpx.Response:
+        """Send an HTTP request and handle common error scenarios.
+
+        Args:
+            method: HTTP method (GET, POST, DELETE, etc.).
+            path: URL path relative to the base URL.
+            json: Optional JSON body for POST/PUT requests.
+            timeout: Optional per-request timeout override.
+
+        Returns:
+            The ``httpx.Response`` object.
+
+        Raises:
+            MaestroConnectionError: On network or timeout failures.
+            MaestroAPIError: On non-2xx status codes.
+
+        """
+        try:
+            response = await self._client.request(
+                method,
+                path,
+                json=json,
+                timeout=timeout,
+            )
+        except httpx.ConnectError as exc:
+            raise MaestroConnectionError(
+                f"Failed to connect to Maestro API at {self._base_url}: {exc}"
+            ) from exc
+        except httpx.TimeoutException as exc:
+            raise MaestroConnectionError(f"Request to Maestro API timed out: {exc}") from exc
+        except httpx.HTTPError as exc:
+            raise MaestroError(f"HTTP error communicating with Maestro API: {exc}") from exc
+
+        if not response.is_success:
+            raise MaestroAPIError(
+                f"Maestro API returned {response.status_code} for {method} {path}",
+                status_code=response.status_code,
+                response_body=response.text,
+            )
+
+        return response
+
+    # -- Public API ----------------------------------------------------------
+
+    async def health_check(self) -> HealthResponse | None:
+        """Check Maestro API health.
+
+        Returns:
+            A ``HealthResponse`` if the service is healthy, or ``None`` if the
+            service is unreachable.
+
+        """
+        try:
+            response = await self._request(
+                "GET",
+                "/api/v1/health",
+                timeout=self._config.health_check_timeout_seconds,
+            )
+            data: dict[str, Any] = response.json() or {}
+            return HealthResponse(**data)
+        except MaestroError:
+            logger.debug("Maestro health check failed", exc_info=True)
+            return None
+
+    async def list_agents(self) -> list[dict[str, Any]]:
+        """List all agents registered with Maestro.
+
+        Returns:
+            A list of agent dictionaries.
+
+        Raises:
+            MaestroConnectionError: On network failures.
+            MaestroAPIError: On non-2xx responses.
+
+        """
+        response = await self._request("GET", "/api/agents")
+        result: list[dict[str, Any]] = response.json() or []
+        return result
+
+    async def inject_failure(self, spec: FailureSpec) -> InjectionResult:
+        """Inject a failure into a target agent.
+
+        Args:
+            spec: The failure specification describing what to inject.
+
+        Returns:
+            An ``InjectionResult`` with the injection ID and status.
+
+        Raises:
+            MaestroConnectionError: On network failures.
+            MaestroAPIError: On non-2xx responses.
+
+        """
+        payload: dict[str, Any] = {
+            "agent_id": spec.agent_id,
+            "failure_type": spec.failure_type,
+            "parameters": spec.parameters or {},
+        }
+        if spec.duration_seconds is not None:
+            payload["duration_seconds"] = spec.duration_seconds
+
+        response = await self._request("POST", "/api/agents/inject", json=payload)
+        data: dict[str, Any] = response.json() or {}
+        return InjectionResult(**data)
+
+    async def clear_failure(self, injection_id: str) -> None:
+        """Remove a previously injected failure.
+
+        Args:
+            injection_id: The injection ID returned by :meth:`inject_failure`.
+
+        Raises:
+            MaestroConnectionError: On network failures.
+            MaestroAPIError: On non-2xx responses.
+
+        """
+        await self._request("DELETE", f"/api/agents/inject/{injection_id}")
+
+    async def get_diagnostics(self) -> dict[str, Any]:
+        """Retrieve Maestro diagnostic information.
+
+        Returns:
+            A dictionary of diagnostic data.
+
+        Raises:
+            MaestroConnectionError: On network failures.
+            MaestroAPIError: On non-2xx responses.
+
+        """
+        response = await self._request("GET", "/api/diagnostics")
+        result: dict[str, Any] = response.json() or {}
+        return result

--- a/src/scylla/maestro/client.py
+++ b/src/scylla/maestro/client.py
@@ -1,0 +1,274 @@
+"""HTTP client for the AI Maestro REST API.
+
+Provides ``MaestroClient``, a thin wrapper around ``httpx.Client`` that
+exposes health-checking, agent listing, failure injection, and diagnostics
+endpoints.  Transient failures are automatically retried with exponential
+backoff (configurable via ``MaestroConfig.max_retries``).
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from typing import Any
+
+import httpx
+
+from scylla.maestro.errors import MaestroAPIError, MaestroConnectionError, MaestroError
+from scylla.maestro.models import (
+    FailureSpec,
+    HealthResponse,
+    InjectionResult,
+    MaestroConfig,
+)
+
+logger = logging.getLogger(__name__)
+
+# Status codes that indicate transient server-side issues worth retrying.
+_RETRYABLE_STATUS_CODES: frozenset[int] = frozenset({502, 503, 504})
+
+# httpx exception types that represent transient network problems.
+_RETRYABLE_EXCEPTIONS: tuple[type[Exception], ...] = (
+    httpx.ConnectError,
+    httpx.TimeoutException,
+    httpx.RemoteProtocolError,
+)
+
+_BASE_RETRY_DELAY: float = 1.0
+_RETRY_BACKOFF_FACTOR: int = 2
+
+
+class MaestroClient:
+    """Synchronous HTTP client for the AI Maestro REST API.
+
+    Typical usage::
+
+        config = MaestroConfig(base_url="http://localhost:23000", enabled=True)
+        with MaestroClient(config) as client:
+            if client.health_check():
+                result = client.inject_failure(spec)
+
+    The client can also be used without a context manager; call :meth:`close`
+    explicitly when done.
+    """
+
+    def __init__(self, config: MaestroConfig) -> None:
+        """Initialize the Maestro client.
+
+        Args:
+            config: Maestro configuration with base URL and timeouts.
+
+        """
+        self._config = config
+        self._base_url = config.base_url.rstrip("/")
+        self._client = httpx.Client(
+            base_url=self._base_url,
+            timeout=httpx.Timeout(config.timeout_seconds),
+        )
+
+    # -- Context manager -----------------------------------------------------
+
+    def __enter__(self) -> MaestroClient:
+        """Enter the context manager."""
+        return self
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_val: BaseException | None,
+        exc_tb: Any,
+    ) -> None:
+        """Exit the context manager and close the underlying HTTP client."""
+        self.close()
+
+    def close(self) -> None:
+        """Close the underlying HTTP connection pool."""
+        self._client.close()
+
+    # -- Helpers -------------------------------------------------------------
+
+    def _request(
+        self,
+        method: str,
+        path: str,
+        *,
+        json: dict[str, Any] | None = None,
+        timeout: float | None = None,
+    ) -> httpx.Response:
+        """Send an HTTP request with automatic retry on transient failures.
+
+        Retries on connection errors, timeouts, remote protocol errors, and
+        HTTP 502/503/504 responses using exponential backoff (1s, 2s, 4s, ...).
+        Non-retryable errors (e.g. HTTP 400/401/403/404) raise immediately.
+
+        Args:
+            method: HTTP method (GET, POST, DELETE, etc.).
+            path: URL path relative to the base URL.
+            json: Optional JSON body for POST/PUT requests.
+            timeout: Optional per-request timeout override.
+
+        Returns:
+            The ``httpx.Response`` object.
+
+        Raises:
+            MaestroConnectionError: On network or timeout failures after retries.
+            MaestroAPIError: On non-2xx status codes (after retries for 502/503/504).
+
+        """
+        max_attempts = self._config.max_retries + 1
+        last_exception: Exception | None = None
+
+        for attempt in range(max_attempts):
+            try:
+                response = self._client.request(
+                    method,
+                    path,
+                    json=json,
+                    timeout=timeout,
+                )
+            except _RETRYABLE_EXCEPTIONS as exc:
+                last_exception = exc
+                if attempt < self._config.max_retries:
+                    delay = _BASE_RETRY_DELAY * (_RETRY_BACKOFF_FACTOR**attempt)
+                    logger.warning(
+                        "Maestro request %s %s failed (attempt %d/%d): %s — retrying in %.1fs",
+                        method,
+                        path,
+                        attempt + 1,
+                        max_attempts,
+                        exc,
+                        delay,
+                    )
+                    time.sleep(delay)
+                    continue
+                # Last attempt exhausted — raise as connection error
+                raise MaestroConnectionError(
+                    f"Failed to connect to Maestro API at {self._base_url} "
+                    f"after {max_attempts} attempts: {exc}"
+                ) from exc
+            except httpx.HTTPError as exc:
+                raise MaestroError(f"HTTP error communicating with Maestro API: {exc}") from exc
+
+            # Check for non-success status codes
+            if not response.is_success:
+                if (
+                    response.status_code in _RETRYABLE_STATUS_CODES
+                    and attempt < self._config.max_retries
+                ):
+                    delay = _BASE_RETRY_DELAY * (_RETRY_BACKOFF_FACTOR**attempt)
+                    logger.warning(
+                        "Maestro API returned %d for %s %s (attempt %d/%d) — retrying in %.1fs",
+                        response.status_code,
+                        method,
+                        path,
+                        attempt + 1,
+                        max_attempts,
+                        delay,
+                    )
+                    time.sleep(delay)
+                    continue
+                raise MaestroAPIError(
+                    f"Maestro API returned {response.status_code} for {method} {path}",
+                    status_code=response.status_code,
+                    response_body=response.text,
+                )
+
+            return response
+
+        # Should only be reached if max_retries > 0 and all attempts raised
+        # retryable exceptions (the last attempt re-raises above, so this is
+        # a safety net for the type checker).
+        raise MaestroConnectionError(  # pragma: no cover
+            f"All {max_attempts} attempts to {method} {path} failed: {last_exception}"
+        )
+
+    # -- Public API ----------------------------------------------------------
+
+    def health_check(self) -> HealthResponse | None:
+        """Check Maestro API health.
+
+        Returns:
+            A ``HealthResponse`` if the service is healthy, or ``None`` if the
+            service is unreachable.
+
+        """
+        try:
+            response = self._request(
+                "GET",
+                "/api/v1/health",
+                timeout=self._config.health_check_timeout_seconds,
+            )
+            data: dict[str, Any] = response.json() or {}
+            return HealthResponse(**data)
+        except MaestroError:
+            logger.debug("Maestro health check failed", exc_info=True)
+            return None
+
+    def list_agents(self) -> list[dict[str, Any]]:
+        """List all agents registered with Maestro.
+
+        Returns:
+            A list of agent dictionaries.
+
+        Raises:
+            MaestroConnectionError: On network failures.
+            MaestroAPIError: On non-2xx responses.
+
+        """
+        response = self._request("GET", "/api/agents")
+        result: list[dict[str, Any]] = response.json() or []
+        return result
+
+    def inject_failure(self, spec: FailureSpec) -> InjectionResult:
+        """Inject a failure into a target agent.
+
+        Args:
+            spec: The failure specification describing what to inject.
+
+        Returns:
+            An ``InjectionResult`` with the injection ID and status.
+
+        Raises:
+            MaestroConnectionError: On network failures.
+            MaestroAPIError: On non-2xx responses.
+
+        """
+        payload: dict[str, Any] = {
+            "agent_id": spec.agent_id,
+            "failure_type": spec.failure_type,
+            "parameters": spec.parameters or {},
+        }
+        if spec.duration_seconds is not None:
+            payload["duration_seconds"] = spec.duration_seconds
+
+        response = self._request("POST", "/api/agents/inject", json=payload)
+        data: dict[str, Any] = response.json() or {}
+        return InjectionResult(**data)
+
+    def clear_failure(self, injection_id: str) -> None:
+        """Remove a previously injected failure.
+
+        Args:
+            injection_id: The injection ID returned by :meth:`inject_failure`.
+
+        Raises:
+            MaestroConnectionError: On network failures.
+            MaestroAPIError: On non-2xx responses.
+
+        """
+        self._request("DELETE", f"/api/agents/inject/{injection_id}")
+
+    def get_diagnostics(self) -> dict[str, Any]:
+        """Retrieve Maestro diagnostic information.
+
+        Returns:
+            A dictionary of diagnostic data.
+
+        Raises:
+            MaestroConnectionError: On network failures.
+            MaestroAPIError: On non-2xx responses.
+
+        """
+        response = self._request("GET", "/api/diagnostics")
+        result: dict[str, Any] = response.json() or {}
+        return result

--- a/src/scylla/maestro/errors.py
+++ b/src/scylla/maestro/errors.py
@@ -1,0 +1,32 @@
+"""Exception hierarchy for AI Maestro REST API integration."""
+
+
+class MaestroError(Exception):
+    """Base exception for all Maestro API errors."""
+
+
+class MaestroConnectionError(MaestroError):
+    """Raised when the Maestro API is unreachable or a connection times out."""
+
+
+class MaestroAPIError(MaestroError):
+    """Raised when the Maestro API returns a non-2xx response.
+
+    Attributes:
+        status_code: HTTP status code from the response.
+        response_body: Raw response body text.
+
+    """
+
+    def __init__(self, message: str, status_code: int, response_body: str = "") -> None:
+        """Initialize MaestroAPIError.
+
+        Args:
+            message: Human-readable error description.
+            status_code: HTTP status code from the response.
+            response_body: Raw response body text.
+
+        """
+        super().__init__(message)
+        self.status_code = status_code
+        self.response_body = response_body

--- a/src/scylla/maestro/models.py
+++ b/src/scylla/maestro/models.py
@@ -1,0 +1,81 @@
+"""Pydantic models for AI Maestro REST API integration.
+
+Defines configuration, request, and response models used by MaestroClient.
+"""
+
+from typing import Any
+
+from pydantic import BaseModel, Field
+
+
+class MaestroConfig(BaseModel):
+    """Configuration for the AI Maestro REST API connection.
+
+    When ``enabled`` is ``False`` (the default), the client is not instantiated
+    and no HTTP calls are made.  This keeps the integration fully opt-in.
+    """
+
+    base_url: str = Field(
+        default="http://localhost:23000",
+        description="Base URL for the Maestro REST API",
+    )
+    enabled: bool = Field(
+        default=False,
+        description="Whether to activate the Maestro integration",
+    )
+    timeout_seconds: int = Field(
+        default=10,
+        ge=1,
+        le=300,
+        description="Timeout in seconds for mutation requests",
+    )
+    health_check_timeout_seconds: int = Field(
+        default=5,
+        ge=1,
+        le=60,
+        description="Timeout in seconds for health-check requests",
+    )
+    max_retries: int = Field(
+        default=3,
+        ge=0,
+        le=10,
+        description="Maximum retry attempts for transient network failures (0 disables retry)",
+    )
+
+
+class FailureSpec(BaseModel):
+    """Specification for a failure to inject via the Maestro API.
+
+    Attributes:
+        agent_id: Target agent identifier.
+        failure_type: Kind of failure (e.g. ``network_delay``, ``crash``, ``timeout``).
+        duration_seconds: Optional duration; ``None`` means permanent until cleared.
+        parameters: Arbitrary key-value parameters for the failure type.
+
+    """
+
+    agent_id: str = Field(..., description="Target agent identifier")
+    failure_type: str = Field(..., description="Kind of failure to inject")
+    duration_seconds: int | None = Field(
+        default=None,
+        ge=1,
+        description="Duration in seconds; None means permanent until cleared",
+    )
+    parameters: dict[str, Any] = Field(
+        default_factory=dict,
+        description="Extra parameters for the failure type",
+    )
+
+
+class HealthResponse(BaseModel):
+    """Response model for the Maestro health endpoint."""
+
+    status: str = Field(..., description="Health status string (e.g. 'ok')")
+    version: str | None = Field(default=None, description="API version string")
+
+
+class InjectionResult(BaseModel):
+    """Response model for a successful failure injection."""
+
+    injection_id: str = Field(..., description="Unique identifier for this injection")
+    status: str = Field(..., description="Injection status (e.g. 'active')")

--- a/tests/unit/maestro/__init__.py
+++ b/tests/unit/maestro/__init__.py
@@ -1,0 +1,1 @@
+"""Unit tests for the Maestro client module."""

--- a/tests/unit/maestro/conftest.py
+++ b/tests/unit/maestro/conftest.py
@@ -1,0 +1,22 @@
+"""Shared fixtures for Maestro client tests."""
+
+import pytest
+
+from scylla.maestro.models import MaestroConfig
+
+
+@pytest.fixture
+def maestro_config() -> MaestroConfig:
+    """Provide a default Maestro configuration for testing.
+
+    Returns:
+        A MaestroConfig with standard test defaults.
+
+    """
+    return MaestroConfig(
+        base_url="http://localhost:23000",
+        enabled=True,
+        timeout_seconds=10,
+        health_check_timeout_seconds=5,
+        max_retries=3,
+    )

--- a/tests/unit/maestro/test_client.py
+++ b/tests/unit/maestro/test_client.py
@@ -1,0 +1,417 @@
+"""Unit tests for MaestroClient with retry logic."""
+
+import logging
+from unittest.mock import MagicMock, Mock, patch
+
+import httpx
+import pytest
+
+from scylla.maestro.client import MaestroClient
+from scylla.maestro.errors import MaestroAPIError, MaestroConnectionError, MaestroError
+from scylla.maestro.models import (
+    FailureSpec,
+    HealthResponse,
+    InjectionResult,
+    MaestroConfig,
+)
+
+
+class TestMaestroClientRetry:
+    """Tests for retry logic in MaestroClient._request()."""
+
+    def test_success_first_attempt(self, maestro_config: MaestroConfig) -> None:
+        """Test successful request on first attempt (no sleep)."""
+        with patch("scylla.maestro.client.httpx.Client") as MockClient:
+            mock_client = Mock()
+            MockClient.return_value = mock_client
+
+            response = Mock()
+            response.is_success = True
+            mock_client.request.return_value = response
+
+            with patch("time.sleep") as mock_sleep:
+                client = MaestroClient(maestro_config)
+                result = client._request("GET", "/api/v1/health")
+
+            assert result is response
+            mock_sleep.assert_not_called()
+            mock_client.request.assert_called_once()
+
+    def test_retry_succeeds_on_second_attempt(
+        self, maestro_config: MaestroConfig
+    ) -> None:
+        """Test retry succeeds on second attempt (1 sleep call)."""
+        with patch("scylla.maestro.client.httpx.Client") as MockClient:
+            mock_client = Mock()
+            MockClient.return_value = mock_client
+
+            ok_response = Mock()
+            ok_response.is_success = True
+            mock_client.request.side_effect = [
+                httpx.ConnectError("Connection failed"),
+                ok_response,
+            ]
+
+            with patch("time.sleep") as mock_sleep:
+                client = MaestroClient(maestro_config)
+                result = client._request("GET", "/api/v1/health")
+
+            assert result is ok_response
+            mock_sleep.assert_called_once_with(1.0)
+            assert mock_client.request.call_count == 2
+
+    def test_retry_succeeds_on_third_attempt(
+        self, maestro_config: MaestroConfig
+    ) -> None:
+        """Test retry succeeds on third attempt (2 sleep calls with correct delays)."""
+        with patch("scylla.maestro.client.httpx.Client") as MockClient:
+            mock_client = Mock()
+            MockClient.return_value = mock_client
+
+            ok_response = Mock()
+            ok_response.is_success = True
+            mock_client.request.side_effect = [
+                httpx.TimeoutException("Timeout"),
+                httpx.ConnectError("Connection failed"),
+                ok_response,
+            ]
+
+            with patch("time.sleep") as mock_sleep:
+                client = MaestroClient(maestro_config)
+                result = client._request("GET", "/api/v1/health")
+
+            assert result is ok_response
+            assert mock_sleep.call_count == 2
+            mock_sleep.assert_any_call(1.0)
+            mock_sleep.assert_any_call(2.0)
+            assert mock_client.request.call_count == 3
+
+    def test_retry_exhausted_raises_connection_error(
+        self, maestro_config: MaestroConfig
+    ) -> None:
+        """Test that exhausted retries raise MaestroConnectionError."""
+        with patch("scylla.maestro.client.httpx.Client") as MockClient:
+            mock_client = Mock()
+            MockClient.return_value = mock_client
+
+            mock_client.request.side_effect = httpx.ConnectError("Connection failed")
+
+            client = MaestroClient(maestro_config)
+            with pytest.raises(MaestroConnectionError) as exc_info:
+                client._request("GET", "/api/v1/health")
+
+            assert "after 4 attempts" in str(exc_info.value)
+            assert mock_client.request.call_count == 4  # max_retries + 1
+
+    def test_max_retries_zero_disables_retry(self) -> None:
+        """Test that max_retries=0 disables retry (single attempt)."""
+        config = MaestroConfig(max_retries=0)
+        with patch("scylla.maestro.client.httpx.Client") as MockClient:
+            mock_client = Mock()
+            MockClient.return_value = mock_client
+
+            mock_client.request.side_effect = httpx.ConnectError("Connection failed")
+
+            client = MaestroClient(config)
+            with pytest.raises(MaestroConnectionError):
+                client._request("GET", "/api/v1/health")
+
+            mock_client.request.assert_called_once()
+
+    def test_timeout_exception_retried(self, maestro_config: MaestroConfig) -> None:
+        """Test that TimeoutException is retried."""
+        with patch("scylla.maestro.client.httpx.Client") as MockClient:
+            mock_client = Mock()
+            MockClient.return_value = mock_client
+
+            ok_response = Mock()
+            ok_response.is_success = True
+            mock_client.request.side_effect = [
+                httpx.TimeoutException("Request timed out"),
+                ok_response,
+            ]
+
+            client = MaestroClient(maestro_config)
+            result = client._request("GET", "/api/v1/health")
+
+            assert result is ok_response
+
+    def test_remote_protocol_error_retried(self, maestro_config: MaestroConfig) -> None:
+        """Test that RemoteProtocolError is retried."""
+        with patch("scylla.maestro.client.httpx.Client") as MockClient:
+            mock_client = Mock()
+            MockClient.return_value = mock_client
+
+            ok_response = Mock()
+            ok_response.is_success = True
+            mock_client.request.side_effect = [
+                httpx.RemoteProtocolError("Protocol error"),
+                ok_response,
+            ]
+
+            client = MaestroClient(maestro_config)
+            result = client._request("GET", "/api/v1/health")
+
+            assert result is ok_response
+
+    def test_http_502_retried(self, maestro_config: MaestroConfig) -> None:
+        """Test that HTTP 502 is retried."""
+        with patch("scylla.maestro.client.httpx.Client") as MockClient:
+            mock_client = Mock()
+            MockClient.return_value = mock_client
+
+            ok_response = Mock()
+            ok_response.is_success = True
+
+            error_response = Mock()
+            error_response.is_success = False
+            error_response.status_code = 502
+            mock_client.request.side_effect = [error_response, ok_response]
+
+            with patch("time.sleep") as mock_sleep:
+                client = MaestroClient(maestro_config)
+                result = client._request("GET", "/api/v1/health")
+
+            assert result is ok_response
+            mock_sleep.assert_called_once()
+
+    def test_http_503_retried(self, maestro_config: MaestroConfig) -> None:
+        """Test that HTTP 503 is retried."""
+        with patch("scylla.maestro.client.httpx.Client") as MockClient:
+            mock_client = Mock()
+            MockClient.return_value = mock_client
+
+            ok_response = Mock()
+            ok_response.is_success = True
+
+            error_response = Mock()
+            error_response.is_success = False
+            error_response.status_code = 503
+            mock_client.request.side_effect = [error_response, ok_response]
+
+            client = MaestroClient(maestro_config)
+            result = client._request("GET", "/api/v1/health")
+
+            assert result is ok_response
+
+    def test_http_504_retried(self, maestro_config: MaestroConfig) -> None:
+        """Test that HTTP 504 is retried."""
+        with patch("scylla.maestro.client.httpx.Client") as MockClient:
+            mock_client = Mock()
+            MockClient.return_value = mock_client
+
+            ok_response = Mock()
+            ok_response.is_success = True
+
+            error_response = Mock()
+            error_response.is_success = False
+            error_response.status_code = 504
+            mock_client.request.side_effect = [error_response, ok_response]
+
+            client = MaestroClient(maestro_config)
+            result = client._request("GET", "/api/v1/health")
+
+            assert result is ok_response
+
+    def test_404_not_retried(self, maestro_config: MaestroConfig) -> None:
+        """Test that HTTP 404 is not retried and raises immediately."""
+        with patch("scylla.maestro.client.httpx.Client") as MockClient:
+            mock_client = Mock()
+            MockClient.return_value = mock_client
+
+            error_response = Mock()
+            error_response.is_success = False
+            error_response.status_code = 404
+            error_response.text = "Not found"
+            mock_client.request.return_value = error_response
+
+            client = MaestroClient(maestro_config)
+            with pytest.raises(MaestroAPIError) as exc_info:
+                client._request("GET", "/api/not-found")
+
+            assert exc_info.value.status_code == 404
+            mock_client.request.assert_called_once()
+
+    def test_500_not_retried(self, maestro_config: MaestroConfig) -> None:
+        """Test that HTTP 500 is not retried and raises immediately."""
+        with patch("scylla.maestro.client.httpx.Client") as MockClient:
+            mock_client = Mock()
+            MockClient.return_value = mock_client
+
+            error_response = Mock()
+            error_response.is_success = False
+            error_response.status_code = 500
+            error_response.text = "Internal server error"
+            mock_client.request.return_value = error_response
+
+            client = MaestroClient(maestro_config)
+            with pytest.raises(MaestroAPIError) as exc_info:
+                client._request("GET", "/api/v1/health")
+
+            assert exc_info.value.status_code == 500
+            mock_client.request.assert_called_once()
+
+    def test_non_retryable_http_error_not_retried(
+        self, maestro_config: MaestroConfig
+    ) -> None:
+        """Test that non-retryable httpx errors raise immediately."""
+        with patch("scylla.maestro.client.httpx.Client") as MockClient:
+            mock_client = Mock()
+            MockClient.return_value = mock_client
+
+            # Use a non-retryable httpx error
+            mock_client.request.side_effect = httpx.HTTPError("Some HTTP error")
+
+            client = MaestroClient(maestro_config)
+            with pytest.raises(MaestroError):
+                client._request("GET", "/api/v1/health")
+
+            mock_client.request.assert_called_once()
+
+    def test_backoff_timing(self, maestro_config: MaestroConfig) -> None:
+        """Test that backoff delays follow exponential pattern (1s, 2s, 4s)."""
+        with patch("scylla.maestro.client.httpx.Client") as MockClient:
+            mock_client = Mock()
+            MockClient.return_value = mock_client
+
+            ok_response = Mock()
+            ok_response.is_success = True
+            mock_client.request.side_effect = [
+                httpx.ConnectError("Connection failed"),
+                httpx.ConnectError("Connection failed"),
+                httpx.ConnectError("Connection failed"),
+                ok_response,
+            ]
+
+            with patch("time.sleep") as mock_sleep:
+                client = MaestroClient(maestro_config)
+                result = client._request("GET", "/api/v1/health")
+
+            assert result is ok_response
+            assert mock_sleep.call_count == 3
+            calls = [call[0][0] for call in mock_sleep.call_args_list]
+            assert calls == [1.0, 2.0, 4.0]
+
+    def test_warning_logged_on_retry(
+        self, maestro_config: MaestroConfig, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Test that warning is logged on retry with attempt info."""
+        with patch("scylla.maestro.client.httpx.Client") as MockClient:
+            mock_client = Mock()
+            MockClient.return_value = mock_client
+
+            ok_response = Mock()
+            ok_response.is_success = True
+            mock_client.request.side_effect = [
+                httpx.ConnectError("Connection failed"),
+                ok_response,
+            ]
+
+            with caplog.at_level(logging.WARNING):
+                client = MaestroClient(maestro_config)
+                client._request("GET", "/api/v1/health")
+
+            assert any("attempt 1/4" in record.message for record in caplog.records)
+            assert any("retrying in 1.0s" in record.message for record in caplog.records)
+
+    def test_context_manager(self, maestro_config: MaestroConfig) -> None:
+        """Test that context manager properly closes the client."""
+        with patch("scylla.maestro.client.httpx.Client") as MockClient:
+            mock_client = Mock()
+            MockClient.return_value = mock_client
+
+            with MaestroClient(maestro_config) as client:
+                pass
+
+            mock_client.close.assert_called_once()
+
+    def test_explicit_close(self, maestro_config: MaestroConfig) -> None:
+        """Test that explicit close() works."""
+        with patch("scylla.maestro.client.httpx.Client") as MockClient:
+            mock_client = Mock()
+            MockClient.return_value = mock_client
+
+            client = MaestroClient(maestro_config)
+            client.close()
+
+            mock_client.close.assert_called_once()
+
+
+class TestMaestroClientPublicAPI:
+    """Tests for public API methods."""
+
+    def test_health_check_success(self, maestro_config: MaestroConfig) -> None:
+        """Test successful health check."""
+        with patch.object(MaestroClient, "_request") as mock_request:
+            response = Mock()
+            response.json.return_value = {"status": "ok", "version": "1.0"}
+            mock_request.return_value = response
+
+            client = MaestroClient(maestro_config)
+            result = client.health_check()
+
+            assert isinstance(result, HealthResponse)
+            assert result.status == "ok"
+            assert result.version == "1.0"
+
+    def test_health_check_failure_returns_none(self, maestro_config: MaestroConfig) -> None:
+        """Test that health check returns None on error."""
+        with patch.object(MaestroClient, "_request") as mock_request:
+            mock_request.side_effect = MaestroConnectionError("Failed to connect")
+
+            client = MaestroClient(maestro_config)
+            result = client.health_check()
+
+            assert result is None
+
+    def test_list_agents(self, maestro_config: MaestroConfig) -> None:
+        """Test listing agents."""
+        with patch.object(MaestroClient, "_request") as mock_request:
+            response = Mock()
+            response.json.return_value = [{"id": "agent-1"}, {"id": "agent-2"}]
+            mock_request.return_value = response
+
+            client = MaestroClient(maestro_config)
+            result = client.list_agents()
+
+            assert len(result) == 2
+            assert result[0]["id"] == "agent-1"
+
+    def test_inject_failure(self, maestro_config: MaestroConfig) -> None:
+        """Test failure injection."""
+        with patch.object(MaestroClient, "_request") as mock_request:
+            response = Mock()
+            response.json.return_value = {"injection_id": "inj-123", "status": "active"}
+            mock_request.return_value = response
+
+            client = MaestroClient(maestro_config)
+            spec = FailureSpec(agent_id="agent-1", failure_type="crash")
+            result = client.inject_failure(spec)
+
+            assert isinstance(result, InjectionResult)
+            assert result.injection_id == "inj-123"
+            assert result.status == "active"
+
+    def test_clear_failure(self, maestro_config: MaestroConfig) -> None:
+        """Test clearing an injected failure."""
+        with patch.object(MaestroClient, "_request") as mock_request:
+            response = Mock()
+            mock_request.return_value = response
+
+            client = MaestroClient(maestro_config)
+            client.clear_failure("inj-123")
+
+            mock_request.assert_called_once_with("DELETE", "/api/agents/inject/inj-123")
+
+    def test_get_diagnostics(self, maestro_config: MaestroConfig) -> None:
+        """Test retrieving diagnostics."""
+        with patch.object(MaestroClient, "_request") as mock_request:
+            response = Mock()
+            response.json.return_value = {"uptime": 3600, "agents": 5}
+            mock_request.return_value = response
+
+            client = MaestroClient(maestro_config)
+            result = client.get_diagnostics()
+
+            assert result["uptime"] == 3600
+            assert result["agents"] == 5

--- a/tests/unit/maestro/test_models.py
+++ b/tests/unit/maestro/test_models.py
@@ -1,0 +1,159 @@
+"""Unit tests for Maestro Pydantic models."""
+
+import pytest
+from pydantic import ValidationError
+
+from scylla.maestro.models import (
+    FailureSpec,
+    HealthResponse,
+    InjectionResult,
+    MaestroConfig,
+)
+
+
+class TestMaestroConfig:
+    """Tests for MaestroConfig model."""
+
+    def test_default_values(self) -> None:
+        """Test that default values are correctly set."""
+        config = MaestroConfig()
+        assert config.base_url == "http://localhost:23000"
+        assert config.enabled is False
+        assert config.timeout_seconds == 10
+        assert config.health_check_timeout_seconds == 5
+        assert config.max_retries == 3
+
+    def test_custom_values(self) -> None:
+        """Test that custom values override defaults."""
+        config = MaestroConfig(
+            base_url="http://example.com:8080",
+            enabled=True,
+            timeout_seconds=20,
+            health_check_timeout_seconds=3,
+            max_retries=5,
+        )
+        assert config.base_url == "http://example.com:8080"
+        assert config.enabled is True
+        assert config.timeout_seconds == 20
+        assert config.health_check_timeout_seconds == 3
+        assert config.max_retries == 5
+
+    def test_max_retries_bounds(self) -> None:
+        """Test that max_retries respects the 0-10 range."""
+        # Valid edge cases
+        config_zero = MaestroConfig(max_retries=0)
+        assert config_zero.max_retries == 0
+
+        config_ten = MaestroConfig(max_retries=10)
+        assert config_ten.max_retries == 10
+
+        # Invalid cases
+        with pytest.raises(ValidationError):
+            MaestroConfig(max_retries=-1)
+
+        with pytest.raises(ValidationError):
+            MaestroConfig(max_retries=11)
+
+    def test_timeout_bounds(self) -> None:
+        """Test that timeout_seconds respects bounds."""
+        # Valid edge cases
+        config_one = MaestroConfig(timeout_seconds=1)
+        assert config_one.timeout_seconds == 1
+
+        config_max = MaestroConfig(timeout_seconds=300)
+        assert config_max.timeout_seconds == 300
+
+        # Invalid cases
+        with pytest.raises(ValidationError):
+            MaestroConfig(timeout_seconds=0)
+
+        with pytest.raises(ValidationError):
+            MaestroConfig(timeout_seconds=301)
+
+
+class TestFailureSpec:
+    """Tests for FailureSpec model."""
+
+    def test_required_fields(self) -> None:
+        """Test that agent_id and failure_type are required."""
+        spec = FailureSpec(agent_id="agent-1", failure_type="network_delay")
+        assert spec.agent_id == "agent-1"
+        assert spec.failure_type == "network_delay"
+
+    def test_missing_required_field(self) -> None:
+        """Test that validation fails when required fields are missing."""
+        with pytest.raises(ValidationError):
+            FailureSpec(failure_type="network_delay")
+
+        with pytest.raises(ValidationError):
+            FailureSpec(agent_id="agent-1")
+
+    def test_optional_fields(self) -> None:
+        """Test optional fields with defaults."""
+        spec = FailureSpec(agent_id="agent-1", failure_type="crash")
+        assert spec.duration_seconds is None
+        assert spec.parameters == {}
+
+    def test_with_optional_fields(self) -> None:
+        """Test setting optional fields."""
+        spec = FailureSpec(
+            agent_id="agent-1",
+            failure_type="timeout",
+            duration_seconds=30,
+            parameters={"delay_ms": 500},
+        )
+        assert spec.duration_seconds == 30
+        assert spec.parameters == {"delay_ms": 500}
+
+    def test_duration_seconds_bounds(self) -> None:
+        """Test that duration_seconds respects bounds."""
+        # Valid case
+        spec = FailureSpec(agent_id="agent-1", failure_type="delay", duration_seconds=1)
+        assert spec.duration_seconds == 1
+
+        # Invalid case
+        with pytest.raises(ValidationError):
+            FailureSpec(agent_id="agent-1", failure_type="delay", duration_seconds=0)
+
+
+class TestHealthResponse:
+    """Tests for HealthResponse model."""
+
+    def test_required_status(self) -> None:
+        """Test that status is required."""
+        response = HealthResponse(status="ok")
+        assert response.status == "ok"
+
+    def test_missing_status(self) -> None:
+        """Test that validation fails without status."""
+        with pytest.raises(ValidationError):
+            HealthResponse()
+
+    def test_with_version(self) -> None:
+        """Test setting optional version field."""
+        response = HealthResponse(status="ok", version="1.0.0")
+        assert response.status == "ok"
+        assert response.version == "1.0.0"
+
+    def test_version_none_by_default(self) -> None:
+        """Test that version defaults to None."""
+        response = HealthResponse(status="ok")
+        assert response.version is None
+
+
+class TestInjectionResult:
+    """Tests for InjectionResult model."""
+
+    def test_required_fields(self) -> None:
+        """Test that injection_id and status are required."""
+        result = InjectionResult(injection_id="inj-123", status="active")
+        assert result.injection_id == "inj-123"
+        assert result.status == "active"
+
+    def test_missing_fields(self) -> None:
+        """Test that validation fails without required fields."""
+        with pytest.raises(ValidationError):
+            InjectionResult(status="active")
+
+        with pytest.raises(ValidationError):
+            InjectionResult(injection_id="inj-123")


### PR DESCRIPTION
## Summary

Add automatic retry with exponential backoff to MaestroClient for handling transient network failures. Retries 3 times (configurable) with 1s/2s/4s delays on connection errors, timeouts, and HTTP 502/503/504 responses. Non-retryable errors (404, 401, 403, 500, etc.) are raised immediately.

- MaestroClient._request() implements retry logic with exponential backoff
- Configurable max_retries (0-10, default 3) in MaestroConfig
- Comprehensive unit tests: 38 tests, 97.5% coverage on sync client
- Includes retry scenario tests: success, retries with backoff, exhaustion, logging
- Status codes 502/503/504 are retried; others raise immediately
- Connection, timeout, and remote protocol errors are retried

## Test plan

- [x] All 38 unit tests pass
- [x] 97.5% coverage on MaestroClient
- [x] Retry logic tested with mocked httpx exceptions
- [x] Backoff timing verified (1s, 2s, 4s)
- [x] Status code handling tested (502/503/504 retried, others not)
- [x] Configuration validation tested (max_retries bounds 0-10)

Closes #1605

Claude Code