### PR TITLE
chore: easy-issue grab-bag triage — refs #1959 #1958 #1957

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -64,7 +64,7 @@ jobs:
 
       - name: Install gitleaks
         run: |
-          GITLEAKS_VERSION="8.21.2"
+          GITLEAKS_VERSION="8.30.1"
           curl -sSfL "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz" \
             | tar xz -C /usr/local/bin gitleaks
 

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -47,11 +47,14 @@ online or offline event.
 
 ## Enforcement
 
-Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders
-responsible for enforcement by reporting issues via GitHub repository Issues. All complaints will be reviewed
-and investigated promptly and fairly.
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported privately to the
+community leaders responsible for enforcement by emailing [research@villmow.us](mailto:research@villmow.us)
+with subject line `[CONDUCT] ProjectScylla - Brief description`. Do **not** use public GitHub Issues for
+conduct reports — they are world-readable and contradict the privacy obligation below. All complaints
+will be reviewed and investigated promptly and fairly.
 
 All community leaders are obligated to respect the privacy and security of the reporter of any incident.
+See [`MAINTAINERS.md`](MAINTAINERS.md) for the current list of leaders responsible for enforcement.
 
 ## Enforcement Guidelines
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 BSD 3-Clause License
 
-Copyright (c) 2025, Micah Villmow
+Copyright (c) 2025-2026, Micah Villmow
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,0 +1,38 @@
+# Maintainers
+
+This file lists the current maintainers of ProjectScylla. Maintainers are the
+"community leaders" referenced throughout [`CODE_OF_CONDUCT.md`](CODE_OF_CONDUCT.md)
+and the responsible parties for the enforcement and security paths defined in
+[`SECURITY.md`](SECURITY.md).
+
+## Current maintainers
+
+| Name          | GitHub        | Role                          | Contact                                              |
+| ------------- | ------------- | ----------------------------- | ---------------------------------------------------- |
+| Micah Villmow | @mvillmow     | Lead maintainer / BDFL        | [research@villmow.us](mailto:research@villmow.us)    |
+
+## Responsibilities
+
+Maintainers listed above are responsible for:
+
+- Triaging issues and reviewing pull requests
+- Receiving and acting on Code of Conduct reports
+  (see [`CODE_OF_CONDUCT.md` Enforcement](CODE_OF_CONDUCT.md#enforcement))
+- Receiving and acting on security disclosures
+  (see [`SECURITY.md`](SECURITY.md))
+- Cutting releases and maintaining the public APIs
+
+## Contact
+
+For non-sensitive questions, open a [GitHub Discussion](https://github.com/HomericIntelligence/ProjectScylla/discussions)
+or a regular issue.
+
+For Code of Conduct or security matters, **always** use the private email
+addresses above — do not file public issues.
+
+## Becoming a maintainer
+
+ProjectScylla currently has a single lead maintainer. As the project grows,
+additional maintainers may be added by consensus of the current maintainers,
+typically after a sustained record of high-quality contributions. Open a
+discussion if you are interested in contributing at this level.

--- a/justfile
+++ b/justfile
@@ -27,7 +27,7 @@ format:
 
 # Run mypy type checker
 typecheck:
-    pixi run mypy scylla scripts tests
+    pixi run mypy src/scylla scripts tests
 
 # Build CI container image
 ci-build:


### PR DESCRIPTION
Triage of 3 [Audit] Minor grab-bag tracker issues. Per-issue decisions:

## #1958 — Compliance & governance gaps (partial implementation)

Picked the 3 most mechanical sub-items:

- **Item 1 — LICENSE year drift**: bumped `Copyright (c) 2025` → `2025-2026` to align with README BibTeX (`year = {2026}`).
- **Item 2 — CoC reporting channel**: redirected Enforcement reports from public GitHub Issues to `research@villmow.us` (the SECURITY.md address), eliminating the privacy contradiction.
- **Item 4 — MAINTAINERS.md**: added file naming the "community leaders" referenced by CoC, with concrete contact info, responsibilities, and cross-links to CoC + SECURITY.md.

Items 3 (NOTICE Python deps), 5 (results/ retention policy), 6 (third-party API governance doc) remain open on the parent issue.

## #1957 — CI/tooling version drift (partial implementation)

Picked the 2 most mechanical sub-items (both pure version-pin fixes, no workflow logic changes):

- **Item 2 — Gitleaks version drift**: bumped `security.yml` from `8.21.2` → `8.30.1` to match `_required.yml` and the pre-commit hook (single source of truth).
- **Item 3 — `just typecheck` path drift**: fixed `pixi run mypy scylla …` → `pixi run mypy src/scylla …` to match the src-layout. Previously the recipe silently no-op'd on the package.

Items 1 (pixi version drift across 3 files — needs centralization design), 4 (Dockerfile SHA alignment), 5 (artifact upload — workflow logic change beyond pinning), 6 (root `/Dockerfile` cleanup) remain open on the parent issue.

## #1959 — Developer experience polish (deferred)

All 6 sub-items are net-new artifacts (`.devcontainer/`, `.vscode/`, watch/debug recipes, `.tool-versions`, doc consolidation) that require design choices. Not suitable for a single mechanical-sweep PR. Comment will be left on the issue.

## Scope

5 files, 47 insertions, 6 deletions. Well under the 400-LOC budget.

## Constraints respected

- Used `Refs #N`, not `Closes #N`; parent issues stay open until remaining sub-items merge.
- No Mojo/C++ source touched.
- Only `.github/workflows/` change is a pure version-string pin (gitleaks bump), per the constraint.