### PR TITLE
chore(deps-dev): Update pre-commit requirement from >=4.5.1 to >=4.6.0

### DIFF
--- a/pixi.lock
+++ b/pixi.lock
@@ -5321,7 +5321,7 @@ packages:
 - pypi: ./
   name: scylla
   version: 0.1.0
-  sha256: 0b59bb5a3f883fb15d8353021b5300404675993e294d2e658b75e738eac6a48f
+  sha256: 3f36c3f099e3279f45694718e043f8ab78303c4ca497c9570fbabffaa5aaf126
   requires_dist:
   - click>=8.0,<9
   - homericintelligence-hephaestus>=0.7.0,<1
@@ -5331,7 +5331,7 @@ packages:
   - pytest>=9.0.3,<10 ; extra == 'dev'
   - pytest-asyncio>=1.3.0,<2 ; extra == 'dev'
   - pytest-cov>=7.1.0,<8 ; extra == 'dev'
-  - pre-commit>=4.5.1,<5 ; extra == 'dev'
+  - pre-commit>=4.6.0,<5 ; extra == 'dev'
   - ruff>=0.1.0,<1 ; extra == 'dev'
   - defusedxml>=0.7,<1 ; extra == 'dev'
   - nats-py>=2.0,<3 ; extra == 'nats'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ dev = [
     "pytest>=9.0.3,<10",
     "pytest-asyncio>=1.3.0,<2",
     "pytest-cov>=7.1.0,<8",
-    "pre-commit>=4.5.1,<5",
+    "pre-commit>=4.6.0,<5",
     "ruff>=0.1.0,<1",
     "defusedxml>=0.7,<1",
 ]


### PR DESCRIPTION
## Summary

Bumps pre-commit from `>=4.5.1,<5` to `>=4.6.0,<5` to pick up the 4.6.0 release.

- pre-commit 4.6.0 adds `--hook-dir` optional support for git 2.54+ hooks
- Regenerates pixi.lock to match updated constraint
- Replaces closed Dependabot PR #1900 (which had a stale pixi.lock)

## Changes

- `pyproject.toml`: bump pre-commit lower bound to `>=4.6.0`
- `pixi.lock`: regenerated

## Test Plan

- [ ] CI pre-commit check passes
- [ ] CI unit and integration tests pass
- [ ] pixi.lock is accepted by `pixi install --locked`

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>