### PR TITLE
feat(logging): add opt-in structured JSON logging foundation

### DIFF
--- a/src/scylla/cli/main.py
+++ b/src/scylla/cli/main.py
@@ -23,6 +23,10 @@ from scylla.reporting import (
     TransitionAssessment,
     create_tier_metrics,
 )
+from scylla.utils.json_logging import (
+    configure_json_logging,
+    is_json_logging_enabled,
+)
 
 # Dict-dispatch mapping format names to generator classes.
 # Adding a new format requires only a new entry here
@@ -41,7 +45,10 @@ def cli() -> None:
 
     Evaluate and benchmark AI agent architectures across multiple tiers.
     """
-    pass
+    # Opt-in structured JSON logging via SCYLLA_JSON_LOGS=1.
+    # Default behaviour (text logs) is unchanged.
+    if is_json_logging_enabled():
+        configure_json_logging()
 
 
 @cli.command()

--- a/src/scylla/utils/json_logging.py
+++ b/src/scylla/utils/json_logging.py
@@ -1,0 +1,155 @@
+"""Opt-in structured JSON logging for ProjectScylla.
+
+This module provides a stdlib-only :class:`JsonFormatter` and a
+:func:`configure_json_logging` helper that installs it on the root logger.
+
+Default behaviour of the application is unchanged. To opt in, set the
+environment variable ``SCYLLA_JSON_LOGS=1`` before invoking the CLI, or
+call :func:`configure_json_logging` directly from a programmatic entry
+point.
+
+Example::
+
+    SCYLLA_JSON_LOGS=1 pixi run scylla run-tier T0
+
+Each emitted record is a single JSON object on its own line with the
+fields ``timestamp`` (ISO-8601 UTC), ``level``, ``name``, and
+``message``. Any keyword arguments passed via ``logger.info(..., extra=...)``
+are merged into the object. Exception information, when present, is
+serialised under the ``traceback`` key.
+
+No third-party dependencies are introduced; this is intentional so the
+foundation can be adopted incrementally without touching existing
+``logger.info(...)`` call sites. Distributed tracing (OpenTelemetry,
+Jaeger, etc.) remains out of scope and will be tracked separately.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import sys
+from datetime import datetime, timezone
+from typing import Any, TextIO
+
+__all__ = [
+    "JsonFormatter",
+    "configure_json_logging",
+    "is_json_logging_enabled",
+]
+
+# Standard LogRecord attributes that should NOT be copied into the
+# JSON payload as "extras". See logging.LogRecord docs.
+_RESERVED_LOGRECORD_ATTRS: frozenset[str] = frozenset(
+    {
+        "args",
+        "asctime",
+        "created",
+        "exc_info",
+        "exc_text",
+        "filename",
+        "funcName",
+        "levelname",
+        "levelno",
+        "lineno",
+        "message",
+        "module",
+        "msecs",
+        "msg",
+        "name",
+        "pathname",
+        "process",
+        "processName",
+        "relativeCreated",
+        "stack_info",
+        "taskName",
+        "thread",
+        "threadName",
+    }
+)
+
+_ENV_VAR = "SCYLLA_JSON_LOGS"
+_CONFIGURED_FLAG = "_scylla_json_logging_configured"
+
+
+class JsonFormatter(logging.Formatter):
+    """Format :class:`logging.LogRecord` instances as a single JSON line.
+
+    The formatter is dependency-free and emits a deterministic field
+    ordering: ``timestamp``, ``level``, ``name``, ``message``, then any
+    extras supplied via ``logger.info(..., extra={...})``. When the
+    record carries exception info, a ``traceback`` field is appended.
+    """
+
+    def format(self, record: logging.LogRecord) -> str:
+        """Render *record* as a single-line JSON string."""
+        timestamp = datetime.fromtimestamp(record.created, tz=timezone.utc).isoformat()
+        payload: dict[str, Any] = {
+            "timestamp": timestamp,
+            "level": record.levelname,
+            "name": record.name,
+            "message": record.getMessage(),
+        }
+
+        # Merge user-provided extras (anything not in the reserved set).
+        for key, value in record.__dict__.items():
+            if key in _RESERVED_LOGRECORD_ATTRS or key.startswith("_"):
+                continue
+            payload[key] = value
+
+        if record.exc_info:
+            payload["traceback"] = self.formatException(record.exc_info)
+        elif record.exc_text:
+            payload["traceback"] = record.exc_text
+
+        return json.dumps(payload, default=str)
+
+
+def configure_json_logging(
+    level: str = "INFO",
+    *,
+    stream: TextIO | None = None,
+) -> None:
+    """Install :class:`JsonFormatter` on the root logger.
+
+    Idempotent: calling this multiple times will replace the formatter
+    on the existing handler rather than stacking new handlers.
+
+    Args:
+        level: Logging level name (e.g. ``"INFO"``, ``"DEBUG"``).
+        stream: Optional output stream; defaults to ``sys.stderr`` to
+            match Python's stdlib :func:`logging.basicConfig` behaviour.
+
+    """
+    root = logging.getLogger()
+    target_stream: TextIO = stream if stream is not None else sys.stderr
+    formatter = JsonFormatter()
+    numeric_level = logging.getLevelName(level.upper())
+    if not isinstance(numeric_level, int):
+        numeric_level = logging.INFO
+
+    # Look for an existing handler we previously installed so this stays
+    # idempotent across repeated calls (e.g. from CLI re-entry in tests).
+    json_handler: logging.Handler | None = None
+    for handler in root.handlers:
+        if getattr(handler, _CONFIGURED_FLAG, False):
+            json_handler = handler
+            break
+
+    if json_handler is None:
+        json_handler = logging.StreamHandler(target_stream)
+        setattr(json_handler, _CONFIGURED_FLAG, True)
+        root.addHandler(json_handler)
+    else:
+        json_handler.setStream(target_stream)  # type: ignore[attr-defined]
+
+    json_handler.setFormatter(formatter)
+    json_handler.setLevel(numeric_level)
+    root.setLevel(numeric_level)
+
+
+def is_json_logging_enabled() -> bool:
+    """Return ``True`` if ``SCYLLA_JSON_LOGS`` is set to a truthy value."""
+    raw = os.environ.get(_ENV_VAR, "")
+    return raw.strip().lower() in {"1", "true", "yes", "on"}

