### PR TITLE
feat(cli): load actual run results in scylla report command

### DIFF
--- a/src/scylla/cli/main.py
+++ b/src/scylla/cli/main.py
@@ -279,6 +279,115 @@ def _warn_format_extension_mismatch(output: str | None, output_format: str) -> N
         )
 
 
+def _load_report_data(
+    test_id: str,
+    results: list[dict[str, Any]],
+) -> ReportData:
+    """Build a fully-populated ReportData from raw run results.
+
+    Groups results by tier, calculates per-tier metrics (pass rate,
+    implementation rate, cost-of-pass, etc.), sensitivity analysis,
+    transition assessments, and recommendations.
+
+    Args:
+        test_id: Test identifier.
+        results: List of result dictionaries (each from a result.json file).
+
+    Returns:
+        ReportData with tiers, sensitivity, transitions, and recommendations.
+
+    Raises:
+        ValueError: If *results* is empty.
+
+    """
+    if not results:
+        raise ValueError(f"No results provided for test: {test_id}")
+
+    # Group results by tier
+    by_tier: dict[str, list[dict[str, Any]]] = {}
+    for r in results:
+        tier_id = r["tier_id"]
+        if tier_id not in by_tier:
+            by_tier[tier_id] = []
+        by_tier[tier_id].append(r)
+
+    # Sort tiers
+    sorted_tiers = sorted(by_tier.keys())
+
+    # Calculate T0 pass rate for uplift calculations
+    t0_pass_rate = None
+    if "T0" in by_tier:
+        t0_results = by_tier["T0"]
+        t0_pass_rates = [r["grading"]["pass_rate"] for r in t0_results]
+        t0_pass_rate = statistics.median(t0_pass_rates)
+
+    # Calculate metrics for each tier
+    tier_metrics = []
+    for tid in sorted_tiers:
+        metrics = _calculate_tier_metrics(tid, by_tier[tid], t0_pass_rate)
+        tier_metrics.append(metrics)
+
+    # Calculate sensitivity analysis if multiple tiers
+    sensitivity = None
+    if len(tier_metrics) > 1:
+        pass_rates = [m.pass_rate_median for m in tier_metrics]
+        impl_rates = [m.impl_rate_median for m in tier_metrics]
+        costs = [
+            m.cost_of_pass_median for m in tier_metrics if m.cost_of_pass_median != float("inf")
+        ]
+
+        sensitivity = SensitivityAnalysis(
+            pass_rate_variance=statistics.variance(pass_rates) if len(pass_rates) > 1 else 0.0,
+            impl_rate_variance=statistics.variance(impl_rates) if len(impl_rates) > 1 else 0.0,
+            cost_variance=statistics.variance(costs) if len(costs) > 1 else 0.0,
+        )
+
+    # Calculate transitions
+    transitions = []
+    for i in range(len(tier_metrics) - 1):
+        from_tier = tier_metrics[i]
+        to_tier = tier_metrics[i + 1]
+
+        pass_delta = to_tier.pass_rate_median - from_tier.pass_rate_median
+        impl_delta = to_tier.impl_rate_median - from_tier.impl_rate_median
+        cost_delta = to_tier.cost_of_pass_median - from_tier.cost_of_pass_median
+
+        # Worth it if pass rate improves more than cost increases (relative)
+        worth_it = pass_delta > 0 and (cost_delta < 0 or pass_delta > cost_delta)
+
+        transitions.append(
+            TransitionAssessment(
+                from_tier=from_tier.tier_id,
+                to_tier=to_tier.tier_id,
+                pass_rate_delta=pass_delta,
+                impl_rate_delta=impl_delta,
+                cost_delta=cost_delta,
+                worth_it=worth_it,
+            )
+        )
+
+    # Determine runs per tier (from first tier's count)
+    runs_per_tier = len(by_tier[sorted_tiers[0]]) if sorted_tiers else 0
+
+    # Create report data
+    timestamp = datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+    return ReportData(
+        test_id=test_id,
+        test_name=test_id.replace("-", " ").title(),
+        timestamp=timestamp,
+        runs_per_tier=runs_per_tier,
+        judge_model=DEFAULT_JUDGE_MODEL,
+        tiers=tier_metrics,
+        sensitivity=sensitivity,
+        transitions=transitions,
+        key_finding=f"Evaluated {len(results)} runs across {len(sorted_tiers)} tier(s).",
+        recommendations=[
+            "Review per-tier metrics to identify optimal configuration.",
+            "Consider cost-of-pass when selecting production tier.",
+        ],
+    )
+
+
 @cli.command()
 @click.argument("test_id")
 @click.option(
@@ -330,93 +439,15 @@ def report(
 
     click.echo(f"  Found {len(results)} run results", err=stdout_mode)
 
-    # Group results by tier
-    by_tier: dict[str, list[dict[str, Any]]] = {}
-    for r in results:
-        tier_id = r["tier_id"]
-        if tier_id not in by_tier:
-            by_tier[tier_id] = []
-        by_tier[tier_id].append(r)
+    report_data = _load_report_data(test_id, results)
 
-    # Sort tiers
-    sorted_tiers = sorted(by_tier.keys())
-
-    # Calculate T0 pass rate for uplift calculations
-    t0_pass_rate = None
-    if "T0" in by_tier:
-        t0_results = by_tier["T0"]
-        t0_pass_rates = [r["grading"]["pass_rate"] for r in t0_results]
-        t0_pass_rate = statistics.median(t0_pass_rates)
-
-    # Calculate metrics for each tier
-    tier_metrics = []
-    for tier_id in sorted_tiers:
-        metrics = _calculate_tier_metrics(tier_id, by_tier[tier_id], t0_pass_rate)
-        tier_metrics.append(metrics)
+    # Log per-tier summary
+    for tier in report_data.tiers:
+        by_tier_count = sum(1 for r in results if r["tier_id"] == tier.tier_id)
         click.echo(
-            f"  {tier_id}: {len(by_tier[tier_id])} runs, pass rate: {metrics.pass_rate_median:.1%}",
+            f"  {tier.tier_id}: {by_tier_count} runs, pass rate: {tier.pass_rate_median:.1%}",
             err=stdout_mode,
         )
-
-    # Calculate sensitivity analysis if multiple tiers
-    sensitivity = None
-    if len(tier_metrics) > 1:
-        pass_rates = [m.pass_rate_median for m in tier_metrics]
-        impl_rates = [m.impl_rate_median for m in tier_metrics]
-        costs = [
-            m.cost_of_pass_median for m in tier_metrics if m.cost_of_pass_median != float("inf")
-        ]
-
-        sensitivity = SensitivityAnalysis(
-            pass_rate_variance=statistics.variance(pass_rates) if len(pass_rates) > 1 else 0.0,
-            impl_rate_variance=statistics.variance(impl_rates) if len(impl_rates) > 1 else 0.0,
-            cost_variance=statistics.variance(costs) if len(costs) > 1 else 0.0,
-        )
-
-    # Calculate transitions
-    transitions = []
-    for i in range(len(tier_metrics) - 1):
-        from_tier = tier_metrics[i]
-        to_tier = tier_metrics[i + 1]
-
-        pass_delta = to_tier.pass_rate_median - from_tier.pass_rate_median
-        impl_delta = to_tier.impl_rate_median - from_tier.impl_rate_median
-        cost_delta = to_tier.cost_of_pass_median - from_tier.cost_of_pass_median
-
-        # Worth it if pass rate improves more than cost increases (relative)
-        worth_it = pass_delta > 0 and (cost_delta < 0 or pass_delta > cost_delta)
-
-        transitions.append(
-            TransitionAssessment(
-                from_tier=from_tier.tier_id,
-                to_tier=to_tier.tier_id,
-                pass_rate_delta=pass_delta,
-                impl_rate_delta=impl_delta,
-                cost_delta=cost_delta,
-                worth_it=worth_it,
-            )
-        )
-
-    # Determine runs per tier (from first tier's count)
-    runs_per_tier = len(by_tier[sorted_tiers[0]]) if sorted_tiers else 0
-
-    # Create report data
-    timestamp = datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
-    report_data = ReportData(
-        test_id=test_id,
-        test_name=test_id.replace("-", " ").title(),
-        timestamp=timestamp,
-        runs_per_tier=runs_per_tier,
-        judge_model=DEFAULT_JUDGE_MODEL,
-        tiers=tier_metrics,
-        sensitivity=sensitivity,
-        transitions=transitions,
-        key_finding=f"Evaluated {len(results)} runs across {len(sorted_tiers)} tier(s).",
-        recommendations=[
-            "Review per-tier metrics to identify optimal configuration.",
-            "Consider cost-of-pass when selecting production tier.",
-        ],
-    )
 
     # Generate report using dict-dispatch — single code path for all formats
     generator_cls = FORMAT_GENERATORS[output_format]

--- a/tests/unit/cli/test_load_report_data.py
+++ b/tests/unit/cli/test_load_report_data.py
@@ -1,0 +1,214 @@
+"""Tests for _load_report_data() loading logic."""
+
+import pytest
+
+from scylla.cli.main import _load_report_data
+from scylla.reporting import ReportData, SensitivityAnalysis, TierMetrics, TransitionAssessment
+
+
+def _make_result(
+    tier_id: str = "T0",
+    pass_rate: float = 0.8,
+    impl_rate: float = 0.7,
+    composite_score: float = 0.75,
+    cost_of_pass: float = 1.50,
+) -> dict[str, object]:
+    """Create a minimal result dict matching the on-disk result.json schema."""
+    return {
+        "tier_id": tier_id,
+        "grading": {
+            "pass_rate": pass_rate,
+            "composite_score": composite_score,
+            "cost_of_pass": cost_of_pass,
+        },
+        "judgment": {
+            "impl_rate": impl_rate,
+            "passed": pass_rate > 0,
+            "letter_grade": "B",
+        },
+        "metrics": {
+            "cost_usd": 0.05,
+        },
+    }
+
+
+class TestLoadReportDataBasic:
+    """Basic behaviour of _load_report_data."""
+
+    def test_returns_report_data(self) -> None:
+        """Returns a ReportData instance."""
+        result = _load_report_data("test-001", [_make_result()])
+        assert isinstance(result, ReportData)
+
+    def test_test_id_propagated(self) -> None:
+        """test_id is set on the returned ReportData."""
+        result = _load_report_data("test-001", [_make_result()])
+        assert result.test_id == "test-001"
+
+    def test_test_name_derived(self) -> None:
+        """test_name is derived from test_id."""
+        result = _load_report_data("my-cool-test", [_make_result()])
+        assert result.test_name == "My Cool Test"
+
+    def test_raises_on_empty_results(self) -> None:
+        """Raises ValueError when results list is empty."""
+        with pytest.raises(ValueError, match="No results provided"):
+            _load_report_data("test-001", [])
+
+
+class TestLoadReportDataSingleTier:
+    """Single-tier scenarios."""
+
+    def test_single_tier_populates_tiers(self) -> None:
+        """A single tier produces exactly one TierMetrics entry."""
+        results = [_make_result("T0")]
+        data = _load_report_data("test-001", results)
+        assert len(data.tiers) == 1
+        assert isinstance(data.tiers[0], TierMetrics)
+        assert data.tiers[0].tier_id == "T0"
+
+    def test_single_tier_pass_rate(self) -> None:
+        """Pass rate median is correctly calculated for a single result."""
+        results = [_make_result("T0", pass_rate=0.6)]
+        data = _load_report_data("test-001", results)
+        assert data.tiers[0].pass_rate_median == pytest.approx(0.6)
+
+    def test_single_tier_impl_rate(self) -> None:
+        """Implementation rate median is correctly calculated."""
+        results = [_make_result("T0", impl_rate=0.9)]
+        data = _load_report_data("test-001", results)
+        assert data.tiers[0].impl_rate_median == pytest.approx(0.9)
+
+    def test_single_tier_cost_of_pass(self) -> None:
+        """Cost-of-pass median is correctly calculated."""
+        results = [_make_result("T0", cost_of_pass=2.50)]
+        data = _load_report_data("test-001", results)
+        assert data.tiers[0].cost_of_pass_median == pytest.approx(2.50)
+
+    def test_single_tier_no_sensitivity(self) -> None:
+        """Sensitivity analysis is None with a single tier."""
+        data = _load_report_data("test-001", [_make_result("T0")])
+        assert data.sensitivity is None
+
+    def test_single_tier_no_transitions(self) -> None:
+        """No transitions with a single tier."""
+        data = _load_report_data("test-001", [_make_result("T0")])
+        assert data.transitions == []
+
+    def test_runs_per_tier_count(self) -> None:
+        """runs_per_tier reflects the number of results for the first tier."""
+        results = [_make_result("T0"), _make_result("T0")]
+        data = _load_report_data("test-001", results)
+        assert data.runs_per_tier == 2
+
+
+class TestLoadReportDataMultipleTiers:
+    """Multi-tier scenarios."""
+
+    def test_two_tiers_sorted(self) -> None:
+        """Tiers are sorted by tier_id."""
+        results = [_make_result("T1"), _make_result("T0")]
+        data = _load_report_data("test-001", results)
+        assert [t.tier_id for t in data.tiers] == ["T0", "T1"]
+
+    def test_sensitivity_populated(self) -> None:
+        """Sensitivity analysis is populated with multiple tiers."""
+        results = [
+            _make_result("T0", pass_rate=0.4, impl_rate=0.3),
+            _make_result("T1", pass_rate=0.8, impl_rate=0.7),
+        ]
+        data = _load_report_data("test-001", results)
+        assert data.sensitivity is not None
+        assert isinstance(data.sensitivity, SensitivityAnalysis)
+        assert data.sensitivity.pass_rate_variance > 0
+
+    def test_transitions_populated(self) -> None:
+        """Transitions are populated with multiple tiers."""
+        results = [
+            _make_result("T0", pass_rate=0.4),
+            _make_result("T1", pass_rate=0.8),
+        ]
+        data = _load_report_data("test-001", results)
+        assert len(data.transitions) == 1
+        assert isinstance(data.transitions[0], TransitionAssessment)
+        assert data.transitions[0].from_tier == "T0"
+        assert data.transitions[0].to_tier == "T1"
+
+    def test_transition_pass_rate_delta(self) -> None:
+        """Transition pass_rate_delta is computed correctly."""
+        results = [
+            _make_result("T0", pass_rate=0.3),
+            _make_result("T1", pass_rate=0.7),
+        ]
+        data = _load_report_data("test-001", results)
+        assert data.transitions[0].pass_rate_delta == pytest.approx(0.4)
+
+    def test_three_tiers_two_transitions(self) -> None:
+        """Three tiers produce two transition assessments."""
+        results = [
+            _make_result("T0"),
+            _make_result("T1"),
+            _make_result("T2"),
+        ]
+        data = _load_report_data("test-001", results)
+        assert len(data.transitions) == 2
+        assert data.transitions[0].from_tier == "T0"
+        assert data.transitions[0].to_tier == "T1"
+        assert data.transitions[1].from_tier == "T1"
+        assert data.transitions[1].to_tier == "T2"
+
+    def test_uplift_vs_t0(self) -> None:
+        """Tiers other than T0 have uplift calculated relative to T0."""
+        results = [
+            _make_result("T0", pass_rate=0.5),
+            _make_result("T1", pass_rate=0.75),
+        ]
+        data = _load_report_data("test-001", results)
+        t0_tier = data.tiers[0]
+        t1_tier = data.tiers[1]
+        assert t0_tier.uplift == 0.0
+        # uplift = ((0.75 - 0.5) / 0.5) * 100 = 50.0
+        assert t1_tier.uplift == pytest.approx(50.0)
+
+
+class TestLoadReportDataEdgeCases:
+    """Edge-case scenarios."""
+
+    def test_inf_cost_of_pass(self) -> None:
+        """Infinity cost_of_pass is handled gracefully."""
+        results = [_make_result("T0", cost_of_pass=float("inf"))]
+        data = _load_report_data("test-001", results)
+        assert data.tiers[0].cost_of_pass_median == float("inf")
+
+    def test_multiple_results_per_tier_median(self) -> None:
+        """Median is computed when multiple results exist for one tier."""
+        results = [
+            _make_result("T0", pass_rate=0.2),
+            _make_result("T0", pass_rate=0.6),
+            _make_result("T0", pass_rate=1.0),
+        ]
+        data = _load_report_data("test-001", results)
+        assert data.tiers[0].pass_rate_median == pytest.approx(0.6)
+
+    def test_key_finding_populated(self) -> None:
+        """key_finding contains run and tier counts."""
+        results = [_make_result("T0"), _make_result("T1")]
+        data = _load_report_data("test-001", results)
+        assert "2 runs" in data.key_finding
+        assert "2 tier" in data.key_finding
+
+    def test_recommendations_populated(self) -> None:
+        """Recommendations list is non-empty."""
+        data = _load_report_data("test-001", [_make_result()])
+        assert len(data.recommendations) >= 1
+
+    def test_timestamp_is_set(self) -> None:
+        """Timestamp is a non-empty string."""
+        data = _load_report_data("test-001", [_make_result()])
+        assert isinstance(data.timestamp, str)
+        assert len(data.timestamp) > 0
+
+    def test_judge_model_is_set(self) -> None:
+        """judge_model is set."""
+        data = _load_report_data("test-001", [_make_result()])
+        assert data.judge_model != ""


### PR DESCRIPTION
## Summary
- Extracted inline report-building logic from the `report()` CLI command into a dedicated `_load_report_data()` function
- The function groups raw results by tier, calculates per-tier metrics (pass rate, implementation rate, cost-of-pass, composite score), sensitivity analysis, transition assessments, and recommendations
- Added 23 unit tests covering single-tier, multi-tier, edge cases (inf cost, median calculation, uplift), and error handling

## Test plan
- [x] All 23 new tests in `test_load_report_data.py` pass
- [x] All 34 existing CLI report tests pass (no regressions)
- [x] Pre-commit checks pass (ruff-format, ruff-check, mypy)

Closes #1646

🤖 Generated with [Claude Code](https://claude.com/claude-code)