### PR TITLE
feat(release): PyPI Trusted Publishing on tag push (#1951)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,11 @@ on:
           - patch
           - minor
           - major
+      testpypi:
+        type: boolean
+        description: "Dry-run: publish to TestPyPI instead of PyPI"
+        required: false
+        default: "false"
   push:
     tags:
       - "v*"
@@ -120,3 +125,101 @@ jobs:
           gh release create "$TAG_NAME" \
             --title "$TAG_NAME" \
             --generate-notes
+
+  # ---------------------------------------------------------------------------
+  # Build distribution artifacts (sdist + wheel)
+  # Runs on every tag push so artifacts are available for both PyPI and TestPyPI.
+  # ---------------------------------------------------------------------------
+  build:
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
+    needs: release
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2f  # v5
+        with:
+          python-version: "3.10"
+
+      - name: Install build frontend
+        run: python -m pip install --upgrade build
+
+      - name: Build sdist and wheel
+        run: python -m build
+
+      - name: Upload dist artifacts
+        uses: actions/upload-artifact@6f51ac03b9356f520e9adb1b1b7802705f340c2b  # v4
+        with:
+          name: dist
+          path: dist/
+          retention-days: 7
+
+  # ---------------------------------------------------------------------------
+  # Publish to PyPI via Trusted Publishing (OIDC — no API token required).
+  # Triggered only on tag push (v*).  A maintainer must configure the PyPI
+  # Trusted Publisher once; see docs/dev/release.md for setup instructions.
+  # ---------------------------------------------------------------------------
+  publish-pypi:
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
+    needs: build
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    environment:
+      name: pypi
+      url: https://pypi.org/p/scylla
+    permissions:
+      id-token: write  # Required for OIDC Trusted Publishing
+
+    steps:
+      - name: Download dist artifacts
+        uses: actions/download-artifact@fa0a91b85d4f404e444306234e0793f6516f1d73  # v4
+        with:
+          name: dist
+          path: dist/
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@76f52bc884231f62b9a034ebfe128415bbaabdfc  # release/v1
+
+  # ---------------------------------------------------------------------------
+  # TestPyPI dry-run — only on workflow_dispatch with testpypi=true.
+  # Lets maintainers smoke-test the publish pipeline before cutting a real tag.
+  # ---------------------------------------------------------------------------
+  publish-testpypi:
+    if: >-
+      github.event_name == 'workflow_dispatch' &&
+      github.event.inputs.testpypi == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    environment:
+      name: testpypi
+      url: https://test.pypi.org/p/scylla
+    permissions:
+      contents: write
+      pull-requests: write
+      id-token: write  # Required for OIDC Trusted Publishing
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2f  # v5
+        with:
+          python-version: "3.10"
+
+      - name: Install build frontend
+        run: python -m pip install --upgrade build
+
+      - name: Build sdist and wheel
+        run: python -m build
+
+      - name: Publish to TestPyPI
+        uses: pypa/gh-action-pypi-publish@76f52bc884231f62b9a034ebfe128415bbaabdfc  # release/v1
+        with:
+          repository-url: https://test.pypi.org/legacy/

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ on:
         type: boolean
         description: "Dry-run: publish to TestPyPI instead of PyPI"
         required: false
-        default: "false"
+        default: false
   push:
     tags:
       - "v*"

--- a/docs/dev/release.md
+++ b/docs/dev/release.md
@@ -1,0 +1,128 @@
+# Release Process
+
+This document describes how to cut a ProjectScylla release and the one-time
+setup required to enable PyPI publishing via Trusted Publishing (OIDC).
+
+## Release workflow overview
+
+The `release.yml` workflow handles the full release pipeline:
+
+| Trigger | Jobs that run |
+|---------|--------------|
+| `workflow_dispatch` (part=patch/minor/major) | `bump-version` — bumps `pyproject.toml`, commits, tags, opens PR |
+| `push` tag `v*` | `release` (GitHub Release) → `build` (sdist + wheel) → `publish-pypi` (PyPI OIDC) |
+| `workflow_dispatch` (testpypi=true) | `publish-testpypi` — publishes to TestPyPI for smoke-testing |
+
+## Normal release procedure
+
+1. Trigger the **Release** workflow via GitHub Actions → *Run workflow* with the
+   desired version part (`patch`, `minor`, or `major`).
+2. The workflow bumps the version in `pyproject.toml` and `pixi.toml`, commits,
+   creates a tag (`vX.Y.Z`), and opens a PR.
+3. Once the version-bump PR merges the tag is already pushed, which triggers the
+   `release` → `build` → `publish-pypi` chain automatically.
+
+## One-time PyPI Trusted Publishing setup
+
+PyPI Trusted Publishing uses OIDC tokens so **no `PYPI_API_TOKEN` secret is
+needed** in the repository or organisation settings.
+
+### Prerequisites
+
+- A PyPI account with maintainer rights (or the ability to create the project).
+- A TestPyPI account for dry-run testing (recommended).
+
+### Steps
+
+#### 1. Create the PyPI project
+
+If the project does not yet exist on PyPI:
+
+```bash
+# Build locally and upload once with a traditional API token to claim the name.
+# After this first upload you can switch to Trusted Publishing.
+python -m build
+python -m twine upload dist/*
+```
+
+Alternatively, create the project through the PyPI web UI at
+<https://pypi.org/manage/projects/> without uploading anything, then configure
+Trusted Publishing before the first upload.
+
+#### 2. Configure Trusted Publishing on PyPI
+
+1. Go to <https://pypi.org/manage/project/scylla/settings/publishing/>.
+2. Under **Add a new publisher**, select **GitHub Actions**.
+3. Fill in the form exactly as shown:
+
+   | Field | Value |
+   |-------|-------|
+   | PyPI project name | `scylla` |
+   | Owner | `HomericIntelligence` |
+   | Repository name | `ProjectScylla` |
+   | Workflow name | `release.yml` |
+   | Environment name | `pypi` |
+
+4. Click **Add**.
+
+#### 3. Configure Trusted Publishing on TestPyPI (optional but recommended)
+
+Repeat step 2 on <https://test.pypi.org/manage/project/scylla/settings/publishing/>
+with the same values except **Environment name** = `testpypi`.
+
+#### 4. Create the GitHub environment
+
+1. Go to **Settings → Environments** in the GitHub repository.
+2. Create an environment named `pypi`.
+3. Optionally add a protection rule (e.g. required reviewers, tag-only
+   deployment) to prevent accidental publishes.
+4. Repeat for `testpypi`.
+
+No secrets need to be added to the environment — the OIDC token is exchanged
+automatically by `pypa/gh-action-pypi-publish`.
+
+## TestPyPI dry-run
+
+To smoke-test the publish pipeline without cutting a real tag:
+
+1. Go to **Actions → Release → Run workflow**.
+2. Set **Version part** to any value (it will not be used).
+3. Set **Dry-run: publish to TestPyPI** to `true`.
+4. Click **Run workflow**.
+
+The `publish-testpypi` job will build and publish to TestPyPI.  Verify the
+package installs correctly:
+
+```bash
+pip install --index-url https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple/ scylla
+```
+
+## Verifying a release
+
+After a successful publish:
+
+```bash
+pip install scylla
+scylla --help
+```
+
+The `scylla` entry-point is defined in `pyproject.toml`:
+
+```toml
+[project.scripts]
+scylla = "scylla.cli.main:cli"
+```
+
+## Artifact inspection
+
+The `build` job uploads `dist/` as a GitHub Actions artifact named `dist` with
+a 7-day retention window.  Download it from the workflow run summary to inspect
+the sdist and wheel before they land on PyPI.
+
+## Security notes
+
+- The workflow uses OIDC (`id-token: write`) only in the publish jobs; the
+  `bump-version` and `release` jobs do not have this permission.
+- No `PYPI_API_TOKEN` or other credentials are stored in GitHub Secrets.
+- The `pypa/gh-action-pypi-publish` action is pinned to a specific commit SHA
+  for supply-chain safety.


### PR DESCRIPTION
## Summary

`pyproject.toml` advertised PyPI-ready metadata (hatchling, classifiers, scripts, urls) but no publish workflow existed — `pip install scylla` did not work.

This PR closes the gap by adding PyPI Trusted Publishing (OIDC) to `release.yml`:

- Build sdist + wheel via `pypa/build` (artifact uploaded for inspection, 7-day retention)
- Publish to PyPI via `pypa/gh-action-pypi-publish@release/v1` using OIDC — **no `PYPI_API_TOKEN` secret required**
- TestPyPI dry-run job gated on `workflow_dispatch` with `testpypi=true` input
- `docs/dev/release.md` documents the one-time PyPI project setup step-by-step

## Workflow changes

| Job | Trigger | Description |
|-----|---------|-------------|
| `build` | tag push `v*` | Builds sdist + wheel, uploads artifact |
| `publish-pypi` | tag push `v*` (after `build`) | Publishes to PyPI via OIDC, environment `pypi` |
| `publish-testpypi` | `workflow_dispatch` + `testpypi=true` | Publishes to TestPyPI for smoke-testing |

## One-time setup required (outside this PR)

A maintainer must:
1. Create the `scylla` project on PyPI (and TestPyPI for dry runs)
2. Configure Trusted Publishing: owner=`HomericIntelligence`, repo=`ProjectScylla`, workflow=`release.yml`, environment=`pypi`
3. Create GitHub environments named `pypi` and `testpypi` in repo Settings

See `docs/dev/release.md` for the complete step-by-step instructions.

## Security

- No `PYPI_API_TOKEN` or other credentials are referenced in the workflow
- `id-token: write` permission is scoped only to the publish jobs
- `pypa/gh-action-pypi-publish` is pinned to a specific commit SHA

Closes #1951

🤖 Generated with [Claude Code](https://claude.com/claude-code)