### PR TITLE
feat(e2e): wire AsyncAgamemnonClient into parallel tier executor

### DIFF
--- a/src/scylla/adapters/agamemnon_client.py
+++ b/src/scylla/adapters/agamemnon_client.py
@@ -1,0 +1,246 @@
+"""Client for Agamemnon failure injection service.
+
+This module provides sync and async HTTP clients for /v1/chaos/* endpoints
+used to inject and clean up transient failures during E2E test runs.
+
+The ``AsyncAgamemnonClient`` is the preferred client for parallel tier
+execution because it avoids blocking threads while waiting on network I/O.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import time
+from typing import Any
+
+import httpx
+
+logger = logging.getLogger(__name__)
+
+
+class AgamemnonConnectionError(Exception):
+    """Raised when an Agamemnon client exhausts retries on transient errors."""
+
+
+# ── Synchronous client ──────────────────────────────────────────────
+
+
+class AgamemnonClient:
+    """Synchronous HTTP client for Agamemnon /v1/chaos/* endpoints.
+
+    Handles transient failures with automatic retry logic (3 attempts,
+    exponential backoff: 1 s, 2 s, 4 s).
+    """
+
+    def __init__(
+        self,
+        base_url: str,
+        timeout: float = 60.0,
+        max_retries: int = 3,
+    ) -> None:
+        """Initialize AgamemnonClient.
+
+        Args:
+            base_url: Base URL for Agamemnon service (e.g., http://localhost:8080).
+            timeout: Request timeout in seconds.
+            max_retries: Maximum number of retry attempts on transient errors.
+
+        """
+        self.base_url = base_url.rstrip("/")
+        self.timeout = timeout
+        self.max_retries = max_retries
+
+    def _request(
+        self,
+        method: str,
+        endpoint: str,
+        **kwargs: Any,
+    ) -> httpx.Response:
+        """Execute an HTTP request with retry logic.
+
+        Args:
+            method: HTTP method (GET, POST, PUT, DELETE).
+            endpoint: Endpoint path (e.g., "/v1/chaos/inject").
+            **kwargs: Additional arguments passed to ``httpx.Client.request``.
+
+        Returns:
+            httpx.Response on success.
+
+        Raises:
+            AgamemnonConnectionError: When retries are exhausted.
+
+        """
+        url = f"{self.base_url}{endpoint}"
+        backoff_delays = [1, 2, 4]
+
+        for attempt in range(self.max_retries):
+            try:
+                with httpx.Client(timeout=self.timeout) as client:
+                    response = client.request(method, url, **kwargs)
+                    response.raise_for_status()
+                    return response
+            except (
+                httpx.ConnectError,
+                httpx.NetworkError,
+                httpx.TimeoutException,
+                TimeoutError,
+            ) as e:
+                if attempt < self.max_retries - 1:
+                    delay = backoff_delays[attempt]
+                    logger.warning(
+                        "Transient error on %s %s (attempt %d/%d): %s. Retrying in %ds.",
+                        method,
+                        url,
+                        attempt + 1,
+                        self.max_retries,
+                        e,
+                        delay,
+                    )
+                    time.sleep(delay)
+                else:
+                    logger.error(
+                        "Failed to connect after %d attempts: %s",
+                        self.max_retries,
+                        e,
+                    )
+                    raise AgamemnonConnectionError(
+                        f"Failed to reach {url} after {self.max_retries} retries: {e}"
+                    ) from e
+
+        raise AgamemnonConnectionError(f"Unexpected error reaching {url}")
+
+    # ── convenience helpers ──────────────────────────────────────────
+
+    def inject_failure(self, spec: dict[str, Any]) -> httpx.Response:
+        """POST /v1/chaos/inject — start failure injection.
+
+        Args:
+            spec: Failure specification payload.
+
+        Returns:
+            httpx.Response from the service.
+
+        """
+        return self._request("POST", "/v1/chaos/inject", json=spec)
+
+    def cleanup_failure(self) -> httpx.Response:
+        """DELETE /v1/chaos/reset — remove all active failures.
+
+        Returns:
+            httpx.Response from the service.
+
+        """
+        return self._request("DELETE", "/v1/chaos/reset")
+
+
+# ── Asynchronous client ─────────────────────────────────────────────
+
+
+class AsyncAgamemnonClient:
+    """Async HTTP client for Agamemnon /v1/chaos/* endpoints.
+
+    Mirrors ``AgamemnonClient`` but uses ``httpx.AsyncClient`` so that
+    callers in an ``asyncio`` event loop do not block threads during
+    failure injection or cleanup.
+    """
+
+    def __init__(
+        self,
+        base_url: str,
+        timeout: float = 60.0,
+        max_retries: int = 3,
+    ) -> None:
+        """Initialize AsyncAgamemnonClient.
+
+        Args:
+            base_url: Base URL for Agamemnon service.
+            timeout: Request timeout in seconds.
+            max_retries: Maximum retry attempts on transient errors.
+
+        """
+        self.base_url = base_url.rstrip("/")
+        self.timeout = timeout
+        self.max_retries = max_retries
+
+    async def _request(
+        self,
+        method: str,
+        endpoint: str,
+        **kwargs: Any,
+    ) -> httpx.Response:
+        """Execute an async HTTP request with retry logic.
+
+        Args:
+            method: HTTP method.
+            endpoint: Endpoint path.
+            **kwargs: Forwarded to ``httpx.AsyncClient.request``.
+
+        Returns:
+            httpx.Response on success.
+
+        Raises:
+            AgamemnonConnectionError: When retries are exhausted.
+
+        """
+        url = f"{self.base_url}{endpoint}"
+        backoff_delays = [1, 2, 4]
+
+        for attempt in range(self.max_retries):
+            try:
+                async with httpx.AsyncClient(timeout=self.timeout) as client:
+                    response = await client.request(method, url, **kwargs)
+                    response.raise_for_status()
+                    return response
+            except (
+                httpx.ConnectError,
+                httpx.NetworkError,
+                httpx.TimeoutException,
+                TimeoutError,
+            ) as e:
+                if attempt < self.max_retries - 1:
+                    delay = backoff_delays[attempt]
+                    logger.warning(
+                        "Transient error on %s %s (attempt %d/%d): %s. Retrying in %ds.",
+                        method,
+                        url,
+                        attempt + 1,
+                        self.max_retries,
+                        e,
+                        delay,
+                    )
+                    await asyncio.sleep(delay)
+                else:
+                    logger.error(
+                        "Failed to connect after %d attempts: %s",
+                        self.max_retries,
+                        e,
+                    )
+                    raise AgamemnonConnectionError(
+                        f"Failed to reach {url} after {self.max_retries} retries: {e}"
+                    ) from e
+
+        raise AgamemnonConnectionError(f"Unexpected error reaching {url}")
+
+    # ── convenience helpers ──────────────────────────────────────────
+
+    async def inject_failure(self, spec: dict[str, Any]) -> httpx.Response:
+        """POST /v1/chaos/inject — start failure injection.
+
+        Args:
+            spec: Failure specification payload.
+
+        Returns:
+            httpx.Response from the service.
+
+        """
+        return await self._request("POST", "/v1/chaos/inject", json=spec)
+
+    async def cleanup_failure(self) -> httpx.Response:
+        """DELETE /v1/chaos/reset — remove all active failures.
+
+        Returns:
+            httpx.Response from the service.
+
+        """
+        return await self._request("DELETE", "/v1/chaos/reset")

--- a/src/scylla/e2e/models.py
+++ b/src/scylla/e2e/models.py
@@ -916,6 +916,8 @@ class ExperimentConfig(BaseModel):
     off_peak: bool = False  # Wait for off-peak hours before each subtest run
     # Failure injection configuration
     agamemnon: AgamemnonConfig = Field(default_factory=AgamemnonConfig)
+    # Agamemnon failure injection (ephemeral, not saved to experiment.json)
+    agamemnon_url: str | None = None  # Base URL for Agamemnon chaos service
 
     @field_validator("models", mode="before")
     @classmethod

--- a/src/scylla/e2e/parallel_executor.py
+++ b/src/scylla/e2e/parallel_executor.py
@@ -4,10 +4,12 @@ This module handles:
 - Sequential execution of subtests
 - Rate limit detection and coordination
 - Retry logic for rate-limited subtests
+- Async failure injection/cleanup via ``AsyncAgamemnonClient``
 """
 
 from __future__ import annotations
 
+import asyncio
 import logging
 import threading
 import time
@@ -15,6 +17,10 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
+from scylla.adapters.agamemnon_client import (
+    AgamemnonConnectionError,
+    AsyncAgamemnonClient,
+)
 from scylla.e2e.models import (
     ExperimentConfig,
     SubTestResult,
@@ -155,6 +161,68 @@ class RateLimitCoordinator:
         return self._shutdown_event.is_set()
 
 
+async def _async_inject_failure(
+    client: AsyncAgamemnonClient,
+    tier_id: TierID,
+    subtest_id: str,
+) -> None:
+    """Inject a failure via the async Agamemnon client before a subtest.
+
+    Logs a warning and continues on connection failure so that a missing
+    Agamemnon service does not abort the experiment.
+
+    Args:
+        client: Async Agamemnon client instance.
+        tier_id: Current tier identifier (included in the failure spec).
+        subtest_id: Current subtest identifier (included in the failure spec).
+
+    """
+    spec = {"tier": tier_id.value, "subtest": subtest_id}
+    try:
+        await client.inject_failure(spec)
+        logger.info(
+            "Failure injected for tier %s subtest %s",
+            tier_id.value,
+            subtest_id,
+        )
+    except AgamemnonConnectionError:
+        logger.warning(
+            "Could not inject failure for %s/%s — Agamemnon unreachable, continuing",
+            tier_id.value,
+            subtest_id,
+        )
+
+
+async def _async_cleanup_failure(
+    client: AsyncAgamemnonClient,
+    tier_id: TierID,
+    subtest_id: str,
+) -> None:
+    """Clean up injected failures after a subtest completes.
+
+    Logs a warning on connection failure; does not raise.
+
+    Args:
+        client: Async Agamemnon client instance.
+        tier_id: Current tier identifier (for logging).
+        subtest_id: Current subtest identifier (for logging).
+
+    """
+    try:
+        await client.cleanup_failure()
+        logger.info(
+            "Failure cleaned up for tier %s subtest %s",
+            tier_id.value,
+            subtest_id,
+        )
+    except AgamemnonConnectionError:
+        logger.warning(
+            "Could not clean up failure for %s/%s — Agamemnon unreachable",
+            tier_id.value,
+            subtest_id,
+        )
+
+
 def run_tier_subtests_parallel(
     config: ExperimentConfig,
     tier_id: TierID,
@@ -169,6 +237,9 @@ def run_tier_subtests_parallel(
     resource_manager: ResourceManager | None = None,
 ) -> dict[str, SubTestResult]:
     """Run all sub-tests for a tier sequentially with rate limit handling.
+
+    When ``config.agamemnon_url`` is set, failure injection and cleanup are
+    performed asynchronously via ``AsyncAgamemnonClient`` around each subtest.
 
     Args:
         config: Experiment configuration
@@ -195,6 +266,12 @@ def run_tier_subtests_parallel(
         config, tier_manager, workspace_manager, resource_manager=resource_manager
     )
 
+    # Build async Agamemnon client when a URL is configured
+    agamemnon_client: AsyncAgamemnonClient | None = None
+    if config.agamemnon_url:
+        agamemnon_client = AsyncAgamemnonClient(base_url=config.agamemnon_url)
+        logger.info("Agamemnon failure injection enabled at %s", config.agamemnon_url)
+
     total_subtests = len(tier_config.subtests)
     start_time = time.time()
     completed_count = 0
@@ -219,6 +296,11 @@ def run_tier_subtests_parallel(
 
         subtest_dir = results_dir / subtest.id
         set_log_context(tier_id=tier_id.value, subtest_id=subtest.id)
+
+        # Inject failure before subtest (async, non-blocking)
+        if agamemnon_client is not None:
+            _run_async(_async_inject_failure(agamemnon_client, tier_id, subtest.id))
+
         try:
             results[subtest.id] = executor.run_subtest(
                 tier_id=tier_id,
@@ -248,37 +330,119 @@ def run_tier_subtests_parallel(
             )
             completed_count += 1
         except RateLimitError as e:
-            # Both weekly and transient rate limits: wait and retry once.
-            # Weekly limits have a parsed reset time in retry_after_seconds —
-            # waiting until then is safe and avoids requiring a manual restart.
-            if checkpoint and checkpoint_path:
-                if is_weekly_limit(e.info):
-                    logger.warning(
-                        "Weekly usage limit detected from %s — waiting until reset. "
-                        "Resume after: %s",
-                        e.info.source,
-                        e.info.error_message,
-                    )
-                else:
-                    logger.info(f"Rate limit detected from {e.info.source}, waiting...")
-                wait_for_rate_limit(e.info.retry_after_seconds, checkpoint, checkpoint_path)
-                # Retry the subtest after wait
-                results[subtest.id] = executor.run_subtest(
-                    tier_id=tier_id,
-                    tier_config=tier_config,
-                    subtest=subtest,
-                    baseline=baseline,
-                    results_dir=subtest_dir,
-                    checkpoint=checkpoint,
-                    checkpoint_path=checkpoint_path,
-                    coordinator=None,
-                    experiment_dir=experiment_dir,
-                )
-                completed_count += 1
-            else:
-                raise  # No checkpoint, can't handle - propagate
+            completed_count = _handle_rate_limit(
+                e,
+                executor=executor,
+                tier_id=tier_id,
+                tier_config=tier_config,
+                subtest=subtest,
+                baseline=baseline,
+                results_dir=subtest_dir,
+                results=results,
+                checkpoint=checkpoint,
+                checkpoint_path=checkpoint_path,
+                experiment_dir=experiment_dir,
+                completed_count=completed_count,
+            )
+        finally:
+            # Always clean up injected failure after subtest completes
+            if agamemnon_client is not None:
+                _run_async(_async_cleanup_failure(agamemnon_client, tier_id, subtest.id))
 
     return results
+
+
+def _handle_rate_limit(
+    error: RateLimitError,
+    *,
+    executor: Any,
+    tier_id: TierID,
+    tier_config: TierConfig,
+    subtest: SubTestConfig,
+    baseline: TierBaseline | None,
+    results_dir: Path,
+    results: dict[str, SubTestResult],
+    checkpoint: E2ECheckpoint | None,
+    checkpoint_path: Path | None,
+    experiment_dir: Path | None,
+    completed_count: int,
+) -> int:
+    """Handle a rate limit error by waiting and retrying.
+
+    Args:
+        error: The RateLimitError that was caught.
+        executor: SubTestExecutor instance.
+        tier_id: Current tier identifier.
+        tier_config: Tier configuration.
+        subtest: The subtest that hit the rate limit.
+        baseline: Previous tier's winning baseline.
+        results_dir: Results directory for this subtest.
+        results: Mutable dict collecting subtest results.
+        checkpoint: Optional checkpoint for resume.
+        checkpoint_path: Path to checkpoint file.
+        experiment_dir: Experiment directory (for T5 inheritance).
+        completed_count: Current count of completed subtests.
+
+    Returns:
+        Updated completed_count.
+
+    Raises:
+        RateLimitError: If no checkpoint is available to handle the error.
+
+    """
+    if not (checkpoint and checkpoint_path):
+        raise error
+
+    if is_weekly_limit(error.info):
+        logger.warning(
+            "Weekly usage limit detected from %s — waiting until reset. Resume after: %s",
+            error.info.source,
+            error.info.error_message,
+        )
+    else:
+        logger.info("Rate limit detected from %s, waiting...", error.info.source)
+
+    wait_for_rate_limit(error.info.retry_after_seconds, checkpoint, checkpoint_path)
+
+    results[subtest.id] = executor.run_subtest(
+        tier_id=tier_id,
+        tier_config=tier_config,
+        subtest=subtest,
+        baseline=baseline,
+        results_dir=results_dir,
+        checkpoint=checkpoint,
+        checkpoint_path=checkpoint_path,
+        coordinator=None,
+        experiment_dir=experiment_dir,
+    )
+    return completed_count + 1
+
+
+def _run_async(coro: Any) -> Any:
+    """Run an async coroutine from synchronous code.
+
+    Uses the running event loop when available (e.g., inside an async
+    framework), otherwise creates a new loop via ``asyncio.run``.
+
+    Args:
+        coro: Awaitable coroutine to execute.
+
+    Returns:
+        The coroutine's return value.
+
+    """
+    try:
+        loop = asyncio.get_running_loop()
+    except RuntimeError:
+        loop = None
+
+    if loop is not None and loop.is_running():
+        # Schedule on the existing loop; block until complete.
+        import concurrent.futures
+
+        with concurrent.futures.ThreadPoolExecutor(max_workers=1) as pool:
+            return pool.submit(asyncio.run, coro).result()
+    return asyncio.run(coro)
 
 
 def _detect_rate_limit_from_results(

--- a/tests/unit/adapters/test_agamemnon_client.py
+++ b/tests/unit/adapters/test_agamemnon_client.py
@@ -1,0 +1,229 @@
+"""Tests for AgamemnonClient and AsyncAgamemnonClient."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import httpx
+import pytest
+
+from scylla.adapters.agamemnon_client import (
+    AgamemnonClient,
+    AgamemnonConnectionError,
+    AsyncAgamemnonClient,
+)
+
+# ── Sync client tests ────────────────────────────────────────────────
+
+
+class TestAgamemnonClientInit:
+    """Tests for AgamemnonClient initialization."""
+
+    def test_stores_base_url(self) -> None:
+        """Base URL is stored without modification."""
+        client = AgamemnonClient(base_url="http://localhost:8080")
+        assert client.base_url == "http://localhost:8080"
+
+    def test_strips_trailing_slash(self) -> None:
+        """Trailing slash is removed from base URL."""
+        client = AgamemnonClient(base_url="http://localhost:8080/")
+        assert client.base_url == "http://localhost:8080"
+
+    def test_default_timeout(self) -> None:
+        """Default timeout is 60 seconds."""
+        client = AgamemnonClient(base_url="http://localhost:8080")
+        assert client.timeout == 60.0
+
+    def test_default_max_retries(self) -> None:
+        """Default max retries is 3."""
+        client = AgamemnonClient(base_url="http://localhost:8080")
+        assert client.max_retries == 3
+
+
+class TestAgamemnonClientRequest:
+    """Tests for AgamemnonClient._request."""
+
+    @patch("scylla.adapters.agamemnon_client.httpx.Client")
+    def test_success(self, mock_client_cls: MagicMock) -> None:
+        """Successful request returns response object."""
+        mock_resp = MagicMock(spec=httpx.Response)
+        mock_resp.raise_for_status.return_value = None
+
+        mock_inst = MagicMock()
+        mock_inst.request.return_value = mock_resp
+        mock_inst.__enter__ = MagicMock(return_value=mock_inst)
+        mock_inst.__exit__ = MagicMock(return_value=None)
+        mock_client_cls.return_value = mock_inst
+
+        client = AgamemnonClient(base_url="http://localhost:8080")
+        result = client._request("POST", "/v1/chaos/inject", json={"tier": "T0"})
+        assert result is mock_resp
+
+    @patch("scylla.adapters.agamemnon_client.time.sleep")
+    @patch("scylla.adapters.agamemnon_client.httpx.Client")
+    def test_retries_then_succeeds(self, mock_client_cls: MagicMock, mock_sleep: MagicMock) -> None:
+        """Request retries on transient error and succeeds on next attempt."""
+        mock_resp = MagicMock(spec=httpx.Response)
+        mock_resp.raise_for_status.return_value = None
+
+        mock_inst = MagicMock()
+        mock_inst.request.side_effect = [
+            httpx.ConnectError("fail"),
+            mock_resp,
+        ]
+        mock_inst.__enter__ = MagicMock(return_value=mock_inst)
+        mock_inst.__exit__ = MagicMock(return_value=None)
+        mock_client_cls.return_value = mock_inst
+
+        client = AgamemnonClient(base_url="http://localhost:8080")
+        result = client._request("POST", "/v1/chaos/inject")
+        assert result is mock_resp
+        mock_sleep.assert_called_once_with(1)
+
+    @patch("scylla.adapters.agamemnon_client.time.sleep")
+    @patch("scylla.adapters.agamemnon_client.httpx.Client")
+    def test_exhausts_retries(self, mock_client_cls: MagicMock, mock_sleep: MagicMock) -> None:
+        """Raises AgamemnonConnectionError after all retries are exhausted."""
+        mock_inst = MagicMock()
+        mock_inst.request.side_effect = httpx.ConnectError("refused")
+        mock_inst.__enter__ = MagicMock(return_value=mock_inst)
+        mock_inst.__exit__ = MagicMock(return_value=None)
+        mock_client_cls.return_value = mock_inst
+
+        client = AgamemnonClient(base_url="http://localhost:8080")
+        with pytest.raises(AgamemnonConnectionError, match="after 3 retries"):
+            client._request("POST", "/v1/chaos/inject")
+
+
+class TestAgamemnonClientConvenience:
+    """Tests for convenience methods inject_failure / cleanup_failure."""
+
+    @patch.object(AgamemnonClient, "_request")
+    def test_inject_failure(self, mock_req: MagicMock) -> None:
+        """inject_failure POSTs to /v1/chaos/inject with the spec payload."""
+        mock_req.return_value = MagicMock(spec=httpx.Response)
+        client = AgamemnonClient(base_url="http://localhost:8080")
+        client.inject_failure({"tier": "T0", "subtest": "s1"})
+        mock_req.assert_called_once_with(
+            "POST", "/v1/chaos/inject", json={"tier": "T0", "subtest": "s1"}
+        )
+
+    @patch.object(AgamemnonClient, "_request")
+    def test_cleanup_failure(self, mock_req: MagicMock) -> None:
+        """cleanup_failure DELETEs /v1/chaos/reset."""
+        mock_req.return_value = MagicMock(spec=httpx.Response)
+        client = AgamemnonClient(base_url="http://localhost:8080")
+        client.cleanup_failure()
+        mock_req.assert_called_once_with("DELETE", "/v1/chaos/reset")
+
+
+# ── Async client tests ───────────────────────────────────────────────
+
+
+class TestAsyncAgamemnonClientInit:
+    """Tests for AsyncAgamemnonClient initialization."""
+
+    def test_stores_base_url(self) -> None:
+        """Base URL is stored without modification."""
+        client = AsyncAgamemnonClient(base_url="http://localhost:8080")
+        assert client.base_url == "http://localhost:8080"
+
+    def test_strips_trailing_slash(self) -> None:
+        """Trailing slash is removed from base URL."""
+        client = AsyncAgamemnonClient(base_url="http://localhost:8080/")
+        assert client.base_url == "http://localhost:8080"
+
+
+class TestAsyncAgamemnonClientRequest:
+    """Tests for AsyncAgamemnonClient._request."""
+
+    @pytest.mark.asyncio()
+    async def test_success(self) -> None:
+        """Successful async request returns response object."""
+        mock_resp = MagicMock(spec=httpx.Response)
+        mock_resp.raise_for_status.return_value = None
+
+        mock_client = AsyncMock()
+        mock_client.request.return_value = mock_resp
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=None)
+
+        with patch(
+            "scylla.adapters.agamemnon_client.httpx.AsyncClient",
+            return_value=mock_client,
+        ):
+            client = AsyncAgamemnonClient(base_url="http://localhost:8080")
+            result = await client._request("POST", "/v1/chaos/inject")
+            assert result is mock_resp
+
+    @pytest.mark.asyncio()
+    async def test_retries_then_succeeds(self) -> None:
+        """Async request retries on transient error and succeeds."""
+        mock_resp = MagicMock(spec=httpx.Response)
+        mock_resp.raise_for_status.return_value = None
+
+        mock_client = AsyncMock()
+        mock_client.request.side_effect = [
+            httpx.ConnectError("fail"),
+            mock_resp,
+        ]
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=None)
+
+        with (
+            patch(
+                "scylla.adapters.agamemnon_client.httpx.AsyncClient",
+                return_value=mock_client,
+            ),
+            patch(
+                "scylla.adapters.agamemnon_client.asyncio.sleep",
+                new_callable=AsyncMock,
+            ),
+        ):
+            client = AsyncAgamemnonClient(base_url="http://localhost:8080")
+            result = await client._request("POST", "/v1/chaos/inject")
+            assert result is mock_resp
+
+    @pytest.mark.asyncio()
+    async def test_exhausts_retries(self) -> None:
+        """Raises AgamemnonConnectionError after retries exhausted."""
+        mock_client = AsyncMock()
+        mock_client.request.side_effect = httpx.ConnectError("refused")
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=None)
+
+        with (
+            patch(
+                "scylla.adapters.agamemnon_client.httpx.AsyncClient",
+                return_value=mock_client,
+            ),
+            patch(
+                "scylla.adapters.agamemnon_client.asyncio.sleep",
+                new_callable=AsyncMock,
+            ),
+        ):
+            client = AsyncAgamemnonClient(base_url="http://localhost:8080")
+            with pytest.raises(AgamemnonConnectionError, match="after 3 retries"):
+                await client._request("POST", "/v1/chaos/inject")
+
+
+class TestAsyncAgamemnonClientConvenience:
+    """Tests for async convenience methods."""
+
+    @pytest.mark.asyncio()
+    async def test_inject_failure(self) -> None:
+        """inject_failure awaits POST to /v1/chaos/inject."""
+        client = AsyncAgamemnonClient(base_url="http://localhost:8080")
+        mock_resp = MagicMock(spec=httpx.Response)
+        with patch.object(client, "_request", new_callable=AsyncMock, return_value=mock_resp):
+            result = await client.inject_failure({"tier": "T0"})
+            assert result is mock_resp
+
+    @pytest.mark.asyncio()
+    async def test_cleanup_failure(self) -> None:
+        """cleanup_failure awaits DELETE to /v1/chaos/reset."""
+        client = AsyncAgamemnonClient(base_url="http://localhost:8080")
+        mock_resp = MagicMock(spec=httpx.Response)
+        with patch.object(client, "_request", new_callable=AsyncMock, return_value=mock_resp):
+            result = await client.cleanup_failure()
+            assert result is mock_resp

--- a/tests/unit/e2e/test_parallel_executor.py
+++ b/tests/unit/e2e/test_parallel_executor.py
@@ -422,3 +422,285 @@ class TestParallelSubtestLoopShutdown:
 
         # Should return empty results since shutdown was requested before any subtest ran
         assert results == {}
+
+
+# ---------------------------------------------------------------------------
+# AsyncAgamemnonClient wiring in run_tier_subtests_parallel
+# ---------------------------------------------------------------------------
+
+
+class TestAsyncAgamemnonWiring:
+    """Tests that AsyncAgamemnonClient inject/cleanup is called around subtests."""
+
+    def _make_subtest_config(self, subtest_id: str = "00-empty") -> MagicMock:
+        subtest = MagicMock()
+        subtest.id = subtest_id
+        return subtest
+
+    def _make_tier_config(self, subtests: list[Any]) -> MagicMock:
+        tier_config = MagicMock()
+        tier_config.subtests = subtests
+        return tier_config
+
+    def test_inject_and_cleanup_called_when_agamemnon_url_set(self, tmp_path: Path) -> None:
+        """When agamemnon_url is configured, inject and cleanup are called."""
+        from scylla.e2e.models import ExperimentConfig, SubTestResult, TierID
+
+        config = ExperimentConfig(
+            experiment_id="test",
+            task_repo="https://example.com/repo",
+            task_commit="abc123",
+            task_prompt_file=Path("prompt.md"),
+            language="python",
+            tiers_to_run=[TierID.T0],
+            agamemnon_url="http://localhost:8080",
+        )
+
+        mock_result = SubTestResult(
+            subtest_id="00-empty",
+            tier_id=TierID.T0,
+            runs=[],
+            pass_rate=0.0,
+        )
+
+        subtest = self._make_subtest_config("00-empty")
+        tier_config = self._make_tier_config([subtest])
+        mock_tier_manager = MagicMock()
+        mock_workspace = MagicMock()
+        mock_executor = MagicMock()
+        mock_executor.run_subtest.return_value = mock_result
+
+        with (
+            patch(
+                "scylla.e2e.subtest_executor.SubTestExecutor",
+                return_value=mock_executor,
+            ),
+            patch("scylla.e2e.parallel_executor._run_async") as mock_run_async,
+        ):
+            from scylla.e2e.parallel_executor import run_tier_subtests_parallel
+
+            results = run_tier_subtests_parallel(
+                config=config,
+                tier_id=TierID.T0,
+                tier_config=tier_config,
+                tier_manager=mock_tier_manager,
+                workspace_manager=mock_workspace,
+                baseline=None,
+                results_dir=tmp_path,
+            )
+
+        assert "00-empty" in results
+        # inject + cleanup = 2 calls
+        assert mock_run_async.call_count == 2
+
+    def test_no_agamemnon_calls_when_url_is_none(self, tmp_path: Path) -> None:
+        """When agamemnon_url is None, no inject/cleanup calls are made."""
+        from scylla.e2e.models import ExperimentConfig, SubTestResult, TierID
+
+        config = ExperimentConfig(
+            experiment_id="test",
+            task_repo="https://example.com/repo",
+            task_commit="abc123",
+            task_prompt_file=Path("prompt.md"),
+            language="python",
+            tiers_to_run=[TierID.T0],
+        )
+
+        mock_result = SubTestResult(
+            subtest_id="00-empty",
+            tier_id=TierID.T0,
+            runs=[],
+            pass_rate=0.0,
+        )
+
+        subtest = self._make_subtest_config("00-empty")
+        tier_config = self._make_tier_config([subtest])
+        mock_tier_manager = MagicMock()
+        mock_workspace = MagicMock()
+        mock_executor = MagicMock()
+        mock_executor.run_subtest.return_value = mock_result
+
+        with (
+            patch(
+                "scylla.e2e.subtest_executor.SubTestExecutor",
+                return_value=mock_executor,
+            ),
+            patch("scylla.e2e.parallel_executor._run_async") as mock_run_async,
+        ):
+            from scylla.e2e.parallel_executor import run_tier_subtests_parallel
+
+            results = run_tier_subtests_parallel(
+                config=config,
+                tier_id=TierID.T0,
+                tier_config=tier_config,
+                tier_manager=mock_tier_manager,
+                workspace_manager=mock_workspace,
+                baseline=None,
+                results_dir=tmp_path,
+            )
+
+        assert "00-empty" in results
+        mock_run_async.assert_not_called()
+
+    def test_cleanup_called_even_on_infrastructure_failure(self, tmp_path: Path) -> None:
+        """Cleanup runs even when the subtest raises InfrastructureFailureError."""
+        from scylla.e2e.models import ExperimentConfig, TierID
+        from scylla.e2e.rate_limit import InfrastructureFailureError
+
+        config = ExperimentConfig(
+            experiment_id="test",
+            task_repo="https://example.com/repo",
+            task_commit="abc123",
+            task_prompt_file=Path("prompt.md"),
+            language="python",
+            tiers_to_run=[TierID.T0],
+            agamemnon_url="http://localhost:8080",
+        )
+
+        subtest = self._make_subtest_config("00-empty")
+        tier_config = self._make_tier_config([subtest])
+        mock_tier_manager = MagicMock()
+        mock_workspace = MagicMock()
+        mock_executor = MagicMock()
+        mock_executor.run_subtest.side_effect = InfrastructureFailureError("crash")
+
+        with (
+            patch(
+                "scylla.e2e.subtest_executor.SubTestExecutor",
+                return_value=mock_executor,
+            ),
+            patch("scylla.e2e.parallel_executor._run_async") as mock_run_async,
+        ):
+            from scylla.e2e.parallel_executor import run_tier_subtests_parallel
+
+            results = run_tier_subtests_parallel(
+                config=config,
+                tier_id=TierID.T0,
+                tier_config=tier_config,
+                tier_manager=mock_tier_manager,
+                workspace_manager=mock_workspace,
+                baseline=None,
+                results_dir=tmp_path,
+            )
+
+        # Subtest was skipped, no result recorded
+        assert results == {}
+        # inject + cleanup = 2 calls (cleanup happens in finally)
+        assert mock_run_async.call_count == 2
+
+
+# ---------------------------------------------------------------------------
+# _run_async helper
+# ---------------------------------------------------------------------------
+
+
+class TestRunAsync:
+    """Tests for the _run_async helper."""
+
+    def test_runs_coroutine(self) -> None:
+        """_run_async executes a coroutine and returns its result."""
+        from scylla.e2e.parallel_executor import _run_async
+
+        async def coro() -> str:
+            return "ok"
+
+        assert _run_async(coro()) == "ok"
+
+    def test_runs_coroutine_inside_running_loop(self) -> None:
+        """_run_async works when called from within a running event loop."""
+        import asyncio
+
+        from scylla.e2e.parallel_executor import _run_async
+
+        async def inner() -> str:
+            return "inner_ok"
+
+        async def outer() -> str:
+            result: str = _run_async(inner())
+            return result
+
+        result = asyncio.run(outer())
+        assert result == "inner_ok"
+
+
+# ---------------------------------------------------------------------------
+# _async_inject_failure / _async_cleanup_failure
+# ---------------------------------------------------------------------------
+
+
+class TestAsyncInjectFailure:
+    """Tests for _async_inject_failure helper."""
+
+    def test_calls_inject_failure(self) -> None:
+        """Calls inject_failure on the client with correct spec."""
+        import asyncio
+        from unittest.mock import AsyncMock
+
+        from scylla.adapters.agamemnon_client import AsyncAgamemnonClient
+        from scylla.e2e.models import TierID
+        from scylla.e2e.parallel_executor import _async_inject_failure
+
+        client = AsyncAgamemnonClient(base_url="http://localhost:8080")
+        client.inject_failure = AsyncMock()  # type: ignore[method-assign]
+
+        asyncio.run(_async_inject_failure(client, TierID.T0, "sub-1"))
+        client.inject_failure.assert_called_once_with({"tier": "T0", "subtest": "sub-1"})
+
+    def test_logs_warning_on_connection_error(self) -> None:
+        """Does not raise on AgamemnonConnectionError; logs warning."""
+        import asyncio
+        from unittest.mock import AsyncMock
+
+        from scylla.adapters.agamemnon_client import (
+            AgamemnonConnectionError,
+            AsyncAgamemnonClient,
+        )
+        from scylla.e2e.models import TierID
+        from scylla.e2e.parallel_executor import _async_inject_failure
+
+        client = AsyncAgamemnonClient(base_url="http://localhost:8080")
+        client.inject_failure = AsyncMock(  # type: ignore[method-assign]
+            side_effect=AgamemnonConnectionError("unreachable")
+        )
+
+        # Should NOT raise
+        asyncio.run(_async_inject_failure(client, TierID.T0, "sub-1"))
+
+
+class TestAsyncCleanupFailure:
+    """Tests for _async_cleanup_failure helper."""
+
+    def test_calls_cleanup_failure(self) -> None:
+        """Calls cleanup_failure on the client."""
+        import asyncio
+        from unittest.mock import AsyncMock
+
+        from scylla.adapters.agamemnon_client import AsyncAgamemnonClient
+        from scylla.e2e.models import TierID
+        from scylla.e2e.parallel_executor import _async_cleanup_failure
+
+        client = AsyncAgamemnonClient(base_url="http://localhost:8080")
+        client.cleanup_failure = AsyncMock()  # type: ignore[method-assign]
+
+        asyncio.run(_async_cleanup_failure(client, TierID.T0, "sub-1"))
+        client.cleanup_failure.assert_called_once()
+
+    def test_logs_warning_on_connection_error(self) -> None:
+        """Does not raise on AgamemnonConnectionError; logs warning."""
+        import asyncio
+        from unittest.mock import AsyncMock
+
+        from scylla.adapters.agamemnon_client import (
+            AgamemnonConnectionError,
+            AsyncAgamemnonClient,
+        )
+        from scylla.e2e.models import TierID
+        from scylla.e2e.parallel_executor import _async_cleanup_failure
+
+        client = AsyncAgamemnonClient(base_url="http://localhost:8080")
+        client.cleanup_failure = AsyncMock(  # type: ignore[method-assign]
+            side_effect=AgamemnonConnectionError("unreachable")
+        )
+
+        # Should NOT raise
+        asyncio.run(_async_cleanup_failure(client, TierID.T0, "sub-1"))


### PR DESCRIPTION
## Summary
- Add `AgamemnonClient` (sync) and `AsyncAgamemnonClient` (async) HTTP clients in `src/scylla/adapters/agamemnon_client.py` targeting `/v1/chaos/*` endpoints with retry logic and exponential backoff
- Wire `AsyncAgamemnonClient` into `run_tier_subtests_parallel()` — when `config.agamemnon_url` is set, failure injection runs before each subtest and cleanup runs after (in a `finally` block)
- Add `agamemnon_url` optional field to `ExperimentConfig` for opt-in failure injection
- Extract `_handle_rate_limit()` helper to reduce cyclomatic complexity below C901 threshold

## Test plan
- [x] 16 new tests for `AgamemnonClient` and `AsyncAgamemnonClient` (sync/async init, request, retries, convenience methods)
- [x] 9 new tests for async wiring in parallel executor (`_async_inject_failure`, `_async_cleanup_failure`, `_run_async`, integration with `run_tier_subtests_parallel`)
- [x] Existing 21 parallel executor tests still pass
- [x] Pre-commit passes (ruff-format, ruff-check, mypy)

Closes #1628

🤖 Generated with [Claude Code](https://claude.com/claude-code)