### PR TITLE
refactor(core): break config↔metrics import cycle (Edge 1 of 3, #1937)

### DIFF
--- a/src/scylla/config/models.py
+++ b/src/scylla/config/models.py
@@ -9,7 +9,7 @@ from typing import Literal
 from pydantic import BaseModel, Field, field_validator, model_validator
 
 from scylla.config.constants import DEFAULT_AGENT_MODEL, DEFAULT_JUDGE_MODEL
-from scylla.metrics.grading import DEFAULT_PASS_THRESHOLD
+from scylla.core.thresholds import DEFAULT_PASS_THRESHOLD
 from scylla.nats.config import NATSConfig
 
 

--- a/src/scylla/core/thresholds.py
+++ b/src/scylla/core/thresholds.py
@@ -1,0 +1,20 @@
+"""Cross-cutting numeric thresholds for ProjectScylla.
+
+This module hosts threshold constants that are referenced by multiple
+top-level packages (e.g. ``config`` and ``metrics``). Placing them in
+``scylla.core`` keeps the dependency direction strictly downward and
+prevents circular imports between feature packages.
+
+See docs/design/grading-scale.md for the grading-scale specification.
+"""
+
+from __future__ import annotations
+
+# Default pass threshold (Good grade - B).
+#
+# A run is considered "passing" when its composite score is at or above
+# this threshold. Promoted from ``scylla.metrics.grading`` to break the
+# ``config`` <-> ``metrics`` import cycle (issue #1937, edge 1 of 3).
+DEFAULT_PASS_THRESHOLD: float = 0.60
+
+__all__ = ["DEFAULT_PASS_THRESHOLD"]

--- a/src/scylla/metrics/grading.py
+++ b/src/scylla/metrics/grading.py
@@ -8,9 +8,12 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
-# Default pass threshold (Good grade - B)
-# See docs/design/grading-scale.md for specification
-DEFAULT_PASS_THRESHOLD = 0.60
+# Re-exported from scylla.core.thresholds to preserve the public symbol
+# ``scylla.metrics.grading.DEFAULT_PASS_THRESHOLD`` for any external callers.
+# The canonical home is now ``scylla.core.thresholds`` so that ``config``
+# does not have to import from ``metrics`` (issue #1937, edge 1 of 3).
+# See docs/design/grading-scale.md for specification.
+from scylla.core.thresholds import DEFAULT_PASS_THRESHOLD as DEFAULT_PASS_THRESHOLD
 
 
 @dataclass

--- a/tests/unit/core/test_thresholds.py
+++ b/tests/unit/core/test_thresholds.py
@@ -1,0 +1,39 @@
+"""Tests for ``scylla.core.thresholds``.
+
+These guard the contract introduced when ``DEFAULT_PASS_THRESHOLD`` was
+promoted from ``scylla.metrics.grading`` to ``scylla.core.thresholds`` to
+break the ``config`` <-> ``metrics`` import cycle (issue #1937, edge 1).
+"""
+
+from __future__ import annotations
+
+
+def test_default_pass_threshold_value() -> None:
+    """The canonical threshold lives in ``scylla.core.thresholds``."""
+    from scylla.core.thresholds import DEFAULT_PASS_THRESHOLD
+
+    assert DEFAULT_PASS_THRESHOLD == 0.60
+
+
+def test_metrics_grading_reexports_threshold() -> None:
+    """``scylla.metrics.grading`` re-exports the constant for back-compat."""
+    import scylla.core.thresholds as core_thresholds
+    import scylla.metrics.grading as grading
+
+    assert grading.DEFAULT_PASS_THRESHOLD is core_thresholds.DEFAULT_PASS_THRESHOLD
+
+
+def test_config_models_does_not_import_metrics() -> None:
+    """``scylla.config.models`` must not import from ``scylla.metrics``.
+
+    Importing ``metrics`` from ``config`` is one direction of the cycle
+    eliminated in #1937 (edge 1 of 3).
+    """
+    import pathlib
+
+    import scylla.config.models as config_models
+
+    source_path = pathlib.Path(config_models.__file__)
+    source = source_path.read_text(encoding="utf-8")
+    assert "from scylla.metrics" not in source
+    assert "import scylla.metrics" not in source


### PR DESCRIPTION
## Summary

Partial fix for #1937 — breaks the first of three confirmed circular import edges between top-level scylla packages.

**Edge 1 fixed:** `config ↔ metrics`
- Promoted `DEFAULT_PASS_THRESHOLD` from `scylla.metrics.grading` to a new `scylla.core.thresholds` module
- `metrics.grading` re-exports the symbol (back-compat for any external callers)
- `config.models` now imports from `core` rather than `metrics`, eliminating one direction of the cycle

**Verification:**
```bash
grep -rn 'from scylla.metrics\|import scylla.metrics' src/scylla/config/
# (empty)
```

## Deferred to follow-ups (this PR is intentionally narrow per the swarm-stall guardrails)

- **Edge 2: `cli ↔ e2e`** — extract progress-event protocol from `e2e/progress.py`. Tracked in #1937.
- **Edge 3: `adapters ↔ e2e`** — promote `TokenStats` from `e2e/models_internals/token_stats.py` to `core/`. Tracked in #1937.
- **`import-linter` CI gate** — will land after all 3 edges close, to avoid blocking this PR on un-fixed edges.

Refs #1937

🤖 Generated with [Claude Code](https://claude.com/claude-code)