### PR TITLE
docs(runbooks): add 5 operational runbooks (#1956)

### DIFF
--- a/docs/runbooks/deployment-rollback.md
+++ b/docs/runbooks/deployment-rollback.md
@@ -1,0 +1,98 @@
+# Deployment Rollback Runbook
+
+This runbook covers how to ship a new release tag and how to revert to
+a prior tag if a release causes regressions.
+
+All procedures assume you are at the repo root with a clean working tree
+and `git remote origin` pointing at `HomericIntelligence/ProjectScylla`.
+
+> **Conventions used below**
+>
+> - `NEW_TAG` — the version being shipped, e.g. `v0.2.0`.
+> - `PREV_TAG` — the last known-good tag, e.g. `v0.1.0`.
+> - All `pixi run` commands assume you are at the repo root.
+
+---
+
+## 1. Shipping a new tag
+
+### Pre-flight checks
+
+```bash
+# Ensure main is up to date
+git fetch origin && git status
+
+# Confirm the version in pyproject.toml matches CHANGELOG.md
+grep -m1 'version' pyproject.toml
+grep -m1 '^## \[' CHANGELOG.md
+
+# Run full pre-commit suite
+pre-commit run --all-files
+```
+
+### Tag and push
+
+```bash
+# Create annotated tag (pixi.lock and pyproject.toml must be committed)
+git tag -a "$NEW_TAG" -m "Release $NEW_TAG"
+git push origin "$NEW_TAG"
+```
+
+CI validates the tag build automatically. Monitor the
+`Release` GitHub Actions workflow to completion before proceeding.
+
+### Verify the release artifact
+
+```bash
+# Confirm the tag is visible and the wheel builds cleanly
+gh release list --repo HomericIntelligence/ProjectScylla | head -5
+pixi run python -m build --wheel --no-isolation 2>&1 | tail -5
+```
+
+---
+
+## 2. Rolling back to a previous tag
+
+### When to roll back
+
+Roll back when all three are true:
+
+1. The new tag is deployed on the evaluation hosts.
+2. Experiment runs started against it produce unexpected failures (not
+   covered by `experiment-failure-recovery.md`).
+3. The defect cannot be hot-patched in a forward commit within ~1 hour.
+
+### Roll-back steps
+
+```bash
+# Branch naming follows <issue-number>-<description>; substitute real values.
+# Example for incident #2001 reverting v0.2.0 back to v0.1.0:
+git checkout -b 2001-rollback-to-v0.1.0 v0.1.0
+
+# If you need to force evaluation hosts to use the prior image, rebuild:
+pixi run ci-build   # builds scylla-ci:local from ci/Containerfile
+
+# Push the rollback branch and open an expedited PR
+git push -u origin 2001-rollback-to-v0.1.0
+gh pr create --repo HomericIntelligence/ProjectScylla \
+  --title "hotfix: rollback to $PREV_TAG" \
+  --body "Emergency rollback. Closes #2001"
+gh pr merge --auto --rebase --repo HomericIntelligence/ProjectScylla
+```
+
+### What we do NOT do
+
+- We do **not** force-push to `main`. Branch protection blocks it; use PRs.
+- We do **not** delete the bad tag from the remote. Tags are immutable
+  historical records; deprecate in `CHANGELOG.md` instead.
+- We do **not** reuse the same version string. Bump patch (e.g.
+  `v0.2.0` → `v0.2.1`) even for a rollback commit.
+
+---
+
+## See also
+
+- `CHANGELOG.md` — per-version release notes
+- `pyproject.toml` — authoritative version string
+- `ci/Containerfile` — CI image used for evaluations
+- `experiment-failure-recovery.md` — recover a running experiment

--- a/docs/runbooks/incident-response.md
+++ b/docs/runbooks/incident-response.md
@@ -1,0 +1,162 @@
+# Incident Response Runbook
+
+This runbook covers what to do when an experiment produces garbage data
+or data whose validity is in doubt, and how to invalidate specific runs
+or whole experiments so they do not pollute analysis.
+
+> **Conventions used below**
+>
+> - `EXP_DIR` — the experiment directory (parent of `checkpoint.json`).
+> - `CKPT` — `$EXP_DIR/checkpoint.json`.
+> - "Garbage data" — results that are structurally valid (parseable JSON)
+>   but scientifically invalid (wrong model, wrong prompt, wrong judge,
+>   API error masked as a pass, etc.).
+
+---
+
+## 1. Detecting garbage data
+
+### Symptoms
+
+- Pass-rate is implausibly high (>0.95) or zero for a tier that
+  previously averaged 0.3-0.7.
+- `run_result.json` shows `total_tokens == 0` with a non-zero cost, or
+  cost `$0.00` with a multi-minute runtime (see the Pydantic
+  None-coercion pattern in MEMORY.md).
+- The `agent_model` field in `run_result.json` does not match the model
+  specified in the experiment config.
+- Judge verdicts are all identical (e.g. all `pass`) across subtests
+  that have known variance.
+- The experiment resumed from a checkpoint with a different config
+  (logged as `ConfigHashMismatch` at `src/scylla/e2e/checkpoint.py:618`).
+
+### Diagnosis commands
+
+```bash
+# Sample a few run_result.json files
+find "$EXP_DIR/runs" -name run_result.json | head -5 \
+  | xargs -I{} python -m json.tool {}
+
+# Check experiment config hash consistency
+pixi run python -c "
+from pathlib import Path
+from scylla.e2e.checkpoint import load_checkpoint
+c = load_checkpoint(Path('$CKPT'))
+print('config_hash:', c.config_hash)
+print('tier_states:', c.tier_states)
+"
+
+# Spot-check token counts across runs
+find "$EXP_DIR/runs" -name run_result.json \
+  | xargs python -c "
+import json, sys
+for f in sys.argv[1:]:
+    d = json.load(open(f))
+    print(f, d.get('total_tokens'), d.get('total_cost_usd'))
+" 2>/dev/null | sort -k2 -n | head -20
+```
+
+---
+
+## 2. Invalidating individual runs
+
+If only specific runs are corrupt, reset them to `pending` and re-execute.
+The runner will recreate the workspace and re-run the agent from scratch.
+
+```bash
+# Snapshot first (always)
+cp -a "$CKPT" "$CKPT.pre-invalidate.$(date +%s)"
+
+# Reset one subtest in tier T3 to pending
+pixi run python scripts/manage_experiment.py run --resume "$EXP_DIR" \
+  --from workspace_setup \
+  --filter-tier T3 \
+  --filter-subtest S0042
+
+# Reset all failed runs across the experiment
+pixi run python scripts/manage_experiment.py run --resume "$EXP_DIR" \
+  --from workspace_setup \
+  --filter-status failed
+```
+
+See `experiment-failure-recovery.md §2` for the full reset flag
+reference and the state-machine ordering.
+
+---
+
+## 3. Invalidating a whole tier
+
+If an entire tier's results are suspect (e.g. wrong model config was
+used for the whole tier):
+
+```bash
+cp -a "$CKPT" "$CKPT.pre-invalidate.$(date +%s)"
+
+pixi run python scripts/manage_experiment.py run --resume "$EXP_DIR" \
+  --from workspace_setup \
+  --filter-tier T2
+```
+
+This resets all runs in T2 to `pending` and cascades the tier state back
+to `pending` (`src/scylla/e2e/checkpoint.py:770-810`).
+
+---
+
+## 4. Marking an experiment as invalid (do not analyse)
+
+There is currently **no first-class "invalidated" experiment state** in
+the checkpoint schema. The supported approach is:
+
+1. Stop the experiment process if it is running.
+2. Rename the experiment directory with an `INVALID-` prefix:
+
+   ```bash
+   mv "$EXP_DIR" "$(dirname $EXP_DIR)/INVALID-$(basename $EXP_DIR)"
+   ```
+
+3. Create a `INVALID.md` inside the renamed directory explaining why:
+
+   ```bash
+   cat > "$(dirname $EXP_DIR)/INVALID-$(basename $EXP_DIR)/INVALID.md" <<'EOF'
+   ## Reason for invalidation
+
+   <date> — <your name>: <one-sentence reason>
+
+   ## Affected tiers / runs
+
+   All tiers — wrong judge model (gpt-4o-mini used instead of claude-3-5-sonnet).
+
+   ## Action
+
+   Re-run required from scratch.
+   EOF
+   ```
+
+4. File a GitHub issue linking the invalidated experiment directory and
+   the root cause. Reference it from the `INVALID.md`.
+
+This keeps the raw data on disk for audit purposes while preventing
+automated analysis scripts (which look for `checkpoint.json` in named
+directories) from picking it up.
+
+---
+
+## 5. Post-incident checklist
+
+- [ ] Snapshot taken before any changes.
+- [ ] Root cause identified and documented (GitHub issue + `INVALID.md`).
+- [ ] Affected runs or experiment marked invalid.
+- [ ] Re-run scheduled or completed.
+- [ ] Analysis pipeline re-run against clean results only.
+- [ ] Post-mortem note added to the GitHub issue.
+
+---
+
+## See also
+
+- `experiment-failure-recovery.md` — checkpoint repair and run resets
+- `src/scylla/e2e/checkpoint.py` — `reset_runs_for_from_state`,
+  `reset_tiers_for_from_state`
+- `scripts/manage_experiment.py` — `run --resume`, `--from`, `--filter-*`
+- MEMORY.md: `Pydantic None Coercion Pattern` — $0 cost symptom
+- MEMORY.md: `Batch Result Analysis` — how to find true first-run results

