### PR TITLE
feat(observability): correlate JSON logs with thread-local context and OTel spans

### DIFF
--- a/docs/dev/tracing.md
+++ b/docs/dev/tracing.md
@@ -82,6 +82,34 @@ under issue #1887.
 - Spans at every logging site.
 - `opentelemetry-instrumentation-*` auto-instrumentation packages.
 - Real OTLP collector deployment / endpoint configuration.
-- Bridging `logging.LogRecord` into spans.
 
 These remain open under issue #1887.
+
+## Log/span correlation
+
+When both `SCYLLA_JSON_LOGS=1` and `SCYLLA_OTEL_EXPORTER=...` are set,
+the JSON formatter automatically enriches each log line with:
+
+- `tier_id`, `subtest_id`, `run_num` — thread-local execution context
+  injected by `scylla.e2e.log_context.ContextFilter`. Empty fields are
+  omitted from output.
+- `trace_id` (32-char lowercase hex) and `span_id` (16-char lowercase
+  hex) — the currently active OpenTelemetry span, matching the
+  [OpenTelemetry log-correlation convention][otel-log-corr]. Omitted
+  when no recording span is active or when `opentelemetry-api` is not
+  installed.
+
+Sample JSON line emitted from inside an active span:
+
+```json
+{"timestamp": "2026-05-07T12:00:00.000000+00:00", "level": "INFO",
+ "name": "scylla.executor", "message": "subtest start",
+ "tier_id": "T0", "subtest_id": "05", "run_num": "1",
+ "trace_id": "4bf92f3577b34da6a3ce929d0e0e4736",
+ "span_id": "00f067aa0ba902b7"}
+```
+
+OpenTelemetry remains an optional dependency: when not installed, the
+trace fields are silently omitted and JSON logging continues to work.
+
+[otel-log-corr]: https://opentelemetry.io/docs/specs/otel/logs/data-model/#trace-context-fields

--- a/src/scylla/utils/json_logging.py
+++ b/src/scylla/utils/json_logging.py
@@ -20,8 +20,14 @@ serialised under the ``traceback`` key.
 
 No third-party dependencies are introduced; this is intentional so the
 foundation can be adopted incrementally without touching existing
-``logger.info(...)`` call sites. Distributed tracing (OpenTelemetry,
-Jaeger, etc.) remains out of scope and will be tracked separately.
+``logger.info(...)`` call sites.
+
+When the OpenTelemetry API is importable AND a recording span is active
+at log time, the formatter additionally injects ``trace_id`` (32-char
+lowercase hex) and ``span_id`` (16-char lowercase hex) fields, matching
+the OpenTelemetry log-correlation convention. OpenTelemetry remains an
+optional dependency: when not installed, these fields are silently
+omitted.
 """
 
 from __future__ import annotations
@@ -38,6 +44,13 @@ __all__ = [
     "configure_json_logging",
     "is_json_logging_enabled",
 ]
+
+# Module-level lazy probe for the OpenTelemetry trace API. Cached on first
+# use of :meth:`JsonFormatter.format` so the import attempt happens at most
+# once per process. The sentinel ``_OTEL_PROBED`` distinguishes "not yet
+# probed" from "probed and unavailable" (``_OTEL_TRACE_MODULE is None``).
+_OTEL_TRACE_MODULE: Any = None
+_OTEL_PROBED: bool = False
 
 # Standard LogRecord attributes that should NOT be copied into the
 # JSON payload as "extras". See logging.LogRecord docs.
@@ -73,6 +86,39 @@ _ENV_VAR = "SCYLLA_JSON_LOGS"
 _CONFIGURED_FLAG = "_scylla_json_logging_configured"
 
 
+def _extract_otel_trace_ids() -> dict[str, str]:
+    """Return ``{"trace_id": ..., "span_id": ...}`` for the current OTel span.
+
+    Returns an empty dict when the OpenTelemetry API is not importable, when
+    no span is active, or when the active span context is not valid. The
+    trace_id is rendered as a 32-char lowercase hex string and the span_id
+    as 16-char lowercase hex, matching the OpenTelemetry log-correlation
+    convention.
+    """
+    global _OTEL_TRACE_MODULE, _OTEL_PROBED
+    if not _OTEL_PROBED:
+        try:
+            from opentelemetry import trace as _otel_trace
+        except ImportError:
+            _OTEL_TRACE_MODULE = None
+        else:
+            _OTEL_TRACE_MODULE = _otel_trace
+        _OTEL_PROBED = True
+
+    trace_mod = _OTEL_TRACE_MODULE
+    if trace_mod is None:
+        return {}
+
+    span = trace_mod.get_current_span()
+    ctx = span.get_span_context()
+    if not ctx.is_valid:
+        return {}
+    return {
+        "trace_id": f"{ctx.trace_id:032x}",
+        "span_id": f"{ctx.span_id:016x}",
+    }
+
+
 class JsonFormatter(logging.Formatter):
     """Format :class:`logging.LogRecord` instances as a single JSON line.
 
