### PR TITLE
fix(architecture): consolidate duplicate circuit-breaker re-export modules

### DIFF
--- a/src/scylla/automation/circuit_breaker.py
+++ b/src/scylla/automation/circuit_breaker.py
@@ -1,6 +1,20 @@
-"""Circuit breaker for automation layer — re-exports from hephaestus.resilience."""
+"""Circuit breaker for automation layer.
 
-from hephaestus.resilience.circuit_breaker import (
+.. deprecated::
+    Import from ``scylla.core.circuit_breaker`` instead.
+    This module is a compatibility shim and will be removed in a future release.
+"""
+
+import warnings
+
+warnings.warn(
+    "scylla.automation.circuit_breaker is deprecated. "
+    "Import from scylla.core.circuit_breaker instead.",
+    DeprecationWarning,
+    stacklevel=2,
+)
+
+from scylla.core.circuit_breaker import (  # noqa: E402
     CircuitBreaker,
     CircuitBreakerOpenError,
     CircuitBreakerState,

--- a/tests/unit/automation/test_circuit_breaker.py
+++ b/tests/unit/automation/test_circuit_breaker.py
@@ -1,18 +1,42 @@
-"""Smoke test for circuit_breaker re-export shim in automation layer."""
+"""Smoke test for the circuit_breaker deprecation shim in the automation layer.
 
-from scylla.automation.circuit_breaker import (
-    CircuitBreaker,
-    CircuitBreakerOpenError,
-    CircuitBreakerState,
-    get_circuit_breaker,
-    reset_all_circuit_breakers,
-)
+Verifies that the deprecated ``scylla.automation.circuit_breaker`` module still
+re-exports all symbols from the canonical ``scylla.core.circuit_breaker`` module,
+and that it emits a ``DeprecationWarning`` on import.
+"""
+
+import importlib
+import warnings
+
+import scylla.core.circuit_breaker as _core_cb
 
 
-def test_circuit_breaker_imports() -> None:
-    """Verify that circuit breaker symbols are importable from scylla.automation."""
-    assert CircuitBreaker is not None
-    assert CircuitBreakerOpenError is not None
-    assert CircuitBreakerState is not None
-    assert get_circuit_breaker is not None
-    assert reset_all_circuit_breakers is not None
+def test_automation_shim_emits_deprecation_warning() -> None:
+    """Importing from scylla.automation.circuit_breaker raises DeprecationWarning."""
+    # Force a fresh import so the warning fires even if the module is cached.
+    import sys
+
+    sys.modules.pop("scylla.automation.circuit_breaker", None)
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        importlib.import_module("scylla.automation.circuit_breaker")
+
+    deprecation_warnings = [w for w in caught if issubclass(w.category, DeprecationWarning)]
+    assert deprecation_warnings, "Expected a DeprecationWarning from the automation shim"
+    assert "scylla.core.circuit_breaker" in str(deprecation_warnings[0].message)
+
+
+def test_automation_shim_re_exports_canonical_symbols() -> None:
+    """Symbols from the shim are identical to those in scylla.core.circuit_breaker."""
+    import sys
+
+    sys.modules.pop("scylla.automation.circuit_breaker", None)
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", DeprecationWarning)
+        shim = importlib.import_module("scylla.automation.circuit_breaker")
+
+    assert shim.CircuitBreaker is _core_cb.CircuitBreaker
+    assert shim.CircuitBreakerOpenError is _core_cb.CircuitBreakerOpenError
+    assert shim.CircuitBreakerState is _core_cb.CircuitBreakerState
+    assert shim.get_circuit_breaker is _core_cb.get_circuit_breaker
+    assert shim.reset_all_circuit_breakers is _core_cb.reset_all_circuit_breakers


### PR DESCRIPTION
## Summary

- `scylla.automation.circuit_breaker` was a verbatim copy of `scylla.core.circuit_breaker`, both re-exporting the same 5 symbols from `hephaestus.resilience.circuit_breaker`
- Makes `scylla.core.circuit_breaker` the single source of truth
- Converts `scylla.automation.circuit_breaker` into a deprecated compatibility shim that re-exports from `scylla.core` and emits a `DeprecationWarning` at import time
- Updates automation-layer tests to verify the deprecation warning and symbol identity

## Test plan

- [ ] `tests/unit/automation/test_circuit_breaker.py` — verifies deprecation warning is emitted and all 5 symbols are identical to `scylla.core.circuit_breaker`
- [ ] `tests/unit/core/test_circuit_breaker.py` — unchanged, all state/registry/thread-safety tests continue to pass
- [ ] All 21 circuit-breaker tests green locally

Closes #1868

🤖 Generated with [Claude Code](https://claude.com/claude-code)