### PR TITLE
feat(reporting): add HTML report format

### DIFF
--- a/src/scylla/cli/main.py
+++ b/src/scylla/cli/main.py
@@ -13,6 +13,7 @@ from scylla import __version__
 from scylla.config import DEFAULT_JUDGE_MODEL, ConfigLoader
 from scylla.e2e.orchestrator import EvalOrchestrator, OrchestratorConfig
 from scylla.reporting import (
+    HtmlReportGenerator,
     JsonReportGenerator,
     MarkdownReportGenerator,
     ReportData,
@@ -24,11 +25,12 @@ from scylla.reporting import (
 )
 
 # Dict-dispatch mapping format names to generator classes.
-# Adding a new format (e.g. HTML) requires only a new entry here
+# Adding a new format requires only a new entry here
 # and a generator class that satisfies the ReportWriter protocol.
 FORMAT_GENERATORS: dict[str, type[ReportWriter]] = {
-    "markdown": MarkdownReportGenerator,
+    "html": HtmlReportGenerator,
     "json": JsonReportGenerator,
+    "markdown": MarkdownReportGenerator,
 }
 
 
@@ -246,7 +248,7 @@ def _resolve_output_path(output: str | None, base_path: Path) -> tuple[Path, Pat
     output_path = Path(output) if output else None
     resolved: Path | None = None
 
-    if output_path is not None and output_path.suffix in (".md", ".json"):
+    if output_path is not None and output_path.suffix in (".md", ".json", ".html"):
         resolved = output_path
         report_dir = output_path.parent
     elif output_path is not None:
@@ -267,7 +269,7 @@ def _warn_format_extension_mismatch(output: str | None, output_format: str) -> N
     """
     if output is None or output == "-":
         return
-    ext_format: dict[str, str] = {".md": "markdown", ".json": "json"}
+    ext_format: dict[str, str] = {".html": "html", ".md": "markdown", ".json": "json"}
     output_ext = Path(output).suffix.lower()
     implied_format = ext_format.get(output_ext)
     if implied_format is not None and implied_format != output_format:

--- a/src/scylla/reporting/__init__.py
+++ b/src/scylla/reporting/__init__.py
@@ -3,6 +3,7 @@
 This module provides result writing and report generation capabilities.
 """
 
+from scylla.reporting.html_report import HtmlReportGenerator
 from scylla.reporting.json_report import JsonReportGenerator
 from scylla.reporting.markdown import (
     MarkdownReportGenerator,
@@ -45,6 +46,7 @@ __all__ = [
     "EvaluationReport",
     "ExecutionInfo",
     "GradingInfo",
+    "HtmlReportGenerator",
     "JsonReportGenerator",
     "JudgmentInfo",
     "MarkdownReportGenerator",

--- a/src/scylla/reporting/html_report.py
+++ b/src/scylla/reporting/html_report.py
@@ -1,0 +1,297 @@
+"""HTML report generator for evaluation results."""
+
+from html import escape
+from pathlib import Path
+
+from scylla.reporting.markdown import ReportData, TierMetrics
+
+
+def _esc(value: str) -> str:
+    """Escape a string for safe HTML embedding."""
+    return escape(str(value))
+
+
+def _format_percentage(value: float) -> str:
+    """Format a value as a percentage string."""
+    return f"{value * 100:.1f}%"
+
+
+def _format_cost(value: float) -> str:
+    """Format a cost value for display."""
+    if value == float("inf"):
+        return "&infin;"
+    return f"${value:.2f}"
+
+
+class HtmlReportGenerator:
+    """Generates self-contained HTML evaluation reports."""
+
+    def __init__(self, base_dir: Path) -> None:
+        """Initialize HTML report generator.
+
+        Args:
+            base_dir: Base directory for reports (e.g., 'reports/')
+
+        """
+        self.base_dir = base_dir
+
+    def get_report_dir(self, test_id: str) -> Path:
+        """Get the directory path for a test report.
+
+        Args:
+            test_id: Test identifier
+
+        Returns:
+            Path to report directory
+
+        """
+        return self.base_dir / test_id
+
+    def _find_best_quality_tier(self, tiers: list[TierMetrics]) -> TierMetrics | None:
+        """Find tier with highest composite score."""
+        if not tiers:
+            return None
+        return max(tiers, key=lambda t: t.composite_median)
+
+    def _find_best_cost_tier(self, tiers: list[TierMetrics]) -> TierMetrics | None:
+        """Find tier with lowest cost-of-pass."""
+        if not tiers:
+            return None
+        valid_tiers = [t for t in tiers if t.cost_of_pass_median != float("inf")]
+        if not valid_tiers:
+            return None
+        return min(valid_tiers, key=lambda t: t.cost_of_pass_median)
+
+    def _find_most_consistent_tier(self, tiers: list[TierMetrics]) -> TierMetrics | None:
+        """Find tier with lowest variance (most consistent)."""
+        if not tiers:
+            return None
+        return min(tiers, key=lambda t: t.consistency_std_dev)
+
+    def _generate_style(self) -> str:
+        """Generate CSS styles for the report."""
+        return """<style>
+  body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto,
+         sans-serif; max-width: 960px; margin: 0 auto; padding: 2rem;
+         color: #333; background: #fafafa; }
+  h1 { border-bottom: 2px solid #2563eb; padding-bottom: 0.5rem; }
+  h2 { color: #1e40af; margin-top: 2rem; }
+  h3 { color: #374151; }
+  table { border-collapse: collapse; width: 100%; margin: 1rem 0; }
+  th, td { border: 1px solid #d1d5db; padding: 0.5rem 0.75rem;
+           text-align: left; }
+  th { background: #2563eb; color: white; }
+  tr:nth-child(even) { background: #f3f4f6; }
+  .meta { color: #6b7280; font-size: 0.9rem; }
+  .summary-card { background: white; border: 1px solid #e5e7eb;
+                  border-radius: 0.5rem; padding: 1rem; margin: 0.5rem 0; }
+  .footer { margin-top: 2rem; padding-top: 1rem;
+            border-top: 1px solid #e5e7eb; color: #9ca3af;
+            font-size: 0.85rem; }
+  ol { padding-left: 1.5rem; }
+</style>"""
+
+    def _generate_header(self, data: ReportData) -> str:
+        """Generate the HTML header section."""
+        return f"""<h1>Evaluation Report: {_esc(data.test_name)}</h1>
+<p class="meta">
+  <strong>Generated:</strong> {_esc(data.timestamp)}<br>
+  <strong>Test ID:</strong> {_esc(data.test_id)}<br>
+  <strong>Runs per Tier:</strong> {data.runs_per_tier}<br>
+  <strong>Judge Model:</strong> {_esc(data.judge_model)}
+</p>
+<hr>"""
+
+    def _generate_executive_summary(self, data: ReportData) -> str:
+        """Generate executive summary section."""
+        best_quality = self._find_best_quality_tier(data.tiers)
+        best_cost = self._find_best_cost_tier(data.tiers)
+        most_consistent = self._find_most_consistent_tier(data.tiers)
+
+        parts = ["<h2>Executive Summary</h2>"]
+
+        if best_quality:
+            parts.append(
+                '<div class="summary-card">'
+                "<h3>Winner by Quality</h3>"
+                f"<p><strong>{_esc(best_quality.tier_name)}</strong> achieved the "
+                f"highest median composite score of "
+                f"<strong>{_esc(_format_percentage(best_quality.composite_median))}"
+                "</strong>.</p></div>"
+            )
+
+        if best_cost:
+            parts.append(
+                '<div class="summary-card">'
+                "<h3>Winner by Cost Efficiency</h3>"
+                f"<p><strong>{_esc(best_cost.tier_name)}</strong> achieved the "
+                f"lowest Cost-of-Pass at "
+                f"<strong>{_format_cost(best_cost.cost_of_pass_median)}"
+                "</strong> per successful run.</p></div>"
+            )
+
+        if most_consistent:
+            parts.append(
+                '<div class="summary-card">'
+                "<h3>Winner by Consistency</h3>"
+                f"<p><strong>{_esc(most_consistent.tier_name)}</strong> showed the "
+                f"lowest variance with std_dev of "
+                f"<strong>{most_consistent.consistency_std_dev:.3f}"
+                "</strong>.</p></div>"
+            )
+
+        if data.key_finding:
+            parts.append(
+                '<div class="summary-card">'
+                "<h3>Key Finding</h3>"
+                f"<p>{_esc(data.key_finding)}</p></div>"
+            )
+
+        parts.append("<hr>")
+        return "\n".join(parts)
+
+    def _generate_tier_comparison(self, data: ReportData) -> str:
+        """Generate tier comparison table."""
+        if not data.tiers:
+            return ""
+
+        rows: list[str] = []
+        for tier in data.tiers:
+            uplift_str = "-" if tier.tier_id == "T0" else f"+{tier.uplift * 100:.1f}%"
+            rows.append(
+                "<tr>"
+                f"<td>{_esc(tier.tier_name)}</td>"
+                f"<td>{_esc(_format_percentage(tier.pass_rate_median))}</td>"
+                f"<td>{_esc(_format_percentage(tier.impl_rate_median))}</td>"
+                f"<td>{_esc(_format_percentage(tier.composite_median))}</td>"
+                f"<td>{_format_cost(tier.cost_of_pass_median)}</td>"
+                f"<td>{tier.consistency_std_dev:.3f}</td>"
+                f"<td>{_esc(uplift_str)}</td>"
+                "</tr>"
+            )
+
+        return (
+            "<h2>Tier Comparison</h2>\n"
+            "<h3>Overall Performance</h3>\n"
+            "<table>\n"
+            "<tr><th>Tier</th><th>Pass Rate</th><th>Impl Rate</th>"
+            "<th>Composite</th><th>Cost/Pass</th><th>Consistency</th>"
+            "<th>Uplift</th></tr>\n" + "\n".join(rows) + "\n</table>\n<hr>"
+        )
+
+    def _generate_sensitivity_analysis(self, data: ReportData) -> str:
+        """Generate prompt sensitivity analysis section."""
+        if not data.sensitivity:
+            return ""
+
+        s = data.sensitivity
+        parts = [
+            "<h2>Prompt Sensitivity Analysis</h2>",
+            "<h3>Variance Metrics</h3>",
+            "<table>",
+            "<tr><th>Metric</th><th>Cross-Tier Variance</th><th>Interpretation</th></tr>",
+            f"<tr><td>Pass Rate</td><td>{s.pass_rate_variance:.4f}</td>"
+            f"<td>{_esc(s.get_sensitivity_level(s.pass_rate_variance))} "
+            "sensitivity</td></tr>",
+            f"<tr><td>Impl Rate</td><td>{s.impl_rate_variance:.4f}</td>"
+            f"<td>{_esc(s.get_sensitivity_level(s.impl_rate_variance))} "
+            "sensitivity</td></tr>",
+            f"<tr><td>Cost</td><td>{s.cost_variance:.4f}</td>"
+            f"<td>{_esc(s.get_sensitivity_level(s.cost_variance))} "
+            "sensitivity</td></tr>",
+            "</table>",
+        ]
+
+        if data.transitions:
+            parts.extend(
+                [
+                    "<h3>Tier Uplift Analysis</h3>",
+                    "<table>",
+                    "<tr><th>Transition</th><th>Pass Rate &Delta;</th>"
+                    "<th>Impl Rate &Delta;</th><th>Cost &Delta;</th>"
+                    "<th>Assessment</th></tr>",
+                ]
+            )
+            for t in data.transitions:
+                assessment = "worth it" if t.worth_it else "not worth it"
+                parts.append(
+                    f"<tr><td>{_esc(t.from_tier)} &rarr; {_esc(t.to_tier)}</td>"
+                    f"<td>{t.pass_rate_delta:+.1%}</td>"
+                    f"<td>{t.impl_rate_delta:+.1%}</td>"
+                    f"<td>{_format_cost(t.cost_delta)}</td>"
+                    f"<td>{_esc(assessment)}</td></tr>"
+                )
+            parts.append("</table>")
+
+        parts.append("<hr>")
+        return "\n".join(parts)
+
+    def _generate_recommendations(self, data: ReportData) -> str:
+        """Generate recommendations section."""
+        if not data.recommendations:
+            return ""
+
+        items = "".join(f"<li>{_esc(rec)}</li>" for rec in data.recommendations)
+        return f"<h2>Recommendations</h2>\n<ol>{items}</ol>\n<hr>"
+
+    def _generate_footer(self) -> str:
+        """Generate report footer."""
+        return '<p class="footer"><em>Generated by ProjectScylla Agent Testing Framework</em></p>'
+
+    def generate_report(self, data: ReportData) -> str:
+        """Generate a complete self-contained HTML report.
+
+        Args:
+            data: Report data
+
+        Returns:
+            Complete HTML report string
+
+        """
+        body = "\n".join(
+            [
+                self._generate_header(data),
+                self._generate_executive_summary(data),
+                self._generate_tier_comparison(data),
+                self._generate_sensitivity_analysis(data),
+                self._generate_recommendations(data),
+                self._generate_footer(),
+            ]
+        )
+
+        return (
+            "<!DOCTYPE html>\n"
+            '<html lang="en">\n<head>\n'
+            '<meta charset="utf-8">\n'
+            f"<title>Evaluation Report: {_esc(data.test_name)}</title>\n"
+            f"{self._generate_style()}\n"
+            "</head>\n<body>\n"
+            f"{body}\n"
+            "</body>\n</html>"
+        )
+
+    def write_report(self, data: ReportData, output_path: Path | None = None) -> Path:
+        """Generate and write an HTML report to file.
+
+        Args:
+            data: Report data
+            output_path: Explicit file path to write the report to. When
+                provided, the report is written to this exact path instead of
+                the convention-based ``{base_dir}/{test_id}/report.html``.
+
+        Returns:
+            Path to written report file.
+
+        """
+        if output_path is not None:
+            report_path = output_path
+        else:
+            report_dir = self.get_report_dir(data.test_id)
+            report_dir.mkdir(parents=True, exist_ok=True)
+            report_path = report_dir / "report.html"
+
+        report_path.parent.mkdir(parents=True, exist_ok=True)
+        report_content = self.generate_report(data)
+        report_path.write_text(report_content)
+
+        return report_path

--- a/tests/unit/reporting/test_html_report.py
+++ b/tests/unit/reporting/test_html_report.py
@@ -1,0 +1,240 @@
+"""Tests for HTML report generator."""
+
+import tempfile
+from pathlib import Path
+
+from scylla.reporting.html_report import HtmlReportGenerator
+from scylla.reporting.markdown import (
+    ReportData,
+    SensitivityAnalysis,
+    TierMetrics,
+    TransitionAssessment,
+)
+
+
+def _make_report_data(test_id: str = "test-001") -> ReportData:
+    """Create minimal ReportData for testing."""
+    return ReportData(
+        test_id=test_id,
+        test_name="Test 001",
+        timestamp="2025-01-01T00:00:00Z",
+        runs_per_tier=10,
+        judge_model="claude-opus-4-6",
+    )
+
+
+def _make_tier() -> TierMetrics:
+    """Create a sample TierMetrics."""
+    return TierMetrics(
+        tier_id="T0",
+        tier_name="Vanilla",
+        pass_rate_median=0.5,
+        impl_rate_median=0.6,
+        composite_median=0.55,
+        cost_of_pass_median=2.50,
+        consistency_std_dev=0.1,
+        uplift=0.0,
+    )
+
+
+class TestHtmlReportGenerator:
+    """Tests for HtmlReportGenerator."""
+
+    def test_get_report_dir(self) -> None:
+        """Report dir is base_dir / test_id."""
+        gen = HtmlReportGenerator(Path("/reports"))
+        assert gen.get_report_dir("test-001") == Path("/reports/test-001")
+
+    def test_generate_report_returns_html(self) -> None:
+        """generate_report returns valid HTML document."""
+        gen = HtmlReportGenerator(Path("/tmp"))
+        data = _make_report_data()
+        result = gen.generate_report(data)
+        assert result.startswith("<!DOCTYPE html>")
+        assert "</html>" in result
+
+    def test_generate_report_contains_metadata(self) -> None:
+        """Report includes test metadata."""
+        gen = HtmlReportGenerator(Path("/tmp"))
+        data = _make_report_data()
+        result = gen.generate_report(data)
+        assert "Test 001" in result
+        assert "test-001" in result
+        assert "2025-01-01T00:00:00Z" in result
+        assert "claude-opus-4-6" in result
+
+    def test_generate_report_contains_tier_table(self) -> None:
+        """Report includes tier comparison table when tiers are present."""
+        gen = HtmlReportGenerator(Path("/tmp"))
+        data = _make_report_data()
+        data.tiers = [_make_tier()]
+        result = gen.generate_report(data)
+        assert "<table>" in result
+        assert "Vanilla" in result
+        assert "50.0%" in result
+
+    def test_generate_report_no_tiers(self) -> None:
+        """Report is valid even without tier data."""
+        gen = HtmlReportGenerator(Path("/tmp"))
+        data = _make_report_data()
+        result = gen.generate_report(data)
+        assert "Tier Comparison" not in result
+
+    def test_generate_report_inf_cost(self) -> None:
+        """Infinity cost renders as the infinity symbol."""
+        gen = HtmlReportGenerator(Path("/tmp"))
+        data = _make_report_data()
+        tier = _make_tier()
+        tier.cost_of_pass_median = float("inf")
+        data.tiers = [tier]
+        result = gen.generate_report(data)
+        assert "&infin;" in result
+
+    def test_generate_report_executive_summary(self) -> None:
+        """Executive summary shows winners when tiers are present."""
+        gen = HtmlReportGenerator(Path("/tmp"))
+        data = _make_report_data()
+        data.tiers = [_make_tier()]
+        result = gen.generate_report(data)
+        assert "Winner by Quality" in result
+        assert "Winner by Cost Efficiency" in result
+        assert "Winner by Consistency" in result
+
+    def test_generate_report_key_finding(self) -> None:
+        """Key finding is rendered when present."""
+        gen = HtmlReportGenerator(Path("/tmp"))
+        data = _make_report_data()
+        data.key_finding = "T2 outperforms T0 significantly."
+        result = gen.generate_report(data)
+        assert "T2 outperforms T0 significantly." in result
+
+    def test_generate_report_sensitivity_analysis(self) -> None:
+        """Sensitivity analysis section is rendered when present."""
+        gen = HtmlReportGenerator(Path("/tmp"))
+        data = _make_report_data()
+        data.sensitivity = SensitivityAnalysis(
+            pass_rate_variance=0.03,
+            impl_rate_variance=0.10,
+            cost_variance=0.20,
+        )
+        result = gen.generate_report(data)
+        assert "Prompt Sensitivity Analysis" in result
+        assert "low sensitivity" in result
+        assert "medium sensitivity" in result
+        assert "high sensitivity" in result
+
+    def test_generate_report_transitions(self) -> None:
+        """Transition assessments are rendered when present."""
+        gen = HtmlReportGenerator(Path("/tmp"))
+        data = _make_report_data()
+        data.sensitivity = SensitivityAnalysis(
+            pass_rate_variance=0.05,
+            impl_rate_variance=0.05,
+            cost_variance=0.05,
+        )
+        data.transitions = [
+            TransitionAssessment(
+                from_tier="T0",
+                to_tier="T1",
+                pass_rate_delta=0.15,
+                impl_rate_delta=0.10,
+                cost_delta=1.50,
+                worth_it=True,
+            )
+        ]
+        result = gen.generate_report(data)
+        assert "Tier Uplift Analysis" in result
+        assert "worth it" in result
+
+    def test_generate_report_recommendations(self) -> None:
+        """Recommendations section is rendered when present."""
+        gen = HtmlReportGenerator(Path("/tmp"))
+        data = _make_report_data()
+        data.recommendations = ["Use T2 for production.", "Monitor costs closely."]
+        result = gen.generate_report(data)
+        assert "Recommendations" in result
+        assert "Use T2 for production." in result
+        assert "Monitor costs closely." in result
+
+    def test_generate_report_escapes_html(self) -> None:
+        """HTML special characters in data are escaped."""
+        gen = HtmlReportGenerator(Path("/tmp"))
+        data = _make_report_data()
+        data.test_name = "<script>alert('xss')</script>"
+        result = gen.generate_report(data)
+        assert "<script>" not in result
+        assert "&lt;script&gt;" in result
+
+    def test_generate_report_self_contained(self) -> None:
+        """Report contains embedded CSS (self-contained)."""
+        gen = HtmlReportGenerator(Path("/tmp"))
+        data = _make_report_data()
+        result = gen.generate_report(data)
+        assert "<style>" in result
+
+    def test_generate_report_footer(self) -> None:
+        """Report contains the ProjectScylla footer."""
+        gen = HtmlReportGenerator(Path("/tmp"))
+        data = _make_report_data()
+        result = gen.generate_report(data)
+        assert "ProjectScylla Agent Testing Framework" in result
+
+    def test_write_report_creates_file(self) -> None:
+        """write_report creates report.html in the correct directory."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            gen = HtmlReportGenerator(Path(tmpdir))
+            data = _make_report_data()
+            path = gen.write_report(data)
+
+            assert path.exists()
+            assert path.name == "report.html"
+            assert path.parent.name == "test-001"
+
+            content = path.read_text()
+            assert "<!DOCTYPE html>" in content
+
+    def test_write_report_creates_directories(self) -> None:
+        """write_report creates missing directories."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            gen = HtmlReportGenerator(Path(tmpdir) / "nested" / "reports")
+            data = _make_report_data()
+            path = gen.write_report(data)
+            assert path.exists()
+
+    def test_write_report_with_explicit_output_path(self) -> None:
+        """When output_path is provided, write to that exact path."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            gen = HtmlReportGenerator(Path(tmpdir))
+            data = _make_report_data()
+            target = Path(tmpdir) / "my-custom-report.html"
+
+            path = gen.write_report(data, output_path=target)
+
+            assert path == target
+            assert target.exists()
+            content = target.read_text()
+            assert "test-001" in content
+
+    def test_write_report_with_output_path_creates_parents(self) -> None:
+        """Parent directories are created when output_path has non-existent parents."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            gen = HtmlReportGenerator(Path(tmpdir))
+            data = _make_report_data()
+            target = Path(tmpdir) / "deep" / "nested" / "report.html"
+
+            path = gen.write_report(data, output_path=target)
+
+            assert path == target
+            assert target.exists()
+
+    def test_write_report_without_output_path_uses_convention(self) -> None:
+        """Default behavior writes to {base_dir}/{test_id}/report.html."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            gen = HtmlReportGenerator(Path(tmpdir))
+            data = _make_report_data()
+
+            path = gen.write_report(data)
+
+            expected = Path(tmpdir) / "test-001" / "report.html"
+            assert path == expected
+            assert path.exists()


### PR DESCRIPTION
## Summary
- Add `HtmlReportGenerator` class in `src/scylla/reporting/html_report.py` that produces self-contained HTML files with embedded CSS, tier comparison tables, executive summary, sensitivity analysis, and recommendations
- Wire `--format html` into the CLI via `FORMAT_GENERATORS` dict-dispatch
- Add 19 unit tests covering all report sections, edge cases (infinity costs, HTML escaping), and file I/O

## Test plan
- [x] All 19 new tests pass (`pixi run python -m pytest tests/unit/reporting/test_html_report.py -v`)
- [x] Pre-commit passes (ruff-format, ruff-check, mypy)
- [ ] CI passes

Closes #1595

🤖 Generated with [Claude Code](https://claude.com/claude-code)