@@ -81,6 +127,11 @@ class JsonFormatter(logging.Formatter):
     extras supplied via ``logger.info(..., extra={...})``. When the
     record carries exception info, a ``traceback`` field is appended.
     """
+
+    # Context fields injected by ``scylla.e2e.log_context.ContextFilter``
+    # are omitted from the JSON payload when their value is empty/None, to
+    # keep logs clean when no thread-local context is set.
+    _OMIT_IF_EMPTY: frozenset[str] = frozenset({"tier_id", "subtest_id", "run_num"})
 
     def format(self, record: logging.LogRecord) -> str:
         """Render *record* as a single-line JSON string."""
@@ -96,7 +147,13 @@ class JsonFormatter(logging.Formatter):
         for key, value in record.__dict__.items():
             if key in _RESERVED_LOGRECORD_ATTRS or key.startswith("_"):
                 continue
+            if key in self._OMIT_IF_EMPTY and not value:
+                continue
             payload[key] = value
+
+        # OTel trace correlation (best-effort; absent when OTel is not
+        # installed or no recording span is active).
+        payload.update(_extract_otel_trace_ids())
 
         if record.exc_info:
             payload["traceback"] = self.formatException(record.exc_info)
@@ -147,6 +204,13 @@ def configure_json_logging(
     json_handler.setFormatter(formatter)
     json_handler.setLevel(numeric_level)
     root.setLevel(numeric_level)
+
+    # Lazy import avoids a circular dependency between
+    # ``scylla.utils.json_logging`` and ``scylla.e2e.log_context``.
+    from scylla.e2e.log_context import ContextFilter
+
+    if not any(isinstance(f, ContextFilter) for f in json_handler.filters):
+        json_handler.addFilter(ContextFilter())
 
 
 def is_json_logging_enabled() -> bool:

--- a/tests/unit/e2e/test_log_context.py
+++ b/tests/unit/e2e/test_log_context.py
@@ -4,14 +4,21 @@ Tests cover:
 - set_log_context + ContextFilter injects fields into log records
 - Default empty strings when no context is set
 - Thread-local isolation (context set in one thread is not visible in another)
+- End-to-end integration with configure_json_logging
 """
 
 from __future__ import annotations
 
+import io
+import json
 import logging
 import threading
+from collections.abc import Iterator
+
+import pytest
 
 from scylla.e2e.log_context import ContextFilter, clear_log_context, set_log_context
+from scylla.utils.json_logging import configure_json_logging
 
 
 class TestContextFilterDefaults:
@@ -223,3 +230,41 @@ class TestHandlerFormatterIntegration:
         assert "context test" in captured[0]
 
         clear_log_context()
