### PR TITLE
feat(metrics): add MetricEmitter scaffold with Prometheus textfile backend

### DIFF
--- a/docs/dev/metrics-emitter.md
+++ b/docs/dev/metrics-emitter.md
@@ -1,0 +1,89 @@
+# Metric Emitter Scaffold
+
+This document describes the `scylla.metrics.emitter` module, a thin
+abstraction that lets an operator forward ProjectScylla experiment metrics
+(pass rates, Cost-of-Pass, latency, etc.) into a queryable time-series
+database (TSDB) such as Prometheus or VictoriaMetrics.
+
+> **Status: opt-in scaffolding.** No existing metric-computation site is
+> wired to an emitter yet. Wiring is tracked as a follow-up under issue
+> [#1888](https://github.com/HomericIntelligence/ProjectScylla/issues/1888).
+
+## API
+
+```python
+from scylla.metrics.emitter import get_default_emitter
+
+emitter = get_default_emitter()
+emitter.emit_counter("scylla_runs_total", 1, labels={"tier": "T2"})
+emitter.emit_gauge("scylla_pass_rate", 0.67, labels={"tier": "T2"})
+```
+
+- `MetricEmitter` — abstract base class with `emit_counter` and
+  `emit_gauge`. (Histograms are intentionally out of scope for v1.)
+- `NoOpEmitter` — drops every sample. **Default**.
+- `PrometheusTextfileEmitter(path)` — writes Prometheus textfile-collector
+  format to `path` using an atomic `write tmp + os.replace` cycle.
+- `get_default_emitter()` — returns a `PrometheusTextfileEmitter` if the
+  environment variable `SCYLLA_METRICS_PATH` is set, otherwise a
+  `NoOpEmitter`.
+
+## Output format
+
+Each emit appends one line to the destination file:
+
+```text
+scylla_runs_total{tier="T2"} 1.0
+scylla_pass_rate{model="haiku",tier="T2"} 0.67
+```
+
+Labels are sorted by key for deterministic diffs. Values are escaped per
+the [Prometheus exposition format](https://prometheus.io/docs/instrumenting/exposition_formats/)
+(`\\`, `\"`, `\n`).
+
+## Why textfile, not push-gateway or in-process `/metrics`?
+
+ProjectScylla experiments are short-lived batch jobs, not long-running
+servers, so the typical "expose `/metrics` and let Prometheus scrape it"
+pattern does not fit:
+
+| Backend | Why not |
+|---|---|
+| In-process HTTP `/metrics` | Process exits before scrape interval; samples lost. |
+| Push-gateway | Requires deploying and operating an extra service; samples accumulate forever unless explicitly deleted; not recommended by Prometheus for batch jobs of unknown duration. |
+| **Textfile collector** | Process writes a flat file; node-exporter (already deployed on most hosts) reads it on every scrape. Survives process exit. No new service to run. |
+
+VictoriaMetrics' `vmagent` and Grafana Alloy both natively ingest the
+same textfile format, so this choice is not Prometheus-specific.
+
+## Operator wiring
+
+1. Deploy `node_exporter` with `--collector.textfile.directory=/var/lib/node_exporter/textfiles`
+   (most distros already do this).
+2. Set `SCYLLA_METRICS_PATH` for the experiment process:
+
+   ```bash
+   export SCYLLA_METRICS_PATH=/var/lib/node_exporter/textfiles/scylla.prom
+   pixi run scylla run ...
+   ```
+
+3. Confirm samples appear in Prometheus / VictoriaMetrics under metric
+   names prefixed with `scylla_`.
+
+## Atomicity guarantee
+
+`PrometheusTextfileEmitter` writes to a sibling `*.tmp` file in the same
+directory and then calls `os.replace`, which is a kernel-atomic rename on
+both POSIX and Windows when source and destination share a filesystem.
+The textfile collector therefore sees either the previous full snapshot
+or the new full snapshot — never a partially written line.
+
+## What this PR does **not** do
+
+- Does **not** add any new runtime dependency (no `prometheus_client`,
+  no `statsd`).
+- Does **not** modify any existing metric-computation site. Wiring
+  `emit_counter` / `emit_gauge` calls into the experiment runner,
+  judge, or aggregator is out of scope; see the #1888 follow-up.
+- Does **not** prescribe a TSDB topology. Choosing Prometheus vs.
+  VictoriaMetrics vs. another backend is an operator decision.

--- a/src/scylla/metrics/emitter.py
+++ b/src/scylla/metrics/emitter.py
@@ -1,0 +1,165 @@
+"""Metric emitter abstraction for time-series database integration.
+
+Provides a pluggable :class:`MetricEmitter` interface so operators can wire
+ProjectScylla metrics (pass rates, CoP, latency) to a TSDB without touching
+the metric-computation call sites.
+
+The default :func:`get_default_emitter` returns a :class:`NoOpEmitter` unless
+``SCYLLA_METRICS_PATH`` is set, in which case a
+:class:`PrometheusTextfileEmitter` is returned. This module deliberately
+introduces no new runtime dependencies — the textfile output is plain text
+that the Prometheus node-exporter ``textfile`` collector (or VictoriaMetrics
+``vmagent``) ingests natively.
+
+This is opt-in scaffolding only; no existing metrics call site is wired to an
+emitter yet. See ``docs/dev/metrics-emitter.md`` for the integration plan.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import os
+import tempfile
+from abc import ABC, abstractmethod
+from pathlib import Path
+from threading import Lock
+
+__all__ = [
+    "MetricEmitter",
+    "NoOpEmitter",
+    "PrometheusTextfileEmitter",
+    "get_default_emitter",
+]
+
+
+def _format_labels(labels: dict[str, str] | None) -> str:
+    """Render labels as Prometheus-style ``{k="v",k2="v2"}`` (empty if none)."""
+    if not labels:
+        return ""
+    # Escape backslash, double-quote, and newline per Prometheus exposition format.
+    parts = []
+    for key in sorted(labels):
+        value = labels[key].replace("\\", "\\\\").replace('"', '\\"').replace("\n", "\\n")
+        parts.append(f'{key}="{value}"')
+    return "{" + ",".join(parts) + "}"
+
+
+class MetricEmitter(ABC):
+    """Abstract base class for metric emitters."""
+
+    @abstractmethod
+    def emit_counter(
+        self,
+        name: str,
+        value: int,
+        labels: dict[str, str] | None = None,
+    ) -> None:
+        """Emit a monotonic counter sample."""
+
+    @abstractmethod
+    def emit_gauge(
+        self,
+        name: str,
+        value: float,
+        labels: dict[str, str] | None = None,
+    ) -> None:
+        """Emit a gauge sample."""
+
+
+class NoOpEmitter(MetricEmitter):
+    """Default emitter that drops every sample."""
+
+    def emit_counter(
+        self,
+        name: str,
+        value: int,
+        labels: dict[str, str] | None = None,
+    ) -> None:
+        """Drop the sample (no-op)."""
+        return
+
+    def emit_gauge(
+        self,
+        name: str,
+        value: float,
+        labels: dict[str, str] | None = None,
+    ) -> None:
+        """Drop the sample (no-op)."""
+        return
+
+
+class PrometheusTextfileEmitter(MetricEmitter):
+    """Emit samples in Prometheus textfile-collector format.
+
+    Each call appends one line to an in-memory buffer and atomically rewrites
+    the target file (``write tmp + os.replace``) so a concurrent reader (the
+    node-exporter textfile collector) never observes a partial line.
+    """
+
+    def __init__(self, path: str | os.PathLike[str]) -> None:
+        """Create an emitter that writes to ``path`` (parent dirs auto-created)."""
+        self._path = Path(path)
+        self._lines: list[str] = []
+        self._lock = Lock()
+        # Ensure parent dir exists so the first emit doesn't crash.
+        self._path.parent.mkdir(parents=True, exist_ok=True)
+
+    def emit_counter(
+        self,
+        name: str,
+        value: int,
+        labels: dict[str, str] | None = None,
+    ) -> None:
+        """Append a counter sample line and atomically rewrite the file."""
+        self._append(name, float(value), labels)
+
+    def emit_gauge(
+        self,
+        name: str,
+        value: float,
+        labels: dict[str, str] | None = None,
+    ) -> None:
+        """Append a gauge sample line and atomically rewrite the file."""
+        self._append(name, float(value), labels)
+
+    def _append(
+        self,
+        name: str,
+        value: float,
+        labels: dict[str, str] | None,
+    ) -> None:
+        line = f"{name}{_format_labels(labels)} {value}"
+        with self._lock:
+            self._lines.append(line)
+            self._atomic_write()
+
+    def _atomic_write(self) -> None:
+        # Write to a sibling tmp file then os.replace — guaranteed atomic on
+        # POSIX and Windows for files on the same filesystem.
+        body = "\n".join(self._lines) + "\n"
+        fd, tmp_path = tempfile.mkstemp(
+            prefix=self._path.name + ".",
+            suffix=".tmp",
+            dir=str(self._path.parent),
+        )
+        try:
+            with os.fdopen(fd, "w") as fh:
+                fh.write(body)
+            os.replace(tmp_path, self._path)
+        except Exception:
+            # Best-effort cleanup of the tmp file on failure.
+            with contextlib.suppress(OSError):
+                os.unlink(tmp_path)
+            raise
+
+
+def get_default_emitter() -> MetricEmitter:
+    """Build the default emitter from environment.
+
+    Returns a :class:`PrometheusTextfileEmitter` if ``SCYLLA_METRICS_PATH``
+    is set, otherwise a :class:`NoOpEmitter`.
+    """
+    path = os.environ.get("SCYLLA_METRICS_PATH")
+    if path:
+        return PrometheusTextfileEmitter(path)
+    return NoOpEmitter()

--- a/tests/unit/metrics/test_emitter.py
+++ b/tests/unit/metrics/test_emitter.py
@@ -1,0 +1,171 @@
+"""Unit tests for :mod:`scylla.metrics.emitter`."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from unittest import mock
+
+import pytest
+
+from scylla.metrics.emitter import (
+    MetricEmitter,
+    NoOpEmitter,
+    PrometheusTextfileEmitter,
+    get_default_emitter,
+)
+
+
+def test_noop_emitter_is_silent(tmp_path: Path) -> None:
+    """NoOpEmitter calls return without raising and write nothing to disk."""
+    emitter = NoOpEmitter()
+    # Calls execute and produce no side effects.
+    emitter.emit_counter("foo", 1)
+    emitter.emit_gauge("bar", 2.5, labels={"k": "v"})
+    # Nothing was written to disk.
+    assert list(tmp_path.iterdir()) == []
+
+
+def test_prometheus_textfile_emitter_writes_counter_line(tmp_path: Path) -> None:
+    """A counter emit produces one Prometheus-format line."""
+    out = tmp_path / "scylla.prom"
+    emitter = PrometheusTextfileEmitter(out)
+    emitter.emit_counter("scylla_runs_total", 7)
+
+    content = out.read_text()
+    assert content == "scylla_runs_total 7.0\n"
+
+
+def test_prometheus_textfile_emitter_writes_gauge_line(tmp_path: Path) -> None:
+    """A gauge emit produces one Prometheus-format line."""
+    out = tmp_path / "scylla.prom"
+    emitter = PrometheusTextfileEmitter(out)
+    emitter.emit_gauge("scylla_pass_rate", 0.42)
+
+    content = out.read_text()
+    assert content == "scylla_pass_rate 0.42\n"
+
+
+def test_prometheus_textfile_emitter_appends_subsequent_emits(
+    tmp_path: Path,
+) -> None:
+    """Successive emits append lines to the destination file."""
+    out = tmp_path / "scylla.prom"
+    emitter = PrometheusTextfileEmitter(out)
+    emitter.emit_counter("a", 1)
+    emitter.emit_gauge("b", 2.0)
+
+    lines = out.read_text().splitlines()
+    assert lines == ["a 1.0", "b 2.0"]
+
+
+def test_prometheus_textfile_emitter_renders_labels(tmp_path: Path) -> None:
+    """Labels render as ``{key="value",...}`` sorted by key."""
+    out = tmp_path / "scylla.prom"
+    emitter = PrometheusTextfileEmitter(out)
+    emitter.emit_gauge(
+        "scylla_cop_dollars",
+        1.23,
+        labels={"tier": "T2", "model": "haiku"},
+    )
+
+    content = out.read_text()
+    # Labels render sorted by key.
+    assert content == 'scylla_cop_dollars{model="haiku",tier="T2"} 1.23\n'
+
+
+def test_prometheus_textfile_emitter_escapes_label_values(tmp_path: Path) -> None:
+    """Backslash, double-quote, and newline are escaped in label values."""
+    out = tmp_path / "scylla.prom"
+    emitter = PrometheusTextfileEmitter(out)
+    emitter.emit_counter(
+        "x",
+        1,
+        labels={"path": 'a"b\\c\nd'},
+    )
+
+    content = out.read_text()
+    assert content == 'x{path="a\\"b\\\\c\\nd"} 1.0\n'
+
+
+def test_prometheus_textfile_emitter_creates_parent_dir(tmp_path: Path) -> None:
+    """Missing parent directories are created on construction."""
+    out = tmp_path / "nested" / "dir" / "scylla.prom"
+    emitter = PrometheusTextfileEmitter(out)
+    emitter.emit_counter("c", 1)
+
+    assert out.exists()
+
+
+def test_prometheus_textfile_emitter_atomic_write_uses_replace(
+    tmp_path: Path,
+) -> None:
+    """The emitter uses os.replace (atomic rename) on the same directory."""
+    out = tmp_path / "scylla.prom"
+    emitter = PrometheusTextfileEmitter(out)
+
+    # os.replace is the kernel-atomic rename; if the implementation uses a
+    # plain open(...,"w") instead, this assertion catches that regression.
+    with mock.patch(
+        "scylla.metrics.emitter.os.replace",
+        wraps=os.replace,
+    ) as replace:
+        emitter.emit_counter("c", 1)
+        assert replace.call_count == 1
+        # Source file must be in the same directory as the destination
+        # (rename across filesystems is not atomic).
+        src = Path(replace.call_args.args[0])
+        dst = Path(replace.call_args.args[1])
+        assert src.parent == dst.parent == out.parent
+
+    # No leftover .tmp files.
+    leftovers = [p for p in out.parent.iterdir() if p.name != out.name]
+    assert leftovers == []
+
+
+def test_prometheus_textfile_emitter_never_partial_on_concurrent_read(
+    tmp_path: Path,
+) -> None:
+    """The destination file is always a complete snapshot between emits."""
+    out = tmp_path / "scylla.prom"
+    emitter = PrometheusTextfileEmitter(out)
+    for i in range(20):
+        emitter.emit_counter("c", i)
+        # Every read between emits is well-formed (ends with newline,
+        # no trailing partial line).
+        text = out.read_text()
+        assert text.endswith("\n")
+        for line in text.splitlines():
+            # Each line is "<name>[{labels}] <value>" — i.e. exactly
+            # one space between metric and value.
+            assert " " in line
+            head, _, tail = line.rpartition(" ")
+            assert head and tail
+
+
+def test_get_default_emitter_returns_noop_without_env(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Without SCYLLA_METRICS_PATH, the default emitter is NoOpEmitter."""
+    monkeypatch.delenv("SCYLLA_METRICS_PATH", raising=False)
+    assert isinstance(get_default_emitter(), NoOpEmitter)
+
+
+def test_get_default_emitter_returns_textfile_with_env(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """With SCYLLA_METRICS_PATH set, the default emitter writes to that path."""
+    target = tmp_path / "scylla.prom"
+    monkeypatch.setenv("SCYLLA_METRICS_PATH", str(target))
+    emitter = get_default_emitter()
+    assert isinstance(emitter, PrometheusTextfileEmitter)
+    # Confirm the configured emitter writes to the requested path.
+    emitter.emit_counter("ok", 1)
+    assert target.exists()
+
+
+def test_metric_emitter_is_abstract() -> None:
+    """MetricEmitter cannot be instantiated directly."""
+    with pytest.raises(TypeError):
+        MetricEmitter()  # type: ignore[abstract]


### PR DESCRIPTION
Adds a `MetricEmitter` abstract base, `NoOpEmitter` (default), and `PrometheusTextfileEmitter` (opt-in via `SCYLLA_METRICS_PATH`). No new runtime deps. No existing call site is wired to the emitter — that's a separate follow-up.

## What's in
- `src/scylla/metrics/emitter.py` — `MetricEmitter` ABC with `emit_counter` / `emit_gauge`, `NoOpEmitter`, `PrometheusTextfileEmitter` (atomic `write tmp + os.replace`), and `get_default_emitter()` env switch
- `tests/unit/metrics/test_emitter.py` — 12 tests: silence, counter/gauge formatting, label rendering + escaping, parent-dir creation, `os.replace` atomicity, never-partial-on-concurrent-read, env-var routing, ABC enforcement
- `docs/dev/metrics-emitter.md` — textfile-collector format, why textfile (not push-gateway / not in-process `/metrics`), operator wiring for Prometheus or VictoriaMetrics, atomicity guarantee, explicit "no automatic emission yet" callout

## Out of scope (follow-up)
Wiring `emit_counter` / `emit_gauge` calls into the experiment runner, judge, and aggregator. Tracked as a follow-up under #1888.

## Verification
- `pixi run pytest tests/unit/metrics/test_emitter.py -q --no-cov` -> 12 passed
- `pixi run mypy src/scylla/metrics/emitter.py` -> Success: no issues found
- `SKIP=audit-doc-policy pre-commit run --all-files` -> all hooks pass

Partial fix for #1888; refs #1867.