### PR TITLE
feat(metrics): wire MetricEmitter into experiment runtime

### DIFF
--- a/src/scylla/e2e/judge_runner.py
+++ b/src/scylla/e2e/judge_runner.py
@@ -20,6 +20,7 @@ from scylla.e2e.llm_judge import run_llm_judge
 from scylla.e2e.models import JudgeResultSummary
 from scylla.e2e.paths import RESULT_FILE, get_judge_result_file
 from scylla.e2e.rate_limit import RateLimitError, RateLimitInfo, _detect_rate_limit_from_stderr
+from scylla.metrics.emitter import MetricEmitter, get_default_emitter
 
 if TYPE_CHECKING:
     from scylla.e2e.llm_judge_models import BuildPipelineResult, JudgeResult
@@ -139,6 +140,7 @@ def _run_judge(
     rubric_path: Path | None = None,
     judge_models: list[str] | None = None,
     pipeline_baseline: BuildPipelineResult | None = None,
+    emitter: MetricEmitter | None = None,
 ) -> tuple[dict[str, Any], list[JudgeResultSummary]]:
     """Run LLM judge evaluation(s) on the result.
 
@@ -164,6 +166,7 @@ def _run_judge(
     if not judge_models:
         raise ValueError("judge_models is required")
 
+    _emitter = emitter if emitter is not None else get_default_emitter()
     judges = []
 
     # Run each configured judge
@@ -201,6 +204,7 @@ def _run_judge(
                 criteria_scores=judge_result.criteria_scores,
             )
             judges.append(judge_summary)
+            _emit_judge_metric(_emitter, model, judge_result.is_valid, judge_result.passed)
 
         except RateLimitError:
             # Rate limit errors must propagate immediately to trigger backoff
@@ -266,6 +270,7 @@ def _run_judge(
                 criteria_scores={},
             )
             judges.append(failed_summary)
+            _emit_judge_metric(_emitter, model, is_valid=False, passed=False)
 
     # Compute consensus from all judges (only valid ones contribute)
     consensus_score, consensus_passed, consensus_grade = _compute_judge_consensus(judges)
@@ -328,6 +333,34 @@ def _run_judge(
     }
 
     return consensus_dict, judges
+
+
+def _emit_judge_metric(
+    emitter: MetricEmitter,
+    model: str,
+    is_valid: bool,
+    passed: bool,
+) -> None:
+    """Increment ``scylla_judge_evaluations_total`` for a judge result.
+
+    Outcome label is one of ``error`` (judge failed to produce a valid
+    result), ``pass`` (valid + passed), or ``fail`` (valid but did not pass).
+    Errors in the emitter must not break judge evaluation.
+    """
+    if not is_valid:
+        outcome = "error"
+    elif passed:
+        outcome = "pass"
+    else:
+        outcome = "fail"
+    try:
+        emitter.emit_counter(
+            "scylla_judge_evaluations_total",
+            1,
+            labels={"model": model, "outcome": outcome},
+        )
+    except Exception as e:  # emitter must never break judge runs
+        logger.warning(f"Judge metric emission failed (non-fatal): {e}")
 
 
 def _phase_log(phase: str, message: str) -> None:

--- a/src/scylla/e2e/runner_internals/experiment_entrypoint.py
+++ b/src/scylla/e2e/runner_internals/experiment_entrypoint.py
@@ -8,6 +8,7 @@ from typing import TYPE_CHECKING
 
 from scylla.e2e.models import ExperimentConfig, ExperimentResult
 from scylla.e2e.runner_internals.runner_core import E2ERunner
+from scylla.metrics.emitter import MetricEmitter
 
 if TYPE_CHECKING:
     from scylla.e2e.resource_manager import ResourceManager
@@ -21,6 +22,7 @@ def run_experiment(
     results_dir: Path,
     fresh: bool = False,
     resource_manager: ResourceManager | None = None,
+    emitter: MetricEmitter | None = None,
 ) -> ExperimentResult:
     """Run an experiment with the given configuration.
 