--- a/docs/runbooks/observability-setup.md
+++ b/docs/runbooks/observability-setup.md
@@ -1,0 +1,123 @@
+# Observability Setup Runbook
+
+This runbook explains how to enable structured JSON logs, OpenTelemetry
+tracing, and Prometheus metrics for a ProjectScylla experiment run.
+
+All three signals are **opt-in**. The defaults produce plain text logs,
+no spans, and no metric output. Default behaviour is unchanged if no
+environment variables are set.
+
+> **Conventions used below**
+>
+> - `EXP_DIR` — the experiment directory (parent of `checkpoint.json`).
+> - Code references: `path:lines`, valid for the tree this runbook was
+>   authored against; function names will not drift even if lines do.
+
+---
+
+## 1. Structured JSON logs (`SCYLLA_JSON_LOGS`)
+
+Set `SCYLLA_JSON_LOGS=1` before invoking the CLI. Implemented at
+`src/scylla/utils/json_logging.py:85` and wired into the CLI at
+`src/scylla/cli/main.py:49-52`.
+
+```bash
+SCYLLA_JSON_LOGS=1 pixi run scylla run-tier T0
+SCYLLA_JSON_LOGS=1 pixi run python scripts/manage_experiment.py run "$EXP_DIR"
+```
+
+Each log line is a JSON object. When an OTel span is active in the same
+process, the formatter injects `trace_id` (32-char hex) and `span_id`
+(16-char hex) into every record automatically
+(`src/scylla/utils/json_logging.py:156`).
+
+**Why plain text is still the default**: JSON log parsing adds latency
+per log call and makes interactive terminal output unreadable for
+developers. Enable it only in environments where a log-aggregation
+pipeline (e.g. Loki, CloudWatch Logs) consumes the output.
+
+---
+
+## 2. OpenTelemetry tracing (`SCYLLA_OTEL_EXPORTER`)
+
+Set `SCYLLA_OTEL_EXPORTER` to one of two recognised values. Implemented
+at `src/scylla/utils/tracing.py:49-155` and activated at
+`src/scylla/cli/main.py:53`.
+
+| Value | Effect |
+|-------|--------|
+| `console` | Spans printed to stderr (development / smoke-test) |
+| `otlp` | Spans sent via gRPC OTLP to `OTEL_EXPORTER_OTLP_ENDPOINT` |
+| unset | NoOp tracer; no SDK imports; zero overhead |
+
+### Console (smoke-test)
+
+```bash
+SCYLLA_OTEL_EXPORTER=console pixi run scylla run <test-id>
+```
+
+### OTLP collector (production)
+
+```bash
+# Start a local OTLP collector (e.g. Grafana Alloy, OpenTelemetry Collector)
+# Default endpoint: http://localhost:4317
+
+pip install opentelemetry-api opentelemetry-sdk opentelemetry-exporter-otlp
+SCYLLA_OTEL_EXPORTER=otlp \
+  OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4317 \
+  pixi run scylla run <test-id>
+```
+
+The OTel SDK is **not** a hard dependency of ProjectScylla; install it
+only on hosts where tracing is required. If the packages are absent when
+`SCYLLA_OTEL_EXPORTER` is set, a `UserWarning` is emitted and the run
+continues with NoOp tracing (`src/scylla/utils/tracing.py:116-123`).
+
+**Span depth**: tier → subtest → run → judge spans are all emitted when
+tracing is enabled (see issue #1933 for the depth documentation).
+
+---
+
+## 3. Prometheus textfile metrics (`SCYLLA_METRICS_PATH`)
+
+Set `SCYLLA_METRICS_PATH` to a writable file path. The
+`PrometheusTextfileEmitter` (`src/scylla/metrics/emitter.py:91`) writes
+Prometheus exposition format to that file after each metric event using
+an atomic rename, so the node-exporter textfile collector never reads a
+partial file.
+
+```bash
+SCYLLA_METRICS_PATH=/var/lib/node_exporter/textfile_collector/scylla.prom \
+  pixi run python scripts/manage_experiment.py run "$EXP_DIR"
+```
+
+If `SCYLLA_METRICS_PATH` is unset, `get_default_emitter()` returns a
+`NoOpEmitter` that drops every sample silently
+(`src/scylla/metrics/emitter.py:156-165`).
+
+**Integration note**: The MetricEmitter scaffold is wired into the
+experiment runner (`src/scylla/e2e/runner_internals/runner_core.py:684`)
+and judge runner (`src/scylla/e2e/judge_runner.py:352`). Full call-site
+coverage is tracked in `docs/dev/metrics-emitter.md`.
+
+---
+
+## Combining all three signals
+
+```bash
+SCYLLA_JSON_LOGS=1 \
+SCYLLA_OTEL_EXPORTER=otlp \
+OTEL_EXPORTER_OTLP_ENDPOINT=http://collector:4317 \
+SCYLLA_METRICS_PATH=/var/lib/node_exporter/textfile_collector/scylla.prom \
+  pixi run python scripts/manage_experiment.py run "$EXP_DIR"
+```
+
+---
+
+## See also
+
+- `src/scylla/utils/json_logging.py` — JSON log formatter
+- `src/scylla/utils/tracing.py` — OTel tracing scaffold
+- `src/scylla/metrics/emitter.py` — MetricEmitter / PrometheusTextfileEmitter
+- `src/scylla/cli/main.py` — CLI entry point wiring all three signals
+- Issue #1887 — follow-up for exhaustive span instrumentation

--- a/docs/runbooks/results-backup.md
+++ b/docs/runbooks/results-backup.md
@@ -1,0 +1,138 @@
+# Results Backup and Disaster Recovery Runbook
+
+This runbook covers what to back up, how to back it up, and how to
+recover when the `results/` artifacts are partially or fully lost.
+
+> **Conventions used below**
+>
+> - `EXP_DIR` — experiment directory (parent of `checkpoint.json`).
+> - `RESULTS_DIR` — the top-level `results/` directory at repo root.
+> - "Source of truth" files — files that cannot be regenerated without
+>   re-running the experiment or the judge; back these up first.
+
+---
+
+## 1. What to back up (and why)
+
+### Irreplaceable (back up every run)
+
+| Path | What it contains |
+|------|-----------------|
+| `$EXP_DIR/checkpoint.json` | Experiment state, tier/run bookkeeping |
+| `$EXP_DIR/config/experiment.json` | Config snapshot (hash-locked on resume) |
+| `$EXP_DIR/runs/<tier>/<sub>/run_N/run_result.json` | Per-run outcome and token counts |
+| `$EXP_DIR/runs/<tier>/<sub>/run_N/judgment*.json` | LLM-judge verdicts |
+| `$EXP_DIR/runs/<tier>/<sub>/run_N/logs/` | Agent logs for audit / post-hoc analysis |
+
+### Reconstructible (back up opportunistically)
+
+| Path | How to reconstruct |
+|------|--------------------|
+| `$EXP_DIR/runs/<tier>/<sub>/run_N/workspace/` | Re-cloned on next resume |
+| `$EXP_DIR/checkpoint.tmp.*.json` | Leftover from a clean run; safe to drop |
+| HTML coverage reports (`htmlcov/`) | `pixi run test` regenerates |
+
+---
+
+## 2. Backup procedure
+
+There is currently **no automated backup** wired into the runner (see
+TODO in `experiment-failure-recovery.md`, issue #1891). Operators must
+run backups manually or via cron.
+
+### Minimal rsync snapshot (recommended)
+
+```bash
+# Exclude reconstructible workspace dirs to save space
+rsync -av --exclude='*/workspace/' \
+  "$EXP_DIR/" \
+  "backup-host:/backups/scylla/$(basename $EXP_DIR)/$(date +%Y%m%dT%H%M%S)/"
+```
+
+### Full tar archive
+
+```bash
+tar --exclude='*/workspace' \
+  -czf "/backups/scylla-$(basename $EXP_DIR)-$(date +%Y%m%dT%H%M%S).tar.gz" \
+  "$EXP_DIR"
+```
+
+### S3 / object store
+
+```bash
+aws s3 sync "$EXP_DIR/" \
+  "s3://your-bucket/scylla/$(basename $EXP_DIR)/" \
+  --exclude "*/workspace/*"
+```
+
+**Backup frequency**: at minimum once per tier completion (~every few
+hours for a T0-T6 run). The checkpoint is updated after every run
+(`save_checkpoint()` at `src/scylla/e2e/checkpoint.py:510-545`), so
+fine-grained snapshots of just `checkpoint.json` are cheap and valuable.
+
+---
+
+## 3. Disaster recovery
+
+### Case A — `checkpoint.json` is lost but run artefacts exist
+
+Use `manage_experiment.py repair` to reconstruct the checkpoint from the
+on-disk `run_result.json` files:
+
+```bash
+pixi run python scripts/manage_experiment.py repair "$EXP_DIR"
+```
+
+This reconciles `completed_runs` and `run_states` with whatever
+`run_result.json` files exist under `$EXP_DIR/runs/`. See
+`experiment-failure-recovery.md §1` for full detail.
+
+### Case B — Partial `run_result.json` loss
+
+1. Identify the missing run dirs:
+
+   ```bash
+   find "$EXP_DIR/runs" -type d -name "run_*" \
+     ! -name "workspace" | sort
+   ```
+
+2. Reset those runs to `pending` and re-execute:
+
+   ```bash
+   pixi run python scripts/manage_experiment.py run --resume "$EXP_DIR" \
+     --from workspace_setup \
+     --filter-tier <TIER> --filter-subtest <SUBTEST>
+   ```
+
+3. Re-run the judge on any run that has `run_result.json` but no
+   `judgment*.json`.
+
+### Case C — Total loss
+
+Restore from the latest backup, then resume:
+
+```bash
+rsync -av "backup-host:/backups/scylla/$(basename $EXP_DIR)/latest/" "$EXP_DIR/"
+pixi run python scripts/manage_experiment.py run --resume "$EXP_DIR"
+```
+
+Runs completed before the backup are preserved; runs in-progress at
+backup time restart from their last known `RunState`.
+
+---
+
+## 4. Data governance
+
+Issue #1958 tracks compliance and governance gaps including data-retention
+policy. Until a formal policy is published, retain experiment results for
+the duration of the associated research project plus 12 months.
+
+---
+
+## See also
+
+- `experiment-failure-recovery.md` — checkpoint repair procedures
+- `src/scylla/e2e/checkpoint.py` — save/load/repair entry points
+- `scripts/manage_experiment.py` — `repair` and `run --resume` commands
+- Issue #1891 — rolling checkpoint backup (`.bak`) tracking issue
+- Issue #1958 — compliance and governance (data-policy tracking)

--- a/docs/runbooks/upgrade-procedure.md
+++ b/docs/runbooks/upgrade-procedure.md
@@ -1,0 +1,127 @@
+# Upgrade Procedure Runbook
+
+This runbook covers how to bump the Python version, the pixi version,
+or the CI container base image without breaking experiments or CI.
+
+Each upgrade type is independent; follow only the section that applies.
+
+> **Conventions used below**
+>
+> - All `pixi run` commands assume you are at the repo root.
+> - `NEW_PY` — the target CPython version, e.g. `3.12`.
+> - `NEW_PIXI` — the target pixi version, e.g. `0.64.0`.
+
+---
+
+## 1. Python version bump
+
+### Files to update
+
+| File | What to change |
+|------|---------------|
+| `pixi.toml` | `[dependencies] python = ">=X.Y"` |
+| `pyproject.toml` | `requires-python = ">=X.Y"` and `Programming Language :: Python :: X.Y` classifier |
+| `ci/Containerfile` | `ARG PYTHON_VERSION=X.Y` (or the `FROM python:X.Y-slim` line in `Dockerfile`) |
+| `.pre-commit-config.yaml` | `language_version: pythonX.Y` entries for hooks that pin it |
+
+### Procedure
+
+```bash
+# 1. Edit the files listed above
+# 2. Regenerate the lock file (Python version changes invalidate SHA256)
+pixi install   # regenerates pixi.lock
+
+# 3. Run full test suite in the updated environment
+pixi run test
+
+# 4. Run type checks (mypy may surface new errors on newer Python)
+pre-commit run mypy --all-files
+
+# 5. Run full pre-commit suite
+pre-commit run --all-files
+
+# 6. Commit (pixi.lock must be staged)
+git add pixi.toml pyproject.toml ci/Containerfile .pre-commit-config.yaml pixi.lock
+git commit -m "chore(deps): bump Python to $NEW_PY"
+```
+
+**NEVER skip `pixi install` after a Python version change.** The lock
+file encodes the SHA256 of the editable install; any source change
+invalidates it and CI will fail with `lock-file not up-to-date`.
+
+---
+
+## 2. pixi version bump
+
+### Files to update
+
+| File | What to change |
+|------|---------------|
+| `ci/Containerfile` | `ARG PIXI_VERSION=X.Y.Z` (line ~29) |
+| Any CI workflow YAML | `pixi-version:` input or pinned install step |
+
+### Procedure
+
+```bash
+# 1. Edit ci/Containerfile PIXI_VERSION
+# 2. Rebuild the CI image locally to confirm it installs cleanly
+pixi run ci-build
+
+# 3. Regenerate pixi.lock against the new pixi binary
+# (install new pixi locally first: https://pixi.sh/install.sh)
+pixi install
+
+# 4. Run tests in the new image
+podman run --rm -v .:/workspace:Z scylla-ci:local pixi run test
+
+# 5. Commit
+git add ci/Containerfile pixi.lock
+git commit -m "chore(deps): bump pixi to $NEW_PIXI"
+```
+
+---
+
+## 3. CI container base image bump
+
+The CI container (`ci/Containerfile`) uses a pinned Python base image.
+The Dockerfile used for evaluation agent containers (`Dockerfile`) is
+separate and may have a different version.
+
+### Procedure
+
+```bash
+# 1. Edit FROM line(s) in ci/Containerfile (and Dockerfile if needed)
+# 2. Rebuild locally
+pixi run ci-build
+
+# 3. Run the full CI suite inside the new image
+podman run --rm -v .:/workspace:Z scylla-ci:local \
+  bash -c "pixi run pre-commit run --all-files && pixi run test"
+
+# 4. Commit
+git add ci/Containerfile Dockerfile
+git commit -m "chore(deps): bump CI container base to python:$NEW_PY-slim"
+```
+
+---
+
+## 4. What we do NOT do
+
+- We do **not** bump the Python version mid-experiment. Running
+  experiments survive resume across Python minor versions only if the
+  checkpoint and `run_result.json` schemas are unchanged. When in doubt,
+  finish or checkpoint-snapshot the experiment first.
+- We do **not** skip `pixi.lock` commits. The lock is load-bearing in CI.
+- We do **not** use `--no-verify` to bypass pre-commit. If a hook fails
+  after an upgrade, fix the code.
+
+---
+
+## See also
+
+- `pixi.toml` — dependency specification
+- `pyproject.toml` — build system and metadata
+- `ci/Containerfile` — CI environment definition
+- `Dockerfile` — evaluation agent container
+- MEMORY.md: `pixi.lock Rebase Conflict Resolution` — how to handle
+  lock-file conflicts during rebase


### PR DESCRIPTION
## Summary

For a multi-day-experiment system with checkpoint resume, partial-failure semantics, rate-limit pauses,
and external API dependencies, operational docs were thin (just one runbook). This PR adds five
one-pager runbooks:

- `deployment-rollback.md` — tag/revert procedure
- `observability-setup.md` — enable OTel + JSON logs + Prometheus (refs real env vars)
- `results-backup.md` — backup and disaster recovery for `results/`
- `upgrade-procedure.md` — Python / pixi / container base bumps
- `incident-response.md` — handle garbage data and invalidation

One-pager each (POLA), matching the existing `experiment-failure-recovery.md` style.

Closes #1956

🤖 Generated with [Claude Code](https://claude.com/claude-code)