### PR TITLE
feat(tracing): add opt-in OpenTelemetry tracing scaffold

### DIFF
--- a/docs/dev/tracing.md
+++ b/docs/dev/tracing.md
@@ -1,0 +1,87 @@
+# Tracing (OpenTelemetry scaffold)
+
+ProjectScylla ships an **opt-in** OpenTelemetry tracing scaffold alongside the
+opt-in JSON logging foundation (PR #1921). This document describes the
+scaffold, what is — and is not — wired up, and how operators activate it.
+
+## Status
+
+- **Scaffold only.** The tracing module and a single root span at the CLI
+  entrypoint are in place. Exhaustive instrumentation across every logging
+  site is intentionally out of scope and tracked as a follow-up under
+  issue #1887.
+- **Opt-in.** Default behaviour of the application is unchanged. With no
+  configuration, no OpenTelemetry SDK imports happen.
+
+## Activation
+
+Set the `SCYLLA_OTEL_EXPORTER` environment variable before invoking the CLI:
+
+| Value     | Behaviour                                                     |
+|-----------|---------------------------------------------------------------|
+| unset / empty | NoOp tracing (default). No SDK imports, no spans emitted. |
+| `console` | Install `ConsoleSpanExporter` — spans printed to stderr.       |
+| `otlp`    | Install OTLP/gRPC exporter (uses `OTEL_EXPORTER_OTLP_ENDPOINT`, default `http://localhost:4317`). |
+| anything else | NoOp tracing + a `UserWarning`.                            |
+
+Example:
+
+```bash
+SCYLLA_OTEL_EXPORTER=console pixi run scylla run 001-justfile-to-makefile --tier T0 --runs 1
+```
+
+## Required packages (operators install these)
+
+OpenTelemetry is **not** a hard dependency of ProjectScylla. Operators who
+opt in must install the packages themselves:
+
+```bash
+pip install opentelemetry-api opentelemetry-sdk
+# For SCYLLA_OTEL_EXPORTER=otlp:
+pip install opentelemetry-exporter-otlp
+```
+
+If `SCYLLA_OTEL_EXPORTER` is set but the packages are missing, a
+`UserWarning` is emitted and tracing is silently disabled — the application
+otherwise runs normally.
+
+## Programmatic API
+
+```python
+from scylla.utils.tracing import configure_tracing, get_tracer
+
+configure_tracing()  # honours SCYLLA_OTEL_EXPORTER; returns Tracer | None
+
+tracer = get_tracer(__name__)
+with tracer.start_as_current_span("my.span") as span:
+    span.set_attribute("key", "value")
+    ...
+```
+
+`get_tracer(name)` returns a name-scoped tracer. When tracing isn't
+configured (or OpenTelemetry isn't installed), it returns a NoOp tracer
+whose `start_as_current_span` is still a real context manager — call sites
+do **not** need to branch on whether tracing is enabled.
+
+## Where the root span lives
+
+The CLI entrypoint (`src/scylla/cli/main.py`) wraps the `run` command body
+in a single root span named `scylla.experiment.run` with attributes:
+
+- `experiment.test_id`
+- `experiment.model`
+- `experiment.runs_per_tier`
+- `experiment.tiers` (when explicit tiers are passed)
+
+This is deliberately the *only* span emitted by this scaffold. Adding spans
+to deeper layers (orchestrator, executor, judge, metrics) is follow-up work
+under issue #1887.
+
+## Out of scope for this scaffold
+
+- Spans at every logging site.
+- `opentelemetry-instrumentation-*` auto-instrumentation packages.
+- Real OTLP collector deployment / endpoint configuration.
+- Bridging `logging.LogRecord` into spans.
+
+These remain open under issue #1887.

--- a/src/scylla/cli/main.py
+++ b/src/scylla/cli/main.py
@@ -27,6 +27,7 @@ from scylla.utils.json_logging import (
     configure_json_logging,
     is_json_logging_enabled,
 )
+from scylla.utils.tracing import configure_tracing, get_tracer
 
 # Dict-dispatch mapping format names to generator classes.
 # Adding a new format requires only a new entry here
@@ -49,6 +50,9 @@ def cli() -> None:
     # Default behaviour (text logs) is unchanged.
     if is_json_logging_enabled():
         configure_json_logging()
+    # Opt-in OpenTelemetry tracing via SCYLLA_OTEL_EXPORTER=console|otlp.
+    # When unset, this is a no-op and no SDK imports happen.
+    configure_tracing()
 
 
 @cli.command()
@@ -129,34 +133,41 @@ def run(
 
     orchestrator = EvalOrchestrator(config)
 
-    try:
-        if runs == 1 and tiers and len(tiers) == 1:
-            # Single run mode
-            result = orchestrator.run_single(
-                test_id=test_id,
-                model_id=model_id,
-                tier_id=tiers[0],
-            )
-            if not quiet:
-                click.echo(f"\nResult: {'PASS' if result.judgment.passed else 'FAIL'}")
-                click.echo(f"Grade: {result.judgment.letter_grade}")
-                click.echo(f"Cost: ${result.metrics.cost_usd:.4f}")
-        else:
-            # Multi-run mode
-            results = orchestrator.run_test(
-                test_id=test_id,
-                models=[model_id],
-                tiers=tiers,
-                runs_per_tier=runs,
-            )
-            if not quiet:
-                passed = sum(1 for r in results if r.judgment.passed)
-                click.echo(f"\nCompleted {len(results)} runs")
-                click.echo(f"Pass rate: {passed}/{len(results)}")
+    tracer = get_tracer(__name__)
+    with tracer.start_as_current_span("scylla.experiment.run") as span:
+        span.set_attribute("experiment.test_id", test_id)
+        span.set_attribute("experiment.model", model_id)
+        span.set_attribute("experiment.runs_per_tier", runs)
+        if tiers is not None:
+            span.set_attribute("experiment.tiers", ",".join(tiers))
+        try:
+            if runs == 1 and tiers and len(tiers) == 1:
+                # Single run mode
+                result = orchestrator.run_single(
+                    test_id=test_id,
+                    model_id=model_id,
+                    tier_id=tiers[0],
+                )
+                if not quiet:
+                    click.echo(f"\nResult: {'PASS' if result.judgment.passed else 'FAIL'}")
+                    click.echo(f"Grade: {result.judgment.letter_grade}")
+                    click.echo(f"Cost: ${result.metrics.cost_usd:.4f}")
+            else:
+                # Multi-run mode
+                results = orchestrator.run_test(
+                    test_id=test_id,
+                    models=[model_id],
+                    tiers=tiers,
+                    runs_per_tier=runs,
+                )
+                if not quiet:
+                    passed = sum(1 for r in results if r.judgment.passed)
+                    click.echo(f"\nCompleted {len(results)} runs")
+                    click.echo(f"Pass rate: {passed}/{len(results)}")
 
-    except Exception as e:
-        click.echo(f"Error: {e}", err=True)
-        sys.exit(1)
+        except Exception as e:
+            click.echo(f"Error: {e}", err=True)
+            sys.exit(1)
 
 
 def _load_results(test_id: str, base_path: Path = Path(".")) -> list[dict[str, Any]]:

--- a/src/scylla/utils/tracing.py
+++ b/src/scylla/utils/tracing.py
@@ -1,0 +1,171 @@
+"""Opt-in OpenTelemetry tracing scaffold for ProjectScylla.
+
+This module mirrors the shape of :mod:`scylla.utils.json_logging` (PR #1921):
+a small, dependency-free shim that turns into a working tracer only when the
+operator explicitly opts in via the ``SCYLLA_OTEL_EXPORTER`` environment
+variable. Default behaviour of the application is unchanged.
+
+The OpenTelemetry SDK is **not** a hard dependency of ProjectScylla. Operators
+who want real spans must install the packages themselves::
+
+    pip install opentelemetry-api opentelemetry-sdk
+
+When the env var is unset (the default), :func:`configure_tracing` returns
+``None`` and :func:`get_tracer` returns a NoOp tracer whose
+``start_as_current_span`` is a real context manager — so call sites can use
+the same ``with tracer.start_as_current_span(...)`` shape regardless of
+whether tracing is actually configured.
+
+Activation::
+
+    SCYLLA_OTEL_EXPORTER=console pixi run scylla run <test-id>
+    SCYLLA_OTEL_EXPORTER=otlp    pixi run scylla run <test-id>
+
+Recognised values:
+
+* ``"console"`` — install a ``ConsoleSpanExporter`` (spans printed to stderr)
+* ``"otlp"``    — install an OTLP exporter pointed at the standard
+  ``OTEL_EXPORTER_OTLP_ENDPOINT`` env var (defaults to ``http://localhost:4317``)
+* unset / empty — NoOp tracing; no SDK imports happen
+
+Exhaustive instrumentation across every logging site is intentionally out of
+scope for this scaffold — see issue #1887 for the follow-up.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import logging
+import os
+import warnings
+from collections.abc import Iterator
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:  # pragma: no cover - typing only
+    from opentelemetry.trace import Tracer
+
+__all__ = ["configure_tracing", "get_tracer"]
+
+_ENV_VAR = "SCYLLA_OTEL_EXPORTER"
+_logger = logging.getLogger(__name__)
+
+
+class _NoOpSpan:
+    """Minimal span shim with the attributes call sites use."""
+
+    def set_attribute(self, key: str, value: Any) -> None:
+        """No-op set_attribute."""
+
+    def set_status(self, status: Any) -> None:
+        """No-op set_status."""
+
+    def record_exception(self, exception: BaseException) -> None:
+        """No-op record_exception."""
+
+
+class _NoOpTracer:
+    """NoOp tracer used when tracing is disabled.
+
+    Matches the subset of the OpenTelemetry ``Tracer`` interface we depend on
+    so call sites can use ``with tracer.start_as_current_span(...)`` without
+    branching on whether tracing was configured.
+    """
+
+    @contextlib.contextmanager
+    def start_as_current_span(self, name: str, *args: Any, **kwargs: Any) -> Iterator[_NoOpSpan]:
+        """Yield a no-op span as a context manager."""
+        del name, args, kwargs
+        yield _NoOpSpan()
+
+
+def configure_tracing() -> Tracer | None:
+    """Configure tracing based on ``SCYLLA_OTEL_EXPORTER``.
+
+    Returns the configured global :class:`~opentelemetry.trace.Tracer` when
+    the env var is set to a recognised value, or ``None`` when tracing is
+    disabled. When the env var is set but the OpenTelemetry packages are not
+    installed, a :class:`UserWarning` is emitted and ``None`` is returned.
+
+    The function is safe to call multiple times: re-configuration installs
+    the new exporter on the existing global ``TracerProvider`` rather than
+    stacking providers.
+    """
+    exporter = os.environ.get(_ENV_VAR, "").strip().lower()
+    if not exporter:
+        return None
+
+    if exporter not in {"console", "otlp"}:
+        warnings.warn(
+            f"Unknown {_ENV_VAR} value {exporter!r}; expected 'console' or 'otlp'. "
+            "Tracing disabled.",
+            UserWarning,
+            stacklevel=2,
+        )
+        return None
+
+    try:
+        from opentelemetry import trace
+        from opentelemetry.sdk.resources import Resource
+        from opentelemetry.sdk.trace import TracerProvider
+        from opentelemetry.sdk.trace.export import (
+            BatchSpanProcessor,
+            ConsoleSpanExporter,
+            SpanExporter,
+        )
+    except ImportError:
+        warnings.warn(
+            f"{_ENV_VAR}={exporter!r} but opentelemetry-api / opentelemetry-sdk "
+            "are not installed; tracing disabled. "
+            "Install with: pip install opentelemetry-api opentelemetry-sdk",
+            UserWarning,
+            stacklevel=2,
+        )
+        return None
+
+    span_exporter: SpanExporter
+    if exporter == "console":
+        span_exporter = ConsoleSpanExporter()
+    elif exporter == "otlp":
+        try:
+            from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import (
+                OTLPSpanExporter,
+            )
+        except ImportError:
+            warnings.warn(
+                f"{_ENV_VAR}=otlp but opentelemetry-exporter-otlp is not installed; "
+                "falling back to ConsoleSpanExporter. "
+                "Install with: pip install opentelemetry-exporter-otlp",
+                UserWarning,
+                stacklevel=2,
+            )
+            span_exporter = ConsoleSpanExporter()
+        else:
+            span_exporter = OTLPSpanExporter()
+    else:  # pragma: no cover - guarded above
+        return None
+
+    provider = trace.get_tracer_provider()
+    # If a real (non-proxy) provider is already installed, attach to it.
+    # Otherwise, install a fresh SDK provider.
+    if not isinstance(provider, TracerProvider):
+        provider = TracerProvider(resource=Resource.create({"service.name": "scylla"}))
+        trace.set_tracer_provider(provider)
+
+    provider.add_span_processor(BatchSpanProcessor(span_exporter))
+    return provider.get_tracer("scylla")
+
+
+def get_tracer(name: str) -> Tracer | _NoOpTracer:
+    """Return a tracer scoped to *name*.
+
+    When the OpenTelemetry API is importable, the global ``TracerProvider``
+    is used (this works whether or not :func:`configure_tracing` has been
+    called — uncalled, the provider is the API's default no-op provider, so
+    span creation is cheap). When the API is not importable at all, a local
+    :class:`_NoOpTracer` is returned so call sites still work.
+    """
+    try:
+        from opentelemetry import trace
+    except ImportError:
+        return _NoOpTracer()
+    return trace.get_tracer(name)

--- a/tests/unit/utils/test_tracing.py
+++ b/tests/unit/utils/test_tracing.py
@@ -1,0 +1,133 @@
+"""Unit tests for :mod:`scylla.utils.tracing`."""
+
+from __future__ import annotations
+
+import importlib
+from typing import Any
+
+import pytest
+
+from scylla.utils import tracing
+from scylla.utils.tracing import _NoOpTracer, configure_tracing, get_tracer
+
+
+def test_configure_tracing_disabled_by_default(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """configure_tracing() returns None when SCYLLA_OTEL_EXPORTER is unset."""
+    monkeypatch.delenv("SCYLLA_OTEL_EXPORTER", raising=False)
+    assert configure_tracing() is None
+
+
+def test_configure_tracing_empty_value_returns_none(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Empty / whitespace SCYLLA_OTEL_EXPORTER is treated as unset."""
+    monkeypatch.setenv("SCYLLA_OTEL_EXPORTER", "")
+    assert configure_tracing() is None
+    monkeypatch.setenv("SCYLLA_OTEL_EXPORTER", "   ")
+    assert configure_tracing() is None
+
+
+def test_configure_tracing_unknown_value_warns_and_returns_none(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Unknown exporter names emit a warning and return None."""
+    monkeypatch.setenv("SCYLLA_OTEL_EXPORTER", "jaeger")
+    with pytest.warns(UserWarning, match="Unknown"):
+        result = configure_tracing()
+    assert result is None
+
+
+def test_get_tracer_noop_context_manager_works(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """get_tracer() must return a tracer whose start_as_current_span is a CM.
+
+    This is the load-bearing contract for call sites: ``with
+    tracer.start_as_current_span(...)`` must work whether or not tracing is
+    actually configured.
+    """
+    monkeypatch.delenv("SCYLLA_OTEL_EXPORTER", raising=False)
+    tracer = get_tracer("scylla.test")
+    with tracer.start_as_current_span("noop") as span:
+        # set_attribute must be safe to call on the no-op span shim too.
+        span.set_attribute("k", "v")
+
+
+def test_get_tracer_returns_local_noop_when_otel_missing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When opentelemetry isn't importable, get_tracer falls back to _NoOpTracer."""
+    import builtins
+
+    real_import = builtins.__import__
+
+    def fake_import(name: str, *args: Any, **kwargs: Any) -> Any:
+        if name == "opentelemetry" or name.startswith("opentelemetry."):
+            raise ImportError("simulated missing opentelemetry")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+    tracer = get_tracer("scylla.test")
+    assert isinstance(tracer, _NoOpTracer)
+    with tracer.start_as_current_span("noop") as span:
+        span.set_attribute("k", "v")
+
+
+def test_configure_tracing_warns_when_otel_missing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """SCYLLA_OTEL_EXPORTER set + opentelemetry uninstalled => UserWarning."""
+    import builtins
+
+    real_import = builtins.__import__
+
+    def fake_import(name: str, *args: Any, **kwargs: Any) -> Any:
+        if name == "opentelemetry" or name.startswith("opentelemetry."):
+            raise ImportError("simulated missing opentelemetry")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+    monkeypatch.setenv("SCYLLA_OTEL_EXPORTER", "console")
+    with pytest.warns(UserWarning, match="not installed"):
+        result = configure_tracing()
+    assert result is None
+
+
+def test_configure_tracing_console_exporter_real_sdk(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """With opentelemetry-sdk installed, console exporter returns a real Tracer."""
+    pytest.importorskip("opentelemetry.sdk.trace")
+    monkeypatch.setenv("SCYLLA_OTEL_EXPORTER", "console")
+    tracer = configure_tracing()
+    assert tracer is not None
+    # The returned tracer must support start_as_current_span as a CM.
+    with tracer.start_as_current_span("scylla.test.span") as span:
+        span.set_attribute("foo", "bar")
+
+
+def test_get_tracer_is_name_scoped(monkeypatch: pytest.MonkeyPatch) -> None:
+    """get_tracer accepts an arbitrary name and returns a usable tracer."""
+    monkeypatch.delenv("SCYLLA_OTEL_EXPORTER", raising=False)
+    a = get_tracer("scylla.module.a")
+    b = get_tracer("scylla.module.b")
+    # Both must be usable as context managers regardless of identity.
+    with a.start_as_current_span("a-span"):
+        pass
+    with b.start_as_current_span("b-span"):
+        pass
+
+
+def test_module_imports_cleanly_without_otel(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The tracing module itself must import even if opentelemetry is absent.
+
+    Lazy-import contract: no opentelemetry.* import happens at module load.
+    """
+    # Reload to verify import succeeds without touching opentelemetry.
+    importlib.reload(tracing)
+    assert hasattr(tracing, "configure_tracing")
+    assert hasattr(tracing, "get_tracer")


### PR DESCRIPTION
## Summary
Adds an opt-in OpenTelemetry tracing scaffold mirroring PR #1921 (JSON logging). Activated via `SCYLLA_OTEL_EXPORTER` env var. Default behavior unchanged. Single root span at runner entrypoint.

## Lazy import
opentelemetry-api / opentelemetry-sdk are imported lazily — the module imports cleanly even when the packages aren't installed. Operators who opt in install the packages themselves.

## Out of scope (separate follow-up)
Exhaustive instrumentation across every logging site stays open under #1887. This PR is scaffold-only.

## Verification
- New tests in tests/unit/utils/test_tracing.py
- pytest passes; mypy clean
- Default-off: no behavior change when SCYLLA_OTEL_EXPORTER is unset

Refs #1887
Refs #1867