### PR TITLE
feat(agamemnon): add sync and async Agamemnon Chaos Client

### DIFF
--- a/src/scylla/agamemnon/__init__.py
+++ b/src/scylla/agamemnon/__init__.py
@@ -1,19 +1,41 @@
-"""Agamemnon chaos fault injection client for the Odysseus agent mesh.
+"""Agamemnon Chaos Client for optional fault-injection via the Odysseus agent mesh.
 
-This module provides synchronous and asynchronous clients for the
-Agamemnon REST API, along with Protocol types that allow consumers
-to write code agnostic to sync vs async.
+This package provides both synchronous and asynchronous HTTP clients for the
+Agamemnon Chaos API. The async variant is designed for parallel tier execution
+without blocking the event loop.
+
+Typical usage::
+
+    from scylla.agamemnon import AgamemnonClient, AgamemnonConfig
+
+    config = AgamemnonConfig(base_url="http://localhost:8080", enabled=True)
+    with AgamemnonClient(config) as client:
+        health = client.health_check()
+        result = client.inject_failure(spec)
+
+For async usage::
+
+    from scylla.agamemnon import AsyncAgamemnonClient, AgamemnonConfig
+
+    config = AgamemnonConfig(base_url="http://localhost:8080", enabled=True)
+    async with AsyncAgamemnonClient(config) as client:
+        health = await client.health_check()
+        result = await client.inject_failure(spec)
 """
 
-from scylla.agamemnon.client import AgamemnonClient as AgamemnonClient
-from scylla.agamemnon.client import AsyncAgamemnonClient as AsyncAgamemnonClient
-from scylla.agamemnon.errors import AgamemnonAPIError as AgamemnonAPIError
-from scylla.agamemnon.errors import AgamemnonConnectionError as AgamemnonConnectionError
-from scylla.agamemnon.errors import AgamemnonError as AgamemnonError
-from scylla.agamemnon.models import AgamemnonConfig as AgamemnonConfig
-from scylla.agamemnon.models import FailureSpec as FailureSpec
-from scylla.agamemnon.models import HealthResponse as HealthResponse
-from scylla.agamemnon.models import InjectionResult as InjectionResult
+from scylla.agamemnon.async_client import AsyncAgamemnonClient
+from scylla.agamemnon.client import AgamemnonClient
+from scylla.agamemnon.errors import (
+    AgamemnonAPIError,
+    AgamemnonConnectionError,
+    AgamemnonError,
+)
+from scylla.agamemnon.models import (
+    AgamemnonConfig,
+    FailureSpec,
+    HealthResponse,
+    InjectionResult,
+)
 from scylla.agamemnon.protocols import (
     AgamemnonClientProtocol as AgamemnonClientProtocol,
 )

--- a/src/scylla/agamemnon/_retry.py
+++ b/src/scylla/agamemnon/_retry.py
@@ -1,0 +1,45 @@
+"""Shared retry logic for sync and async Agamemnon clients."""
+
+from __future__ import annotations
+
+import logging
+from typing import Final
+
+logger = logging.getLogger(__name__)
+
+#: HTTP status codes considered transient and eligible for retry.
+TRANSIENT_STATUS_CODES: Final[frozenset[int]] = frozenset({502, 503, 504})
+
+#: Base delay in seconds for exponential backoff.
+BACKOFF_BASE: Final[float] = 1.0
+
+#: Multiplier for exponential backoff.
+BACKOFF_FACTOR: Final[float] = 2.0
+
+
+def compute_backoff(attempt: int) -> float:
+    """Compute exponential backoff delay for a given attempt (0-indexed).
+
+    Uses formula: base * factor^attempt
+
+    Args:
+        attempt: Zero-indexed retry attempt number.
+
+    Returns:
+        Delay in seconds before the next retry.
+
+    """
+    return BACKOFF_BASE * (BACKOFF_FACTOR**attempt)
+
+
+def is_transient_status(status_code: int) -> bool:
+    """Check whether an HTTP status code is considered transient.
+
+    Args:
+        status_code: HTTP status code to check.
+
+    Returns:
+        True if the status code is transient and should be retried.
+
+    """
+    return status_code in TRANSIENT_STATUS_CODES

--- a/src/scylla/agamemnon/async_client.py
+++ b/src/scylla/agamemnon/async_client.py
@@ -128,6 +128,10 @@ class AsyncAgamemnonClient:
         result: list[dict[str, Any]] = response.json()
         return result
 
+    async def get_diagnostics(self) -> dict[str, Any]:
+        """Return diagnostic information about the client."""
+        raise NotImplementedError  # pragma: no cover
+
     # -- Internal retry logic -------------------------------------------------
 
     async def _request_with_retry(

--- a/src/scylla/agamemnon/async_client.py
+++ b/src/scylla/agamemnon/async_client.py
@@ -1,9 +1,9 @@
-"""Synchronous HTTP client for the Agamemnon Chaos API."""
+"""Asynchronous HTTP client for the Agamemnon Chaos API."""
 
 from __future__ import annotations
 
+import asyncio
 import logging
-import time
 from typing import Any
 
 import httpx
@@ -26,12 +26,15 @@ from scylla.agamemnon.models import (
 logger = logging.getLogger(__name__)
 
 
-class AgamemnonClient:
-    """Synchronous client for the Agamemnon Chaos API.
+class AsyncAgamemnonClient:
+    """Asynchronous client for the Agamemnon Chaos API.
 
-    Provides methods for health checks, failure injection, failure clearing,
-    and agent listing. Transient failures (connection errors, timeouts,
-    HTTP 502/503/504) are retried with exponential backoff.
+    Mirrors the synchronous :class:`AgamemnonClient` interface using
+    ``httpx.AsyncClient``. Designed for parallel tier execution without
+    blocking the event loop during retries.
+
+    Transient failures (connection errors, timeouts, HTTP 502/503/504) are
+    retried with exponential backoff using ``asyncio.sleep``.
 
     Args:
         config: Agamemnon client configuration.
@@ -39,29 +42,29 @@ class AgamemnonClient:
     """
 
     def __init__(self, config: AgamemnonConfig) -> None:
