### PR TITLE
docs(adr): add ADRs for 5 major design decisions

### DIFF
--- a/docs/dev/adr/README.md
+++ b/docs/dev/adr/README.md
@@ -1,0 +1,32 @@
+# Architectural Decision Records
+
+This directory holds the ProjectScylla ADRs — short, dated records
+documenting non-trivial architecture and design decisions. Each ADR
+follows the standard `Status / Context / Decision / Consequences /
+References` shape and cites real file paths and line numbers as
+evidence.
+
+## Index
+
+| ADR | Status | Date | Topic |
+|-----|--------|------|-------|
+| [Docker Integration Testing Deferred](docker-testing-deferred.md) | Accepted | 2026-02-27 | Why `tests/docker/` does not exist and the CI workflow validates only Dockerfile/compose syntax. |
+| [Ecosystem Role Reconciliation](ecosystem-role-reconciliation.md) | Accepted | 2026-03-25 | ProjectScylla's role is ablation benchmarking, not chaos testing. |
+| [Four-Level State Machine Hierarchy](state-machine-hierarchy.md) | Accepted | 2026-05-06 | Experiment / Tier / Subtest / Run state machines with checkpoint persistence. |
+| [`to_dict()` Serialization Pattern](to-dict-serialization-pattern.md) | Accepted | 2026-05-06 | Persistence boundary for Pydantic models — JSON-mode dump, ephemeral exclusion, legacy injection. |
+| [Circuit-Breaker Consolidation](circuit-breaker-consolidation.md) | Accepted | 2026-05-06 | Single circuit-breaker implementation owned by `hephaestus.resilience` (resolved by PR #1914). |
+| [`TIER_DEPENDENCIES` Topology](tier-dependencies-topology.md) | Accepted | 2026-05-06 | Topological grouping of T0–T6 for parallel execution. |
+| [Bootstrap BCa Confidence Intervals](bootstrap-bca-ci-statistics.md) | Accepted | 2026-05-06 | BCa bootstrap as the canonical CI method for all reported statistics. |
+
+## Authoring guidelines
+
+- Filename: kebab-case, no date prefix (decisions are tagged by their
+  `**Date**:` line, not by filename).
+- Length: 80–200 lines. ADRs are reference material, not stubs.
+- Always cite specific files and line numbers. ADRs without evidence
+  rot quickly.
+- Sections required: `Status`, `Context`, `Decision`, `Consequences`,
+  `References`. `Reasons` is acceptable as a substitute for the
+  positive half of `Consequences` if the older ADRs in this directory
+  use it.
+- New ADRs should be added to the index above in the same PR.

--- a/docs/dev/adr/bootstrap-bca-ci-statistics.md
+++ b/docs/dev/adr/bootstrap-bca-ci-statistics.md
@@ -1,0 +1,114 @@
+# ADR: Bootstrap BCa Confidence Intervals for Statistical Reporting
+
+**Date**: 2026-05-06
+**Status**: Accepted
+**Issue**: [#1882](https://github.com/HomericIntelligence/ProjectScylla/issues/1882)
+
+## Context
+
+Ablation results in ProjectScylla are reported with confidence intervals on
+both summary statistics (e.g., mean pass-rate per tier) and effect sizes
+(e.g., Cliff's delta between tiers). Two properties of the experimental
+data make naive interval methods unsafe:
+
+1. **Small samples.** Each subtest typically has on the order of 10 runs
+   per model (`runs_per_subtest`, default in `ExperimentConfig`).
+   Asymptotic / normal-theory CIs (mean ± 1.96·SE/√n) are unreliable at
+   n ≈ 10.
+2. **Boundary-bound binary metrics.** Pass-rate is a fraction in [0, 1].
+   When the true value is near 0 or 1, symmetric Wald-style intervals
+   produce nonsensical bounds (negative pass-rates or pass-rates above
+   100%) and have systematic coverage error.
+3. **Skewed effect-size distributions.** Cliff's delta is bounded in
+   [-1, 1] and is typically skewed when one group dominates. Percentile
+   bootstrap is biased on skewed estimators; basic bootstrap is biased
+   in the opposite direction. Both have known coverage problems.
+
+The published method that addresses all three concerns is the
+bias-corrected and accelerated (BCa) bootstrap of Efron (1987). It
+adjusts the percentile bootstrap for both bias and skewness using the
+jackknife-estimated acceleration parameter, and produces transformation-
+respecting intervals that stay inside the support of the statistic.
+
+scipy ships `scipy.stats.bootstrap(..., method="BCa")` which makes this
+trivially callable.
+
+## Decision
+
+All bootstrap confidence intervals reported by ProjectScylla use the BCa
+method. There are exactly two call sites, both in
+[`src/scylla/analysis/stats.py`](../../../src/scylla/analysis/stats.py):
+
+1. `bootstrap_ci()` at line 48 — the general mean-CI used by the
+   reporting pipeline. Calls `scipy.stats.bootstrap(..., method="BCa",
+   random_state=config.bootstrap_random_state)` at line 94.
+2. `cliffs_delta_ci()` at line 666 — effect-size CI for the Cliff's
+   delta tier-pair comparisons. Same `method="BCa"` at line 720.
+
+Defaults are centralised in
+[`src/scylla/analysis/config.py:67-79`](../../../src/scylla/analysis/config.py):
+
+- `bootstrap_resamples = 10000`
+- `bootstrap_confidence = 0.95`
+- `bootstrap_random_state = 42` (fixed seed for reproducibility)
+
+Both functions degrade gracefully when BCa cannot be applied:
+
+- n < 2 returns the point estimate as both bounds (`stats.py:77-83`,
+  `stats.py:700-705`) with a warning. BCa requires at least two samples
+  for the jackknife.
+- Zero-variance samples return the point estimate as both bounds
+  (`stats.py:86-91`). BCa fails on degenerate distributions because the
+  acceleration computation divides by the standard deviation.
+
+## Consequences
+
+**Positive**:
+
+- Reported CIs respect the natural support of the statistic. Pass-rate
+  intervals stay in [0, 1]; Cliff's delta intervals stay in [-1, 1].
+- Coverage is approximately nominal even at n ≈ 10 and even when the
+  underlying statistic is skewed. This matters for the headline plots
+  in the published paper, which compare tiers whose pass-rates are
+  near 0 or 1 (e.g., T0 vs T6).
+- Reproducibility is built in: the random state is config-driven and
+  defaults to 42, so re-running `export_data.py` on the same data
+  produces byte-identical CIs.
+- Both call sites share a single configured implementation, so a future
+  change (e.g., to studentized bootstrap or to a different `n_resamples`)
+  is one PR, not two.
+
+**Negative**:
+
+- BCa is ~2× slower than percentile bootstrap because it requires a
+  jackknife pass to estimate acceleration. At n_resamples=10000 and
+  ~120 subtests this is still cheap (seconds, not minutes), but it is
+  the dominant cost of `bootstrap_ci` for very small datasets.
+- The graceful-degradation paths (n<2, zero variance) silently collapse
+  the CI to a point. Downstream readers must understand that
+  `(x, x, x)` is a sentinel for "BCa not applicable" rather than
+  "estimate is exact." The functions log warnings, but the JSON
+  output does not flag the case explicitly.
+- BCa is implemented in scipy.stats; we depend on scipy's
+  implementation correctness. The pinned scipy minimum version is
+  enforced through `pyproject.toml`; downgrading is not safe.
+- Reported CIs in `statistical_results.json` come from
+  `bootstrap_ci`/`cliffs_delta_ci` invoked from `scripts/export_data.py`.
+  CIs that appear in tables but not in `statistical_results.json` are
+  the canonical confusion for paper reviewers — see MEMORY.md
+  "Statistical Claim Verification Pattern."
+
+## References
+
+- [`src/scylla/analysis/stats.py:48-103`](../../../src/scylla/analysis/stats.py)
+  — `bootstrap_ci()`.
+- [`src/scylla/analysis/stats.py:666-724`](../../../src/scylla/analysis/stats.py)
+  — `cliffs_delta_ci()`.
+- [`src/scylla/analysis/config.py:67-79`](../../../src/scylla/analysis/config.py)
+  — bootstrap defaults.
+- Efron, B. (1987). "Better Bootstrap Confidence Intervals."
+  *Journal of the American Statistical Association*, 82(397), 171–185.
+- scipy docs: `scipy.stats.bootstrap`, `method="BCa"`.
+- Related: MEMORY.md "Statistical Claim Verification Pattern" notes that
+  BCa CIs in paper tables are generated from `scripts/export_data.py`
+  via these two functions, not from a separate analysis path.

--- a/docs/dev/adr/circuit-breaker-consolidation.md
+++ b/docs/dev/adr/circuit-breaker-consolidation.md
@@ -1,0 +1,98 @@
+# ADR: Circuit-Breaker Consolidation on `hephaestus.resilience`
+
+**Date**: 2026-05-06
+**Status**: Accepted
+**Issues**: [#1870](https://github.com/HomericIntelligence/ProjectScylla/issues/1870),
+[#1882](https://github.com/HomericIntelligence/ProjectScylla/issues/1882)
+
+## Context
+
+ProjectScylla calls external APIs (Anthropic for agents, Anthropic again for
+LLM judges, occasionally GitHub for issue and PR operations). Each of these
+endpoints can fail transiently, rate-limit aggressively, or stall for minutes.
+Long ablation runs amplify the cost of unprotected retries: a single broken
+endpoint can burn the wall-clock budget for a 120-subtest sweep before any
+human notices.
+
+Historically the project carried two import paths for the same circuit-breaker
+implementation:
+
+- `scylla.core.circuit_breaker` — a thin re-export shim with the docstring
+  "This module re-exports from hephaestus.resilience.circuit_breaker for
+  backwards compatibility."
+- `scylla.automation.circuit_breaker` — a second, identically-shaped re-export
+  inside the `scylla.automation` package, which itself was a re-export shim.
+
+Both pointed at the same upstream symbols in
+`hephaestus.resilience.circuit_breaker`. The duplicate import surface was
+flagged in audit issue #1870 ("automation/ package contains only a re-export
+shim") under the strict-audit epic #1867. PR
+[#1914](https://github.com/HomericIntelligence/ProjectScylla/pull/1914)
+removed the `scylla.automation` shim, leaving exactly one in-repo import
+path plus the canonical upstream module.
+
+## Decision
+
+Use **one** circuit-breaker implementation, owned by ProjectHephaestus. New
+code imports directly from `hephaestus.resilience.circuit_breaker`. Existing
+call sites may continue to import via `scylla.core` for source compatibility.
+
+PR #1914 removed:
+
+- `src/scylla/automation/__init__.py`
+- `src/scylla/automation/circuit_breaker.py`
+- `tests/unit/automation/test_circuit_breaker.py`
+
+The remaining surface is:
+
+- `hephaestus.resilience.circuit_breaker` — canonical implementation
+  (CircuitBreaker, CircuitBreakerOpenError, CircuitBreakerState,
+  `get_circuit_breaker`, `reset_all_circuit_breakers`).
+- [`src/scylla/core/__init__.py`](../../../src/scylla/core/__init__.py) —
+  package-level re-export, lines 6–12 and 22–32. New code is encouraged to
+  import directly from hephaestus, but the `scylla.core` re-export is
+  retained because several call sites already use it and the shim has zero
+  ongoing maintenance cost.
+- [`src/scylla/core/circuit_breaker.py`](../../../src/scylla/core/circuit_breaker.py)
+  — module-level re-export, marked "for backwards compatibility" in its
+  docstring (line 3). Retained for the same reason: free, zero-cost,
+  removable later if every caller migrates.
+
+The `scylla.automation` package no longer exists. Any future import of
+`scylla.automation.*` is an error.
+
+## Consequences
+
+**Positive**:
+
+- A single source of truth for retry/cooldown semantics across the
+  ecosystem. Bugs and tuning changes in
+  `hephaestus.resilience.circuit_breaker` fix every consumer at once.
+- The audit finding from #1870 is resolved: there is no longer a package
+  whose only purpose is to re-export another package.
+- New contributors no longer need to choose between two indistinguishable
+  import paths.
+
+**Negative**:
+
+- One re-export shim still exists at `scylla.core.circuit_breaker`. It is
+  three lines of imports plus an `__all__`. The cost of removing it is
+  larger than the cost of keeping it (touches every call site), so it
+  stays. New code should prefer `from hephaestus.resilience.circuit_breaker
+  import …`.
+- ProjectScylla now has a hard runtime dependency on a specific
+  hephaestus version range (`homericintelligence-hephaestus>=0.7.0,<1`,
+  pinned in `pyproject.toml` per issue #1885). Bumping this range
+  requires testing the consumer here.
+
+## References
+
+- [`src/scylla/core/__init__.py`](../../../src/scylla/core/__init__.py)
+  — current public re-export, lines 6–12.
+- [`src/scylla/core/circuit_breaker.py`](../../../src/scylla/core/circuit_breaker.py)
+  — module-level re-export.
+- PR [#1914](https://github.com/HomericIntelligence/ProjectScylla/pull/1914)
+  — removed the duplicate `scylla.automation` shim.
+- Audit issues: [#1870](https://github.com/HomericIntelligence/ProjectScylla/issues/1870),
+  [#1867](https://github.com/HomericIntelligence/ProjectScylla/issues/1867).
+- Upstream: `hephaestus.resilience.circuit_breaker` in ProjectHephaestus.

--- a/docs/dev/adr/state-machine-hierarchy.md
+++ b/docs/dev/adr/state-machine-hierarchy.md
@@ -1,0 +1,99 @@
+# ADR: Four-Level State Machine Hierarchy
+
+**Date**: 2026-05-06
+**Status**: Accepted
+**Issue**: [#1882](https://github.com/HomericIntelligence/ProjectScylla/issues/1882)
+
+## Context
+
+ProjectScylla executes long-running ablation experiments that can take hours
+or days to complete. Each experiment runs many tiers; each tier runs many
+subtests; each subtest runs many individual agent invocations. Any of these
+can be interrupted by rate limits, kill signals, or transient failures, and
+the cost of restarting from scratch is unacceptable (full T0–T6 sweeps cost
+tens of dollars and many wall-hours).
+
+The runner therefore needs a resumable execution model. Rather than tracking
+progress in ad-hoc booleans scattered across the codebase, the framework
+models execution as a hierarchy of **four nested state machines**, each
+persisted to a single `checkpoint.json`. Every transition saves the
+checkpoint atomically so a crash, kill, or rate-limit error leaves the
+experiment in a well-defined state from which `--resume` can continue.
+
+## Decision
+
+Model E2E execution as four nested state machines, from outermost (longest
+lifetime) to innermost (shortest):
+
+| Level | Enum | States | Defined in |
+|-------|------|--------|------------|
+| Experiment | `ExperimentState` | INITIALIZING → DIR_CREATED → REPO_CLONED → TIERS_RUNNING → TIERS_COMPLETE → REPORTS_GENERATED → COMPLETE (terminals: COMPLETE, INTERRUPTED, FAILED) | [`src/scylla/e2e/models.py:147`](../../../src/scylla/e2e/models.py) |
+| Tier | `TierState` | PENDING → CONFIG_LOADED → SUBTESTS_RUNNING → SUBTESTS_COMPLETE → BEST_SELECTED → REPORTS_GENERATED → COMPLETE (terminal: COMPLETE, FAILED) | [`src/scylla/e2e/models.py:134`](../../../src/scylla/e2e/models.py) |
+| Subtest | `SubtestState` | PENDING → RUNS_IN_PROGRESS → RUNS_COMPLETE → AGGREGATED (terminal: AGGREGATED, FAILED) | [`src/scylla/e2e/models.py:124`](../../../src/scylla/e2e/models.py) |
+| Run | `RunState` | PENDING → DIR_STRUCTURE_CREATED → WORKTREE_CREATED → SYMLINKS_APPLIED → CONFIG_COMMITTED → BASELINE_CAPTURED → PROMPT_WRITTEN → REPLAY_GENERATED → AGENT_COMPLETE → AGENT_CHANGES_COMMITTED → DIFF_CAPTURED → PROMOTED_TO_COMPLETED → JUDGE_PIPELINE_RUN → JUDGE_PROMPT_BUILT → JUDGE_COMPLETE → RUN_FINALIZED → REPORT_WRITTEN → CHECKPOINTED → WORKTREE_CLEANED (terminals: WORKTREE_CLEANED, FAILED, RATE_LIMITED) | [`src/scylla/e2e/models.py:85`](../../../src/scylla/e2e/models.py) |
+
+Each level has a dedicated state-machine module that owns its transition
+registry, terminal-state set, and `advance()` driver:
+
+- [`experiment_state_machine.py`](../../../src/scylla/e2e/experiment_state_machine.py)
+  — see `EXPERIMENT_TRANSITION_REGISTRY` (line 69) and
+  `ExperimentStateMachine.advance` (line 191).
+- [`tier_state_machine.py`](../../../src/scylla/e2e/tier_state_machine.py)
+  — `TIER_TRANSITION_REGISTRY` (line 67).
+- [`subtest_state_machine.py`](../../../src/scylla/e2e/subtest_state_machine.py)
+  — `SUBTEST_TRANSITION_REGISTRY` (line 71). Notably also defines
+  `UntilHaltError` (line 32) so the `--until-run` flag can stop
+  cleanly without poisoning the subtest as FAILED.
+- Run-level transitions are driven by `subtest_executor.py` which mutates
+  `RunState` per checkpoint save.
+
+The four enums are colocated in `src/scylla/e2e/models.py` so they share
+a single import path and a single canonical ordering.
+
+## Consequences
+
+**Positive**:
+
+- Resume is uniform: `--resume` reads `checkpoint.json` and asks each
+  state machine "what's next?" by looking up the registry. There is no
+  per-component custom resume code.
+- Partial failures are first-class. A tier in `FAILED` does not abort the
+  experiment — `experiment_state` can reach `COMPLETE` even with mixed
+  `tier_states` (this is the behavior CLAUDE.md flags under "Partial-Failure
+  Semantics" and is enforced by the disjoint terminal sets above).
+- `--until-experiment`, `--until-tier`, `--until-run`, and the symmetric
+  `--from-*` flags all map directly to one state value at one level.
+  See `ExperimentStateMachine.advance_to_completion(until_state=…)` at
+  [`experiment_state_machine.py:250`](../../../src/scylla/e2e/experiment_state_machine.py).
+- Each level's transition registry is small, reviewable, and can be tested
+  independently of the others.
+
+**Negative**:
+
+- Adding a new state at any level is a four-touch change: enum, transition
+  registry, action handler, and (often) checkpoint schema migration. This
+  is intentional friction — states are persisted on disk and renaming one
+  breaks every in-flight experiment.
+- The `RunState` enum has 19 non-terminal states, which is more granular
+  than the other three levels combined. The granularity is justified by
+  the cost of redoing work (e.g., re-running the agent after a crash in
+  `JUDGE_PROMPT_BUILT` would waste the entire agent execution), but it
+  also means `RunState` is the primary place where checkpoint schema
+  evolution is painful.
+- Operators must inspect the correct level when diagnosing stalls.
+  `experiment_state=COMPLETE` does not imply success; `tier_states` must
+  be checked too (called out explicitly in CLAUDE.md).
+
+## References
+
+- [`src/scylla/e2e/models.py:85-160`](../../../src/scylla/e2e/models.py) —
+  all four state enums.
+- [`src/scylla/e2e/experiment_state_machine.py`](../../../src/scylla/e2e/experiment_state_machine.py)
+  — top-level driver, full state sequence at line 36, registry at line 69.
+- [`src/scylla/e2e/tier_state_machine.py`](../../../src/scylla/e2e/tier_state_machine.py)
+- [`src/scylla/e2e/subtest_state_machine.py`](../../../src/scylla/e2e/subtest_state_machine.py)
+- [`src/scylla/e2e/checkpoint.py`](../../../src/scylla/e2e/checkpoint.py)
+  — `save_checkpoint()` provides the atomic-write primitive every level
+  depends on.
+- CLAUDE.md, "Partial-Failure Semantics" — operator-facing rule that
+  follows directly from disjoint per-level terminal sets.

--- a/docs/dev/adr/tier-dependencies-topology.md
+++ b/docs/dev/adr/tier-dependencies-topology.md
@@ -1,0 +1,111 @@
+# ADR: `TIER_DEPENDENCIES` Topological Execution Model
+
+**Date**: 2026-05-06
+**Status**: Accepted
+**Issue**: [#1882](https://github.com/HomericIntelligence/ProjectScylla/issues/1882)
+
+## Context
+
+The ablation framework defines seven tiers (T0–T6) with structural
+dependencies dictated by the experimental design:
+
+- T0 (Prompts), T1 (Skills), T2 (Tooling), T3 (Delegation), and T4
+  (Hierarchy) are **independent ablations**. None of them needs results
+  from the others.
+- T5 (Hybrid) is defined as "best combinations and permutations of T0–T4."
+  It must run *after* the five base tiers so it can read each base
+  tier's winning subtest.
+- T6 (Super) is "everything enabled at maximum capability" and is defined
+  as the extension of T5's winner, so it depends on T5.
+
+Running T0–T4 sequentially when they have no inter-tier data dependency
+is a multi-hour waste. The runner has to discover this parallelism
+without hard-coding "run these five together, then this one, then this
+one" into control flow — that style of code rots the moment a new tier
+is added or removed at the CLI.
+
+## Decision
+
+Encode tier dependencies as a single dictionary, `TIER_DEPENDENCIES`, in
+[`src/scylla/e2e/models.py:197`](../../../src/scylla/e2e/models.py):
+
+```python
+TIER_DEPENDENCIES: dict[TierID, list[TierID]] = {
+    TierID.T0: [],
+    TierID.T1: [],
+    TierID.T2: [],
+    TierID.T3: [],
+    TierID.T4: [],
+    TierID.T5: [TierID.T0, TierID.T1, TierID.T2, TierID.T3, TierID.T4],
+    TierID.T6: [TierID.T5],
+}
+```
+
+The runner consumes this map via `_get_tier_groups()` in
+[`src/scylla/e2e/runner.py:163`](../../../src/scylla/e2e/runner.py),
+which performs a topological *layering* — repeatedly extracting the set
+of tiers whose dependencies are already satisfied — and returns a list
+of parallelizable groups. For the canonical full sweep this yields
+`[[T0, T1, T2, T3, T4], [T5], [T6]]` (documented as the example in the
+function docstring at line 174).
+
+The grouping algorithm has three properties worth noting:
+
+1. **User-scoped**: a dependency is considered satisfied if it is *not in
+   `tiers_to_run`*. Running just T5 in isolation is legal — the
+   dependency check at `runner.py:190` reads
+   `dep in completed or dep not in tiers_to_run`. This lets operators
+   run partial sweeps (e.g., `--tiers T2,T5`) without the runner
+   complaining about missing T0/T1/T3/T4.
+2. **Deterministic order within a group**: ready tiers are sorted before
+   being appended (`runner.py:201`), so logs and parallel-group ordering
+   are reproducible.
+3. **Cycle detection**: if `remaining` is non-empty but `ready` is
+   empty, the runner raises `ValueError("Unable to resolve tier
+   dependencies …")` (`runner.py:194-199`). This is dead code under the
+   current static map, but it future-proofs against an edit that
+   accidentally introduces a cycle.
+
+## Consequences
+
+**Positive**:
+
+- One declaration, one consumer. Adding T7 is a one-line edit to
+  `TIER_DEPENDENCIES`; the runner discovers the new layer
+  automatically.
+- The "T0–T4 in parallel" behavior is *emergent* from the empty
+  dependency lists, not from a special-case branch in the runner.
+- Partial runs work without configuration: `--tiers T5` is valid because
+  the dependency check tolerates "missing" base tiers — the operator is
+  presumed to know they are pointing T5 at a previous experiment's
+  best-subtest record.
+- The map is colocated with the `TierID` enum it references, so the
+  one-and-only place to look when triaging "why is T5 running before
+  T1 finished?" is `models.py:197`.
+
+**Negative**:
+
+- The empty-dependency-tolerated case (`dep not in tiers_to_run`) is
+  pragmatic but easy to misuse. An operator who runs just T5 expecting
+  the runner to also schedule T0–T4 will be surprised. The CLI
+  documentation, not the data model, has to teach this.
+- Tiers are coarse: the topology has nothing to say about subtest-level
+  dependencies. Cross-subtest inheritance (T5 reading T0–T4 winners) is
+  handled separately in `SubTestConfig.inherit_best_from` and
+  best-subtest selection — see
+  [`src/scylla/e2e/models.py:229-232`](../../../src/scylla/e2e/models.py).
+- The "tiers within a group can run in parallel" guarantee imposes
+  constraints on what a tier's action functions can do (no shared mutable
+  state across tier executions). This is enforced by review, not types.
+
+## References
+
+- [`src/scylla/e2e/models.py:197-205`](../../../src/scylla/e2e/models.py)
+  — the `TIER_DEPENDENCIES` declaration with the three-line comment
+  explaining the topology.
+- [`src/scylla/e2e/runner.py:163-205`](../../../src/scylla/e2e/runner.py)
+  — `_get_tier_groups()` implementation.
+- CLAUDE.md "Testing Tiers (Ablation Study Framework)" — operator-facing
+  description of the seven tiers and their roles.
+- Related ADR: [State Machine Hierarchy](state-machine-hierarchy.md) —
+  tier execution within a group is driven by `TierStateMachine`.

--- a/docs/dev/adr/to-dict-serialization-pattern.md
+++ b/docs/dev/adr/to-dict-serialization-pattern.md
@@ -1,0 +1,118 @@
+# ADR: `to_dict()` Serialization Pattern on Pydantic Models
+
+**Date**: 2026-05-06
+**Status**: Accepted
+**Issue**: [#1882](https://github.com/HomericIntelligence/ProjectScylla/issues/1882)
+
+## Context
+
+ProjectScylla persists almost every long-lived data object as JSON: experiment
+configs, checkpoints, per-run results, judge outputs, and the rolled-up
+experiment results. The data classes themselves are Pydantic `BaseModel`s,
+which already provide `model_dump()` and `model_dump_json()`. Despite that,
+the codebase consistently exposes a hand-written `to_dict(self) -> dict[str, Any]`
+method on every model that is written to disk, and call sites use that method
+rather than calling `model_dump()` directly.
+
+A naive reader will ask: why duplicate Pydantic's serialization API? The
+answer is that several persisted models need behavior that plain `model_dump()`
+cannot express:
+
+1. **Mode coercion**. Persisted JSON must always be in `mode="json"` (so
+   `Path` becomes `str`, `Enum` becomes its value, etc.). Most call sites
+   would otherwise forget the kwarg.
+2. **Legacy field injection**. `E2ERunResult.to_dict()` re-injects
+   `tokens_input` / `tokens_output` derived properties so older readers
+   that predate `TokenStats` still parse run JSONs.
+3. **Ephemeral-field exclusion**. `ExperimentConfig.to_dict()` strips a
+   curated allowlist of CLI-only fields (`--until-*`, `--from-*`, filter
+   flags, `keep_failed_workspaces`, etc.) so they do not get persisted into
+   the experiment's canonical config and accidentally re-applied on
+   `--resume`.
+4. **Nested override**. `E2ECheckpoint.to_dict()` overwrites the full
+   `model_dump()` of `config` with `config.to_dict()` so the ephemeral-field
+   filter actually takes effect through nested serialization.
+
+These are non-trivial behaviors. Centralising them in `to_dict()` lets every
+caller serialize correctly with one method and gives reviewers a single
+place to audit the JSON contract.
+
+## Decision
+
+Every persisted Pydantic model in `scylla.e2e` and adjacent packages
+exposes a `to_dict(self) -> dict[str, Any]` method. Call sites that write
+JSON go through `to_dict()`; they do **not** call `model_dump()` directly.
+
+The canonical implementations live in [`src/scylla/e2e/models.py`](../../../src/scylla/e2e/models.py):
+
+- `TokenStats.to_dict` (line 61) — simplest case, plain
+  `self.model_dump()` so legacy callers can swap dataclasses for Pydantic
+  without touching call sites.
+- `SubTestConfig.to_dict` (line 248), `TierConfig.to_dict` (line 275),
+  `JudgeResultSummary.to_dict` (line 306), `SubTestResult.to_dict` (line 436),
+  `TierResult.to_dict` (line 466) — all delegate to
+  `self.model_dump(mode="json")`.
+- `E2ERunResult.to_dict` (line 378) — JSON-mode dump plus injected
+  `tokens_input` / `tokens_output` legacy keys (lines 382–383).
+- `ExperimentConfig.to_dict` (line 813) — JSON-mode dump with the
+  ephemeral-field allowlist excluded (lines 822–842). The exclusion list
+  is the authoritative declaration of which CLI flags are *not* persisted.
+- `E2ECheckpoint.to_dict` (line 915) — composes `model_dump()` then
+  replaces the embedded `config` with `self.config.to_dict()` so the
+  ephemeral exclusion propagates (line 919).
+
+Other modules follow the same shape:
+
+- [`src/scylla/e2e/llm_judge_models.py:38`](../../../src/scylla/e2e/llm_judge_models.py)
+- [`src/scylla/e2e/judge_selection.py:35,60`](../../../src/scylla/e2e/judge_selection.py)
+
+Persistence call sites use `to_dict()` exclusively, e.g.:
+
+- `models.py:506,848,926` — `json.dump(self.to_dict(), f, indent=2)` from
+  the model's own `save()` method.
+- [`src/scylla/e2e/experiment_result_writer.py:85`](../../../src/scylla/e2e/experiment_result_writer.py)
+- [`src/scylla/e2e/stage_finalization.py:425,519`](../../../src/scylla/e2e/stage_finalization.py)
+- [`src/scylla/e2e/run_report_hierarchy.py:131,366,511`](../../../src/scylla/e2e/run_report_hierarchy.py)
+- [`src/scylla/e2e/regenerate.py:416`](../../../src/scylla/e2e/regenerate.py)
+- [`src/scylla/e2e/pipeline_scripts.py:244`](../../../src/scylla/e2e/pipeline_scripts.py)
+
+## Consequences
+
+**Positive**:
+
+- One method per model defines the on-disk JSON shape. Schema review
+  becomes "read every `to_dict()`," not "audit every call site."
+- Ephemeral-vs-persisted is enforced by code, not by convention.
+  `--resume` cannot accidentally reapply a one-shot CLI flag because the
+  flag never reaches disk.
+- Backward-compatible field injection (the `tokens_input` /
+  `tokens_output` case) is invisible to callers.
+- `mode="json"` is applied uniformly, so `Path` / `Enum` / `datetime`
+  values are always serialized to strings.
+
+**Negative**:
+
+- Boilerplate. ~13 near-identical `to_dict()` methods exist in `models.py`
+  alone, most of which are one-liners. A shared base class or mixin
+  would reduce the duplication, but each model has different override
+  needs (`E2ERunResult` injects, `ExperimentConfig` excludes,
+  `E2ECheckpoint` recurses), so the duplication is largely irreducible.
+- Reviewers must remember that adding a new field to `ExperimentConfig`
+  requires a decision: persist it, or add it to the ephemeral allowlist?
+  The default (persist) is usually wrong for CLI-only fields and right
+  for everything else.
+- `model_dump()` is *not* banned at non-persistence call sites (e.g.,
+  in-memory diffing, logging). The boundary is "anything that hits
+  disk," which is enforceable by review but not by mypy.
+
+## References
+
+- [`src/scylla/e2e/models.py`](../../../src/scylla/e2e/models.py)
+  — all canonical `to_dict()` implementations, lines 61, 248, 275, 306,
+  378, 436, 466, 498, 569, 813, 915.
+- [`src/scylla/e2e/llm_judge_models.py`](../../../src/scylla/e2e/llm_judge_models.py)
+- [`src/scylla/e2e/judge_selection.py`](../../../src/scylla/e2e/judge_selection.py)
+- Persisted JSON consumers: `experiment_result_writer.py`,
+  `stage_finalization.py`, `run_report_hierarchy.py`, `pipeline_scripts.py`.
+- Related: MEMORY.md "Pydantic None Coercion Pattern" — defensive
+  validators that keep `to_dict()` round-trips lossless.


### PR DESCRIPTION
Authors ADRs for the 4-level state machine, to_dict() serialization pattern, circuit-breaker consolidation (resolved by PR #1914), TIER_DEPENDENCIES topology, and bootstrap BCa CI choice. Closes #1882. Refs #1867.