### PR TITLE
feat(safety): add hard-abort + optional flag to log_resource_preflight

### DIFF
--- a/scripts/manage_experiment.py
+++ b/scripts/manage_experiment.py
@@ -282,6 +282,15 @@ def _add_run_args(parser: argparse.ArgumentParser) -> None:
         metavar="N",
         help="Max concurrent claude CLI processes (default: min(threads, cpu_count))",
     )
+    parser.add_argument(
+        "--fail-on-resource-check",
+        action="store_true",
+        default=False,
+        help=(
+            "Abort instead of warn when pre-flight RAM/disk are below the "
+            "warning thresholds. Critical-threshold breaches always abort."
+        ),
+    )
     parser.add_argument("-v", "--verbose", action="store_true", help="Enable verbose logging")
     parser.add_argument("-q", "--quiet", action="store_true", help="Suppress non-error output")
 
@@ -743,6 +752,7 @@ def _run_batch(test_dirs: list[Path], args: argparse.Namespace) -> int:
                 keep_failed_workspaces=args.keep_failed_workspaces,
                 max_concurrent_workspaces=args.max_concurrent_workspaces,
                 max_concurrent_agents=args.max_concurrent_agents,
+                fail_on_resource_check=args.fail_on_resource_check,
             )
 
             # If --from specified, load existing checkpoint and reset states
@@ -1166,6 +1176,7 @@ def cmd_run(args: argparse.Namespace) -> int:  # CLI dispatch with many command 
         keep_failed_workspaces=args.keep_failed_workspaces,
         max_concurrent_workspaces=args.max_concurrent_workspaces,
         max_concurrent_agents=args.max_concurrent_agents,
+        fail_on_resource_check=args.fail_on_resource_check,
     )
 
     # If --from specified, load existing checkpoint and reset states

--- a/src/scylla/e2e/checkpoint.py
+++ b/src/scylla/e2e/checkpoint.py
@@ -609,6 +609,7 @@ def compute_config_hash(config: ExperimentConfig) -> str:
     config_dict.pop("keep_failed_workspaces", None)
     config_dict.pop("max_concurrent_workspaces", None)
     config_dict.pop("max_concurrent_agents", None)
+    config_dict.pop("fail_on_resource_check", None)
 
     # Stable JSON serialization (sorted keys)
     config_json = json.dumps(config_dict, sort_keys=True)

--- a/src/scylla/e2e/health.py
+++ b/src/scylla/e2e/health.py
@@ -284,31 +284,95 @@ def _log_resource_usage() -> None:
         pass
 
 
-def log_resource_preflight() -> None:
+# Warning thresholds (low-resource notice; recoverable):
+WARN_RAM_MB = 4096
+WARN_DISK_GB = 50
+
+# Critical thresholds (hard abort regardless of fail_on_warn flag).
+# Set conservatively so a typical CI runner (16GB RAM / 50+GB disk) never
+# trips them — only genuinely under-provisioned hosts do.
+CRITICAL_RAM_MB = 512
+CRITICAL_DISK_GB = 5
+
+
+class ResourcePreflightError(RuntimeError):
+    """Raised when log_resource_preflight() refuses to proceed.
+
+    Raised in two cases:
+    1. A critical-threshold breach (RAM < CRITICAL_RAM_MB or disk <
+       CRITICAL_DISK_GB) regardless of any flag — the host is so
+       under-provisioned that proceeding will almost certainly corrupt
+       the experiment.
+    2. A warning-threshold breach (RAM < WARN_RAM_MB or disk <
+       WARN_DISK_GB) when the caller passes ``fail_on_warn=True``,
+       typically wired to a ``--fail-on-resource-check`` CLI flag.
+    """
+
+
+def log_resource_preflight(*, fail_on_warn: bool = False) -> None:
     """Log resource availability before an experiment starts.
 
-    Warns if memory < 4GB available or disk < 50GB free.
+    Always raises :class:`ResourcePreflightError` when RAM or disk is
+    below the critical thresholds (:data:`CRITICAL_RAM_MB`,
+    :data:`CRITICAL_DISK_GB`), so a wildly under-provisioned host is
+    caught even if the operator misses log lines.
+
+    Warns when RAM or disk is below the warning thresholds
+    (:data:`WARN_RAM_MB`, :data:`WARN_DISK_GB`). When
+    ``fail_on_warn=True`` (typically wired from a
+    ``--fail-on-resource-check`` CLI flag), warning-level breaches also
+    raise instead of just logging.
+
+    Args:
+        fail_on_warn: When True, warning-level shortages also raise
+            :class:`ResourcePreflightError`. Defaults to False so
+            existing callers see no behaviour change at the warning
+            thresholds.
+
+    Raises:
+        ResourcePreflightError: On a critical-threshold breach, or on a
+            warning-threshold breach when ``fail_on_warn=True``.
+
     """
     import shutil
