### PR TITLE
refactor(e2e): break E402 circular-import workarounds in models.py and runner.py

### DIFF
--- a/src/scylla/e2e/models.py
+++ b/src/scylla/e2e/models.py
@@ -21,12 +21,10 @@ from scylla.config.constants import (
     normalize_model_id,
 )
 from scylla.core.results import RunResultBase
+from scylla.e2e.rate_limit import RateLimitInfo
 
 # Grade ordering for min/max calculations (F=worst, S=best)
 GRADE_ORDER: list[str] = ["F", "D", "C", "B", "A", "S"]
-
-# Import after models are defined to avoid circular import at module level
-# This is safe because RateLimitInfo is only used in type hints within SubTestResult
 
 
 class TokenStats(BaseModel):
@@ -921,8 +919,8 @@ class ExperimentResult(BaseModel):
             json.dump(self.to_dict(), f, indent=2)
 
 
-# Resolve forward references after all models are defined
-# Import RateLimitInfo and rebuild SubTestResult to resolve the forward reference
-from scylla.e2e.rate_limit import RateLimitInfo  # noqa: E402
-
+# Resolve forward references after all models are defined. The
+# RateLimitInfo import is at the top of this module since
+# scylla.e2e.rate_limit only imports from stdlib + scylla.e2e.paths
+# (a leaf module), so no cycle exists.
 SubTestResult.model_rebuild()

--- a/src/scylla/e2e/runner.py
+++ b/src/scylla/e2e/runner.py
@@ -47,6 +47,11 @@ from scylla.e2e.models import (
 )
 from scylla.e2e.parallel_tier_runner import ParallelTierRunner
 from scylla.e2e.resume_manager import ResumeManager
+from scylla.e2e.shutdown import (
+    ShutdownInterruptedError,
+    is_shutdown_requested,
+    request_shutdown,
+)
 from scylla.e2e.tier_action_builder import TierActionBuilder
 from scylla.e2e.tier_manager import TierManager
 from scylla.e2e.workspace_manager import WorkspaceManager
@@ -56,14 +61,10 @@ logger = logging.getLogger(__name__)
 # Checkpoint status constant (kept as string for JSON serialization compatibility)
 _STATUS_RUNNING = "running"
 
-# Shutdown coordination — re-exported from shutdown.py for backward compatibility.
-# Callers that only need these symbols should import from scylla.e2e.shutdown directly
-# to avoid the circular import: runner -> ... -> rate_limit -> runner.
-from scylla.e2e.shutdown import (  # noqa: E402
-    ShutdownInterruptedError,
-    is_shutdown_requested,
-    request_shutdown,
-)
+# Shutdown coordination is re-exported from scylla.e2e.shutdown for backward
+# compatibility (see __all__ below). Callers needing only these symbols should
+# import scylla.e2e.shutdown directly. shutdown.py is a leaf module (only
+# stdlib imports) so no cycle is created by the top-level import above.
 
 __all__ = [
     "ShutdownInterruptedError",


### PR DESCRIPTION
Both bottom-of-file E402 suppressions were vestigial — the modules they imported (`scylla.e2e.rate_limit` and `scylla.e2e.shutdown`) are leaf-level imports with no actual cycle to `models.py`/`runner.py`. Moves the imports to each file's top imports block, removes the suppressions, and updates the misleading 'circular import' comments.

Verification: `grep -rn "noqa: E402" src/scylla/e2e/` returns empty. All 1685 tests/unit/e2e tests pass.

Closes #1875. Refs #1867.