### PR TITLE
fix(ci): install hatchling build backend before build step

### DIFF
--- a/.github/workflows/_required.yml
+++ b/.github/workflows/_required.yml
@@ -310,9 +310,15 @@ jobs:
             docker build --check -f "$df" ./docker || exit 1
           done
 
+      - name: Install build backend dependencies
+        run: |
+          # --no-isolation skips the isolated venv, so the build backend must be
+          # present in the active environment.  Install both the 'build' frontend
+          # and hatchling (declared in pyproject.toml [build-system].requires).
+          pixi run pip install build "hatchling>=1.29.0,<2"
+
       - name: Build Python package (sdist + wheel)
         run: |
-          pixi run pip install build
           pixi run python -m build --no-isolation
           ls -lh dist/
 


### PR DESCRIPTION
## Summary

- Fixes pre-existing `build` CI failure: `Backend 'hatchling.build' is not available`
- The `build` job used `python -m build --no-isolation`, which skips the isolated venv and requires the build backend to be present in the active environment
- The previous step only installed the `build` frontend via `pip install build`; `hatchling` (declared in `pyproject.toml` `[build-system].requires`) was never installed
- Split into two steps: one installs both `build` and `hatchling>=1.29.0,<2`, one runs `python -m build --no-isolation`

## Effect

This unblocks all pending Dependabot PRs (#1861, #1900) which are waiting on the required `build` check from the `homeric-main-baseline` ruleset.

## Test plan

- [ ] Confirm `build` job passes on this PR's CI run
- [ ] Confirm Dependabot PRs auto-merge once `build` is green on `main`

🤖 Generated with [Claude Code](https://claude.com/claude-code)