+
+
+@pytest.fixture
+def reset_root_logger() -> Iterator[None]:
+    """Snapshot and restore root logger state around the JSON integration test."""
+    root = logging.getLogger()
+    original_handlers = list(root.handlers)
+    original_level = root.level
+    for handler in original_handlers:
+        root.removeHandler(handler)
+    try:
+        yield
+    finally:
+        for handler in list(root.handlers):
+            root.removeHandler(handler)
+        for handler in original_handlers:
+            root.addHandler(handler)
+        root.setLevel(original_level)
+
+
+class TestJsonLoggingIntegration:
+    """End-to-end: configure_json_logging + set_log_context surface in JSON."""
+
+    def test_context_fields_appear_in_json_output(self, reset_root_logger: None) -> None:
+        """All three context fields must appear in the JSON log line."""
+        stream = io.StringIO()
+        configure_json_logging(stream=stream)
+        set_log_context(tier_id="T4", subtest_id="07", run_num=3)
+        try:
+            logging.getLogger("scylla.integration").info("e2e ctx")
+        finally:
+            clear_log_context()
+
+        payload = json.loads(stream.getvalue().strip().splitlines()[-1])
+        assert payload["tier_id"] == "T4"
+        assert payload["subtest_id"] == "07"
+        assert payload["run_num"] == "3"
+        assert payload["message"] == "e2e ctx"

--- a/tests/unit/utils/test_json_logging.py
+++ b/tests/unit/utils/test_json_logging.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import builtins
 import io
 import json
 import logging
@@ -11,6 +12,7 @@ from typing import Any
 
 import pytest
 