+
+    breaches: list[str] = []
 
     mem = _get_memory_info()
     if mem:
         avail_mb, total_mb = mem
         logger.info(f"Pre-flight: {avail_mb}MB RAM available / {total_mb}MB total")
-        if avail_mb < 4096:
-            logger.warning(
+        if avail_mb < CRITICAL_RAM_MB:
+            breaches.append(
+                f"CRITICAL: only {avail_mb}MB RAM available (threshold {CRITICAL_RAM_MB}MB)"
+            )
+        elif avail_mb < WARN_RAM_MB:
+            msg = (
                 f"Low memory warning: only {avail_mb}MB available. "
                 f"Consider reducing --threads or --max-concurrent-agents."
             )
+            logger.warning(msg)
+            if fail_on_warn:
+                breaches.append(msg)
 
     try:
         usage = shutil.disk_usage("/")
         free_gb = usage.free / (1024**3)
         logger.info(f"Pre-flight: {free_gb:.1f}GB disk free")
-        if free_gb < 50:
-            logger.warning(
+        if free_gb < CRITICAL_DISK_GB:
+            breaches.append(
+                f"CRITICAL: only {free_gb:.1f}GB disk free (threshold {CRITICAL_DISK_GB}GB)"
+            )
+        elif free_gb < WARN_DISK_GB:
+            msg = (
                 f"Low disk warning: only {free_gb:.1f}GB free. "
                 f"Consider cleaning up old experiment workspaces."
             )
+            logger.warning(msg)
+            if fail_on_warn:
+                breaches.append(msg)
     except OSError:
         pass
+
+    if breaches:
+        raise ResourcePreflightError("; ".join(breaches))

--- a/src/scylla/e2e/models.py
+++ b/src/scylla/e2e/models.py
@@ -795,6 +795,10 @@ class ExperimentConfig(BaseModel):
     max_concurrent_workspaces: int | None = None  # Limit live workspaces (None = auto)
     max_concurrent_agents: int | None = None  # Limit concurrent claude CLI processes (None = auto)
     off_peak: bool = False  # Wait for off-peak hours before each subtest run
+    # Abort instead of warn when log_resource_preflight() finds RAM/disk
+    # below the warning thresholds. Critical-threshold breaches always abort
+    # regardless of this flag. Wired from --fail-on-resource-check.
+    fail_on_resource_check: bool = False
 
     @field_validator("models", mode="before")
     @classmethod
@@ -833,6 +837,7 @@ class ExperimentConfig(BaseModel):
             "max_concurrent_workspaces",
             "max_concurrent_agents",
             "off_peak",
+            "fail_on_resource_check",
         }
         return self.model_dump(mode="json", exclude=_ephemeral)
 

--- a/src/scylla/e2e/runner.py
+++ b/src/scylla/e2e/runner.py
@@ -613,7 +613,7 @@ class E2ERunner:
         from scylla.e2e.health import log_resource_preflight
         from scylla.e2e.resource_manager import ResourceManager
 
-        log_resource_preflight()
+        log_resource_preflight(fail_on_warn=self.config.fail_on_resource_check)
         if self._resource_manager is None:
             self._resource_manager = ResourceManager(
                 max_workspaces=self.config.max_concurrent_workspaces,

--- a/tests/unit/e2e/test_health.py
+++ b/tests/unit/e2e/test_health.py
@@ -19,10 +19,16 @@ import pytest
 
 from scylla.e2e.checkpoint import E2ECheckpoint, load_checkpoint, save_checkpoint
 from scylla.e2e.health import (
+    CRITICAL_DISK_GB,
+    CRITICAL_RAM_MB,
+    WARN_DISK_GB,
+    WARN_RAM_MB,
     HeartbeatThread,
+    ResourcePreflightError,
     _heartbeat_is_stale,
     _pid_is_alive,
     is_zombie,
+    log_resource_preflight,
     reset_zombie_checkpoint,
 )
 
@@ -342,3 +348,111 @@ class TestHeartbeatThread:
         # Verify heartbeat was written to disk
         assert reloaded.last_heartbeat != ""
         assert not _heartbeat_is_stale(reloaded.last_heartbeat, timeout_seconds=30)
+
+
+# ---------------------------------------------------------------------------
+# log_resource_preflight tests
+# ---------------------------------------------------------------------------
+
+
+class TestLogResourcePreflight:
+    """Tests for log_resource_preflight critical/warning thresholds and flag."""
+
+    def test_above_all_thresholds_returns_normally(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Plenty of RAM and disk: returns without raising or warnings."""
+        monkeypatch.setattr(
+            "scylla.e2e.health._get_memory_info",
+            lambda: (WARN_RAM_MB * 4, WARN_RAM_MB * 8),
+        )
+
+        class _Usage:
+            free = (WARN_DISK_GB * 4) * 1024**3
+            total = (WARN_DISK_GB * 8) * 1024**3
+            used = total - free
+
+        import shutil
+
+        monkeypatch.setattr(shutil, "disk_usage", lambda _path: _Usage())
+        log_resource_preflight()  # no raise
+        log_resource_preflight(fail_on_warn=True)  # still no raise
+
+    def test_below_warn_threshold_warns_but_does_not_raise(
+        self, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Below warning threshold: logs WARNING, does not raise (default)."""
+        monkeypatch.setattr(
+            "scylla.e2e.health._get_memory_info",
+            lambda: (WARN_RAM_MB - 1, WARN_RAM_MB * 4),
+        )
+
+        class _Usage:
+            free = (WARN_DISK_GB - 1) * 1024**3
+            total = WARN_DISK_GB * 4 * 1024**3
+            used = total - free
+
+        import shutil
+
+        monkeypatch.setattr(shutil, "disk_usage", lambda _path: _Usage())
+        with caplog.at_level("WARNING", logger="scylla.e2e.health"):
+            log_resource_preflight()
+        warning_messages = [r.message for r in caplog.records if r.levelname == "WARNING"]
+        assert any("Low memory warning" in m for m in warning_messages)
+        assert any("Low disk warning" in m for m in warning_messages)
+
+    def test_below_warn_threshold_raises_when_flag_set(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Below warning threshold + fail_on_warn=True: raises."""
+        monkeypatch.setattr(
+            "scylla.e2e.health._get_memory_info",
+            lambda: (WARN_RAM_MB - 1, WARN_RAM_MB * 4),
+        )
+
+        class _Usage:
+            free = (WARN_DISK_GB - 1) * 1024**3
+            total = WARN_DISK_GB * 4 * 1024**3
+            used = total - free
+
+        import shutil
+
+        monkeypatch.setattr(shutil, "disk_usage", lambda _path: _Usage())
+        with pytest.raises(ResourcePreflightError):
+            log_resource_preflight(fail_on_warn=True)
+
+    def test_below_critical_ram_always_raises(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """RAM below critical threshold: raises regardless of flag."""
+        monkeypatch.setattr(
+            "scylla.e2e.health._get_memory_info",
+            lambda: (CRITICAL_RAM_MB - 1, WARN_RAM_MB * 4),
+        )
+
+        class _Usage:
+            free = WARN_DISK_GB * 4 * 1024**3
+            total = WARN_DISK_GB * 8 * 1024**3
+            used = total - free
+
+        import shutil
+
+        monkeypatch.setattr(shutil, "disk_usage", lambda _path: _Usage())
+        with pytest.raises(ResourcePreflightError, match="CRITICAL"):
+            log_resource_preflight()
+        with pytest.raises(ResourcePreflightError, match="CRITICAL"):
+            log_resource_preflight(fail_on_warn=False)
+
+    def test_below_critical_disk_always_raises(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Disk below critical threshold: raises regardless of flag."""
+        monkeypatch.setattr(
+            "scylla.e2e.health._get_memory_info",
+            lambda: (WARN_RAM_MB * 2, WARN_RAM_MB * 4),
+        )
+
+        class _Usage:
+            free = (CRITICAL_DISK_GB - 1) * 1024**3
+            total = WARN_DISK_GB * 4 * 1024**3
+            used = total - free
+
+        import shutil
+
+        monkeypatch.setattr(shutil, "disk_usage", lambda _path: _Usage())
+        with pytest.raises(ResourcePreflightError, match="CRITICAL"):
+            log_resource_preflight()


### PR DESCRIPTION
Adds critical-threshold abort (RAM <512MB or disk <5GB always raise) and a `--fail-on-resource-check` CLI flag (warning-level shortages also raise when set). Existing callers' default behaviour is unchanged.

Wired through `ExperimentConfig.fail_on_resource_check` (ephemeral, excluded from config-hash and persisted JSON) and `scripts/manage_experiment.py`.

5 new unit tests in tests/unit/e2e/test_health.py.

Closes #1880. Refs #1867.