### PR TITLE
refactor(e2e): consolidate and simplify e2e modules

### DIFF
--- a/src/scylla/e2e/__init__.py
+++ b/src/scylla/e2e/__init__.py
@@ -21,7 +21,8 @@ from scylla.e2e.checkpoint import (
     save_checkpoint,
     validate_checkpoint_config,
 )
-from scylla.e2e.llm_judge import JudgeResult, run_llm_judge
+from scylla.e2e.llm_judge import run_llm_judge
+from scylla.e2e.llm_judge_models import JudgeResult
 from scylla.e2e.models import (
     E2ERunResult,
     ExperimentConfig,

--- a/src/scylla/e2e/experiment_setup_manager.py
+++ b/src/scylla/e2e/experiment_setup_manager.py
@@ -164,7 +164,7 @@ class ExperimentSetupManager:
             logger.info("Experiment-level pipeline baseline already captured — skipping")
             return
 
-        from scylla.e2e.llm_judge import _run_build_pipeline
+        from scylla.e2e.build_pipeline import _run_build_pipeline
         from scylla.e2e.subtest_executor import _save_pipeline_baseline
 
         # Create a temporary worktree so the baseline runs on a clean repo state

--- a/src/scylla/e2e/judge_runner.py
+++ b/src/scylla/e2e/judge_runner.py
@@ -22,7 +22,7 @@ from scylla.e2e.paths import RESULT_FILE, get_judge_result_file
 from scylla.e2e.rate_limit import RateLimitError, RateLimitInfo, _detect_rate_limit_from_stderr
 
 if TYPE_CHECKING:
-    from scylla.e2e.llm_judge import BuildPipelineResult, JudgeResult
+    from scylla.e2e.llm_judge_models import BuildPipelineResult, JudgeResult
 
 logger = logging.getLogger(__name__)
 

--- a/src/scylla/e2e/llm_judge.py
+++ b/src/scylla/e2e/llm_judge.py
@@ -21,97 +21,10 @@ from typing import Any
 from hephaestus.resilience.circuit_breaker import get_circuit_breaker
 
 from scylla.config.constants import DEFAULT_JUDGE_MODEL
-
-# Re-export build pipeline functions for backward compatibility
-from scylla.e2e.build_pipeline import (
-    _execute_python_scripts as _execute_python_scripts,
-)
-from scylla.e2e.build_pipeline import (
-    _format_pipeline_result as _format_pipeline_result,
-)
-from scylla.e2e.build_pipeline import (
-    _get_pipeline_env as _get_pipeline_env,
-)
-from scylla.e2e.build_pipeline import (
-    _is_modular_repo as _is_modular_repo,
-)
-from scylla.e2e.build_pipeline import (
-    _run_and_log_pipeline as _run_and_log_pipeline,
-)
-from scylla.e2e.build_pipeline import (
-    _run_build_pipeline as _run_build_pipeline,
-)
-from scylla.e2e.build_pipeline import (
-    _run_mojo_build_step as _run_mojo_build_step,
-)
-from scylla.e2e.build_pipeline import (
-    _run_mojo_format_step as _run_mojo_format_step,
-)
-from scylla.e2e.build_pipeline import (
-    _run_mojo_pipeline as _run_mojo_pipeline,
-)
-from scylla.e2e.build_pipeline import (
-    _run_mojo_test_step as _run_mojo_test_step,
-)
-from scylla.e2e.build_pipeline import (
-    _run_precommit_step as _run_precommit_step,
-)
-from scylla.e2e.build_pipeline import (
-    _run_python_build_step as _run_python_build_step,
-)
-from scylla.e2e.build_pipeline import (
-    _run_python_format_step as _run_python_format_step,
-)
-from scylla.e2e.build_pipeline import (
-    _run_python_pipeline as _run_python_pipeline,
-)
-from scylla.e2e.build_pipeline import (
-    _run_python_test_step as _run_python_test_step,
-)
+from scylla.e2e.build_pipeline import _format_pipeline_result, _run_and_log_pipeline
 from scylla.e2e.filters import is_test_config_file
-
-# Re-export models for backward compatibility
-from scylla.e2e.llm_judge_models import (
-    BuildPipelineResult as BuildPipelineResult,
-)
-from scylla.e2e.llm_judge_models import (
-    JudgeResult as JudgeResult,
-)
-from scylla.e2e.llm_judge_models import (
-    _score_to_grade as _score_to_grade,
-)
-
-# Re-export pipeline script functions for backward compatibility
-from scylla.e2e.pipeline_scripts import (
-    _create_mojo_build_script as _create_mojo_build_script,
-)
-from scylla.e2e.pipeline_scripts import (
-    _create_mojo_format_script as _create_mojo_format_script,
-)
-from scylla.e2e.pipeline_scripts import (
-    _create_mojo_scripts as _create_mojo_scripts,
-)
-from scylla.e2e.pipeline_scripts import (
-    _create_mojo_test_script as _create_mojo_test_script,
-)
-from scylla.e2e.pipeline_scripts import (
-    _create_precommit_script as _create_precommit_script,
-)
-from scylla.e2e.pipeline_scripts import (
-    _create_python_scripts as _create_python_scripts,
-)
-from scylla.e2e.pipeline_scripts import (
-    _create_run_all_script as _create_run_all_script,
-)
-from scylla.e2e.pipeline_scripts import (
-    _save_judge_logs as _save_judge_logs,
-)
-from scylla.e2e.pipeline_scripts import (
-    _save_pipeline_commands as _save_pipeline_commands,
-)
-from scylla.e2e.pipeline_scripts import (
-    _save_pipeline_outputs as _save_pipeline_outputs,
-)
+from scylla.e2e.llm_judge_models import BuildPipelineResult, JudgeResult, _score_to_grade
+from scylla.e2e.pipeline_scripts import _save_judge_logs
 from scylla.judge import extract_json_from_llm_response
 from scylla.judge.prompts import JUDGE_SYSTEM_PROMPT_FILE, build_task_prompt
 

--- a/src/scylla/e2e/regenerate.py
+++ b/src/scylla/e2e/regenerate.py
@@ -336,8 +336,8 @@ def rejudge_missing_runs(  # noqa: C901  # workspace state detection with many f
                             from scylla.e2e.llm_judge import (
                                 _call_claude_judge,
                                 _parse_judge_response,
-                                _save_judge_logs,
                             )
+                            from scylla.e2e.pipeline_scripts import _save_judge_logs
 
                             judge_start = time.time()
 

--- a/src/scylla/e2e/rerun_judges.py
+++ b/src/scylla/e2e/rerun_judges.py
@@ -342,7 +342,8 @@ def _rerun_single_judge_slot(
         import time
         from datetime import datetime, timezone
 
-        from scylla.e2e.llm_judge import _call_claude_judge, _parse_judge_response, _save_judge_logs
+        from scylla.e2e.llm_judge import _call_claude_judge, _parse_judge_response
+        from scylla.e2e.pipeline_scripts import _save_judge_logs
 
         try:
             judge_start = time.time()

--- a/src/scylla/e2e/stage_finalization.py
+++ b/src/scylla/e2e/stage_finalization.py
@@ -132,8 +132,9 @@ def stage_execute_judge(ctx: RunContext) -> None:
         return
 
     from scylla.e2e.judge_runner import _compute_judge_consensus, _save_judge_result
-    from scylla.e2e.llm_judge import JudgeResult, _save_judge_logs
+    from scylla.e2e.llm_judge_models import JudgeResult
     from scylla.e2e.models import JudgeResultSummary
+    from scylla.e2e.pipeline_scripts import _save_judge_logs
     from scylla.e2e.rate_limit import RateLimitError
 
     judge_dir = get_judge_dir(ctx.run_dir)

--- a/src/scylla/e2e/stages.py
+++ b/src/scylla/e2e/stages.py
@@ -98,7 +98,7 @@ if TYPE_CHECKING:
     from scylla.adapters.base import AdapterConfig, AdapterResult
     from scylla.adapters.claude_code import ClaudeCodeAdapter
     from scylla.e2e.checkpoint import E2ECheckpoint
-    from scylla.e2e.llm_judge import BuildPipelineResult
+    from scylla.e2e.llm_judge_models import BuildPipelineResult
     from scylla.e2e.models import JudgeResultSummary
     from scylla.e2e.parallel_executor import RateLimitCoordinator
     from scylla.e2e.resource_manager import ResourceManager
@@ -355,7 +355,7 @@ def stage_capture_baseline(ctx: RunContext) -> None:
         ctx.pipeline_baseline = _load_pipeline_baseline(subtest_dir)
 
     if ctx.pipeline_baseline is None:
-        from scylla.e2e.llm_judge import _run_build_pipeline
+        from scylla.e2e.build_pipeline import _run_build_pipeline
 
         logger.info("Capturing pipeline baseline inline (experiment-level baseline unavailable)")
         _lock = ctx.resource_manager.pipeline_slot() if ctx.resource_manager else _pipeline_lock
@@ -881,7 +881,8 @@ def stage_run_judge_pipeline(ctx: RunContext) -> None:
         # Resumed — judge result already loaded in stage_capture_diff
         return
 
-    from scylla.e2e.llm_judge import _run_build_pipeline, _save_pipeline_commands
+    from scylla.e2e.build_pipeline import _run_build_pipeline
+    from scylla.e2e.pipeline_scripts import _save_pipeline_commands
 
     logger.info(f"Running {ctx.config.language} build pipeline for judge evaluation")
     _lock = ctx.resource_manager.pipeline_slot() if ctx.resource_manager else _pipeline_lock
@@ -895,7 +896,7 @@ def stage_run_judge_pipeline(ctx: RunContext) -> None:
     _save_pipeline_commands(ctx.run_dir, ctx.workspace, language=ctx.config.language)
 
     # Save pipeline outputs
-    from scylla.e2e.llm_judge import _save_pipeline_outputs
+    from scylla.e2e.pipeline_scripts import _save_pipeline_outputs
 
     _save_pipeline_outputs(ctx.run_dir, ctx.judge_pipeline_result, language=ctx.config.language)
 

--- a/src/scylla/e2e/subtest_executor.py
+++ b/src/scylla/e2e/subtest_executor.py
@@ -22,7 +22,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
-    from scylla.e2e.llm_judge import BuildPipelineResult
+    from scylla.e2e.llm_judge_models import BuildPipelineResult
     from scylla.e2e.resource_manager import ResourceManager
 
 from scylla.adapters.claude_code import ClaudeCodeAdapter
@@ -66,50 +66,23 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
-# Re-export functions for backward compatibility
-# These imports ensure existing code like:
-#   from scylla.e2e.subtest_executor import _commit_test_config
-#   from scylla.e2e.subtest_executor import run_tier_subtests_parallel
-# continue to work without modification
 __all__ = [
-    # Parallel executor exports (imported lazily to avoid circular imports)
-    "RateLimitCoordinator",
     "SubTestExecutor",
     "_commit_test_config",
     "_compute_judge_consensus",
     "_create_agent_model_md",
-    "_detect_rate_limit_from_results",  # noqa: F822
     "_has_valid_agent_result",
     "_has_valid_judge_result",
     "_load_agent_result",
     "_load_judge_result",
-    # Workspace setup exports
     "_move_to_failed",
     "_restore_run_context",
     "_run_judge",
-    "_run_subtest",  # noqa: F822
-    # Agent runner exports
     "_save_agent_result",
-    # Judge runner exports
     "_save_judge_result",
     "_setup_workspace",
     "aggregate_run_results",
-    "run_tier_subtests_parallel",  # noqa: F822
 ]
-
-
-def __getattr__(name: str):  # type: ignore[no-untyped-def]
-    """Lazy import for parallel executor functions to avoid circular dependency."""
-    if name in [
-        "RateLimitCoordinator",
-        "run_tier_subtests_parallel",
-        "_detect_rate_limit_from_results",
-        "_run_subtest",
-    ]:
-        from scylla.e2e import parallel_executor
-
-        return getattr(parallel_executor, name)
-    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
 
 def _restore_run_context(ctx: Any, current_state: str) -> None:
@@ -237,7 +210,7 @@ def _load_pipeline_baseline(results_dir: Path) -> BuildPipelineResult | None:
         BuildPipelineResult if file exists, None otherwise
 
     """
-    from scylla.e2e.llm_judge import BuildPipelineResult
+    from scylla.e2e.llm_judge_models import BuildPipelineResult
 
     baseline_path = results_dir / "pipeline_baseline.json"
     if not baseline_path.exists():

--- a/src/scylla/e2e/tier_action_builder.py
+++ b/src/scylla/e2e/tier_action_builder.py
@@ -22,7 +22,7 @@ from scylla.e2e.models import (
     TierState,
     TokenStats,
 )
-from scylla.e2e.subtest_executor import run_tier_subtests_parallel
+from scylla.e2e.parallel_executor import run_tier_subtests_parallel
 
 if TYPE_CHECKING:
     from scylla.e2e.checkpoint import E2ECheckpoint
@@ -142,7 +142,7 @@ class TierActionBuilder:
                 tier_id=tier_id,
                 tier_config=tier_ctx.tier_config,
                 tier_manager=tier_manager,
-                workspace_manager=workspace_manager,
+                workspace_manager=workspace_manager,  # type: ignore[arg-type]  # pre-existing: Optional passed to non-Optional
                 baseline=baseline,
                 results_dir=tier_ctx.tier_dir,
                 checkpoint=checkpoint,

--- a/tests/unit/e2e/test_baseline_regression.py
+++ b/tests/unit/e2e/test_baseline_regression.py
@@ -6,7 +6,7 @@ from pathlib import Path
 
 import pytest
 
-from scylla.e2e.llm_judge import BuildPipelineResult
+from scylla.e2e.llm_judge_models import BuildPipelineResult
 from scylla.e2e.models import E2ERunResult, TokenStats
 from scylla.e2e.subtest_executor import _load_pipeline_baseline, _save_pipeline_baseline
 from scylla.judge.prompts import build_task_prompt

--- a/tests/unit/e2e/test_experiment_setup_manager.py
+++ b/tests/unit/e2e/test_experiment_setup_manager.py
@@ -225,7 +225,7 @@ class TestCaptureBaseline:
         workspace_manager = MagicMock()
 
         with (
-            patch("scylla.e2e.llm_judge._run_build_pipeline") as mock_pipeline,
+            patch("scylla.e2e.build_pipeline._run_build_pipeline") as mock_pipeline,
             patch("scylla.e2e.subtest_executor._save_pipeline_baseline"),
         ):
             mock_result = MagicMock()
@@ -246,7 +246,7 @@ class TestCaptureBaseline:
         workspace_manager = MagicMock()
 
         with (
-            patch("scylla.e2e.llm_judge._run_build_pipeline") as mock_pipeline,
+            patch("scylla.e2e.build_pipeline._run_build_pipeline") as mock_pipeline,
             patch("scylla.e2e.subtest_executor._save_pipeline_baseline"),
         ):
             mock_result = MagicMock()
@@ -266,7 +266,7 @@ class TestCaptureBaseline:
 
         workspace_manager = MagicMock()
 
-        with patch("scylla.e2e.llm_judge._run_build_pipeline") as mock_pipeline:
+        with patch("scylla.e2e.build_pipeline._run_build_pipeline") as mock_pipeline:
             mock_pipeline.side_effect = RuntimeError("build failed")
 
             # Should NOT propagate — baseline capture is non-critical
@@ -284,7 +284,7 @@ class TestCaptureBaseline:
         workspace_manager = MagicMock()
 
         with (
-            patch("scylla.e2e.llm_judge._run_build_pipeline") as mock_pipeline,
+            patch("scylla.e2e.build_pipeline._run_build_pipeline") as mock_pipeline,
             patch("scylla.e2e.subtest_executor._save_pipeline_baseline"),
         ):
             mock_result = MagicMock()

--- a/tests/unit/e2e/test_llm_judge.py
+++ b/tests/unit/e2e/test_llm_judge.py
@@ -12,25 +12,9 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from scylla.e2e.llm_judge import (
-    BuildPipelineResult,
-    JudgeResult,
-    _call_claude_judge,
-    _create_mojo_build_script,
-    _create_mojo_format_script,
-    _create_mojo_scripts,
-    _create_mojo_test_script,
-    _create_precommit_script,
-    _create_python_scripts,
-    _create_run_all_script,
+from scylla.e2e.build_pipeline import (
     _execute_python_scripts,
-    _gather_judge_context,
-    _get_deleted_files,
-    _get_patchfile,
     _get_pipeline_env,
-    _get_workspace_state,
-    _load_reference_patch,
-    _parse_judge_response,
     _run_build_pipeline,
     _run_mojo_build_step,
     _run_mojo_format_step,
@@ -41,10 +25,29 @@ from scylla.e2e.llm_judge import (
     _run_python_format_step,
     _run_python_pipeline,
     _run_python_test_step,
+)
+from scylla.e2e.llm_judge import (
+    _call_claude_judge,
+    _gather_judge_context,
+    _get_deleted_files,
+    _get_patchfile,
+    _get_workspace_state,
+    _load_reference_patch,
+    _parse_judge_response,
+    run_llm_judge,
+)
+from scylla.e2e.llm_judge_models import BuildPipelineResult, JudgeResult
+from scylla.e2e.pipeline_scripts import (
+    _create_mojo_build_script,
+    _create_mojo_format_script,
+    _create_mojo_scripts,
+    _create_mojo_test_script,
+    _create_precommit_script,
+    _create_python_scripts,
+    _create_run_all_script,
     _save_judge_logs,
     _save_pipeline_commands,
     _save_pipeline_outputs,
-    run_llm_judge,
 )
 from scylla.e2e.rate_limit import RateLimitError
 
@@ -1059,7 +1062,7 @@ class TestRunLlmJudge:
         ):
             with patch("scylla.e2e.llm_judge._get_deleted_files", return_value=[]):
                 with patch(
-                    "scylla.e2e.llm_judge._run_build_pipeline",
+                    "scylla.e2e.build_pipeline._run_build_pipeline",
                     return_value=mock_pipeline_result,
                 ):
                     with patch("scylla.e2e.llm_judge._call_claude_judge") as mock_judge:
@@ -1121,7 +1124,7 @@ class TestRunLlmJudge:
             with patch("scylla.e2e.llm_judge._get_patchfile", return_value="(no changes)"):
                 with patch("scylla.e2e.llm_judge._get_deleted_files", return_value=[]):
                     with patch(
-                        "scylla.e2e.llm_judge._run_build_pipeline",
+                        "scylla.e2e.build_pipeline._run_build_pipeline",
                         return_value=mock_pipeline_result,
                     ):
                         with patch("scylla.e2e.llm_judge._call_claude_judge") as mock_judge:

--- a/tests/unit/e2e/test_parallel_rate_limit_handling.py
+++ b/tests/unit/e2e/test_parallel_rate_limit_handling.py
@@ -23,14 +23,12 @@ from scylla.e2e.models import (
     SubTestConfig,
     TierConfig,
 )
+from scylla.e2e.parallel_executor import RateLimitCoordinator
 from scylla.e2e.rate_limit import (
     RateLimitError,
     RateLimitInfo,
     detect_rate_limit,
     wait_for_rate_limit,
-)
-from scylla.e2e.subtest_executor import (
-    RateLimitCoordinator,
 )
 
 
@@ -170,7 +168,7 @@ class TestParallelRateLimitHandling:
             results_dir.mkdir()
 
             # Test the coordinator directly instead of trying to mock the entire parallel execution
-            from scylla.e2e.subtest_executor import RateLimitCoordinator
+            from scylla.e2e.parallel_executor import RateLimitCoordinator
 
             coordinator = RateLimitCoordinator()
 

--- a/tests/unit/e2e/test_rate_limit_recovery.py
+++ b/tests/unit/e2e/test_rate_limit_recovery.py
@@ -6,10 +6,8 @@ import json
 from pathlib import Path
 
 from scylla.e2e.models import SubTestResult, TierID
+from scylla.e2e.parallel_executor import _detect_rate_limit_from_results
 from scylla.e2e.rate_limit import RateLimitInfo
-from scylla.e2e.subtest_executor import (
-    _detect_rate_limit_from_results,
-)
 
 
 class TestDetectRateLimitFromResults:

--- a/tests/unit/e2e/test_stages.py
+++ b/tests/unit/e2e/test_stages.py
@@ -442,7 +442,7 @@ class TestStageCaptureBaseline:
         existing = MagicMock()
         stage_context.pipeline_baseline = existing
 
-        with patch("scylla.e2e.llm_judge._run_build_pipeline") as mock_pipeline:
+        with patch("scylla.e2e.build_pipeline._run_build_pipeline") as mock_pipeline:
             stage_capture_baseline(stage_context)
 
         mock_pipeline.assert_not_called()
@@ -454,7 +454,7 @@ class TestStageCaptureBaseline:
         Checks that if pipeline_baseline.json exists at experiment level, it is loaded
         instead of running the pipeline again.
         """
-        from scylla.e2e.llm_judge import BuildPipelineResult
+        from scylla.e2e.llm_judge_models import BuildPipelineResult
 
         # experiment_dir is the preferred location for the baseline
         assert stage_context.experiment_dir is not None
@@ -472,7 +472,7 @@ class TestStageCaptureBaseline:
             json.dumps(baseline_data.model_dump())
         )
 
-        with patch("scylla.e2e.llm_judge._run_build_pipeline") as mock_pipeline:
+        with patch("scylla.e2e.build_pipeline._run_build_pipeline") as mock_pipeline:
             stage_capture_baseline(stage_context)
 
         mock_pipeline.assert_not_called()
@@ -481,7 +481,7 @@ class TestStageCaptureBaseline:
 
     def test_loads_from_subtest_dir_as_backward_compat(self, stage_context: RunContext) -> None:
         """If no experiment-level baseline but subtest-level exists, loads it (backward compat)."""
-        from scylla.e2e.llm_judge import BuildPipelineResult
+        from scylla.e2e.llm_judge_models import BuildPipelineResult
 
         # Ensure experiment_dir has NO baseline (simulate old checkpoint)
         assert stage_context.experiment_dir is not None
@@ -500,7 +500,7 @@ class TestStageCaptureBaseline:
         )
         (subtest_dir / "pipeline_baseline.json").write_text(json.dumps(baseline_data.model_dump()))
 
-        with patch("scylla.e2e.llm_judge._run_build_pipeline") as mock_pipeline:
+        with patch("scylla.e2e.build_pipeline._run_build_pipeline") as mock_pipeline:
             stage_capture_baseline(stage_context)
 
         mock_pipeline.assert_not_called()
@@ -509,7 +509,7 @@ class TestStageCaptureBaseline:
 
     def test_runs_pipeline_and_saves_if_not_cached(self, stage_context: RunContext) -> None:
         """If no cached baseline anywhere, runs pipeline and saves to subtest dir."""
-        from scylla.e2e.llm_judge import BuildPipelineResult
+        from scylla.e2e.llm_judge_models import BuildPipelineResult
 
         mock_result = BuildPipelineResult(
             language="python",
@@ -525,7 +525,7 @@ class TestStageCaptureBaseline:
         subtest_dir = stage_context.run_dir.parent
         subtest_dir.mkdir(parents=True, exist_ok=True)
 
-        with patch("scylla.e2e.llm_judge._run_build_pipeline", return_value=mock_result):
+        with patch("scylla.e2e.build_pipeline._run_build_pipeline", return_value=mock_result):
             stage_capture_baseline(stage_context)
 
         assert stage_context.pipeline_baseline is mock_result
@@ -714,14 +714,14 @@ class TestStageRunJudgePipeline:
         """If judgment already loaded (resume), pipeline is skipped."""
         stage_context.judgment = {"score": 0.9, "passed": True, "grade": "A", "reasoning": "ok"}
 
-        with patch("scylla.e2e.llm_judge._run_build_pipeline") as mock_pipeline:
+        with patch("scylla.e2e.build_pipeline._run_build_pipeline") as mock_pipeline:
             stage_run_judge_pipeline(stage_context)
 
         mock_pipeline.assert_not_called()
 
     def test_runs_pipeline_and_sets_result(self, stage_context: RunContext) -> None:
         """stage_run_judge_pipeline runs pipeline and stores result."""
-        from scylla.e2e.llm_judge import BuildPipelineResult
+        from scylla.e2e.llm_judge_models import BuildPipelineResult
 
         mock_result = BuildPipelineResult(
             language="python",
@@ -733,9 +733,9 @@ class TestStageRunJudgePipeline:
         )
         stage_context.diff_result = {"workspace_state": "", "patchfile": "", "deleted_files": []}
 
-        with patch("scylla.e2e.llm_judge._run_build_pipeline", return_value=mock_result):
-            with patch("scylla.e2e.llm_judge._save_pipeline_commands"):
-                with patch("scylla.e2e.llm_judge._save_pipeline_outputs"):
+        with patch("scylla.e2e.build_pipeline._run_build_pipeline", return_value=mock_result):
+            with patch("scylla.e2e.pipeline_scripts._save_pipeline_commands"):
+                with patch("scylla.e2e.pipeline_scripts._save_pipeline_outputs"):
                     stage_run_judge_pipeline(stage_context)
 
         assert stage_context.judge_pipeline_result is mock_result
@@ -793,7 +793,7 @@ class TestStageExecuteJudge:
     def test_runs_judge_and_saves_result(self, stage_context: RunContext) -> None:
         """stage_execute_judge calls Claude judge and persists results to disk."""
         from scylla.adapters.base import AdapterResult, AdapterTokenStats
-        from scylla.e2e.llm_judge import JudgeResult
+        from scylla.e2e.llm_judge_models import JudgeResult
 
         stage_context.agent_result = AdapterResult(
             exit_code=0,
@@ -819,7 +819,7 @@ class TestStageExecuteJudge:
             with patch(
                 "scylla.e2e.llm_judge._parse_judge_response", return_value=mock_judge_result
             ):
-                with patch("scylla.e2e.llm_judge._save_judge_logs"):
+                with patch("scylla.e2e.pipeline_scripts._save_judge_logs"):
                     with patch("scylla.e2e.judge_runner._save_judge_result"):
                         stage_execute_judge(stage_context)
 


### PR DESCRIPTION
## Summary

- Remove ~90 lines of backward-compatibility re-export shims from `llm_judge.py` (18 build_pipeline, 3 llm_judge_models, 11 pipeline_scripts re-exports)
- Remove `__getattr__` lazy-import shim and stale `__all__` entries from `subtest_executor.py`
- Redirect all 16 affected call sites (source + tests) to import from canonical modules: `build_pipeline`, `pipeline_scripts`, `llm_judge_models`, `parallel_executor`
- Update mock patch targets in test files to match new import paths

## Test plan

- [x] All 4959 tests pass (0 failures)
- [x] Coverage at 79.91% (above 75% threshold)
- [x] ruff format passes
- [x] ruff check passes
- [x] mypy passes

Closes #1685