### PR TITLE
fix(ci): rename slash job-ids to dashes in _required.yml

### DIFF
--- a/.github/workflows/_required.yml
+++ b/.github/workflows/_required.yml
@@ -209,7 +209,7 @@ jobs:
           retention-days: 7
 
   # ── 4. security/dependency-scan ────────────────────────────────────────────
-  security/dependency-scan:
+  security-dependency-scan:
     name: security/dependency-scan
     runs-on: ubuntu-24.04
     timeout-minutes: 15
@@ -242,7 +242,7 @@ jobs:
           } >> "$GITHUB_STEP_SUMMARY"
 
   # ── 5. security/secrets-scan ───────────────────────────────────────────────
-  security/secrets-scan:
+  security-secrets-scan:
     name: security/secrets-scan
     runs-on: ubuntu-24.04
     timeout-minutes: 10
@@ -346,7 +346,7 @@ jobs:
           done
 
   # ── 8. deps/version-sync ───────────────────────────────────────────────────
-  deps/version-sync:
+  deps-version-sync:
     name: deps/version-sync
     runs-on: ubuntu-24.04
     timeout-minutes: 10


### PR DESCRIPTION
## Summary

- Rename the three workflow job IDs that contained `/` to use `-` instead: `security/dependency-scan` → `security-dependency-scan`, `security/secrets-scan` → `security-secrets-scan`, `deps/version-sync` → `deps-version-sync`
- The `name:` values for each job are **unchanged** — the exact context strings registered in the `homeric-main-baseline` ruleset (`security/dependency-scan`, `security/secrets-scan`, `deps/version-sync`) continue to match

## Root cause

GitHub Actions requires job IDs (YAML map keys) to match `[a-zA-Z0-9_-]+` — slashes are not permitted. The three affected jobs caused the entire workflow to fail at parse time with "This run likely failed because of a workflow file issue," producing 0 check-runs and making every PR to `main` permanently `BLOCKED` by the branch ruleset.

## Test plan

- [ ] Confirm the post-merge run on `main` has non-zero duration and 8 jobs (not 0s/"workflow file issue")
- [ ] Confirm `gh api repos/HomericIntelligence/ProjectScylla/commits/<post-merge-sha>/check-runs --jq '[.check_runs[].name]'` includes all 8 canonical contexts
- [ ] Confirm ruleset still has 8 `required_status_checks` entries (`gh api repos/HomericIntelligence/ProjectScylla/rulesets/15556492 --jq '.rules[] | select(.type=="required_status_checks") | .parameters.required_status_checks | length'` returns `8`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)