+from scylla.e2e.log_context import ContextFilter, clear_log_context, set_log_context
 from scylla.utils.json_logging import (
     JsonFormatter,
     configure_json_logging,
@@ -159,3 +161,126 @@ def test_is_json_logging_enabled_unset(monkeypatch: pytest.MonkeyPatch) -> None:
     """When SCYLLA_JSON_LOGS is unset, JSON logging must be disabled."""
     monkeypatch.delenv("SCYLLA_JSON_LOGS", raising=False)
     assert is_json_logging_enabled() is False
+
+
+# ---------------------------------------------------------------------------
+# Log/span correlation: thread-local context + OTel trace_id/span_id
+# ---------------------------------------------------------------------------
+
+
+def test_json_log_includes_context_when_set(reset_root_logger: None) -> None:
+    """ContextFilter values must surface in the JSON payload when set."""
+    stream = io.StringIO()
+    configure_json_logging(stream=stream)
+    set_log_context(tier_id="T0", subtest_id="05", run_num=2)
+    try:
+        logging.getLogger("scylla.ctx.test").info("with context")
+    finally:
+        clear_log_context()
+
+    payload = json.loads(stream.getvalue().strip().splitlines()[-1])
+    assert payload["tier_id"] == "T0"
+    assert payload["subtest_id"] == "05"
+    assert payload["run_num"] == "2"
+
+
+def test_json_log_omits_context_when_empty(reset_root_logger: None) -> None:
+    """Empty thread-local context fields must be omitted from JSON output."""
+    stream = io.StringIO()
+    configure_json_logging(stream=stream)
+    clear_log_context()
+
+    logging.getLogger("scylla.ctx.empty").info("no context")
+
+    payload = json.loads(stream.getvalue().strip().splitlines()[-1])
+    assert "tier_id" not in payload
+    assert "subtest_id" not in payload
+    assert "run_num" not in payload
+
+
+def test_configure_json_logging_idempotent_filter(reset_root_logger: None) -> None:
+    """Repeated configure calls must attach exactly one ContextFilter."""
+    stream = io.StringIO()
+    configure_json_logging(stream=stream)
+    configure_json_logging(stream=stream)
+    configure_json_logging(stream=stream)
+
+    root = logging.getLogger()
+    [json_handler] = [
+        h for h in root.handlers if getattr(h, "_scylla_json_logging_configured", False)
+    ]
+    context_filters = [f for f in json_handler.filters if isinstance(f, ContextFilter)]
+    assert len(context_filters) == 1
+
+
+def test_json_log_includes_trace_ids_when_span_active(
+    reset_root_logger: None, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """When an OTel recording span is active, trace_id and span_id appear in JSON."""
+    pytest.importorskip("opentelemetry")
+    from opentelemetry import trace
+    from opentelemetry.sdk.trace import TracerProvider
+
+    # Reset cached probe so the test exercises the import path freshly.
+    monkeypatch.setattr("scylla.utils.json_logging._OTEL_PROBED", False)
+    monkeypatch.setattr("scylla.utils.json_logging._OTEL_TRACE_MODULE", None)
+
+    provider = TracerProvider()
+    trace.set_tracer_provider(provider)
+    tracer = trace.get_tracer("scylla.test")
+
+    stream = io.StringIO()
+    configure_json_logging(stream=stream)
+
+    with tracer.start_as_current_span("test-span"):
+        logging.getLogger("scylla.trace.test").info("inside span")
+
+    payload = json.loads(stream.getvalue().strip().splitlines()[-1])
+    assert "trace_id" in payload
+    assert "span_id" in payload
+    assert len(payload["trace_id"]) == 32
+    assert len(payload["span_id"]) == 16
+    int(payload["trace_id"], 16)  # valid hex
+    int(payload["span_id"], 16)
+
+
+def test_json_log_omits_trace_ids_without_span(
+    reset_root_logger: None, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """No active recording span -> no trace_id/span_id keys."""
+    monkeypatch.setattr("scylla.utils.json_logging._OTEL_PROBED", False)
+    monkeypatch.setattr("scylla.utils.json_logging._OTEL_TRACE_MODULE", None)
+
+    stream = io.StringIO()
+    configure_json_logging(stream=stream)
+    logging.getLogger("scylla.trace.none").info("no span")
+
+    payload = json.loads(stream.getvalue().strip().splitlines()[-1])
+    assert "trace_id" not in payload
+    assert "span_id" not in payload
+
+
+def test_json_log_omits_trace_ids_when_otel_missing(
+    reset_root_logger: None, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """If opentelemetry is not importable, formatter must not raise."""
+    # Force the lazy probe to re-run, and make the import fail.
+    monkeypatch.setattr("scylla.utils.json_logging._OTEL_PROBED", False)
+    monkeypatch.setattr("scylla.utils.json_logging._OTEL_TRACE_MODULE", None)
+
+    real_import = builtins.__import__
+
+    def fake_import(name: str, *args: Any, **kwargs: Any) -> Any:
+        if name == "opentelemetry" or name.startswith("opentelemetry."):
+            raise ImportError(f"forced: {name}")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+
+    stream = io.StringIO()
+    configure_json_logging(stream=stream)
+    logging.getLogger("scylla.trace.missing").info("no otel")
+
+    payload = json.loads(stream.getvalue().strip().splitlines()[-1])
+    assert "trace_id" not in payload
+    assert "span_id" not in payload


### PR DESCRIPTION
Part of #1887.

## Summary

Bridges structured-logging context and OpenTelemetry trace correlation into the existing JSON log output (sub-task A of #1887).

- Wires `scylla.e2e.log_context.ContextFilter` into the JSON logging handler in `configure_json_logging()` so thread-local `tier_id`/`subtest_id`/`run_num` flow into JSON output. Idempotent: repeated calls do not stack filters.
- Adds `JsonFormatter._OMIT_IF_EMPTY = {tier_id, subtest_id, run_num}` so empty context fields are dropped from output, keeping logs clean when no context is set.
- Adds best-effort OpenTelemetry trace correlation: when an OTel recording span is active at log time, the formatter injects `trace_id` (32-char lowercase hex) and `span_id` (16-char lowercase hex), matching the OpenTelemetry log-correlation convention.
- OTel remains optional. Import is gated on a module-level lazy probe (`_OTEL_TRACE_MODULE`/`_OTEL_PROBED`) so the cost is paid at most once per process; when `opentelemetry` is unavailable, fields are silently omitted.
- Appends a `## Log/span correlation` section to `docs/dev/tracing.md` describing the behavior with a sample JSON line.

## Files changed

- `src/scylla/utils/json_logging.py` (+65)
- `tests/unit/utils/test_json_logging.py` (+125)
- `tests/unit/e2e/test_log_context.py` (+45)
- `docs/dev/tracing.md` (+27)

## Test plan

- [x] `pytest tests/unit/utils/test_json_logging.py tests/unit/e2e/test_log_context.py` (27 passed, 1 skipped — the OTel-active-span test, gated on `pytest.importorskip("opentelemetry")`)
- [x] `mypy src/scylla/utils/json_logging.py`
- [x] `ruff check`
- [x] `pre-commit run --all-files`

Refs #1887.