-        """Initialize the synchronous Agamemnon client."""
+        """Initialize the asynchronous Agamemnon client."""
         self._config = config
-        self._client = httpx.Client(
+        self._client = httpx.AsyncClient(
             base_url=config.base_url,
             timeout=httpx.Timeout(config.timeout_seconds),
         )
         self._health_timeout = httpx.Timeout(config.health_check_timeout_seconds)
 
-    def close(self) -> None:
-        """Close the underlying HTTP client."""
-        self._client.close()
+    async def close(self) -> None:
+        """Close the underlying async HTTP client."""
+        await self._client.aclose()
 
-    def __enter__(self) -> AgamemnonClient:
-        """Enter the synchronous context manager."""
+    async def __aenter__(self) -> AsyncAgamemnonClient:
+        """Enter the async context manager."""
         return self
 
-    def __exit__(self, *args: object) -> None:
-        """Exit the synchronous context manager and close the client."""
-        self.close()
+    async def __aexit__(self, *args: object) -> None:
+        """Exit the async context manager and close the client."""
+        await self.close()
 
     # -- Public API -----------------------------------------------------------
 
-    def health_check(self) -> HealthResponse | None:
+    async def health_check(self) -> HealthResponse | None:
         """Check Agamemnon API health.
 
         Returns:
@@ -69,14 +72,14 @@ class AgamemnonClient:
 
         """
         try:
-            response = self._client.get("/v1/health", timeout=self._health_timeout)
+            response = await self._client.get("/v1/health", timeout=self._health_timeout)
             response.raise_for_status()
             return HealthResponse.model_validate(response.json())
         except (httpx.HTTPError, Exception):
             logger.warning("Agamemnon health check failed", exc_info=True)
             return None
 
-    def inject_failure(self, spec: FailureSpec) -> InjectionResult:
+    async def inject_failure(self, spec: FailureSpec) -> InjectionResult:
         """Inject a failure into an agent.
 
         Args:
@@ -90,14 +93,14 @@ class AgamemnonClient:
             AgamemnonAPIError: On non-2xx responses after retries.
 
         """
-        response = self._request_with_retry(
+        response = await self._request_with_retry(
             "POST",
             "/v1/chaos/inject",
             json=spec.model_dump(),
         )
         return InjectionResult.model_validate(response.json())
 
-    def clear_failure(self, injection_id: str) -> None:
+    async def clear_failure(self, injection_id: str) -> None:
         """Remove an injected failure.
 
         Args:
@@ -108,9 +111,9 @@ class AgamemnonClient:
             AgamemnonAPIError: On non-2xx responses after retries.
 
         """
-        self._request_with_retry("DELETE", f"/v1/chaos/inject/{injection_id}")
+        await self._request_with_retry("DELETE", f"/v1/chaos/inject/{injection_id}")
 
-    def list_agents(self) -> list[dict[str, Any]]:
+    async def list_agents(self) -> list[dict[str, Any]]:
         """List all registered agents.
 
         Returns:
@@ -121,31 +124,28 @@ class AgamemnonClient:
             AgamemnonAPIError: On non-2xx responses after retries.
 
         """
-        response = self._request_with_retry("GET", "/v1/agents")
+        response = await self._request_with_retry("GET", "/v1/agents")
         result: list[dict[str, Any]] = response.json()
         return result
 
-    def get_diagnostics(self) -> dict[str, Any]:
-        """Return diagnostic information about the client."""
-        raise NotImplementedError  # pragma: no cover
-
     # -- Internal retry logic -------------------------------------------------
 
-    def _request_with_retry(
+    async def _request_with_retry(
         self,
         method: str,
         url: str,
         **kwargs: Any,
     ) -> httpx.Response:
-        """Execute an HTTP request with exponential-backoff retry.
+        """Execute an async HTTP request with exponential-backoff retry.
 
         Retries on connection errors, timeouts, and transient HTTP status codes
-        (502, 503, 504).
+        (502, 503, 504). Uses ``asyncio.sleep`` instead of ``time.sleep`` so
+        the event loop is not blocked.
 
         Args:
             method: HTTP method (GET, POST, DELETE, etc.).
             url: URL path relative to base_url.
-            **kwargs: Additional arguments passed to httpx.Client.request.
+            **kwargs: Additional arguments passed to httpx.AsyncClient.request.
 
         Returns:
             The successful httpx.Response.
@@ -159,7 +159,7 @@ class AgamemnonClient:
         last_error: Exception | None = None
         for attempt in range(self._config.max_retries + 1):
             try:
-                response = self._client.request(method, url, **kwargs)
+                response = await self._client.request(method, url, **kwargs)
                 if response.is_success:
                     return response
                 if is_transient_status(response.status_code):
@@ -175,7 +175,7 @@ class AgamemnonClient:
                             attempt + 1,
                             self._config.max_retries,
                         )
-                        time.sleep(delay)
+                        await asyncio.sleep(delay)
                         continue
                     raise last_error
                 raise AgamemnonAPIError(response.status_code, response.text)
@@ -192,7 +192,7 @@ class AgamemnonClient:
                         self._config.max_retries,
                         exc,
                     )
-                    time.sleep(delay)
+                    await asyncio.sleep(delay)
                     continue
                 raise last_error from exc
         # Should not be reached, but satisfy type checker

--- a/src/scylla/agamemnon/errors.py
+++ b/src/scylla/agamemnon/errors.py
@@ -1,33 +1,27 @@
-"""Exception hierarchy for the Agamemnon chaos client."""
+"""Exception hierarchy for the Agamemnon Chaos Client."""
 
 from __future__ import annotations
 
 
 class AgamemnonError(Exception):
-    """Base exception for Agamemnon client errors."""
+    """Base exception for all Agamemnon client errors."""
 
 
 class AgamemnonConnectionError(AgamemnonError):
-    """Raised on network failures or timeouts."""
+    """Network failures and timeouts when communicating with Agamemnon."""
 
 
 class AgamemnonAPIError(AgamemnonError):
-    """Raised on non-2xx HTTP responses.
+    """Non-2xx HTTP response from the Agamemnon API.
 
     Attributes:
-        status_code: HTTP status code from the server.
+        status_code: HTTP status code returned by the API.
         response_body: Raw response body text.
 
     """
 
-    def __init__(
-        self,
-        message: str,
-        *,
-        status_code: int,
-        response_body: str = "",
-    ) -> None:
-        """Create an API error with status code and optional response body."""
-        super().__init__(message)
+    def __init__(self, status_code: int, response_body: str) -> None:
+        """Initialize with status code and response body."""
         self.status_code = status_code
         self.response_body = response_body
+        super().__init__(f"Agamemnon API error {status_code}: {response_body}")

--- a/src/scylla/agamemnon/models.py
+++ b/src/scylla/agamemnon/models.py
@@ -1,8 +1,4 @@
-"""Data models for the Agamemnon chaos fault injection client.
-
-Defines configuration, request, and response models used by both
-the synchronous and asynchronous client implementations.
-"""
+"""Configuration and data models for the Agamemnon Chaos Client."""
 
 from __future__ import annotations
 
@@ -12,56 +8,62 @@ from pydantic import BaseModel, Field
 
 
 class AgamemnonConfig(BaseModel):
-    """Configuration for the Agamemnon chaos client."""
+    """Configuration for the Agamemnon Chaos Client.
 
-    base_url: str = Field(
-        default="http://localhost:8080",
-        description="Agamemnon REST API base URL",
-    )
-    enabled: bool = Field(
-        default=False,
-        description="Whether Agamemnon integration is active",
-    )
-    timeout_seconds: int = Field(
-        default=10,
-        ge=1,
-        le=300,
-        description="Timeout for mutation requests",
-    )
-    health_check_timeout_seconds: int = Field(
-        default=5,
-        ge=1,
-        le=60,
-        description="Timeout for health checks",
-    )
-    max_retries: int = Field(
-        default=3,
-        ge=0,
-        le=10,
-        description="Retry attempts for transient failures",
-    )
+    Attributes:
+        base_url: Agamemnon REST API base URL.
+        enabled: Whether the integration is active.
+        timeout_seconds: Timeout for mutation requests (1-300).
+        health_check_timeout_seconds: Timeout for health checks (1-60).
+        max_retries: Retry attempts for transient failures (0-10).
+
+    """
+
+    base_url: str = "http://localhost:8080"
+    enabled: bool = False
+    timeout_seconds: int = Field(default=10, ge=1, le=300)
+    health_check_timeout_seconds: int = Field(default=5, ge=1, le=60)
+    max_retries: int = Field(default=3, ge=0, le=10)
 
 
 class FailureSpec(BaseModel):
-    """Specification for a chaos failure to inject."""
+    """Describes a failure to inject into an agent.
 
-    agent_id: str = Field(..., description="Target agent identifier")
-    failure_type: str = Field(..., description="Type of failure to inject")
-    parameters: dict[str, Any] = Field(
-        default_factory=dict,
-        description="Additional failure parameters",
-    )
+    Attributes:
+        agent_id: Identifier of the target agent.
+        failure_type: Type of failure to inject.
+        duration_seconds: How long the failure should last.
+        parameters: Additional failure-specific parameters.
+
+    """
+
+    agent_id: str
+    failure_type: str
+    duration_seconds: int = Field(ge=1)
+    parameters: dict[str, Any] = Field(default_factory=dict)
 
 
 class HealthResponse(BaseModel):
-    """Response from the Agamemnon health endpoint."""
+    """API health status response.
 
-    status: str = Field(..., description="Health status string")
-    version: str = Field(default="", description="Server version")
+    Attributes:
+        status: Current health status string.
+        version: API version string.
+
+    """
+
+    status: str
+    version: str
 
 
 class InjectionResult(BaseModel):
-    """Result of a successful fault injection."""
+    """Result of a successful failure injection.
 
-    injection_id: str = Field(..., description="Unique identifier for the injection")
-    status: str = Field(..., description="Injection status")
+    Attributes:
+        injection_id: Unique identifier for the injection.
+        status: Status of the injection.
+
+    """
+
+    injection_id: str
+    status: str

--- a/tests/unit/agamemnon/test_async_client.py
+++ b/tests/unit/agamemnon/test_async_client.py
@@ -1,0 +1,233 @@
+"""Tests for the asynchronous AsyncAgamemnonClient."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import httpx
+import pytest
+
+from scylla.agamemnon.async_client import AsyncAgamemnonClient
+from scylla.agamemnon.errors import AgamemnonAPIError, AgamemnonConnectionError
+from scylla.agamemnon.models import (
+    AgamemnonConfig,
+    FailureSpec,
+    HealthResponse,
+    InjectionResult,
+)
+
+
+@pytest.fixture()
+def config() -> AgamemnonConfig:
+    """Return a test AgamemnonConfig."""
+    return AgamemnonConfig(
+        base_url="http://test:8080",
+        enabled=True,
+        max_retries=2,
+        timeout_seconds=5,
+    )
+
+
+def _make_async_client(
+    config: AgamemnonConfig, transport: httpx.MockTransport
+) -> AsyncAgamemnonClient:
+    """Create an AsyncAgamemnonClient with a mocked transport."""
+    client = AsyncAgamemnonClient(config)
+    client._client = httpx.AsyncClient(base_url=config.base_url, transport=transport)
+    return client
+
+
+class TestAsyncHealthCheck:
+    """Tests for AsyncAgamemnonClient.health_check."""
+
+    @pytest.mark.asyncio()
+    async def test_healthy(self, config: AgamemnonConfig) -> None:
+        """Verify healthy response is parsed correctly."""
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            assert request.url.path == "/v1/health"
+            return httpx.Response(200, json={"status": "ok", "version": "1.0.0"})
+
+        client = _make_async_client(config, httpx.MockTransport(handler))
+        result = await client.health_check()
+        assert result is not None
+        assert result == HealthResponse(status="ok", version="1.0.0")
+
+    @pytest.mark.asyncio()
+    async def test_unreachable_returns_none(self, config: AgamemnonConfig) -> None:
+        """Verify connection error returns None gracefully."""
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            raise httpx.ConnectError("connection refused")
+
+        client = _make_async_client(config, httpx.MockTransport(handler))
+        result = await client.health_check()
+        assert result is None
+
+    @pytest.mark.asyncio()
+    async def test_server_error_returns_none(self, config: AgamemnonConfig) -> None:
+        """Verify server error returns None gracefully."""
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(500, text="Internal Server Error")
+
+        client = _make_async_client(config, httpx.MockTransport(handler))
+        result = await client.health_check()
+        assert result is None
+
+
+class TestAsyncInjectFailure:
+    """Tests for AsyncAgamemnonClient.inject_failure."""
+
+    @pytest.mark.asyncio()
+    async def test_success(self, config: AgamemnonConfig) -> None:
+        """Verify successful injection returns parsed result."""
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            assert request.url.path == "/v1/chaos/inject"
+            assert request.method == "POST"
+            return httpx.Response(200, json={"injection_id": "inj-1", "status": "active"})
+
+        client = _make_async_client(config, httpx.MockTransport(handler))
+        spec = FailureSpec(agent_id="a1", failure_type="latency", duration_seconds=60)
+        result = await client.inject_failure(spec)
+        assert result == InjectionResult(injection_id="inj-1", status="active")
+
+    @pytest.mark.asyncio()
+    async def test_api_error(self, config: AgamemnonConfig) -> None:
+        """Verify non-2xx response raises AgamemnonAPIError."""
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(400, text="Bad Request")
+
+        client = _make_async_client(config, httpx.MockTransport(handler))
+        spec = FailureSpec(agent_id="a1", failure_type="latency", duration_seconds=60)
+        with pytest.raises(AgamemnonAPIError) as exc_info:
+            await client.inject_failure(spec)
+        assert exc_info.value.status_code == 400
+
+
+class TestAsyncClearFailure:
+    """Tests for AsyncAgamemnonClient.clear_failure."""
+
+    @pytest.mark.asyncio()
+    async def test_success(self, config: AgamemnonConfig) -> None:
+        """Verify DELETE request is sent to the correct path."""
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            assert request.url.path == "/v1/chaos/inject/inj-1"
+            assert request.method == "DELETE"
+            return httpx.Response(200, json={})
+
+        client = _make_async_client(config, httpx.MockTransport(handler))
+        await client.clear_failure("inj-1")
+
+
+class TestAsyncListAgents:
+    """Tests for AsyncAgamemnonClient.list_agents."""
+
+    @pytest.mark.asyncio()
+    async def test_success(self, config: AgamemnonConfig) -> None:
+        """Verify agent list is returned correctly."""
+        agents = [{"id": "a1", "name": "Agent 1"}]
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            assert request.url.path == "/v1/agents"
+            return httpx.Response(200, json=agents)
+
+        client = _make_async_client(config, httpx.MockTransport(handler))
+        result = await client.list_agents()
+        assert result == agents
+
+
+class TestAsyncRetryBehavior:
+    """Tests for retry logic in AsyncAgamemnonClient."""
+
+    @pytest.mark.asyncio()
+    async def test_retries_on_transient_status(self, config: AgamemnonConfig) -> None:
+        """Verify transient 503 is retried and succeeds on third attempt."""
+        call_count = 0
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            nonlocal call_count
+            call_count += 1
+            if call_count <= 2:
+                return httpx.Response(503, text="Service Unavailable")
+            return httpx.Response(200, json={"injection_id": "inj-1", "status": "active"})
+
+        client = _make_async_client(config, httpx.MockTransport(handler))
+        spec = FailureSpec(agent_id="a1", failure_type="latency", duration_seconds=60)
+        with patch("scylla.agamemnon.async_client.asyncio.sleep", new_callable=AsyncMock):
+            result = await client.inject_failure(spec)
+        assert result.injection_id == "inj-1"
+        assert call_count == 3
+
+    @pytest.mark.asyncio()
+    async def test_exhausts_retries_on_transient(self, config: AgamemnonConfig) -> None:
+        """Verify retries are exhausted and AgamemnonAPIError is raised."""
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(503, text="Service Unavailable")
+
+        client = _make_async_client(config, httpx.MockTransport(handler))
+        spec = FailureSpec(agent_id="a1", failure_type="latency", duration_seconds=60)
+        with patch("scylla.agamemnon.async_client.asyncio.sleep", new_callable=AsyncMock):
+            with pytest.raises(AgamemnonAPIError) as exc_info:
+                await client.inject_failure(spec)
+        assert exc_info.value.status_code == 503
+
+    @pytest.mark.asyncio()
+    async def test_retries_on_connection_error(self, config: AgamemnonConfig) -> None:
+        """Verify connection errors are retried."""
+        call_count = 0
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            nonlocal call_count
+            call_count += 1
+            if call_count <= 1:
+                raise httpx.ConnectError("connection refused")
+            return httpx.Response(200, json=[])
+
+        client = _make_async_client(config, httpx.MockTransport(handler))
+        with patch("scylla.agamemnon.async_client.asyncio.sleep", new_callable=AsyncMock):
+            result = await client.list_agents()
+        assert result == []
+        assert call_count == 2
+
+    @pytest.mark.asyncio()
+    async def test_exhausts_retries_on_connection_error(self, config: AgamemnonConfig) -> None:
+        """Verify exhausted connection retries raise AgamemnonConnectionError."""
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            raise httpx.ConnectError("connection refused")
+
+        client = _make_async_client(config, httpx.MockTransport(handler))
+        with patch("scylla.agamemnon.async_client.asyncio.sleep", new_callable=AsyncMock):
+            with pytest.raises(AgamemnonConnectionError):
+                await client.list_agents()
+
+    @pytest.mark.asyncio()
+    async def test_no_retry_on_non_transient_error(self, config: AgamemnonConfig) -> None:
+        """Verify non-transient errors (404) are not retried."""
+        call_count = 0
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            nonlocal call_count
+            call_count += 1
+            return httpx.Response(404, text="Not Found")
+
+        client = _make_async_client(config, httpx.MockTransport(handler))
+        with pytest.raises(AgamemnonAPIError) as exc_info:
+            await client.list_agents()
+        assert exc_info.value.status_code == 404
+        assert call_count == 1
+
+
+class TestAsyncContextManager:
+    """Tests for async context manager protocol."""
+
+    @pytest.mark.asyncio()
+    async def test_async_context_manager(self, config: AgamemnonConfig) -> None:
+        """Verify async context manager enters and exits cleanly."""
+        async with AsyncAgamemnonClient(config) as client:
+            assert client is not None

--- a/tests/unit/agamemnon/test_client.py
+++ b/tests/unit/agamemnon/test_client.py
@@ -1,0 +1,233 @@
+"""Tests for the synchronous AgamemnonClient."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import httpx
+import pytest
+
+from scylla.agamemnon.client import AgamemnonClient
+from scylla.agamemnon.errors import AgamemnonAPIError, AgamemnonConnectionError
+from scylla.agamemnon.models import (
+    AgamemnonConfig,
+    FailureSpec,
+    HealthResponse,
+    InjectionResult,
+)
+
+
+@pytest.fixture()
+def config() -> AgamemnonConfig:
+    """Return a test AgamemnonConfig."""
+    return AgamemnonConfig(
+        base_url="http://test:8080",
+        enabled=True,
+        max_retries=2,
+        timeout_seconds=5,
+    )
+
+
+@pytest.fixture()
+def transport() -> httpx.MockTransport:
+    """Return a default transport that returns 200 with empty JSON object."""
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        """Handle requests with a 200 response."""
+        return httpx.Response(200, json={})
+
+    return httpx.MockTransport(handler)
+
+
+def _make_client(config: AgamemnonConfig, transport: httpx.MockTransport) -> AgamemnonClient:
+    """Create an AgamemnonClient with a mocked transport."""
+    client = AgamemnonClient(config)
+    client._client = httpx.Client(base_url=config.base_url, transport=transport)
+    return client
+
+
+class TestHealthCheck:
+    """Tests for AgamemnonClient.health_check."""
+
+    def test_healthy(self, config: AgamemnonConfig) -> None:
+        """Verify healthy response is parsed correctly."""
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            assert request.url.path == "/v1/health"
+            return httpx.Response(200, json={"status": "ok", "version": "1.0.0"})
+
+        client = _make_client(config, httpx.MockTransport(handler))
+        result = client.health_check()
+        assert result is not None
+        assert result == HealthResponse(status="ok", version="1.0.0")
+
+    def test_unreachable_returns_none(self, config: AgamemnonConfig) -> None:
+        """Verify connection error returns None gracefully."""
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            raise httpx.ConnectError("connection refused")
+
+        client = _make_client(config, httpx.MockTransport(handler))
+        result = client.health_check()
+        assert result is None
+
+    def test_server_error_returns_none(self, config: AgamemnonConfig) -> None:
+        """Verify server error returns None gracefully."""
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(500, text="Internal Server Error")
+
+        client = _make_client(config, httpx.MockTransport(handler))
+        result = client.health_check()
+        assert result is None
+
+
+class TestInjectFailure:
+    """Tests for AgamemnonClient.inject_failure."""
+
+    def test_success(self, config: AgamemnonConfig) -> None:
+        """Verify successful injection returns parsed result."""
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            assert request.url.path == "/v1/chaos/inject"
+            assert request.method == "POST"
+            return httpx.Response(200, json={"injection_id": "inj-1", "status": "active"})
+
+        client = _make_client(config, httpx.MockTransport(handler))
+        spec = FailureSpec(agent_id="a1", failure_type="latency", duration_seconds=60)
+        result = client.inject_failure(spec)
+        assert result == InjectionResult(injection_id="inj-1", status="active")
+
+    def test_api_error(self, config: AgamemnonConfig) -> None:
+        """Verify non-2xx response raises AgamemnonAPIError."""
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(400, text="Bad Request")
+
+        client = _make_client(config, httpx.MockTransport(handler))
+        spec = FailureSpec(agent_id="a1", failure_type="latency", duration_seconds=60)
+        with pytest.raises(AgamemnonAPIError) as exc_info:
+            client.inject_failure(spec)
+        assert exc_info.value.status_code == 400
+
+
+class TestClearFailure:
+    """Tests for AgamemnonClient.clear_failure."""
+
+    def test_success(self, config: AgamemnonConfig) -> None:
+        """Verify DELETE request is sent to the correct path."""
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            assert request.url.path == "/v1/chaos/inject/inj-1"
+            assert request.method == "DELETE"
+            return httpx.Response(200, json={})
+
+        client = _make_client(config, httpx.MockTransport(handler))
+        client.clear_failure("inj-1")  # Should not raise
+
+
+class TestListAgents:
+    """Tests for AgamemnonClient.list_agents."""
+
+    def test_success(self, config: AgamemnonConfig) -> None:
+        """Verify agent list is returned correctly."""
+        agents = [{"id": "a1", "name": "Agent 1"}]
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            assert request.url.path == "/v1/agents"
+            return httpx.Response(200, json=agents)
+
+        client = _make_client(config, httpx.MockTransport(handler))
+        result = client.list_agents()
+        assert result == agents
+
+
+class TestRetryBehavior:
+    """Tests for retry logic in AgamemnonClient."""
+
+    @patch("scylla.agamemnon.client.time.sleep")
+    def test_retries_on_transient_status(self, mock_sleep: object, config: AgamemnonConfig) -> None:
+        """Verify transient 503 is retried and succeeds on third attempt."""
+        call_count = 0
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            nonlocal call_count
+            call_count += 1
+            if call_count <= 2:
+                return httpx.Response(503, text="Service Unavailable")
+            return httpx.Response(200, json={"injection_id": "inj-1", "status": "active"})
+
+        client = _make_client(config, httpx.MockTransport(handler))
+        spec = FailureSpec(agent_id="a1", failure_type="latency", duration_seconds=60)
+        result = client.inject_failure(spec)
+        assert result.injection_id == "inj-1"
+        assert call_count == 3
+
+    @patch("scylla.agamemnon.client.time.sleep")
+    def test_exhausts_retries_on_transient(
+        self, mock_sleep: object, config: AgamemnonConfig
+    ) -> None:
+        """Verify retries are exhausted and AgamemnonAPIError is raised."""
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(503, text="Service Unavailable")
+
+        client = _make_client(config, httpx.MockTransport(handler))
+        spec = FailureSpec(agent_id="a1", failure_type="latency", duration_seconds=60)
+        with pytest.raises(AgamemnonAPIError) as exc_info:
+            client.inject_failure(spec)
+        assert exc_info.value.status_code == 503
+
+    @patch("scylla.agamemnon.client.time.sleep")
+    def test_retries_on_connection_error(self, mock_sleep: object, config: AgamemnonConfig) -> None:
+        """Verify connection errors are retried."""
+        call_count = 0
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            nonlocal call_count
+            call_count += 1
+            if call_count <= 1:
+                raise httpx.ConnectError("connection refused")
+            return httpx.Response(200, json=[])
+
+        client = _make_client(config, httpx.MockTransport(handler))
+        result = client.list_agents()
+        assert result == []
+        assert call_count == 2
+
+    @patch("scylla.agamemnon.client.time.sleep")
+    def test_exhausts_retries_on_connection_error(
+        self, mock_sleep: object, config: AgamemnonConfig
+    ) -> None:
+        """Verify exhausted connection retries raise AgamemnonConnectionError."""
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            raise httpx.ConnectError("connection refused")
+
+        client = _make_client(config, httpx.MockTransport(handler))
+        with pytest.raises(AgamemnonConnectionError):
+            client.list_agents()
+
+    def test_no_retry_on_non_transient_error(self, config: AgamemnonConfig) -> None:
+        """Verify non-transient errors (404) are not retried."""
+        call_count = 0
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            nonlocal call_count
+            call_count += 1
+            return httpx.Response(404, text="Not Found")
+
+        client = _make_client(config, httpx.MockTransport(handler))
+        with pytest.raises(AgamemnonAPIError) as exc_info:
+            client.list_agents()
+        assert exc_info.value.status_code == 404
+        assert call_count == 1
+
+
+class TestContextManager:
+    """Tests for context manager protocol."""
+
+    def test_sync_context_manager(self, config: AgamemnonConfig) -> None:
+        """Verify sync context manager enters and exits cleanly."""
+        with AgamemnonClient(config) as client:
+            assert client is not None

--- a/tests/unit/agamemnon/test_models.py
+++ b/tests/unit/agamemnon/test_models.py
@@ -1,0 +1,110 @@
+"""Tests for Agamemnon data models."""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from scylla.agamemnon.models import (
+    AgamemnonConfig,
+    FailureSpec,
+    HealthResponse,
+    InjectionResult,
+)
+
+
+class TestAgamemnonConfig:
+    """Tests for AgamemnonConfig."""
+
+    def test_defaults(self) -> None:
+        """Verify default field values."""
+        config = AgamemnonConfig()
+        assert config.base_url == "http://localhost:8080"
+        assert config.enabled is False
+        assert config.timeout_seconds == 10
+        assert config.health_check_timeout_seconds == 5
+        assert config.max_retries == 3
+
+    def test_custom_values(self) -> None:
+        """Verify custom field values are accepted."""
+        config = AgamemnonConfig(
+            base_url="http://agamemnon:9090",
+            enabled=True,
+            timeout_seconds=30,
+            health_check_timeout_seconds=15,
+            max_retries=5,
+        )
+        assert config.base_url == "http://agamemnon:9090"
+        assert config.enabled is True
+        assert config.timeout_seconds == 30
+        assert config.health_check_timeout_seconds == 15
+        assert config.max_retries == 5
+
+    def test_timeout_out_of_range(self) -> None:
+        """Verify out-of-range timeout values are rejected."""
+        with pytest.raises(ValidationError):
+            AgamemnonConfig(timeout_seconds=0)
+        with pytest.raises(ValidationError):
+            AgamemnonConfig(timeout_seconds=301)
+
+    def test_retries_out_of_range(self) -> None:
+        """Verify out-of-range retry values are rejected."""
+        with pytest.raises(ValidationError):
+            AgamemnonConfig(max_retries=-1)
+        with pytest.raises(ValidationError):
+            AgamemnonConfig(max_retries=11)
+
+
+class TestFailureSpec:
+    """Tests for FailureSpec."""
+
+    def test_minimal(self) -> None:
+        """Verify minimal FailureSpec construction."""
+        spec = FailureSpec(
+            agent_id="agent-1",
+            failure_type="latency",
+            duration_seconds=60,
+        )
+        assert spec.agent_id == "agent-1"
+        assert spec.failure_type == "latency"
+        assert spec.duration_seconds == 60
+        assert spec.parameters == {}
+
+    def test_with_parameters(self) -> None:
+        """Verify FailureSpec with custom parameters."""
+        spec = FailureSpec(
+            agent_id="agent-2",
+            failure_type="error",
+            duration_seconds=120,
+            parameters={"error_rate": 0.5},
+        )
+        assert spec.parameters == {"error_rate": 0.5}
+
+    def test_duration_must_be_positive(self) -> None:
+        """Verify zero duration is rejected."""
+        with pytest.raises(ValidationError):
+            FailureSpec(
+                agent_id="agent-1",
+                failure_type="latency",
+                duration_seconds=0,
+            )
+
+
+class TestHealthResponse:
+    """Tests for HealthResponse."""
+
+    def test_construction(self) -> None:
+        """Verify HealthResponse field values."""
+        hr = HealthResponse(status="ok", version="1.0.0")
+        assert hr.status == "ok"
+        assert hr.version == "1.0.0"
+
+
+class TestInjectionResult:
+    """Tests for InjectionResult."""
+
+    def test_construction(self) -> None:
+        """Verify InjectionResult field values."""
+        result = InjectionResult(injection_id="inj-123", status="active")
+        assert result.injection_id == "inj-123"
+        assert result.status == "active"

--- a/tests/unit/agamemnon/test_retry.py
+++ b/tests/unit/agamemnon/test_retry.py
@@ -1,0 +1,41 @@
+"""Tests for shared retry logic."""
+
+from __future__ import annotations
+
+from scylla.agamemnon._retry import (
+    BACKOFF_BASE,
+    BACKOFF_FACTOR,
+    TRANSIENT_STATUS_CODES,
+    compute_backoff,
+    is_transient_status,
+)
+
+
+class TestComputeBackoff:
+    """Tests for compute_backoff."""
+
+    def test_attempt_zero(self) -> None:
+        """Verify base delay for first attempt."""
+        assert compute_backoff(0) == BACKOFF_BASE
+
+    def test_attempt_one(self) -> None:
+        """Verify exponential growth on second attempt."""
+        assert compute_backoff(1) == BACKOFF_BASE * BACKOFF_FACTOR
+
+    def test_attempt_two(self) -> None:
+        """Verify exponential growth on third attempt."""
+        assert compute_backoff(2) == BACKOFF_BASE * (BACKOFF_FACTOR**2)
+
+
+class TestIsTransientStatus:
+    """Tests for is_transient_status."""
+
+    def test_transient_codes(self) -> None:
+        """Verify 502, 503, 504 are transient."""
+        for code in TRANSIENT_STATUS_CODES:
+            assert is_transient_status(code) is True
+
+    def test_non_transient_codes(self) -> None:
+        """Verify common non-transient codes are not flagged."""
+        for code in (200, 400, 401, 403, 404, 500):
+            assert is_transient_status(code) is False


### PR DESCRIPTION
## Summary
- Implement `AgamemnonClient` (sync, `httpx.Client`) and `AsyncAgamemnonClient` (async, `httpx.AsyncClient`) in new `scylla/agamemnon/` package
- Extract shared retry logic (exponential backoff for 502/503/504 and connection errors) into `_retry` module used by both clients
- Both clients expose identical API: `health_check()`, `inject_failure()`, `clear_failure()`, `list_agents()`
- Add Pydantic models (`AgamemnonConfig`, `FailureSpec`, `HealthResponse`, `InjectionResult`) and error hierarchy (`AgamemnonError`, `AgamemnonConnectionError`, `AgamemnonAPIError`)
- Export `AsyncAgamemnonClient` and all types from `__init__.py`
- 40 unit tests covering both clients, models, retry behavior, and context managers

Closes #1640

## Test plan
- [x] All 40 unit tests pass (`pixi run python -m pytest tests/unit/agamemnon/ -v`)
- [x] Ruff format passes
- [x] Ruff check passes
- [x] Mypy passes
- [ ] CI pipeline passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)