### PR TITLE
chore: refactor || true workarounds; add forbid-suppressions guard

### DIFF
--- a/.github/workflows/_required.yml
+++ b/.github/workflows/_required.yml
@@ -20,6 +20,63 @@ permissions:
   contents: read
 
 jobs:
+  # ── 0. forbid-suppressions ─────────────────────────────────────────────────
+  # Regression guard for HomericIntelligence/Odysseus#280: rejects `|| true`
+  # and `continue-on-error: true` in shell/YAML/Dockerfile/justfile/HCL files
+  # and in GitHub Actions workflows. Refactor to an explicit `if`-guard, a
+  # real conditional, or a documented `set +e`/`set -e` bracket.
+  forbid-suppressions:
+    name: forbid-suppressions
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
+
+      - name: "Reject silent-failure workaround in shell/YAML/Dockerfile/justfile/HCL"
+        run: |
+          set -euo pipefail
+          mapfile -t files < <(git ls-files \
+            -- \
+            '*.sh' '*.bash' '*.yml' '*.yaml' '*.hcl' \
+            'Dockerfile*' '**/Dockerfile*' \
+            'justfile' '**/justfile' 'Justfile' '**/Justfile')
+          declare -a scan_files=()
+          for f in "${files[@]}"; do
+            case "$f" in
+              # Exempt this workflow file (heredoc would otherwise self-match)
+              .github/workflows/_required.yml) continue ;;
+              # Exempt any runbook that documents the rule (if present)
+              docs/runbooks/no-silent-failures.md) continue ;;
+            esac
+            scan_files+=("$f")
+          done
+          if [ "${#scan_files[@]}" -eq 0 ]; then
+            echo "No files to scan"
+            exit 0
+          fi
+          if grep -nE '\|\|[[:space:]]*true([[:space:]]*$|[[:space:]]+#)' "${scan_files[@]}"; then
+            echo ""
+            echo '::error::Found silent-failure workarounds above. Refactor per HomericIntelligence/Odysseus#280.'
+            exit 1
+          fi
+          echo 'OK: no silent-failure workarounds found'
+
+      - name: "Reject continue-on-error workflow opt-out"
+        run: |
+          set -euo pipefail
+          mapfile -t files < <(git ls-files -- '.github/workflows/*.yml' '.github/workflows/*.yaml')
+          if [ "${#files[@]}" -eq 0 ]; then
+            echo "No workflow files"
+            exit 0
+          fi
+          if grep -nE '^[[:space:]]*continue-on-error:[[:space:]]*true[[:space:]]*$' "${files[@]}"; then
+            echo ""
+            echo '::error::Found "continue-on-error: true" above.'
+            echo '::error::Fix the root cause per HomericIntelligence/Odysseus#280.'
+            exit 1
+          fi
+          echo 'OK: no "continue-on-error: true" found'
+
   # ── 1. lint ────────────────────────────────────────────────────────────────
   lint:
     name: lint
@@ -264,6 +321,8 @@ jobs:
           gitleaks version
 
       - name: Run Gitleaks
+        # --exit-code 0 ensures the step always succeeds; findings are reported
+        # via the SARIF artifact uploaded below. No silent-failure suppression.
         run: |
           if [ -f .gitleaks.toml ]; then
             gitleaks detect --source . --config .gitleaks.toml \
@@ -272,7 +331,6 @@ jobs:
             gitleaks detect --source . \
               --report-format sarif --report-path gitleaks.sarif --exit-code 0
           fi
-        continue-on-error: true
 
       - name: Upload Gitleaks SARIF
         if: always() && hashFiles('gitleaks.sarif') != ''

--- a/.github/workflows/ci-image.yml
+++ b/.github/workflows/ci-image.yml
@@ -88,16 +88,17 @@ jobs:
 
       - name: Check npm audit (non-blocking)
         id: npm_audit
-        continue-on-error: true
         run: |
           # Run npm audit inside the built CI image to check for high/critical vulnerabilities.
-          # Non-blocking (continue-on-error: true) — findings are reported as warnings only.
+          # Non-blocking: findings are reported to the step summary as warnings, the
+          # step itself always succeeds because the script captures and inspects the
+          # audit exit code instead of letting it propagate.
           AUDIT_OUTPUT=$(podman run --rm "${IMAGE_NAME}:latest" \
             npm audit --audit-level=high 2>&1) || AUDIT_EXIT=$?
           AUDIT_EXIT=${AUDIT_EXIT:-0}
 
           if [ "$AUDIT_EXIT" -ne 0 ]; then
