### PR TITLE
fix(build): add sdist include config so py.typed survives sdist→wheel build

### DIFF
--- a/.github/workflows/_required.yml
+++ b/.github/workflows/_required.yml
@@ -310,9 +310,15 @@ jobs:
             docker build --check -f "$df" ./docker || exit 1
           done
 
+      - name: Install build backend dependencies
+        run: |
+          # --no-isolation skips the isolated venv, so the build backend must be
+          # present in the active environment.  Install both the 'build' frontend
+          # and hatchling (declared in pyproject.toml [build-system].requires).
+          pixi run pip install build "hatchling>=1.29.0,<2"
+
       - name: Build Python package (sdist + wheel)
         run: |
-          pixi run pip install build
           pixi run python -m build --no-isolation
           ls -lh dist/
 

--- a/pixi.lock
+++ b/pixi.lock
@@ -5321,7 +5321,7 @@ packages:
 - pypi: ./
   name: scylla
   version: 0.1.0
-  sha256: 3b4b7871d528c1313b2f2f6cd6b6b2d4efde8a0991d7a2c4a82df0a4ecc4ea4f
+  sha256: 252d99d0e8ef4112f5fa337a43ac318da1b97be6692370ffd5a3b6f02ff4aef9
   requires_dist:
   - click>=8.0,<9
   - homericintelligence-hephaestus>=0.7.0,<1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,6 +73,14 @@ packages = ["src/scylla"]
 "src/scylla/analysis/schemas" = "scylla/analysis/schemas"
 "src/scylla/py.typed" = "scylla/py.typed"
 
+[tool.hatch.build.targets.sdist]
+include = [
+  "src/scylla",
+  "tests",
+  "pyproject.toml",
+  "README.md",
+]
+
 [tool.ruff]
 line-length = 100
 target-version = "py310"


### PR DESCRIPTION
## Summary

- Adds `[tool.hatch.build.targets.sdist]` include list to `pyproject.toml`
- Fixes `FileNotFoundError: Forced include not found: .../src/scylla/py.typed` when building wheel from sdist

The root cause: `python -m build --no-isolation` builds an sdist first, then extracts it to a temp dir and builds the wheel from there. The `wheel.force-include` path `src/scylla/py.typed` resolves relative to the original source tree but doesn't exist inside the extracted sdist temp dir. By explicitly including `src/scylla` in the sdist, `py.typed` is present when the wheel is built from the sdist.

Supersedes #1903 and #1902 (which added hatchling to the build env but didn't fix this path resolution issue).

## Test plan

- [ ] `build` job passes in CI
- [ ] `python -m build --no-isolation` succeeds locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>