@@ -31,13 +33,16 @@ def run_experiment(
         fresh: If True, ignore existing checkpoints and start fresh
         resource_manager: Optional shared ResourceManager for concurrency control.
             When running in batch mode, all experiments share the same instance.
+        emitter: Optional :class:`MetricEmitter` for time-series export.
+            Defaults to :func:`get_default_emitter` (NoOp unless
+            ``SCYLLA_METRICS_PATH`` is set).
 
     Returns:
         ExperimentResult with all results.
 
     """
     try:
-        runner = E2ERunner(config, tiers_dir, results_dir, fresh=fresh)
+        runner = E2ERunner(config, tiers_dir, results_dir, fresh=fresh, emitter=emitter)
         runner._resource_manager = resource_manager
         return runner.run()
     except (

--- a/src/scylla/e2e/runner_internals/runner_core.py
+++ b/src/scylla/e2e/runner_internals/runner_core.py
@@ -44,6 +44,7 @@ from scylla.e2e.shutdown import (
 from scylla.e2e.tier_action_builder import TierActionBuilder
 from scylla.e2e.tier_manager import TierManager
 from scylla.e2e.workspace_manager import WorkspaceManager
+from scylla.metrics.emitter import MetricEmitter, get_default_emitter
 
 if TYPE_CHECKING:
     from scylla.e2e.resource_manager import ResourceManager
@@ -82,6 +83,7 @@ class E2ERunner:
         tiers_dir: Path,
         results_base_dir: Path,
         fresh: bool = False,
+        emitter: MetricEmitter | None = None,
     ) -> None:
         """Initialize the E2E runner.
 
@@ -90,6 +92,9 @@ class E2ERunner:
             tiers_dir: Path to tier configurations
             results_base_dir: Base directory for results
             fresh: If True, ignore existing checkpoints and start fresh
+            emitter: Optional metric emitter for time-series export. Defaults
+                to :func:`scylla.metrics.emitter.get_default_emitter` (a
+                :class:`NoOpEmitter` unless ``SCYLLA_METRICS_PATH`` is set).
 
         """
         self.config = config
@@ -101,6 +106,7 @@ class E2ERunner:
         self._fresh = fresh
         self._last_experiment_result: ExperimentResult | None = None
         self._resource_manager: ResourceManager | None = None
+        self._emitter = emitter if emitter is not None else get_default_emitter()
 
     def _result_writer(self) -> ExperimentResultWriter:
         """Create an ExperimentResultWriter bound to current state.
@@ -496,6 +502,7 @@ class E2ERunner:
         result = self._aggregate_results(tier_results, start_time)
         self._save_final_results(result)
         self._generate_report(result)
+        self._emit_experiment_metrics(tier_results, result)
         self._last_experiment_result = result
 
     def _action_exp_reports_generated(self) -> None:
@@ -666,6 +673,85 @@ class E2ERunner:
 
             tier_results.update(load_experiment_tier_results(self.experiment_dir, self.config))
         return self._aggregate_results(tier_results, start_time)
+
+    def _emit_experiment_metrics(
+        self,
+        tier_results: dict[TierID, TierResult],
+        result: ExperimentResult,
+    ) -> None:
+        """Emit per-tier counters and gauges via the configured MetricEmitter.
+
+        Default emitter is a NoOpEmitter, so this is a cheap no-op when
+        ``SCYLLA_METRICS_PATH`` is unset. Failures in the emitter must not
+        break experiment finalization.
+
+        Args:
+            tier_results: Per-tier results accumulated during the experiment.
+            result: Aggregated experiment result (unused for now but reserved
+                for experiment-level metrics).
+
+        """
+        del result  # currently only per-tier metrics; reserved for future use
+        experiment_id = self.config.experiment_id
+        try:
+            for tier_id, tier_result in tier_results.items():
+                tier_label = tier_id.value
+                # Outcome from best-subtest pass_rate: pass if any run passed.
+                best = (
+                    tier_result.subtest_results.get(tier_result.best_subtest)
+                    if tier_result.best_subtest
+                    else None
+                )
+                pass_rate = best.pass_rate if best is not None else 0.0
+                outcome = "pass" if pass_rate > 0 else "fail"
+                self._emitter.emit_counter(
+                    "scylla_tier_runs_total",
+                    1,
+                    labels={"tier": tier_label, "outcome": outcome},
+                )
+
+                # Per-subtest run outcome counts
+                pass_runs = 0
+                fail_runs = 0
+                for subtest in tier_result.subtest_results.values():
+                    for run in subtest.runs:
+                        if run.judge_passed:
+                            pass_runs += 1
+                        else:
+                            fail_runs += 1
+                if pass_runs:
+                    self._emitter.emit_counter(
+                        "scylla_subtest_runs_total",
+                        pass_runs,
+                        labels={"tier": tier_label, "outcome": "pass"},
+                    )
+                if fail_runs:
+                    self._emitter.emit_counter(
+                        "scylla_subtest_runs_total",
+                        fail_runs,
+                        labels={"tier": tier_label, "outcome": "fail"},
+                    )
+
+                labels = {"experiment": experiment_id, "tier": tier_label}
+                self._emitter.emit_gauge(
+                    "scylla_experiment_pass_rate", float(pass_rate), labels=labels
+                )
+                cop = tier_result.cost_of_pass
+                # Skip infinite CoP — emit only when finite to keep textfile
+                # collector parsable.
+                if cop != float("inf"):
+                    self._emitter.emit_gauge(
+                        "scylla_experiment_cost_of_pass_usd",
+                        float(cop),
+                        labels=labels,
+                    )
+                self._emitter.emit_gauge(
+                    "scylla_experiment_latency_seconds",
+                    float(tier_result.total_duration),
+                    labels=labels,
+                )
+        except Exception as e:  # emitter must never break finalization
+            logger.warning(f"Metric emission failed (non-fatal): {e}")
 
     def _setup_manager(self) -> ExperimentSetupManager:
         """Create an ExperimentSetupManager bound to current state."""

--- a/tests/unit/metrics/test_emitter_wiring.py
+++ b/tests/unit/metrics/test_emitter_wiring.py
@@ -1,0 +1,325 @@
+"""Tests that the runner / judge wire MetricEmitter correctly.
+
+Default behavior must be unchanged when ``SCYLLA_METRICS_PATH`` is unset
+(NoOpEmitter, no I/O). When a recording emitter is injected, expected
+counters / gauges must be observed.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from scylla.e2e.judge_runner import _emit_judge_metric, _run_judge
+from scylla.e2e.models import (
+    E2ERunResult,
+    ExperimentConfig,
+    ExperimentResult,
+    SubTestResult,
+    TierID,
+    TierResult,
+    TokenStats,
+)
+from scylla.e2e.runner import E2ERunner
+from scylla.metrics.emitter import (
+    MetricEmitter,
+    NoOpEmitter,
+    PrometheusTextfileEmitter,
+    get_default_emitter,
+)
+
+
+class RecordingEmitter(MetricEmitter):
+    """Capture emit calls for assertions."""
+
+    def __init__(self) -> None:
+        """Initialize with empty call lists."""
+        self.counters: list[tuple[str, int, dict[str, str] | None]] = []
+        self.gauges: list[tuple[str, float, dict[str, str] | None]] = []
+
+    def emit_counter(
+        self,
+        name: str,
+        value: int,
+        labels: dict[str, str] | None = None,
+    ) -> None:
+        """Record a counter call."""
+        self.counters.append((name, value, labels))
+
+    def emit_gauge(
+        self,
+        name: str,
+        value: float,
+        labels: dict[str, str] | None = None,
+    ) -> None:
+        """Record a gauge call."""
+        self.gauges.append((name, value, labels))
+
+
+def _make_run(passed: bool, cost: float = 0.1) -> E2ERunResult:
+    return E2ERunResult(
+        run_number=1,
+        cost_usd=cost,
+        duration_seconds=1.0,
+        exit_code=0,
+        token_stats=TokenStats(),
+        agent_duration_seconds=1.0,
+        judge_duration_seconds=0.5,
+        judge_score=0.9 if passed else 0.0,
+        judge_passed=passed,
+        judge_grade="A" if passed else "F",
+        judge_reasoning="ok",
+        workspace_path=Path("/tmp/ws"),
+        logs_path=Path("/tmp/logs"),
+    )
+
+
+def _make_tier_result(tier: TierID, pass_runs: int, fail_runs: int) -> TierResult:
+    runs = [_make_run(True) for _ in range(pass_runs)] + [
+        _make_run(False) for _ in range(fail_runs)
+    ]
+    total = pass_runs + fail_runs
+    pass_rate = pass_runs / total if total else 0.0
+    sub = SubTestResult(
+        subtest_id="s1",
+        tier_id=tier,
+        runs=runs,
+        pass_rate=pass_rate,
+        mean_cost=0.1,
+        total_cost=0.1 * total,
+    )
+    return TierResult(
+        tier_id=tier,
+        subtest_results={"s1": sub},
+        best_subtest="s1",
+        best_subtest_score=pass_rate,
+        total_cost=sub.total_cost,
+        total_duration=12.5,
+    )
+
+
+def _make_runner(emitter: MetricEmitter | None = None, tmp_path: Path | None = None) -> E2ERunner:
+    config = ExperimentConfig(
+        experiment_id="exp-test",
+        task_repo="https://example/repo",
+        task_commit="abc",
+        task_prompt_file=Path("prompt.md"),
+        language="python",
+    )
+    base = tmp_path or Path("/tmp")
+    return E2ERunner(
+        config=config,
+        tiers_dir=base,
+        results_base_dir=base,
+        emitter=emitter,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Default behavior unchanged
+# ---------------------------------------------------------------------------
+
+
+def test_runner_default_emitter_is_noop_when_env_unset(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """With SCYLLA_METRICS_PATH unset, the runner uses NoOpEmitter and writes nothing."""
+    monkeypatch.delenv("SCYLLA_METRICS_PATH", raising=False)
+    runner = _make_runner(tmp_path=tmp_path)
+    assert isinstance(runner._emitter, NoOpEmitter)
+    # Sanity: emit a metric — no file should appear in tmp_path.
+    tier_results = {TierID.T0: _make_tier_result(TierID.T0, 1, 0)}
+    fake_result = MagicMock(spec=ExperimentResult)
+    runner._emit_experiment_metrics(tier_results, fake_result)
+    assert list(tmp_path.iterdir()) == []
+
+
+def test_runner_uses_textfile_emitter_when_env_set(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """With SCYLLA_METRICS_PATH set, the runner uses PrometheusTextfileEmitter."""
+    out = tmp_path / "scylla.prom"
+    monkeypatch.setenv("SCYLLA_METRICS_PATH", str(out))
+    runner = _make_runner(tmp_path=tmp_path)
+    assert isinstance(runner._emitter, PrometheusTextfileEmitter)
+
+
+# ---------------------------------------------------------------------------
+# DI: recording emitter records calls
+# ---------------------------------------------------------------------------
+
+
+def test_runner_emits_per_tier_counters_and_gauges() -> None:
+    """A recording emitter sees the expected metric names and labels."""
+    rec = RecordingEmitter()
+    runner = _make_runner(emitter=rec)
+    tier_results = {
+        TierID.T0: _make_tier_result(TierID.T0, pass_runs=3, fail_runs=1),
+        TierID.T1: _make_tier_result(TierID.T1, pass_runs=0, fail_runs=2),
+    }
+    fake_result = MagicMock(spec=ExperimentResult)
+    runner._emit_experiment_metrics(tier_results, fake_result)
+
+    counter_names = {c[0] for c in rec.counters}
+    gauge_names = {g[0] for g in rec.gauges}
+
+    assert "scylla_tier_runs_total" in counter_names
+    assert "scylla_subtest_runs_total" in counter_names
+    assert "scylla_experiment_pass_rate" in gauge_names
+    assert "scylla_experiment_latency_seconds" in gauge_names
+    assert "scylla_experiment_cost_of_pass_usd" in gauge_names
+
+    # T0 tier counter outcome=pass; T1 counter outcome=fail.
+    tier_outcomes = {
+        (c[2] or {}).get("tier"): (c[2] or {}).get("outcome")
+        for c in rec.counters
+        if c[0] == "scylla_tier_runs_total"
+    }
+    assert tier_outcomes["T0"] == "pass"
+    assert tier_outcomes["T1"] == "fail"
+
+    # Subtest counters split by outcome.
+    subtest_pass = sum(
+        c[1]
+        for c in rec.counters
+        if c[0] == "scylla_subtest_runs_total" and (c[2] or {}).get("outcome") == "pass"
+    )
+    subtest_fail = sum(
+        c[1]
+        for c in rec.counters
+        if c[0] == "scylla_subtest_runs_total" and (c[2] or {}).get("outcome") == "fail"
+    )
+    assert subtest_pass == 3  # only T0 has passing runs
+    assert subtest_fail == 3  # T0 (1) + T1 (2)
+
+
+def test_runner_emits_to_textfile(tmp_path: Path) -> None:
+    """A PrometheusTextfileEmitter produces the expected lines after a tier completes."""
+    out = tmp_path / "scylla.prom"
+    emitter = PrometheusTextfileEmitter(out)
+    runner = _make_runner(emitter=emitter)
+    tier_results = {TierID.T0: _make_tier_result(TierID.T0, pass_runs=2, fail_runs=0)}
+    fake_result = MagicMock(spec=ExperimentResult)
+    runner._emit_experiment_metrics(tier_results, fake_result)
+
+    content = out.read_text()
+    assert "scylla_tier_runs_total" in content
+    assert "scylla_subtest_runs_total" in content
+    assert "scylla_experiment_pass_rate" in content
+    assert "scylla_experiment_latency_seconds" in content
+    assert 'tier="T0"' in content
+    assert 'experiment="exp-test"' in content
+
+
+def test_runner_emit_metrics_swallows_emitter_errors() -> None:
+    """An emitter that raises must not propagate out of _emit_experiment_metrics."""
+
+    class BoomEmitter(NoOpEmitter):
+        """Emitter that raises on every counter emit."""
+
+        def emit_counter(
+            self,
+            name: str,
+            value: int,
+            labels: dict[str, str] | None = None,
+        ) -> None:
+            """Raise unconditionally."""
+            raise RuntimeError("boom")
+
+    runner = _make_runner(emitter=BoomEmitter())
+    tier_results = {TierID.T0: _make_tier_result(TierID.T0, 1, 0)}
+    fake_result = MagicMock(spec=ExperimentResult)
+    # Should not raise.
+    runner._emit_experiment_metrics(tier_results, fake_result)
+
+
+# ---------------------------------------------------------------------------
+# Judge wiring
+# ---------------------------------------------------------------------------
+
+
+def test_emit_judge_metric_outcomes() -> None:
+    """_emit_judge_metric maps (is_valid, passed) -> outcome label correctly."""
+    rec = RecordingEmitter()
+    _emit_judge_metric(rec, "claude-haiku-4-5", is_valid=True, passed=True)
+    _emit_judge_metric(rec, "claude-haiku-4-5", is_valid=True, passed=False)
+    _emit_judge_metric(rec, "claude-haiku-4-5", is_valid=False, passed=False)
+
+    assert len(rec.counters) == 3
+    outcomes = [(c[2] or {}).get("outcome") for c in rec.counters]
+    assert outcomes == ["pass", "fail", "error"]
+    for c in rec.counters:
+        assert c[0] == "scylla_judge_evaluations_total"
+        assert (c[2] or {}).get("model") == "claude-haiku-4-5"
+
+
+def test_run_judge_emits_counter_per_judge(tmp_path: Path) -> None:
+    """_run_judge emits one scylla_judge_evaluations_total per configured judge."""
+    rec = RecordingEmitter()
+
+    fake_judge_result = MagicMock()
+    fake_judge_result.score = 0.9
+    fake_judge_result.passed = True
+    fake_judge_result.grade = "A"
+    fake_judge_result.reasoning = "good"
+    fake_judge_result.is_valid = True
+    fake_judge_result.criteria_scores = {}
+
+    judge_dir = tmp_path / "judge"
+    judge_dir.mkdir()
+    with patch("scylla.e2e.judge_runner.run_llm_judge", return_value=fake_judge_result):
+        consensus, judges = _run_judge(
+            workspace=tmp_path,
+            task_prompt="t",
+            stdout="s",
+            judge_dir=judge_dir,
+            judge_models=["claude-haiku-4-5", "claude-sonnet-4-5"],
+            emitter=rec,
+        )
+    assert consensus["passed"] is True
+    assert len(judges) == 2
+    judge_counters = [c for c in rec.counters if c[0] == "scylla_judge_evaluations_total"]
+    assert len(judge_counters) == 2
+    models = {(c[2] or {}).get("model") for c in judge_counters}
+    assert models == {"claude-haiku-4-5", "claude-sonnet-4-5"}
+
+
+def test_run_judge_default_emitter_is_noop_when_env_unset(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """When emitter not passed and SCYLLA_METRICS_PATH unset, no file is written."""
+    monkeypatch.delenv("SCYLLA_METRICS_PATH", raising=False)
+    fake_judge_result = MagicMock()
+    fake_judge_result.score = 0.9
+    fake_judge_result.passed = True
+    fake_judge_result.grade = "A"
+    fake_judge_result.reasoning = "good"
+    fake_judge_result.is_valid = True
+    fake_judge_result.criteria_scores = {}
+
+    judge_dir = tmp_path / "judge"
+    judge_dir.mkdir()
+    sentinel_dir = tmp_path / "sentinel"
+    sentinel_dir.mkdir()
+    with patch("scylla.e2e.judge_runner.run_llm_judge", return_value=fake_judge_result):
+        _run_judge(
+            workspace=tmp_path,
+            task_prompt="t",
+            stdout="s",
+            judge_dir=judge_dir,
+            judge_models=["claude-haiku-4-5"],
+        )
+    # Nothing leaked into the sentinel directory.
+    assert list(sentinel_dir.iterdir()) == []
+
+
+def test_get_default_emitter_picks_textfile_when_env_set(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """get_default_emitter is read at runtime, not import time."""
+    monkeypatch.delenv("SCYLLA_METRICS_PATH", raising=False)
+    assert isinstance(get_default_emitter(), NoOpEmitter)
+    monkeypatch.setenv("SCYLLA_METRICS_PATH", str(tmp_path / "out.prom"))
+    assert isinstance(get_default_emitter(), PrometheusTextfileEmitter)


### PR DESCRIPTION
## Summary
Follow-up to #1922 (MetricEmitter scaffold). Wires `emit_counter` / `emit_gauge` into the experiment runner and judge so operators get time-series data when `SCYLLA_METRICS_PATH` is set.

## Default behavior unchanged
With `SCYLLA_METRICS_PATH` unset, `get_default_emitter()` returns `NoOpEmitter` and zero new I/O occurs. The emitter is injected via constructor (`E2ERunner(..., emitter=...)`) / kwarg (`_run_judge(..., emitter=...)`) with `MetricEmitter | None = None` defaulting to `get_default_emitter()` at call time so the env var is read late.

## Metrics emitted
- counter `scylla_tier_runs_total{tier, outcome}` — one increment per tier on completion
- counter `scylla_subtest_runs_total{tier, outcome}` — bulk-incremented per tier with the count of pass/fail subtest runs
- gauge   `scylla_experiment_pass_rate{experiment, tier}`
- gauge   `scylla_experiment_cost_of_pass_usd{experiment, tier}` (skipped when CoP is +inf — no passes — so the textfile stays parsable)
- gauge   `scylla_experiment_latency_seconds{experiment, tier}`
- counter `scylla_judge_evaluations_total{model, outcome}` — one per judge invocation, outcome ∈ {pass, fail, error}

## Wire sites
- `src/scylla/e2e/runner.py` — `E2ERunner.__init__` accepts `emitter`; emission happens in `_action_exp_tiers_complete` after aggregation, via new helper `_emit_experiment_metrics`. Emitter failures are logged and swallowed so finalization is never broken.
- `src/scylla/e2e/judge_runner.py` — `_run_judge(..., emitter=...)` emits `scylla_judge_evaluations_total` per judge model on both success and failure paths.

## Skipped
The "aggregator" step in the issue body has no clean per-experiment aggregation seam distinct from `aggregate_results`/`_action_exp_tiers_complete` — emitting from the runner covers it. KISS.

## Verification
- New tests in `tests/unit/metrics/test_emitter_wiring.py` (9 tests) assert: NoOp default when env unset, PrometheusTextfileEmitter when set, recording emitter sees expected metric names + labels, textfile written contains expected lines, emitter errors are swallowed, judge counters fire on success and failure paths
- `pixi run pytest tests/unit/metrics/ tests/unit/e2e/test_runner.py tests/unit/e2e/test_judge_runner.py -q --no-cov` → 340 passed
- `pixi run mypy src/scylla/metrics/ src/scylla/e2e/runner.py src/scylla/e2e/judge_runner.py src/scylla/judge/ tests/unit/metrics/test_emitter_wiring.py` → 0 issues

Closes #1888
Refs #1867