--- a/tests/unit/utils/test_json_logging.py
+++ b/tests/unit/utils/test_json_logging.py
@@ -1,0 +1,161 @@
+"""Unit tests for :mod:`scylla.utils.json_logging`."""
+
+from __future__ import annotations
+
+import io
+import json
+import logging
+import sys
+from collections.abc import Iterator
+from typing import Any
+
+import pytest
+
+from scylla.utils.json_logging import (
+    JsonFormatter,
+    configure_json_logging,
+    is_json_logging_enabled,
+)
+
+
+@pytest.fixture
+def reset_root_logger() -> Iterator[None]:
+    """Snapshot and restore root logger state around each test."""
+    root = logging.getLogger()
+    original_handlers = list(root.handlers)
+    original_level = root.level
+    # Detach existing handlers so configure_json_logging starts clean.
+    for handler in original_handlers:
+        root.removeHandler(handler)
+    try:
+        yield
+    finally:
+        for handler in list(root.handlers):
+            root.removeHandler(handler)
+        for handler in original_handlers:
+            root.addHandler(handler)
+        root.setLevel(original_level)
+
+
+def _make_record(
+    *,
+    name: str = "scylla.test",
+    level: int = logging.INFO,
+    msg: str = "hello",
+    extra: dict[str, Any] | None = None,
+    exc_info: tuple[Any, ...] | None = None,
+) -> logging.LogRecord:
+    """Build a LogRecord for formatter testing."""
+    record = logging.LogRecord(
+        name=name,
+        level=level,
+        pathname=__file__,
+        lineno=10,
+        msg=msg,
+        args=None,
+        exc_info=exc_info,
+    )
+    if extra:
+        for key, value in extra.items():
+            setattr(record, key, value)
+    return record
+
+
+def test_formatter_emits_required_fields() -> None:
+    """Formatter must emit timestamp/level/name/message in valid JSON."""
+    formatter = JsonFormatter()
+    record = _make_record(msg="hi there")
+
+    payload = json.loads(formatter.format(record))
+
+    assert payload["level"] == "INFO"
+    assert payload["name"] == "scylla.test"
+    assert payload["message"] == "hi there"
+    assert "timestamp" in payload
+    # Timestamp must be parseable and tz-aware.
+    assert payload["timestamp"].endswith("+00:00")
+
+
+def test_formatter_includes_extras() -> None:
+    """Extras passed via record attributes must appear in the JSON payload."""
+    formatter = JsonFormatter()
+    record = _make_record(extra={"tier": "T2", "subtest_id": "abc-123"})
+
+    payload = json.loads(formatter.format(record))
+
+    assert payload["tier"] == "T2"
+    assert payload["subtest_id"] == "abc-123"
+
+
+def test_formatter_includes_traceback_on_exception() -> None:
+    """When exc_info is set, formatted output must include a traceback field."""
+    formatter = JsonFormatter()
+    try:
+        raise ValueError("boom")
+    except ValueError:
+        record = _make_record(level=logging.ERROR, exc_info=sys.exc_info())
+
+    payload = json.loads(formatter.format(record))
+
+    assert "traceback" in payload
+    assert "ValueError" in payload["traceback"]
+    assert "boom" in payload["traceback"]
+
+
+def test_configure_json_logging_is_idempotent(reset_root_logger: None) -> None:
+    """Repeated configure calls must not stack handlers."""
+    stream = io.StringIO()
+    configure_json_logging(stream=stream)
+    configure_json_logging(stream=stream)
+    configure_json_logging(stream=stream)
+
+    root = logging.getLogger()
+    json_handlers = [
+        h for h in root.handlers if getattr(h, "_scylla_json_logging_configured", False)
+    ]
+    assert len(json_handlers) == 1
+    assert isinstance(json_handlers[0].formatter, JsonFormatter)
+
+
+def test_configure_json_logging_emits_json(reset_root_logger: None) -> None:
+    """End-to-end: configure then log produces a JSON line on the stream."""
+    stream = io.StringIO()
+    configure_json_logging(level="DEBUG", stream=stream)
+
+    logger = logging.getLogger("scylla.cfg.test")
+    logger.info("structured", extra={"run_id": "r1"})
+
+    output = stream.getvalue().strip()
+    assert output, "expected JSON line on stream"
+    payload = json.loads(output.splitlines()[-1])
+    assert payload["message"] == "structured"
+    assert payload["run_id"] == "r1"
+    assert payload["level"] == "INFO"
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        ("1", True),
+        ("true", True),
+        ("TRUE", True),
+        ("yes", True),
+        ("on", True),
+        ("0", False),
+        ("false", False),
+        ("", False),
+        ("nope", False),
+    ],
+)
+def test_is_json_logging_enabled(
+    value: str, expected: bool, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """SCYLLA_JSON_LOGS env var must be parsed for common truthy/falsy spellings."""
+    monkeypatch.setenv("SCYLLA_JSON_LOGS", value)
+    assert is_json_logging_enabled() is expected
+
+
+def test_is_json_logging_enabled_unset(monkeypatch: pytest.MonkeyPatch) -> None:
+    """When SCYLLA_JSON_LOGS is unset, JSON logging must be disabled."""
+    monkeypatch.delenv("SCYLLA_JSON_LOGS", raising=False)
+    assert is_json_logging_enabled() is False


### PR DESCRIPTION
Adds an opt-in JsonFormatter and configure_json_logging() helper. Activated via SCYLLA_JSON_LOGS=1 env var. Default behaviour unchanged. Distributed tracing remains out of scope (separate follow-up). Partial fix for #1887; refs #1867.