### PR TITLE
fix(logging): replace print() with logger in judge/e2e; enable ruff T201 (#1943)

### DIFF
--- a/pixi.lock
+++ b/pixi.lock
@@ -5321,7 +5321,7 @@ packages:
 - pypi: ./
   name: scylla
   version: 0.1.0
-  sha256: f2ddbeadded913f2b9715c9767df360035bd2fd87ddbafc80bb03a11de72942c
+  sha256: b55b1dbc8e45801215f5bf533972fc88d7f12db628cbdeaa05287995af7a146b
   requires_dist:
   - click>=8.0,<9
   - homericintelligence-hephaestus>=0.7.0,<1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,7 +85,7 @@ target-version = "py310"
 # S101 is selected explicitly (not via the full "S"/bandit group) so that
 # assert statements are flagged as errors in production code.  Tests are
 # exempted below via per-file-ignores, where assert is the pytest idiom.
-select = ["E", "F", "W", "I", "N", "D", "UP", "S101", "B", "SIM", "C4", "C901", "RUF"]
+select = ["E", "F", "W", "I", "N", "D", "UP", "S101", "B", "SIM", "C4", "C901", "RUF", "T201"]
 ignore = [
     "D100",  # Missing docstring in public module
     "D104",  # Missing docstring in public package
@@ -104,11 +104,16 @@ ignore = [
 max-complexity = 10
 
 [tool.ruff.lint.per-file-ignores]
-# assert is idiomatic in pytest; S101 suppressed for all test files only
-"tests/**" = ["S101"]
+# assert is idiomatic in pytest; S101 suppressed for all test files only.
+# T201 (no print) is also suppressed for tests — print is common in fixtures/notebooks.
+"tests/**" = ["S101", "T201"]
 # C901 (mccabe complexity) threshold of 10 is enforced only for src/scylla/ production code.
 # scripts/ utilities are exempt — they are standalone tools, not production modules.
-"scripts/**" = ["C901"]
+# T201 (no print) is also exempted for scripts/ — they are CLI tools that use print for output.
+"scripts/**" = ["C901", "T201"]
+# T201 (no print) is enforced for all src/scylla/ code except the CLI layer,
+# which may legitimately use print() for direct user output.
+"src/scylla/cli/**" = ["T201"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]

--- a/src/scylla/analysis/figures/diagnostics.py
+++ b/src/scylla/analysis/figures/diagnostics.py
@@ -82,7 +82,7 @@ def fig23_qq_plots(runs_df: pd.DataFrame, output_dir: Path, render: bool = True)
     qq_df = pd.DataFrame(qq_data)
 
     if len(qq_df) == 0:
-        print("  Warning: No data for Q-Q plots")
+        print("  Warning: No data for Q-Q plots")  # noqa: T201
         return
 
     # Generate separate figure for each tier
@@ -186,7 +186,7 @@ def _compute_kde_data(runs_df: pd.DataFrame, tier_order: list[str]) -> pd.DataFr
                         {"agent_model": model, "tier": tier, "score": x, "density": density}
                     )
             except Exception as e:
-                print(f"  Warning: KDE failed for {model}/{tier}: {e}")
+                print(f"  Warning: KDE failed for {model}/{tier}: {e}")  # noqa: T201
     return pd.DataFrame(kde_data)
 
 

--- a/src/scylla/analysis/figures/impl_rate_analysis.py
+++ b/src/scylla/analysis/figures/impl_rate_analysis.py
@@ -40,7 +40,7 @@ def fig25_impl_rate_by_tier(
     """
     # Check if impl_rate column exists
     if "impl_rate" not in runs_df.columns:
-        print("Warning: impl_rate column not found in runs_df, skipping fig25")
+        print("Warning: impl_rate column not found in runs_df, skipping fig25")  # noqa: T201
         return
 
     # Derive tier order from data
@@ -171,7 +171,7 @@ def fig26_impl_rate_vs_pass_rate(
     """
     # Check required columns
     if "impl_rate" not in runs_df.columns:
-        print("Warning: impl_rate column not found in runs_df, skipping fig26")
+        print("Warning: impl_rate column not found in runs_df, skipping fig26")  # noqa: T201
         return
 
     # Compute aggregate metrics per (agent_model, tier)
@@ -190,7 +190,7 @@ def fig26_impl_rate_vs_pass_rate(
     df = pd.DataFrame(stats)
 
     if len(df) == 0:
-        print("Warning: No valid data for fig26")
+        print("Warning: No valid data for fig26")  # noqa: T201
         return
 
     # Derive tier order
@@ -251,14 +251,14 @@ def fig27_impl_rate_distribution(
     """
     # Check if impl_rate column exists
     if "impl_rate" not in runs_df.columns:
-        print("Warning: impl_rate column not found in runs_df, skipping fig27")
+        print("Warning: impl_rate column not found in runs_df, skipping fig27")  # noqa: T201
         return
 
     # Filter out NaN values
     df = runs_df[["agent_model", "tier", "impl_rate"]].dropna()
 
     if len(df) == 0:
-        print("Warning: No valid data for fig27")
+        print("Warning: No valid data for fig27")  # noqa: T201
         return
 
     # Derive tier order from data

--- a/src/scylla/analysis/figures/model_comparison.py
+++ b/src/scylla/analysis/figures/model_comparison.py
@@ -171,7 +171,7 @@ def fig11_tier_uplift(runs_df: pd.DataFrame, output_dir: Path, render: bool = Tr
     # Also save significance table
     sig_csv = output_dir / "fig11_tier_uplift_significance.csv"
     significance_df.to_csv(sig_csv, index=False)
-    print(f"  Saved significance data: {sig_csv}")
+    print(f"  Saved significance data: {sig_csv}")  # noqa: T201
 
 
 def fig12_consistency(runs_df: pd.DataFrame, output_dir: Path, render: bool = True) -> None:

--- a/src/scylla/analysis/figures/spec_builder.py
+++ b/src/scylla/analysis/figures/spec_builder.py
@@ -186,7 +186,7 @@ def save_figure(
     spec = chart.to_dict()
     spec_path = output_dir / f"{name}.vl.json"
     spec_path.write_text(json.dumps(spec, indent=2) + "\n")
-    print(f"  Saved spec: {spec_path}")
+    print(f"  Saved spec: {spec_path}")  # noqa: T201
 
     # Optionally render to images
     if render:
@@ -197,9 +197,9 @@ def save_figure(
                     chart.save(str(img_path), scale_factor=3.0)  # 300 DPI for publication
                 else:
                     chart.save(str(img_path))
-                print(f"  Rendered: {img_path}")
+                print(f"  Rendered: {img_path}")  # noqa: T201
             except Exception as e:
-                print(f"  Warning: Could not render {fmt}: {e}")
+                print(f"  Warning: Could not render {fmt}: {e}")  # noqa: T201
 
         # Generate LaTeX inclusion snippet if PDF was rendered
         if "pdf" in formats:
@@ -246,4 +246,4 @@ def _generate_latex_snippet(
     # Save snippet
     snippet_path = output_dir / f"{name}_include.tex"
     snippet_path.write_text(latex_snippet)
-    print(f"  Saved LaTeX snippet: {snippet_path}")
+    print(f"  Saved LaTeX snippet: {snippet_path}")  # noqa: T201

--- a/src/scylla/e2e/rerun.py
+++ b/src/scylla/e2e/rerun.py
@@ -59,23 +59,23 @@ class RerunStats(BaseModel):
 
     def print_summary(self) -> None:
         """Print a summary of rerun statistics."""
-        print("\n" + "=" * 70)
-        print("RUN STATUS CLASSIFICATION")
-        print("=" * 70)
-        print(f"Total expected runs:     {self.total_expected_runs}")
-        print(f"  ✓ completed:           {self.completed}")
-        print(f"  ⚠ results:             {self.results}")
-        print(f"  ✗ failed:              {self.failed}")
-        print(f"  ⋯ partial:             {self.partial}")
-        print(f"  ○ missing:             {self.missing}")
-        print(f"  - skipped (filter):    {self.runs_skipped_by_filter}")
-        print()
-        print("RERUN RESULTS")
-        print("=" * 70)
-        print(f"Successfully rerun:      {self.runs_rerun_success}")
-        print(f"Failed rerun:            {self.runs_rerun_failed}")
-        print(f"Regenerated:             {self.runs_regenerated}")
-        print("=" * 70)
+        print("\n" + "=" * 70)  # noqa: T201
+        print("RUN STATUS CLASSIFICATION")  # noqa: T201
+        print("=" * 70)  # noqa: T201
+        print(f"Total expected runs:     {self.total_expected_runs}")  # noqa: T201
+        print(f"  ✓ completed:           {self.completed}")  # noqa: T201
+        print(f"  ⚠ results:             {self.results}")  # noqa: T201
+        print(f"  ✗ failed:              {self.failed}")  # noqa: T201
+        print(f"  ⋯ partial:             {self.partial}")  # noqa: T201
+        print(f"  ○ missing:             {self.missing}")  # noqa: T201
+        print(f"  - skipped (filter):    {self.runs_skipped_by_filter}")  # noqa: T201
+        print()  # noqa: T201
+        print("RERUN RESULTS")  # noqa: T201
+        print("=" * 70)  # noqa: T201
+        print(f"Successfully rerun:      {self.runs_rerun_success}")  # noqa: T201
+        print(f"Failed rerun:            {self.runs_rerun_failed}")  # noqa: T201
+        print(f"Regenerated:             {self.runs_regenerated}")  # noqa: T201
+        print("=" * 70)  # noqa: T201
 
 
 class RunToRerun(BaseModel):

--- a/src/scylla/e2e/rerun_base.py
+++ b/src/scylla/e2e/rerun_base.py
@@ -115,25 +115,25 @@ def print_dry_run_summary(
         max_preview: Maximum number of items to preview per status (default: 10)
 
     """
-    print("\n" + "=" * 70)
-    print("DRY RUN MODE - No changes will be made")
-    print("=" * 70)
+    print("\n" + "=" * 70)  # noqa: T201
+    print("DRY RUN MODE - No changes will be made")  # noqa: T201
+    print("=" * 70)  # noqa: T201
 
     for status, items in items_by_status.items():
         if items:
             display_name = status_names.get(status, status.value.upper())
-            print(f"\n{display_name} ({len(items)} items):")
+            print(f"\n{display_name} ({len(items)} items):")  # noqa: T201
             for item in items[:max_preview]:
                 # Format item based on its attributes
                 if hasattr(item, "judge_number"):
                     # Judge slot format
-                    print(
+                    print(  # noqa: T201
                         f"  - {item.tier_id}/{item.subtest_id}/run_{item.run_number:02d} "
                         f"judge_{item.judge_number:02d} ({item.judge_model}): {item.reason}"
                     )
                 else:
                     # Run format
                     run_id = f"{item.tier_id}/{item.subtest_id}/run_{item.run_number:02d}"
-                    print(f"  - {run_id}: {item.reason}")
+                    print(f"  - {run_id}: {item.reason}")  # noqa: T201
             if len(items) > max_preview:
-                print(f"  ... and {len(items) - max_preview} more")
+                print(f"  ... and {len(items) - max_preview} more")  # noqa: T201

--- a/src/scylla/e2e/rerun_judges.py
+++ b/src/scylla/e2e/rerun_judges.py
@@ -63,31 +63,29 @@ class RerunJudgeStats(BaseModel):
     runs_skipped_by_filter: int = 0
 
     def print_summary(self, judge_models: list[str]) -> None:
-        """Print a summary of rerun statistics."""
-        print("\n" + "=" * 70)
-        print("JUDGE SLOT CLASSIFICATION")
-        print("=" * 70)
-        print(f"Total expected judge slots: {self.total_expected_slots}")
-        print()
-        print("  Per-slot breakdown:")
+        """Log a summary of rerun statistics."""
+        logger.info("=" * 70)
+        logger.info("JUDGE SLOT CLASSIFICATION")
+        logger.info("=" * 70)
+        logger.info(f"Total expected judge slots: {self.total_expected_slots}")
+        logger.info("  Per-slot breakdown:")
 
         for judge_num in sorted(self.per_slot_stats.keys()):
             stats = self.per_slot_stats[judge_num]
             model = judge_models[judge_num - 1] if judge_num <= len(judge_models) else "unknown"
-            print(f"    judge_{judge_num:02d} ({model}):")
-            print(
-                f"      ✓ complete: {stats.get('complete', 0):4d}    "
-                f"○ missing: {stats.get('missing', 0):4d}     "
-                f"✗ failed: {stats.get('failed', 0):4d}"
+            logger.info(f"    judge_{judge_num:02d} ({model}):")
+            logger.info(
+                f"      complete: {stats.get('complete', 0):4d}    "
+                f"missing: {stats.get('missing', 0):4d}     "
+                f"failed: {stats.get('failed', 0):4d}"
             )
 
-        print()
-        print("RERUN RESULTS")
-        print("=" * 70)
-        print(f"Judge slots rerun successfully:  {self.slots_rerun_success}")
-        print(f"Judge slots failed to rerun:     {self.slots_rerun_failed}")
-        print(f"Consensus regenerated (runs):    {self.consensus_regenerated}")
-        print("=" * 70)
+        logger.info("RERUN RESULTS")
+        logger.info("=" * 70)
+        logger.info(f"Judge slots rerun successfully:  {self.slots_rerun_success}")
+        logger.info(f"Judge slots failed to rerun:     {self.slots_rerun_failed}")
+        logger.info(f"Consensus regenerated (runs):    {self.consensus_regenerated}")
+        logger.info("=" * 70)
 
 
 class JudgeSlotToRerun(BaseModel):
@@ -676,11 +674,11 @@ def rerun_judges_experiment(  # noqa: C901  # judge rerun with many retry/skip p
         logger.info(f"Found {len(runs_to_regenerate)} runs needing consensus regeneration")
 
         if dry_run:
-            print("\n" + "=" * 70)
-            print("DRY RUN MODE - No changes will be made")
-            print("=" * 70)
-            print(f"\nWould regenerate consensus for {len(runs_to_regenerate)} runs")
-            print("(All runs have complete judge slots but missing judge/result.json)")
+            logger.info("=" * 70)
+            logger.info("DRY RUN MODE - No changes will be made")
+            logger.info("=" * 70)
+            logger.info(f"Would regenerate consensus for {len(runs_to_regenerate)} runs")
+            logger.info("(All runs have complete judge slots but missing judge/result.json)")
             stats.print_summary(config.judge_models)
             return stats
 

--- a/src/scylla/judge/runner.py
+++ b/src/scylla/judge/runner.py
@@ -336,12 +336,10 @@ def main() -> int:
 
     except RunnerError as e:
         logger.error(f"Runner error: {e}")
-        print(f"Error: {e}", file=sys.stderr)
         return 1
 
     except Exception as e:
         logger.exception(f"Unexpected error: {e}")
-        print(f"Unexpected error: {e}", file=sys.stderr)
         return 1
 
 

--- a/src/scylla/utils/terminal.py
+++ b/src/scylla/utils/terminal.py
@@ -66,7 +66,7 @@ def install_signal_handlers(shutdown_fn: Callable[[], None]) -> None:
             sys.exit(128 + signum)
         else:
             _shutdown_requested = True
-            print(
+            print(  # noqa: T201
                 f"\nReceived signal {signum}. Shutting down gracefully… "
                 "(press Ctrl+C again to force quit)",
                 flush=True,

--- a/tests/unit/e2e/test_rerun_judges.py
+++ b/tests/unit/e2e/test_rerun_judges.py
@@ -689,8 +689,10 @@ class TestRerunJudgeStats:
         assert stats.agent_failed == 0
         assert stats.per_slot_stats == {}
 
-    def test_print_summary(self, capsys: Any) -> None:
-        """Test print_summary output."""
+    def test_print_summary(self, caplog: Any) -> None:
+        """Test print_summary logs the expected output."""
+        import logging
+
         stats = RerunJudgeStats(
             total_expected_slots=10,
             complete=5,
@@ -706,12 +708,13 @@ class TestRerunJudgeStats:
         }
 
         judge_models = ["claude-opus-4-6", "claude-sonnet-4-6"]
-        stats.print_summary(judge_models)
+        with caplog.at_level(logging.INFO, logger="scylla.e2e.rerun_judges"):
+            stats.print_summary(judge_models)
 
-        captured = capsys.readouterr()
-        assert "Total expected judge slots: 10" in captured.out
-        assert "Judge slots rerun successfully:  4" in captured.out
-        assert "Consensus regenerated (runs):    3" in captured.out
+        log_text = "\n".join(caplog.messages)
+        assert "Total expected judge slots: 10" in log_text
+        assert "Judge slots rerun successfully:  4" in log_text
+        assert "Consensus regenerated (runs):    3" in log_text
 
 
 class TestJudgeSlotToRerun:


### PR DESCRIPTION
## Summary

Two business modules emitted user-facing output via `print()` despite importing a logger, bypassing the project's structured-logging path (`SCYLLA_JSON_LOGS=1`).

- `src/scylla/judge/runner.py:339,344` — `print(..., file=sys.stderr)` was duplicating `logger.error/exception` for the same content. Dropped the duplicate print.
- `src/scylla/e2e/rerun_judges.py:67-90,679-681` — `JudgeRerunStats.print_summary` had 20+ `print()` calls; converted to `logger.info`.
- `pyproject.toml` — added ruff `T201` (no `print`) to lint rules for `src/scylla/`, with `per-file-ignores` exempting `src/scylla/cli/`, `scripts/`, and `tests/` (those layers may legitimately use print).
- Pre-existing `print()` calls in `src/scylla/` outside the two target files suppressed with `# noqa: T201` to avoid blocking CI (those are tracked as future cleanup).
- `tests/unit/e2e/test_rerun_judges.py` — updated `test_print_summary` to use `caplog` instead of `capsys`.

JSON logs now capture what used to be lost.

Closes #1943

🤖 Generated with [Claude Code](https://claude.com/claude-code)