### PR TITLE
fix(cli): align tier-name mapping to CLAUDE.md (#1953)

### DIFF
--- a/src/scylla/cli/main.py
+++ b/src/scylla/cli/main.py
@@ -209,13 +209,13 @@ def _calculate_tier_metrics(
 
     """
     tier_names = {
-        "T0": "Vanilla",
-        "T1": "Prompted",
-        "T2": "Skills",
-        "T3": "Tooling",
-        "T4": "Delegation",
-        "T5": "Hierarchy",
-        "T6": "Hybrid",
+        "T0": "Prompts",
+        "T1": "Skills",
+        "T2": "Tooling",
+        "T3": "Delegation",
+        "T4": "Hierarchy",
+        "T5": "Hybrid",
+        "T6": "Super",
     }
 
     pass_rates = [r["grading"]["pass_rate"] for r in results]
@@ -545,13 +545,13 @@ def list_tiers() -> None:
 
     """
     tiers = [
-        ("T0", "Vanilla", "Base LLM with zero-shot prompting"),
-        ("T1", "Prompted", "System prompts and chain-of-thought"),
-        ("T2", "Skills", "Prompt-encoded domain expertise"),
-        ("T3", "Tooling", "External function calling with JSON schemas"),
-        ("T4", "Delegation", "Flat multi-agent systems"),
-        ("T5", "Hierarchy", "Nested orchestration with self-correction"),
-        ("T6", "Hybrid", "Optimal combinations of proven components"),
+        ("T0", "Prompts", "System prompt ablation (empty → full CLAUDE.md)"),
+        ("T1", "Skills", "Domain expertise via installed skills by category"),
+        ("T2", "Tooling", "External tools and MCP servers"),
+        ("T3", "Delegation", "Flat multi-agent with specialist agents"),
+        ("T4", "Hierarchy", "Nested orchestration with orchestrator agents"),
+        ("T5", "Hybrid", "Best combinations and permutations"),
+        ("T6", "Super", "Everything enabled at maximum capability"),
     ]
 
     click.echo("Evaluation tiers:\n")


### PR DESCRIPTION
## Summary

CLI tier-name mapping in `src/scylla/cli/main.py` was shifted by one position (T0=Vanilla, T1=Prompted, T2=Skills, …, T6=Hybrid) and missing the canonical T0/T6 names. Downstream analysis tooling that joins on tier ID produced incorrect tables.

This PR realigns the mapping to the canonical `CLAUDE.md` definitions:

| Tier | Name |
|------|------|
| T0 | Prompts |
| T1 | Skills |
| T2 | Tooling |
| T3 | Delegation |
| T4 | Hierarchy |
| T5 | Hybrid |
| T6 | Super |

Two locations updated in `src/scylla/cli/main.py`:
- Line 211–219: `tier_names` dict used for `tier_name` field in `TierMetrics`
- Line 547–555: `list_tiers` command display tuples (also updated descriptions to match CLAUDE.md)

No tests asserted the old wrong CLI names — the config-loader and reporting tests that reference "Vanilla"/"Prompted" use fixture files directly and are unrelated to the CLI mapping dict.

Closes #1953

🤖 Generated with [Claude Code](https://claude.com/claude-code)