### PR TITLE
chore(ci): add unified required-checks workflow

### DIFF
--- a/.github/workflows/_required.yml
+++ b/.github/workflows/_required.yml
@@ -1,0 +1,388 @@
+# Gold-standard reference implementation for the org-wide homeric-main-baseline ruleset.
+# This workflow defines the 9 canonical status-check contexts that the branch protection
+# ruleset requires. All other HomericIntelligence repos should mirror this structure,
+# adapting only the implementation steps to their own tech stack.
+#
+# Job name: strings are the EXACT context strings registered in the ruleset — do not rename.
+name: Required Checks
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+# One run per branch at a time; cancel any in-progress run when a new commit arrives.
+concurrency:
+  group: required-${{ github.head_ref || github.sha }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  # ── 1. lint ────────────────────────────────────────────────────────────────
+  lint:
+    name: lint
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
+        with:
+          fetch-depth: 0
+
+      - name: Set up Pixi
+        uses: ./.github/actions/setup-pixi
+        with:
+          environment: lint
+
+      - name: Cache pre-commit environments
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5
+        with:
+          path: ~/.cache/pre-commit
+          key: pre-commit-${{ runner.os }}-${{ hashFiles('.pre-commit-config.yaml') }}
+          restore-keys: |
+            pre-commit-${{ runner.os }}-
+
+      - name: Run pre-commit (all files)
+        run: |
+          pixi install --environment lint
+          pixi run --environment lint pre-commit run --all-files --show-diff-on-failure
+
+      - name: Enforce complexity limit (C901)
+        run: pixi run --environment lint ruff check --select C901 src/scylla/ scripts/
+
+  # ── 2. unit-tests ──────────────────────────────────────────────────────────
+  unit-tests:
+    name: unit-tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
+
+      - name: Enforce no new deprecated BaseExecutionInfo usage
+        run: |
+          count=$(grep -rn "BaseExecutionInfo" . \
+            --include="*.py" \
+            --exclude-dir=".pixi" \
+            | grep -v "src/scylla/core/results.py" \
+            | grep -v "src/scylla/core/__init__.py" \
+            | grep -v "# deprecated" \
+            | grep -v "(deprecated)" \
+            | grep -v "test_results.py" \
+            | wc -l)
+          echo "BaseExecutionInfo usage count: $count"
+          if [ "$count" -gt "0" ]; then
+            echo "::error::Found $count usages of deprecated BaseExecutionInfo — remove before merging"
+            exit 1
+          fi
+
+      - name: Enforce no new deprecated BaseRunMetrics usage
+        run: |
+          count=$(grep -rn "BaseRunMetrics" . \
+            --include="*.py" \
+            --exclude-dir=".pixi" \
+            | grep -v "src/scylla/core/results.py" \
+            | grep -v "# deprecated" \
+            | grep -v "(deprecated)" \
+            | grep -v "test_results.py" \
+            | wc -l)
+          echo "BaseRunMetrics usage count: $count"
+          if [ "$count" -gt "0" ]; then
+            echo "::error::Found $count usages of deprecated BaseRunMetrics — remove before merging"
+            exit 1
+          fi
+
+      - name: Enforce tier label consistency in metrics-definitions.md
+        run: |
+          BAD_PATS="T3.{0,10}Tool|T4.{0,10}Deleg|T5.{0,10}Hier|T2.{0,10}Skill|T2.{0,10}Deleg|T3.{0,10}Hier|T4.{0,10}Hybrid|T1.{0,10}Tool|T0.{0,10}Skill|T1.{0,10}Prompt|T2.{0,10}Prompt|T3.{0,10}Skill|T4.{0,10}Tool|T5.{0,10}Deleg|T6.{0,10}Hier|T6.{0,10}Hybrid|T0.{0,10}Tool|T0.{0,10}Deleg|T5.{0,10}Skill|T6.{0,10}Deleg"
+          count=$(grep -En "$BAD_PATS" .claude/shared/metrics-definitions.md | wc -l)
+          echo "Bad tier label count: $count"
+          if [ "$count" -gt "0" ]; then
+            echo "::error::Found $count tier label mismatch(es) in metrics-definitions.md"
+            grep -En "$BAD_PATS" .claude/shared/metrics-definitions.md
+            exit 1
+          fi
+
+      - name: Set up Pixi
+        uses: ./.github/actions/setup-pixi
+
+      - name: Check Python version consistency (pyproject.toml vs Dockerfile)
+        run: pixi run python scripts/check_python_version_consistency.py
+
+      - name: Check version consistency (pyproject.toml, pixi.toml, src/scylla/__init__.py)
+        run: pixi run python scripts/check_version_consistency.py
+
+      - name: Validate pixi.lock is up-to-date
+        run: |
+          if ! pixi install --locked 2>/dev/null; then
+            echo "::error::pixi.lock is stale — run 'pixi install' locally and commit pixi.lock"
+            exit 1
+          fi
+
+      - name: Check doc/config consistency
+        run: pixi run python scripts/check_doc_config_consistency.py --verbose
+
+      - name: Check CHANGELOG version entry
+        run: pixi run python scripts/check_changelog_version.py --verbose
+
+      - name: Enforce tests/unit/ structure conventions
+        run: pixi run python scripts/check_unit_test_structure.py
+
+      - name: Validate config schemas
+        run: pixi run python scripts/validate_config_schemas.py config/defaults.yaml config/models/*.yaml tests/fixtures/config/tiers/*.yaml
+
+      - name: Check cyclomatic complexity
+        run: pixi run python scripts/check_max_complexity.py --threshold 10
+
+      - name: Run unit tests
+        run: |
+          pixi run pip install -e .
+          pixi run pytest tests/unit/ --override-ini="addopts=" -v --strict-markers \
+            --cov=src/scylla --cov-report=term-missing --cov-report=xml --cov-fail-under=75 \
+            --junitxml="junit-unit.xml"
+
+      - name: Upload coverage
+        uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2  # v5
+        with:
+          files: ./coverage.xml
+          flags: unit
+          token: ${{ secrets.CODECOV_TOKEN }}
+          fail_ci_if_error: false
+
+      - name: Upload test artifacts on failure
+        if: failure()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7
+        with:
+          name: test-results-unit
+          path: |
+            coverage.xml
+            junit-unit.xml
+          retention-days: 7
+
+  # ── 3. integration-tests ───────────────────────────────────────────────────
+  integration-tests:
+    name: integration-tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
+
+      - name: Install nats-server
+        run: |
+          NATS_VERSION="v2.10.24"
+          NATS_SHA256="ee6500f364e3a741b496ae0296c04f2a9d53bbaabac457104ac74596b4a59d85"
+          curl -fsSL "https://github.com/nats-io/nats-server/releases/download/${NATS_VERSION}/nats-server-${NATS_VERSION}-linux-amd64.tar.gz" -o nats-server.tar.gz
+          echo "${NATS_SHA256}  nats-server.tar.gz" | sha256sum --check
+          tar xz -f nats-server.tar.gz
+          sudo mv nats-server-${NATS_VERSION}-linux-amd64/nats-server /usr/local/bin/
+          rm nats-server.tar.gz
+          nats-server --version
+
+      - name: Set up Pixi
+        uses: ./.github/actions/setup-pixi
+
+      - name: Validate pixi.lock is up-to-date
+        run: |
+          if ! pixi install --locked 2>/dev/null; then
+            echo "::error::pixi.lock is stale — run 'pixi install' locally and commit pixi.lock"
+            exit 1
+          fi
+
+      - name: Run integration tests
+        run: |
+          pixi run pytest tests/integration/ -v \
+            --cov=src/scylla --cov-report=term-missing --cov-report=xml --cov-fail-under=5 \
+            --reruns 2 --reruns-delay 5 \
+            --junitxml="junit-integration.xml"
+
+      - name: Upload test artifacts on failure
+        if: failure()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7
+        with:
+          name: test-results-integration
+          path: |
+            coverage.xml
+            junit-integration.xml
+          retention-days: 7
+
+  # ── 4. security/dependency-scan ────────────────────────────────────────────
+  security/dependency-scan:
+    name: security/dependency-scan
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
+
+      - name: Set up Pixi
+        uses: ./.github/actions/setup-pixi
+        with:
+          environment: lint
+
+      - name: Run pip-audit
+        id: pip-audit
+        run: pixi run --environment lint pip-audit
+
+      - name: Post pip-audit summary
+        if: always()
+        env:
+          AUDIT_OUTCOME: ${{ steps.pip-audit.outcome }}
+        run: |
+          {
+            echo "## pip-audit Security Scan"
+            echo ""
+            if [ "$AUDIT_OUTCOME" = "success" ]; then
+              echo "No HIGH/CRITICAL vulnerabilities found."
+            else
+              echo "Vulnerabilities detected — see job logs for details."
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"
+
+  # ── 5. security/secrets-scan ───────────────────────────────────────────────
+  security/secrets-scan:
+    name: security/secrets-scan
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      # Full history so gitleaks can scan all commits, not just HEAD.
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
+        with:
+          fetch-depth: 0
+
+      - name: Install gitleaks
+        run: |
+          GITLEAKS_VERSION="8.21.2"
+          curl -sSfL "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz" \
+            | tar xz -C /usr/local/bin gitleaks
+
+      - name: Run gitleaks
+        run: gitleaks detect --source . --config .gitleaks.toml --verbose
+
+  # ── 6. build ───────────────────────────────────────────────────────────────
+  build:
+    name: build
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
+
+      - name: Set up Pixi
+        uses: ./.github/actions/setup-pixi
+
+      - name: Validate Dockerfile syntax
+        run: |
+          # Validate all Dockerfiles in the repo using docker build --check (BuildKit dry-run)
+          find . -name "Dockerfile*" \
+            -not -path "./.pixi/*" \
+            -not -path "./docker/*" \
+            | sort | while read -r df; do
+              echo "Checking $df ..."
+              docker build --check -f "$df" . || exit 1
+            done
+          # Also check docker/ subdirectory Dockerfiles independently
+          find ./docker -name "Dockerfile*" 2>/dev/null | sort | while read -r df; do
+            echo "Checking $df ..."
+            docker build --check -f "$df" ./docker || exit 1
+          done
+
+      - name: Build Python package (sdist + wheel)
+        run: |
+          pixi run pip install build
+          pixi run python -m build --no-isolation
+          ls -lh dist/
+
+  # ── 7. typecheck ───────────────────────────────────────────────────────────
+  typecheck:
+    name: typecheck
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
+
+      - name: Set up Pixi
+        uses: ./.github/actions/setup-pixi
+        with:
+          environment: lint
+
+      - name: Run mypy
+        run: pixi run --environment lint mypy scripts/ src/scylla/ tests/
+
+  # ── 8. schema-validation ───────────────────────────────────────────────────
+  schema-validation:
+    name: schema-validation
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
+
+      - name: Set up Pixi
+        uses: ./.github/actions/setup-pixi
+        with:
+          environment: lint
+
+      - name: Validate workflow YAML schemas
+        run: |
+          pixi run --environment lint pip install check-jsonschema
+          find .github/workflows -name "*.yml" | sort | \
+            xargs pixi run --environment lint check-jsonschema \
+              --schemafile https://json.schemastore.org/github-workflow
+
+      - name: Validate JSON schemas in schemas/
+        run: |
+          # Ensure every schema file in schemas/ is valid JSON
+          find schemas/ -name "*.json" 2>/dev/null | sort | while read -r f; do
+            echo "Checking $f ..."
+            python3 -c "import json, sys; json.load(open('$f'))" || exit 1
+          done
+
+  # ── 9. deps/version-sync ───────────────────────────────────────────────────
+  deps/version-sync:
+    name: deps/version-sync
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
+
+      - name: Set up Pixi
+        uses: ./.github/actions/setup-pixi
+
+      - name: Check version consistency (pyproject.toml, pixi.toml, __init__.py)
+        run: pixi run python scripts/check_version_consistency.py
+
+      - name: Cross-check pyproject.toml and pixi.toml versions
+        run: |
+          pixi run python3 - <<'EOF'
+          import tomllib, sys
+
+          with open("pyproject.toml", "rb") as f:
+              pyproject = tomllib.load(f)
+          with open("pixi.toml", "rb") as f:
+              pixi = tomllib.load(f)
+
+          pyproject_ver = pyproject.get("project", {}).get("version") or \
+                          pyproject.get("tool", {}).get("poetry", {}).get("version")
+          pixi_ver = pixi.get("workspace", {}).get("version") or pixi.get("package", {}).get("version")
+
+          print(f"pyproject.toml version : {pyproject_ver}")
+          print(f"pixi.toml version      : {pixi_ver}")
+
+          if pyproject_ver and pixi_ver and pyproject_ver != pixi_ver:
+              print(f"::error::Version mismatch: pyproject.toml={pyproject_ver}, pixi.toml={pixi_ver}")
+              sys.exit(1)
+          print("Versions are consistent.")
+          EOF
+
+      - name: Validate pixi.lock is up-to-date
+        run: |
+          if ! pixi install --locked 2>/dev/null; then
+            echo "::error::pixi.lock is stale — run 'pixi install' locally and commit pixi.lock"
+            exit 1
+          fi


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/_required.yml` with 9 canonical status-check contexts for the org-wide `homeric-main-baseline` ruleset
- ProjectScylla is the gold-standard reference implementation — other repos look to this file when adopting the ruleset
- Uses the existing `.github/actions/setup-pixi` composite action and existing pixi tasks throughout (no new tooling introduced)

## Job coverage table

| # | Job name (context string) | Implementation |
|---|--------------------------|----------------|
| 1 | `lint` | `pixi run --environment lint pre-commit run --all-files` + ruff C901 check |
| 2 | `unit-tests` | `pixi run pytest tests/unit/` with coverage ≥75%, plus all existing gate steps from `test.yml` |
| 3 | `integration-tests` | `pixi run pytest tests/integration/` with nats-server install and `--reruns 2` |
| 4 | `security/dependency-scan` | `pixi run --environment lint pip-audit` (mirrors security.yml pip-audit job) |
| 5 | `security/secrets-scan` | gitleaks v8.21.2 with full history checkout and `.gitleaks.toml` config |
| 6 | `build` | `docker build --check` for all Dockerfiles + `python -m build --no-isolation` |
| 7 | `typecheck` | `pixi run --environment lint mypy scripts/ src/scylla/ tests/` |
| 8 | `schema-validation` | `check-jsonschema` against GitHub workflow schema + JSON schema file validation |
| 9 | `deps/version-sync` | `check_version_consistency.py` + cross-check pyproject.toml vs pixi.toml + lock file freshness |

## Design notes

- **No path filters** — all jobs run on every PR/push to main, fulfilling required-check semantics
- **Concurrency group** uses `required-${{ github.head_ref || github.sha }}` so all 9 jobs share one cancellation slot
- **Pinned action SHAs** match those already in use by the existing workflows

🤖 Generated with Claude Code