### PR TITLE
refactor(scripts): move claude-code compose/generate utilities out of tests/

### DIFF
--- a/pixi.lock
+++ b/pixi.lock
@@ -5321,7 +5321,7 @@ packages:
 - pypi: ./
   name: scylla
   version: 0.1.0
-  sha256: 3f36c3f099e3279f45694718e043f8ab78303c4ca497c9570fbabffaa5aaf126
+  sha256: bab2c4d2261dab9e09e91c39bb62684c8381c51a8aa529fc437020ae7c372cd4
   requires_dist:
   - click>=8.0,<9
   - homericintelligence-hephaestus>=0.7.0,<1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -167,6 +167,10 @@ source = ["src/scylla", "scripts"]
 omit = [
     "*/tests/*",
     "*/__init__.py",
+    # claude-code subtier compose/generate utilities are CLI-only generators run
+    # manually via subprocess to produce test inputs; they have no pytest coverage.
+    # Tracked in #1872 (relocated from tests/claude-code/shared/compose/).
+    "scripts/claude_code_compose/*",
 ]
 
 [tool.coverage.report]

--- a/scripts/claude_code_compose/__init__.py
+++ b/scripts/claude_code_compose/__init__.py
@@ -1,0 +1,1 @@
+# Package marker for scripts.claude_code_compose

--- a/scripts/claude_code_compose/compose_agents.py
+++ b/scripts/claude_code_compose/compose_agents.py
@@ -25,8 +25,9 @@ import sys
 from pathlib import Path
 from typing import Any
 
-# Directory containing the organized agents
-AGENTS_DIR = Path(__file__).parent.parent / "agents"
+# Directory containing the organized agents (test inputs live under tests/claude-code/shared/)
+REPO_ROOT = Path(__file__).resolve().parents[2]
+AGENTS_DIR = REPO_ROOT / "tests" / "claude-code" / "shared" / "agents"
 
 # Preset configurations
 PRESETS: dict[str, Any] = {

--- a/scripts/claude_code_compose/compose_claude_md.py
+++ b/scripts/claude_code_compose/compose_claude_md.py
@@ -21,8 +21,9 @@ import sys
 from pathlib import Path
 from typing import Any
 
-# Directory containing the extracted blocks
-BLOCKS_DIR = Path(__file__).parent.parent / "blocks"
+# Directory containing the extracted blocks (test inputs live under tests/claude-code/shared/)
+REPO_ROOT = Path(__file__).resolve().parents[2]
+BLOCKS_DIR = REPO_ROOT / "tests" / "claude-code" / "shared" / "blocks"
 
 # Block metadata
 BLOCKS: dict[str, Any] = {

--- a/scripts/claude_code_compose/compose_skills.py
+++ b/scripts/claude_code_compose/compose_skills.py
@@ -23,8 +23,9 @@ import shutil
 import sys
 from pathlib import Path
 
-# Directory containing the organized skills
-SKILLS_DIR = Path(__file__).parent.parent / "skills"
+# Directory containing the organized skills (test inputs live under tests/claude-code/shared/)
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SKILLS_DIR = REPO_ROOT / "tests" / "claude-code" / "shared" / "skills"
 
 # Available categories
 CATEGORIES = [
@@ -123,7 +124,7 @@ def get_skill_by_name(skill_name: str) -> Path | None:
     return None
 
 
-def compose(  # noqa: C901  # skill composition with many conditional branches
+def compose(  # skill composition with many conditional branches
     categories: list[str] | None,
     skills: list[str] | None,
     output: Path,

--- a/scripts/claude_code_compose/generate_subtiers.py
+++ b/scripts/claude_code_compose/generate_subtiers.py
@@ -31,8 +31,10 @@ import sys
 from pathlib import Path
 from typing import Any
 
-# Base directory for tests
-TESTS_DIR = Path(__file__).parent.parent.parent
+# Base directory for tests; this script lives in scripts/claude_code_compose/, so we walk up to the
+# repo root and into tests/claude-code/ where the generated subtier output trees live.
+REPO_ROOT = Path(__file__).resolve().parents[2]
+TESTS_DIR = REPO_ROOT / "tests" / "claude-code"
 COMPOSE_DIR = Path(__file__).parent
 
 # Models to generate for
@@ -456,7 +458,7 @@ def list_configurations() -> None:
     print(f"Total test cases: {total * len(MODELS)}")
 
 
-def main() -> None:  # noqa: C901  # CLI main with multiple tier generation modes
+def main() -> None:  # CLI main with multiple tier generation modes
     """Generate sub-tier configurations from command line arguments."""
     parser = argparse.ArgumentParser(
         description="Generate sub-tier configurations for testing",


### PR DESCRIPTION
Relocates `compose_agents/compose_claude_md/compose_skills/generate_subtiers` to `scripts/claude_code_compose/` since they generate test inputs and are not pytest test cases. Updates `Path(__file__).parents[N]` indices, coverage omit list, and pixi.lock (SHA bump from rename).

No behaviour change. Both `compose_agents.py --list` and `generate_subtiers.py --list` smoke-tested OK from the new location. pytest collects cleanly.

Closes #1872. Refs #1867.