### PR TITLE
fix(e2e): infrastructure failures skip subtest instead of aborting experiment

### DIFF
--- a/src/scylla/e2e/parallel_executor.py
+++ b/src/scylla/e2e/parallel_executor.py
@@ -22,13 +22,13 @@ from scylla.e2e.models import (
     TierID,
 )
 from scylla.e2e.rate_limit import (
+    InfrastructureFailureError,
     RateLimitError,
     RateLimitInfo,
     detect_rate_limit,
     is_weekly_limit,
     wait_for_rate_limit,
 )
-from scylla.e2e.runner import InfrastructureFailureError
 
 if TYPE_CHECKING:
     from scylla.e2e.checkpoint import E2ECheckpoint

--- a/src/scylla/e2e/parallel_executor.py
+++ b/src/scylla/e2e/parallel_executor.py
@@ -28,6 +28,7 @@ from scylla.e2e.rate_limit import (
     is_weekly_limit,
     wait_for_rate_limit,
 )
+from scylla.e2e.runner import InfrastructureFailureError
 
 if TYPE_CHECKING:
     from scylla.e2e.checkpoint import E2ECheckpoint
@@ -239,6 +240,13 @@ def run_tier_subtests_parallel(
                 f"{completed_count}/{total_subtests} complete, "
                 f"{remaining} remaining, elapsed: {elapsed:.0f}s"
             )
+        except InfrastructureFailureError as e:
+            # Agent crashed before making API calls — skip this subtest and continue.
+            # The run has already been archived to .failed/ by stage_commit_agent_changes().
+            logger.warning(
+                f"[SKIP] Subtest {subtest.id} skipped due to infrastructure failure: {e}"
+            )
+            completed_count += 1
         except RateLimitError as e:
             # Both weekly and transient rate limits: wait and retry once.
             # Weekly limits have a parsed reset time in retry_after_seconds —

--- a/src/scylla/e2e/rate_limit.py
+++ b/src/scylla/e2e/rate_limit.py
@@ -50,6 +50,14 @@ class RateLimitInfo(BaseModel):
         return self
 
 
+class InfrastructureFailureError(Exception):
+    """Raised when an agent crashes before making any API calls (exit_code=-1, zero tokens).
+
+    Caught at the subtest level in run_tier_subtests_parallel() so the failed
+    run is skipped and the experiment continues with remaining subtests/tiers.
+    """
+
+
 class RateLimitError(Exception):
     """Raised when rate limit is detected from agent or judge.
 

--- a/src/scylla/e2e/runner.py
+++ b/src/scylla/e2e/runner.py
@@ -69,6 +69,15 @@ class ShutdownInterruptedError(Exception):
     """
 
 
+class InfrastructureFailureError(Exception):
+    """Raised when an agent crashes before making any API calls (exit_code=-1, zero tokens).
+
+    Unlike a generic RuntimeError, this is caught at the subtest level in
+    run_tier_subtests_parallel() so the failed run is skipped and the experiment
+    continues with remaining subtests/tiers instead of aborting.
+    """
+
+
 def request_shutdown() -> None:
     """Request graceful shutdown of the experiment.
 

--- a/src/scylla/e2e/runner.py
+++ b/src/scylla/e2e/runner.py
@@ -69,15 +69,6 @@ class ShutdownInterruptedError(Exception):
     """
 
 
-class InfrastructureFailureError(Exception):
-    """Raised when an agent crashes before making any API calls (exit_code=-1, zero tokens).
-
-    Unlike a generic RuntimeError, this is caught at the subtest level in
-    run_tier_subtests_parallel() so the failed run is skipped and the experiment
-    continues with remaining subtests/tiers instead of aborting.
-    """
-
-
 def request_shutdown() -> None:
     """Request graceful shutdown of the experiment.
 

--- a/src/scylla/e2e/stages.py
+++ b/src/scylla/e2e/stages.py
@@ -55,7 +55,7 @@ from scylla.e2e.models import (
     TierID,
 )
 from scylla.e2e.paths import get_agent_dir, get_judge_dir
-from scylla.e2e.runner import InfrastructureFailureError
+from scylla.e2e.rate_limit import InfrastructureFailureError
 from scylla.e2e.stage_finalization import (
     stage_cleanup_worktree as stage_cleanup_worktree,
 )

--- a/src/scylla/e2e/stages.py
+++ b/src/scylla/e2e/stages.py
@@ -55,6 +55,7 @@ from scylla.e2e.models import (
     TierID,
 )
 from scylla.e2e.paths import get_agent_dir, get_judge_dir
+from scylla.e2e.runner import InfrastructureFailureError
 from scylla.e2e.stage_finalization import (
     stage_cleanup_worktree as stage_cleanup_worktree,
 )
@@ -745,7 +746,7 @@ def stage_commit_agent_changes(ctx: RunContext) -> None:
                 f"[AGENT] Infrastructure failure detected (exit_code=-1, zero tokens) — "
                 f"run moved to {dest}"
             )
-            raise RuntimeError(
+            raise InfrastructureFailureError(
                 f"Infrastructure failure in run {ctx.run_number} "
                 f"({ctx.tier_id.value}/{ctx.subtest.id}): agent crashed before making any API calls"
             )

--- a/tests/unit/e2e/test_stage_commit_agent_changes.py
+++ b/tests/unit/e2e/test_stage_commit_agent_changes.py
@@ -8,6 +8,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from scylla.e2e.models import TierID
+from scylla.e2e.rate_limit import InfrastructureFailureError
 
 
 def _make_ctx(
@@ -58,7 +59,7 @@ class TestStageCommitAgentChanges:
 
         ctx = _make_ctx(tmp_path, exit_code=-1, input_tokens=0, output_tokens=0)
 
-        with pytest.raises(RuntimeError, match="Infrastructure failure"):
+        with pytest.raises(InfrastructureFailureError, match="Infrastructure failure"):
             stage_commit_agent_changes(ctx)
 
         # Run dir should have been moved to .failed/


### PR DESCRIPTION
## Summary

When an agent crashes before making any API calls (`exit_code=-1`, zero tokens), the experiment was aborting entirely. This fix makes infrastructure failures recoverable:

- Add `InfrastructureFailureError` in `runner.py` alongside `ShutdownInterruptedError`
- Raise it (instead of `RuntimeError`) in `stage_commit_agent_changes()` in `stages.py`
- Catch it in `run_tier_subtests_parallel()` in `parallel_executor.py` — log a warning, skip the subtest, and continue with remaining subtests/tiers

The failed run is still archived to `.failed/` as before. The experiment continues and can reach `COMPLETE` even when individual runs crash.

## Before

```
[ERROR] Infrastructure failure in run 3 (T3/22): agent crashed before making any API calls
[ERROR] Experiment failed in state tiers_running: Infrastructure failure in run 3 (T3/22): ...
```

## After

```
[WARNING] [SKIP] Subtest 22 skipped due to infrastructure failure: Infrastructure failure in run 3 (T3/22): ...
[INFO] Tier T3: 2/3 complete, 1 remaining, elapsed: 185s
```

## Files Changed

- `src/scylla/e2e/runner.py` — add `InfrastructureFailureError`
- `src/scylla/e2e/stages.py` — raise `InfrastructureFailureError`, import it
- `src/scylla/e2e/parallel_executor.py` — catch and skip on `InfrastructureFailureError`