### PR TITLE
feat(security): add suffix-based fallback to API_KEY_VARS masking

### DIFF
--- a/src/scylla/executor/docker.py
+++ b/src/scylla/executor/docker.py
@@ -129,6 +129,41 @@ class DockerExecutor:
         "AZURE_OPENAI_ENDPOINT",
     )
 
+    # Suffix-based fallback for catching secret-bearing env vars whose names
+    # are not in the explicit ``API_KEY_VARS`` enumeration. This provides
+    # defense-in-depth so a new provider's credential (e.g., ``FOO_API_KEY``,
+    # ``BAR_TOKEN``) is forwarded into containers without code changes.
+    #
+    # The bare ``_KEY`` suffix is intentionally excluded because it has a high
+    # false-positive rate (e.g., ``PUBLIC_KEY_PATH``, ``SSH_KEY_FILE`` would
+    # never end in ``_KEY`` themselves but ``OBJECT_STORE_KEY``/``CACHE_KEY``
+    # might be non-secret). Callers needing those can pass an explicit
+    # ``var_names`` list to :meth:`get_api_keys_from_env`.
+    API_KEY_SUFFIXES: tuple[str, ...] = (
+        "_API_KEY",
+        "_SECRET",
+        "_TOKEN",
+        "_PASSWORD",
+    )
+
+    @classmethod
+    def is_secret_var(cls, name: str) -> bool:
+        """Check whether an env var name looks like it carries a secret.
+
+        Returns ``True`` if ``name`` is in :attr:`API_KEY_VARS` or ends with
+        any suffix in :attr:`API_KEY_SUFFIXES`.
+
+        Args:
+            name: Environment variable name (case-sensitive).
+
+        Returns:
+            True if the name should be treated as secret-bearing.
+
+        """
+        if name in cls.API_KEY_VARS:
+            return True
+        return any(name.endswith(suffix) for suffix in cls.API_KEY_SUFFIXES)
+
     def __init__(self) -> None:
         """Initialize DockerExecutor and verify Docker is available."""
         self._check_docker_available()
@@ -509,14 +544,19 @@ class DockerExecutor:
         for passing to containers via environment variables.
 
         Args:
-            var_names: Variable names to extract. Defaults to API_KEY_VARS.
+            var_names: Variable names to extract. When ``None`` (the default),
+                returns every host env var that satisfies
+                :meth:`is_secret_var` — that is, any name in
+                :attr:`API_KEY_VARS` plus any name ending with one of
+                :attr:`API_KEY_SUFFIXES`. Pass an explicit list to restrict
+                extraction to those names.
 
         Returns:
             Dict of variable names to values (only includes set variables).
 
         """
         if var_names is None:
-            var_names = cls.API_KEY_VARS
+            return {name: value for name, value in os.environ.items() if cls.is_secret_var(name)}
 
         return {name: os.environ[name] for name in var_names if name in os.environ}
 

--- a/tests/unit/executor/test_docker.py
+++ b/tests/unit/executor/test_docker.py
@@ -497,6 +497,65 @@ class TestAPIKeyHandling:
 
             assert keys == {"MY_API_KEY": "my-key", "OTHER_KEY": "other"}
 
+    def test_is_secret_var_explicit_match(self) -> None:
+        """Names in API_KEY_VARS are treated as secrets."""
+        assert DockerExecutor.is_secret_var("ANTHROPIC_API_KEY") is True
+        assert DockerExecutor.is_secret_var("OPENAI_API_KEY") is True
+
+    def test_is_secret_var_suffix_match(self) -> None:
+        """Names ending with an API_KEY_SUFFIXES entry are treated as secrets."""
+        assert DockerExecutor.is_secret_var("FOO_API_KEY") is True
+        assert DockerExecutor.is_secret_var("DATABASE_PASSWORD") is True
+        assert DockerExecutor.is_secret_var("GITHUB_TOKEN") is True
+        assert DockerExecutor.is_secret_var("STRIPE_SECRET") is True
+
+    def test_is_secret_var_negative_cases(self) -> None:
+        """Names without an exact match or qualifying suffix are not secrets."""
+        # Bare ``_KEY`` was deliberately excluded due to false-positive risk.
+        assert DockerExecutor.is_secret_var("PUBLIC_KEY_PATH") is False
+        assert DockerExecutor.is_secret_var("CACHE_KEY") is False
+        # Affixes elsewhere in the name don't count.
+        assert DockerExecutor.is_secret_var("TOKEN_PATH") is False
+        assert DockerExecutor.is_secret_var("PASSWORD_FILE") is False
+        # Empty / unrelated.
+        assert DockerExecutor.is_secret_var("") is False
+        assert DockerExecutor.is_secret_var("HOME") is False
+
+    def test_get_api_keys_from_env_includes_suffix_matches(self) -> None:
+        """Default extraction picks up suffix-matching names not in API_KEY_VARS."""
+        with patch.dict(
+            "os.environ",
+            {
+                "ANTHROPIC_API_KEY": "ant-key",
+                "FOO_API_KEY": "foo-key",
+                "GITHUB_TOKEN": "gh-tok",
+                "DATABASE_PASSWORD": "pw",
+                "STRIPE_SECRET": "ss",
+                "CACHE_KEY": "ck",
+                "HOME": "/home/test",
+            },
+            clear=True,
+        ):
+            keys = DockerExecutor.get_api_keys_from_env()
+
+            assert keys == {
+                "ANTHROPIC_API_KEY": "ant-key",
+                "FOO_API_KEY": "foo-key",
+                "GITHUB_TOKEN": "gh-tok",
+                "DATABASE_PASSWORD": "pw",
+                "STRIPE_SECRET": "ss",
+            }
+
+    def test_get_api_keys_explicit_var_names_unaffected(self) -> None:
+        """Explicit var_names argument is unchanged by suffix logic."""
+        with patch.dict(
+            "os.environ",
+            {"FOO_API_KEY": "foo-key", "OTHER": "other"},
+            clear=True,
+        ):
+            keys = DockerExecutor.get_api_keys_from_env(["OTHER"])
+            assert keys == {"OTHER": "other"}
+
 
 class TestImageOperations:
     """Tests for Docker image operations."""


### PR DESCRIPTION
Adds `API_KEY_SUFFIXES` catch-all (`_API_KEY`, `_SECRET`, `_TOKEN`, `_PASSWORD`) and `DockerExecutor.is_secret_var()` so credentials using non-enumerated naming patterns are forwarded into containers without code changes. Bare `_KEY` excluded due to false-positive risk (CACHE_KEY, OBJECT_STORE_KEY).

5 new unit tests in tests/unit/executor/test_docker.py.

Closes #1879. Refs #1867.