-            VULN_COUNT=$(echo "$AUDIT_OUTPUT" | grep -c 'high\|critical' || true)
+            VULN_COUNT=$(printf '%s\n' "$AUDIT_OUTPUT" | awk '/high|critical/{n++} END{print n+0}')
             echo "::warning file=ci/Containerfile::npm audit found ${VULN_COUNT} high/critical advisory line(s) in scylla-ci image"
             {
               echo "## npm audit (high/critical)"

--- a/.github/workflows/docker-test.yml
+++ b/.github/workflows/docker-test.yml
@@ -74,16 +74,17 @@ jobs:
 
       - name: Check npm audit (non-blocking)
         id: npm_audit
-        continue-on-error: true
         run: |
           # Run npm audit inside the built container to check for high/critical vulnerabilities.
-          # This is non-blocking (continue-on-error: true) — findings are reported as warnings.
+          # Non-blocking: findings are reported to the step summary as warnings, the
+          # step itself always succeeds because the script captures and inspects the
+          # audit exit code instead of letting it propagate.
           AUDIT_OUTPUT=$(docker run --rm scylla-experiment:trivy-scan \
             npm audit --audit-level=high 2>&1) || AUDIT_EXIT=$?
           AUDIT_EXIT=${AUDIT_EXIT:-0}
 
           if [ "$AUDIT_EXIT" -ne 0 ]; then
-            VULN_COUNT=$(echo "$AUDIT_OUTPUT" | grep -c 'high\|critical' || true)
+            VULN_COUNT=$(printf '%s\n' "$AUDIT_OUTPUT" | awk '/high|critical/{n++} END{print n+0}')
             echo "::warning file=docker/Dockerfile::npm audit found ${VULN_COUNT} high/critical advisory line(s) in scylla-experiment image"
             {
               echo "## npm audit (high/critical)"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,6 +14,31 @@ repos:
     hooks:
       - id: gitleaks
 
+  # Silent-failure suppression guards (see HomericIntelligence/Odysseus#280)
+  - repo: local
+    hooks:
+      - id: forbid-or-true
+        name: "forbid silent-failure workaround in shell/YAML/Dockerfile/justfile/HCL"
+        description: >
+          Rejects the `or-true` idiom (and its whitespace variants) in shell,
+          YAML, Dockerfile, justfile, and HCL sources. Refactor to an explicit
+          `if`-guard, a real conditional, or a documented `set +e`/`set -e`
+          bracket. See HomericIntelligence/Odysseus#280.
+        language: pygrep
+        entry: '\|\|\s*true(\s*$|\s+#)'
+        files: \.(sh|bash|yml|yaml|hcl)$|(^|/)Dockerfile[^/]*$|(^|/)[Jj]ustfile$
+        types: [text]
+        pass_filenames: true
+      - id: forbid-continue-on-error
+        name: "forbid continue-on-error workflow opt-out"
+        description: >
+          GitHub Actions `continue-on-error true` (truthy form) hides real CI
+          failures. Fix the underlying job/step instead.
+        language: pygrep
+        entry: '^\s*continue-on-error:\s*true\s*$'
+        files: ^\.github/workflows/.*\.ya?ml$
+        pass_filenames: true
+
   # Security checks
   - repo: local
     hooks:

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -284,8 +284,12 @@ run_agent() {
         log_info "Agent execution completed with exit code: ${exit_code}"
     fi
 
-    # Make output files world-writable so host can overwrite them
-    chmod 666 /output/result.json /output/stdout.log /output/stderr.log 2>/dev/null || true
+    # Make output files world-writable so host can overwrite them.
+    # Best-effort: some files may not exist depending on execution path; log unexpected
+    # failures (other than missing files) to stderr rather than aborting the agent.
+    if ! chmod 666 /output/result.json /output/stdout.log /output/stderr.log 2>/dev/null; then
+        echo "warn: chmod on /output/{result.json,stdout.log,stderr.log} encountered errors (idempotent)" >&2
+    fi
 
     exit ${exit_code}
 }

--- a/scripts/build_paper.sh
+++ b/scripts/build_paper.sh
@@ -22,7 +22,9 @@ command -v bibtex >/dev/null 2>&1 || { error "bibtex not found"; exit 1; }
 success "LaTeX tools available"
 
 info "Setting up build environment..."
-rm -rf "$WORK_DIR" 2>/dev/null || true
+if [ -d "$WORK_DIR" ]; then
+    rm -rf "$WORK_DIR"
+fi
 mkdir -p "$WORK_DIR"
 
 info "Copying source files..."
@@ -40,7 +42,12 @@ fi
 
 info "Building PDF..."
 pdflatex -interaction=nonstopmode main.tex > /dev/null 2>&1
-bibtex main > /dev/null 2>&1 || true
+# bibtex returns non-zero when there are no .aux entries or no citations were
+# emitted by pdflatex on the first pass; that's expected and non-fatal here.
+# Surface unexpected bibtex failures via the log so silent breakage stops happening.
+if ! bibtex main > /tmp/bibtex.log 2>&1; then
+    echo "warn: bibtex returned non-zero (often expected for citation-free runs); see /tmp/bibtex.log" >&2
+fi
 pdflatex -interaction=nonstopmode main.tex > /dev/null 2>&1
 pdflatex -interaction=nonstopmode main.tex
 

--- a/tests/scripts/test_cleanup_stale_worktrees.sh
+++ b/tests/scripts/test_cleanup_stale_worktrees.sh
@@ -53,7 +53,10 @@ assert_output_contains() {
     local desc="$1" expected="$2"
     shift 2
     local output
-    output=$("$@" 2>&1) || true
+    local rc=0
+    # Capture output regardless of command exit code; we only assert on stdout/stderr content.
+    output=$("$@" 2>&1) || rc=$?
+    : "${rc:=0}"  # rc intentionally inspected only to suppress set -e
     if [[ "$output" == *"$expected"* ]]; then
         pass "$desc"
     else
@@ -69,7 +72,10 @@ assert_output_not_contains() {
     local desc="$1" unexpected="$2"
     shift 2
     local output
-    output=$("$@" 2>&1) || true
+    local rc=0
+    # Capture output regardless of command exit code; we only assert on stdout/stderr content.
+    output=$("$@" 2>&1) || rc=$?
+    : "${rc:=0}"  # rc intentionally inspected only to suppress set -e
     if [[ "$output" != *"$unexpected"* ]]; then
         pass "$desc"
     else
@@ -136,7 +142,7 @@ run_test "--help exits with 0" 0 "$SCRIPT" --help
 
 # 2. Unknown option exits with non-zero
 echo "2. Unknown option"
-run_test "Unknown option exits non-zero" 1 "$SCRIPT" --unknown-flag 2>/dev/null || true
+run_test "Unknown option exits non-zero" 1 "$SCRIPT" --unknown-flag
 
 # 3. No stale worktrees → clean exit
 echo "3. No stale worktrees"
@@ -157,7 +163,10 @@ REPO=$(setup_repo)
 WT=$(add_worktree "$REPO" "42-merged-feature" "merged")
 (
     cd "$REPO"
-    output=$("$SCRIPT" --force --log-file "${TMPDIR_BASE}/test4.log" 2>&1) || true
+    # Capture combined stdout/stderr; the test inspects content, not exit code.
+    rc=0
+    output="$("$SCRIPT" --force --log-file "${TMPDIR_BASE}/test4.log" 2>&1)" || rc=$?
+    : "${rc:=0}"  # rc intentionally inspected only to suppress set -e
     if [[ "$output" == *"Removed worktree"* ]] || [[ "$output" == *"42-merged-feature"* ]]; then
         pass "Merged worktree detected and processed"
     else
@@ -173,7 +182,10 @@ REPO=$(setup_repo)
 WT=$(add_worktree "$REPO" "99-dry-run-feature" "merged")
 (
     cd "$REPO"
-    "$SCRIPT" --dry-run --log-file "${TMPDIR_BASE}/test5.log" 2>&1 || true
+    # Side-effect test: we only care whether the worktree dir survives, not the exit code.
+    rc=0
+    "$SCRIPT" --dry-run --log-file "${TMPDIR_BASE}/test5.log" >/dev/null 2>&1 || rc=$?
+    : "${rc:=0}"  # rc intentionally inspected only to suppress set -e
     if [[ -d "$WT" ]]; then
         pass "Dry-run: worktree directory still exists"
     else
@@ -201,7 +213,9 @@ WT=$(add_worktree "$REPO" "77-dirty" "merged")
 echo "dirty" > "${WT}/dirty.txt"
 (
     cd "$REPO"
-    output=$("$SCRIPT" --force --log-file "${TMPDIR_BASE}/test7.log" 2>&1) || true
+    rc=0
+    output="$("$SCRIPT" --force --log-file "${TMPDIR_BASE}/test7.log" 2>&1)" || rc=$?
+    : "${rc:=0}"  # rc intentionally inspected only to suppress set -e
     if [[ "$output" == *"uncommitted"* ]] || [[ "$output" == *"SKIP"* ]] || [[ -d "$WT" ]]; then
         pass "Dirty worktree was skipped"
     else
@@ -216,8 +230,10 @@ add_worktree "$REPO" "33-log-test" "merged" > /dev/null
 LOG="${TMPDIR_BASE}/test8.log"
 (
     cd "$REPO"
-    "$SCRIPT" --force --log-file "$LOG" 2>&1 || true
-    # Log created if something was processed
+    # Side-effect test: assertion is on $LOG existence, not the script's exit code.
+    rc=0
+    "$SCRIPT" --force --log-file "$LOG" >/dev/null 2>&1 || rc=$?
+    : "${rc:=0}"  # rc intentionally inspected only to suppress set -e
     if [[ -f "$LOG" ]]; then
         pass "Log file created when action taken"
     else
@@ -231,7 +247,10 @@ echo "9. Main worktree not removed"
 REPO=$(setup_repo)
 (
     cd "$REPO"
-    "$SCRIPT" --force --log-file "${TMPDIR_BASE}/test9.log" 2>&1 || true
+    # Side-effect test: the main worktree must NOT be removed; we ignore the script's exit code.
+    rc=0
+    "$SCRIPT" --force --log-file "${TMPDIR_BASE}/test9.log" >/dev/null 2>&1 || rc=$?
+    : "${rc:=0}"  # rc intentionally inspected only to suppress set -e
     if [[ -d "$REPO" ]]; then
         pass "Main worktree directory still exists"
     else

--- a/tests/shell/docker/entrypoint/helpers/common.bash
+++ b/tests/shell/docker/entrypoint/helpers/common.bash
@@ -9,19 +9,22 @@ setup_mocks() {
 }
 
 # Unset all mock control variables so each test starts clean.
+# `unset` returns 0 for non-existent (and non-readonly) variables, so no
+# error-suppression is needed here. If any variable becomes readonly in the
+# future, unset will fail loudly — that's the desired behaviour.
 clean_state() {
-    unset CLAUDE_MOCK_EXIT      || true
-    unset TIMEOUT_MOCK_EXIT     || true
-    unset GIT_MOCK_CLONE_EXIT   || true
-    unset PYTHON_MOCK_EXIT      || true
-    unset ANTHROPIC_API_KEY     || true
-    unset OPENAI_API_KEY        || true
-    unset TIER                  || true
-    unset RUN_NUMBER            || true
-    unset MODEL                 || true
-    unset TEST_ID               || true
-    unset TIMEOUT               || true
-    unset REPO_URL              || true
-    unset REPO_HASH             || true
-    unset TEST_COMMAND          || true
+    unset CLAUDE_MOCK_EXIT
+    unset TIMEOUT_MOCK_EXIT
+    unset GIT_MOCK_CLONE_EXIT
+    unset PYTHON_MOCK_EXIT
+    unset ANTHROPIC_API_KEY
+    unset OPENAI_API_KEY
+    unset TIER
+    unset RUN_NUMBER
+    unset MODEL
+    unset TEST_ID
+    unset TIMEOUT
+    unset REPO_URL
+    unset REPO_HASH
+    unset TEST_COMMAND
 }

--- a/tests/shell/skills/github/gh-implement-issue/helpers/common.bash
+++ b/tests/shell/skills/github/gh-implement-issue/helpers/common.bash
@@ -9,12 +9,15 @@ setup_mocks() {
 }
 
 # Unset all mock control variables so each test starts clean.
+# `unset` returns 0 for non-existent (and non-readonly) variables, so no
+# error-suppression is needed here. If any variable becomes readonly in the
+# future, unset will fail loudly — that's the desired behaviour.
 clean_state() {
-    unset GH_MOCK_ISSUE_STATE    || true
-    unset GH_MOCK_PR_JSON        || true
-    unset GH_MOCK_ISSUE_COMMENTS || true
-    unset GH_MOCK_PR_CLOSES      || true
-    unset GIT_MOCK_LOG           || true
-    unset GIT_MOCK_WORKTREE      || true
-    unset GIT_MOCK_BRANCH        || true
+    unset GH_MOCK_ISSUE_STATE
+    unset GH_MOCK_PR_JSON
+    unset GH_MOCK_ISSUE_COMMENTS
+    unset GH_MOCK_PR_CLOSES
+    unset GIT_MOCK_LOG
+    unset GIT_MOCK_WORKTREE
+    unset GIT_MOCK_BRANCH
 }

--- a/tests/unit/ci/test_npm_audit_step.py
+++ b/tests/unit/ci/test_npm_audit_step.py
@@ -28,21 +28,44 @@ def test_npm_audit_uses_high_level() -> None:
 
 
 def test_npm_audit_is_non_blocking() -> None:
-    """Npm audit step must use continue-on-error: true."""
+    """Npm audit step must be non-blocking — the step never fails the workflow.
+
+    Historically this was achieved with ``continue-on-error: true`` on the
+    step itself. That approach silently swallowed *any* failure in the step
+    (not just an npm-audit non-zero exit), so it was replaced by capturing
+    the audit command's exit code in-script:
+
+        AUDIT_OUTPUT=$(docker run ... npm audit ...) || AUDIT_EXIT=$?
+        AUDIT_EXIT=${AUDIT_EXIT:-0}
+
+    Either mechanism keeps PRs unblocked, so accept whichever is present.
+    """
     content = _DOCKER_TEST_WORKFLOW.read_text()
     lines = content.splitlines()
+
     in_audit_step = False
-    found_continue_on_error = False
+    step_body: list[str] = []
     for line in lines:
         if "npm audit" in line and "name:" in line.lower():
             in_audit_step = True
-        elif in_audit_step and "continue-on-error: true" in line:
-            found_continue_on_error = True
+            continue
+        if in_audit_step and line.strip().startswith("- name:"):
             break
-        elif in_audit_step and line.strip().startswith("- name:"):
-            break
-    assert found_continue_on_error, (
-        "npm audit step must have continue-on-error: true to avoid blocking PRs"
+        if in_audit_step:
+            step_body.append(line)
+
+    body = "\n".join(step_body)
+
+    has_continue_on_error = "continue-on-error: true" in body
+    # In-script capture pattern: "|| AUDIT_EXIT=$?" followed by a default
+    # assignment that swallows the exit code so the step itself succeeds.
+    has_inline_capture = "|| AUDIT_EXIT=$?" in body and "AUDIT_EXIT:-0" in body
+
+    assert has_continue_on_error or has_inline_capture, (
+        "npm audit step must be non-blocking: either set "
+        "'continue-on-error: true' on the step or capture the audit exit "
+        "code in-script (|| AUDIT_EXIT=$? + AUDIT_EXIT=${AUDIT_EXIT:-0}) "
+        "so the step itself never fails."
     )
 
 


### PR DESCRIPTION
## Summary

Ports the silent-failures regression guard from [HomericIntelligence/Odysseus#280](https://github.com/HomericIntelligence/Odysseus/pull/280) and refactors all `|| true` and `continue-on-error: true` suppressions in this repo per Bucket A-E classification.

- 32 `|| true` occurrences refactored (across 5 files)
- 3 `continue-on-error: true` opt-outs removed (across 3 workflow files)
- Adds 2 pygrep `pre-commit` hooks (`forbid-or-true`, `forbid-continue-on-error`)
- Adds CI job `forbid-suppressions` in `.github/workflows/_required.yml` so the pattern cannot return

## Refactor inventory

| File | Line(s) (pre-edit) | Bucket | Before -> After |
|------|--------------------|--------|-----------------|
| `docker/entrypoint.sh` | 288 | B (best-effort teardown) | `chmod 666 ... 2>/dev/null \|\| true` -> `if ! chmod ...; then echo "warn: ..." >&2; fi` |
| `scripts/build_paper.sh` | 25 | B (idempotent teardown) | `rm -rf "$WORK_DIR" 2>/dev/null \|\| true` -> `if [ -d "$WORK_DIR" ]; then rm -rf "$WORK_DIR"; fi` |
| `scripts/build_paper.sh` | 43 | A (masked a real failure) | `bibtex main >/dev/null 2>&1 \|\| true` -> capture log; `echo warn` on non-zero (bibtex with no citations is expected non-zero) |
| `tests/scripts/test_cleanup_stale_worktrees.sh` | 56 | D (capture, ignore exit) | `output=$("$@" 2>&1) \|\| true` -> explicit `rc=0; ... \|\| rc=$?; : ${rc:=0}` |
| `tests/scripts/test_cleanup_stale_worktrees.sh` | 72 | D (capture, ignore exit) | same pattern as above |
| `tests/scripts/test_cleanup_stale_worktrees.sh` | 139 | A (dead suffix) | `run_test ... \|\| true` -> dropped (`run_test` already absorbs exit codes via internal `\|\| actual_exit=$?`) |
| `tests/scripts/test_cleanup_stale_worktrees.sh` | 160 | D | `output=$(...) \|\| true` -> `rc=0; output=$(...) \|\| rc=$?; : ${rc:=0}` |
| `tests/scripts/test_cleanup_stale_worktrees.sh` | 176 | D (side-effect test) | `"$SCRIPT" ... \|\| true` -> `rc=0; ... \|\| rc=$?; : ${rc:=0}` |
| `tests/scripts/test_cleanup_stale_worktrees.sh` | 204 | D | same pattern |
| `tests/scripts/test_cleanup_stale_worktrees.sh` | 219 | D (side-effect test) | same pattern |
| `tests/scripts/test_cleanup_stale_worktrees.sh` | 234 | D (side-effect test) | same pattern |
| `tests/shell/docker/entrypoint/helpers/common.bash` | 13-26 (x14) | A (unnecessary suppression) | `unset VAR \|\| true` -> `unset VAR` (unset returns 0 for non-readonly vars; suppression was cargo-culted) |
| `tests/shell/skills/github/gh-implement-issue/helpers/common.bash` | 13-19 (x7) | A (unnecessary suppression) | same pattern |
| `.github/workflows/_required.yml` | 275 | E | `continue-on-error: true` on Gitleaks step removed; the underlying command already uses `--exit-code 0`, so the suppression was redundant |
| `.github/workflows/ci-image.yml` | 91 | E + D | Removed `continue-on-error: true` (script already captures `AUDIT_EXIT` and never propagates it); replaced inner `grep -c \|\| true` with `awk '/.../{n++} END{print n+0}'` |
| `.github/workflows/docker-test.yml` | 77 | E + D | Same pattern as ci-image.yml |

## Regression guard

- `.pre-commit-config.yaml`: added `forbid-or-true` and `forbid-continue-on-error` pygrep hooks under the existing `repos: - repo: local` block.
- `.github/workflows/_required.yml`: added `forbid-suppressions` job near the top of the file with two checks (`|| true` in shell/YAML/Dockerfile/justfile/HCL, and `continue-on-error: true` in workflows). The job exempts the workflow file itself and `docs/runbooks/no-silent-failures.md` to avoid self-matching the heredoc patterns.

## Verification

Run locally before requesting merge:

- [x] `bash -n` on every modified `.sh`/`.bash` file -> all pass
- [x] `python3 -c "import yaml; yaml.safe_load(open(...))"` on every modified YAML -> all parse
- [x] `pixi run --environment lint yamllint -c .yamllint.yaml ...` on modified YAML -> only pre-existing line-length warnings
- [x] `pre-commit run shellcheck --all-files` -> Passed
- [x] `pre-commit run forbid-or-true --all-files` -> Passed
- [x] `pre-commit run forbid-continue-on-error --all-files` -> Passed
- [x] `pre-commit run trailing-whitespace / end-of-file-fixer / mixed-line-ending / check-merge-conflict --all-files` -> Passed
- [x] No remaining `|| true` matches in tracked shell/yaml/dockerfile/justfile/hcl files
- [x] No remaining `continue-on-error: true` matches in `.github/workflows/*.yml`

The local Python 3.9 system interpreter could not bootstrap the `yamllint` pre-commit isolated env (yamllint requires Python >=3.10) so I verified yamllint via `pixi run --environment lint yamllint` instead. This is a pre-existing local-env issue unrelated to this PR.

## Test plan

- [ ] CI green on all required checks, including the new `forbid-suppressions` job
- [ ] Confirm `forbid-suppressions` actually fails a PR that reintroduces `|| true` (manually verified locally by reverting one fix and re-running the hook -> fails as expected)

## Notes on skipped / out-of-scope items

- `tests/fixtures/` was excluded from refactors per the brief; this repo's fixtures are markdown/YAML config and contain no `|| true` patterns, so no files needed to be skipped on that ground.
- Pre-existing yamllint `line-length` warnings (3 lines in `_required.yml`, 4 in `.pre-commit-config.yaml`) were not "fixed" because they are pre-existing, warning-level, and unrelated to this PR's scope.
- The `pixi run shellcheck` task does not exist in this repo's pixi config; ran shellcheck via the pre-commit hook pinned at `shellcheck-py v0.9.0.6` instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)