### PR TITLE
docs(governance): close remaining #1958 items (NOTICE deps, data-policy, third-party API)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -502,6 +502,8 @@ def calculate_metric(data: pd.DataFrame, threshold: float = 0.5) -> float:
 - **README.md**: Update if changing user-facing features
 - **CLAUDE.md**: Reference for AI agent development (don't modify without discussion)
 - **docs/**: Add design docs for major features
+- **docs/dev/data-policy.md**: Data retention and deletion policy for the `results/` directory
+  (what is stored, how long to keep it, and how to purge runs)
 
 ## Code Review Process
 

--- a/NOTICE
+++ b/NOTICE
@@ -85,10 +85,54 @@ copyright notice and this permission notice appear in all copies.
 THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES.
 
 ================================================================================
+Python runtime dependencies (sdist/wheel and Docker image)
+================================================================================
+
+The following Python packages are installed as runtime dependencies when the
+ProjectScylla package is installed (via pip/pixi) or inside the Docker image.
+They are not modified or redistributed in source form, but are listed here
+for license-compliance transparency.
+
+--------------------------------------------------------------------------------
+click
+--------------------------------------------------------------------------------
+Version: 8.x
+License: BSD-3-Clause
+Source:  https://github.com/pallets/click
+Copyright (c) 2014 by the Pallets team.
+
+--------------------------------------------------------------------------------
+httpx
+--------------------------------------------------------------------------------
+Version: 0.28.x
+License: BSD-3-Clause
+Source:  https://github.com/encode/httpx
+Copyright (c) 2019, Tom Christie. All rights reserved.
+
+--------------------------------------------------------------------------------
+pydantic
+--------------------------------------------------------------------------------
+Version: 2.x
+License: MIT
+Source:  https://github.com/pydantic/pydantic
+Copyright (c) 2017 to present Pydantic Services Inc. and individual contributors.
+
+--------------------------------------------------------------------------------
+PyYAML
+--------------------------------------------------------------------------------
+Version: 6.x
+License: MIT
+Source:  https://github.com/yaml/pyyaml
+Copyright (c) 2017-2021 Ingy dot Net
+Copyright (c) 2006-2016 Kirill Simonov
+
+================================================================================
 Notes
 ================================================================================
 
 This NOTICE file is provided for transparency. ProjectScylla itself is BSD
-3-Clause licensed (see LICENSE). The above MIT/ISC packages are bundled only
+3-Clause licensed (see LICENSE). The npm packages listed above are bundled only
 within the published Docker image, not in the Python distribution, and are
 listed here to document attribution requirements for image distribution.
+The Python runtime dependencies listed above ship in both the sdist/wheel and
+the Docker image.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -44,6 +44,26 @@ The following are in scope for security reports:
 - Issues requiring physical access to the machine
 - Social engineering attacks
 
+## Data Sent to Third Parties
+
+When ProjectScylla runs evaluations it sends data to the **Anthropic API**:
+
+- **Prompts**: system prompts, task descriptions, and any CLAUDE.md content included in the run
+- **Repository content**: file snippets and code passed to the agent as context during test execution
+- **Agent outputs**: intermediate tool calls, reasoning traces, and final responses (used as judge inputs)
+
+No data is sent to third-party services other than the Anthropic API unless you explicitly configure
+additional MCP servers or tool integrations.
+
+Users are responsible for ensuring that repository content included in prompts complies with their
+organisation's data-handling policies before running evaluations against the Anthropic API.
+
+Refer to [Anthropic's usage policies](https://www.anthropic.com/legal/usage-policy) and
+[privacy policy](https://www.anthropic.com/legal/privacy) for details on how submitted data is handled.
+
+For guidance on what experiment outputs are stored locally and how long to retain them, see
+[docs/dev/data-policy.md](docs/dev/data-policy.md).
+
 ## Security Practices
 
 ProjectScylla follows these security practices:

--- a/docs/dev/data-policy.md
+++ b/docs/dev/data-policy.md
@@ -1,0 +1,52 @@
+# Data Retention and Deletion Policy for `results/`
+
+## What lives in `results/`
+
+The `results/` directory is the default output root for all experiment runs. It contains:
+
+- Per-run subdirectories named by run ID (e.g., `results/<run-id>/`)
+- JSON checkpoint files (`checkpoint.json`, `batch_summary.json`)
+- Per-tier and per-subtest output files (logs, judge outputs, metric snapshots)
+- Analysis artefacts: figures (`*.png`), tables (`*.csv`), and statistical summaries
+
+`results/` is listed in `.gitignore` and is **never committed to version control**.
+
+## Retention Recommendation
+
+| Storage tier | Recommended retention |
+|--------------|-----------------------|
+| Local workstation | Keep the last **90 days** of run data |
+| Long-term archive (e.g., S3, NAS) | Archive runs associated with published results indefinitely |
+
+Runs older than 90 days that are not linked to a publication or active comparison study
+can be deleted without loss of reproducibility, provided the corresponding experiment
+YAML configs (in `config/`) are retained.
+
+## How to Purge a Run
+
+To delete a single run:
+
+```bash
+rm -rf results/<run-id>
+```
+
+To purge all runs older than 90 days:
+
+```bash
+find results/ -mindepth 1 -maxdepth 1 -type d -mtime +90 -exec rm -rf {} +
+```
+
+Always verify the run ID before deleting. There is no recovery path once a run directory
+is removed.
+
+## Sensitive Content
+
+Run directories may contain:
+
+- Prompts sent to the Anthropic API (which may include repository source code)
+- Agent outputs and judge reasoning traces
+- API cost/token data
+
+These should be treated as potentially sensitive. Do not share raw `results/` directories
+publicly without reviewing their contents. See [SECURITY.md](../../SECURITY.md) for the
+third-party API data-flow disclosure.


### PR DESCRIPTION
## Summary

Completes #1958 by addressing the three sub-items left open after PR #1967:

- **NOTICE** — added Python runtime dependencies section listing click, httpx, pydantic, pyyaml
  (top BSD/MIT/Apache deps that ship with sdist/wheel and Docker images)
- **`docs/dev/data-policy.md`** — new file describing what `results/` contains, recommended
  retention (90-day local, optional archive), and purge procedure
- **`SECURITY.md`** — new 'Data Sent to Third Parties' subsection describing the Anthropic API
  data flow (prompts, repo contents, agent outputs) with link to Anthropic's terms
- **`CONTRIBUTING.md`** — link to data-policy.md under Project Documentation

PR #1967 already handled items 1 (LICENSE year), 2 (CoC channel), 4 (MAINTAINERS.md).

Closes #1958

🤖 Generated with [Claude Code](https://claude.com/claude-code)