### PR TITLE
feat(core): generic StateMachine[TState] + port experiment FSM (#1942)

### DIFF
--- a/src/scylla/core/state_machine.py
+++ b/src/scylla/core/state_machine.py
@@ -1,0 +1,271 @@
+"""Generic state machine abstraction for E2E execution flows.
+
+This module provides a single, reusable `StateMachine[TState]` generic that
+consolidates the cross-cutting concerns shared by the experiment-/tier-/
+subtest-/run-level FSMs in :mod:`scylla.e2e`:
+
+* a transition-table that defines the legal `(from_state -> to_state)` edges
+* validation that rejects illegal transitions
+* a persistence hook protocol invoked on every successful transition
+* an event-emission hook protocol invoked on every successful transition
+* an `advance_to_completion` driver with caller-supplied error-to-state
+  mapping (so RateLimitError -> INTERRUPTED, ShutdownInterruptedError ->
+  resumable, etc. can be customised per FSM without forking the driver)
+
+Tier/subtest/run FSMs will be ported to use this generic in follow-up PRs;
+see issue #1942 for the consolidation tracker.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Generic, TypeVar
+
+logger = logging.getLogger(__name__)
+
+
+# State enums used by the four E2E FSMs are all `str, Enum` subclasses, so
+# bounding `TState` to `Enum` keeps the generic typed under strict mypy while
+# remaining flexible across every concrete FSM.
+TState = TypeVar("TState", bound=Enum)
+
+
+# Hook type aliases. Defined as Callable types (rather than Protocols) so that
+# any ordinary function with the right signature is accepted under strict mypy
+# — Protocols require argument-name conformance, which is unnecessary noise
+# for simple callbacks like these.
+#
+# PersistenceHook: runs after each transition to durably persist the new state
+# (e.g. atomic checkpoint save). Exceptions propagate to the caller.
+#
+# EventHook: runs after persistence for observability (logging/metrics/tracing).
+# Exceptions raised by event hooks are swallowed and logged; they never
+# interrupt state-machine progress.
+PersistenceHook = Callable[[TState], None]
+EventHook = Callable[[TState, TState, str], None]
+
+
+@dataclass(frozen=True)
+class Transition(Generic[TState]):
+    """A single edge in the state-machine transition table.
+
+    Attributes:
+        from_state: State the FSM is in before the transition.
+        to_state: State the FSM enters when the transition succeeds.
+        description: Human-readable label used for log lines.
+
+    """
+
+    from_state: TState
+    to_state: TState
+    description: str
+
+
+@dataclass
+class StateMachine(Generic[TState]):
+    """Generic state machine with transition validation and hooks.
+
+    Concrete FSMs construct a `StateMachine` by supplying:
+
+    * the ordered transition table for their state enum
+    * the terminal-state set (terminal states cannot be advanced from)
+    * a callable that reads the current state from durable storage
+    * an `apply_state` callable that updates durable storage with the new state
+      (the in-memory mutation is the caller's responsibility — this lets the
+      generic stay agnostic about how state is persisted)
+    * optional `persistence_hook` / `event_hook`
+
+    The generic itself does **not** own the state; it delegates reads and
+    writes to the caller-supplied callables so that existing checkpoint
+    objects can be reused without modification.
+
+    Attributes:
+        transitions: Ordered list of legal transitions.
+        terminal_states: States that cannot be advanced from.
+        get_state: Callable returning the current state.
+        apply_state: Callable applying a new state (e.g. writing it back to
+            the checkpoint object). It runs *after* the action succeeds.
+        persistence_hook: Optional hook run after `apply_state` to persist
+            state to durable storage (e.g. atomic checkpoint save).
+        event_hook: Optional hook run for observability after persistence.
+        label: Short label for log lines (e.g. ``"experiment"``).
+
+    """
+
+    transitions: list[Transition[TState]]
+    terminal_states: frozenset[TState]
+    get_state: Callable[[], TState]
+    apply_state: Callable[[TState], None]
+    persistence_hook: PersistenceHook[TState] | None = None
+    event_hook: EventHook[TState] | None = None
+    label: str = "state-machine"
+
+    _by_from: dict[TState, Transition[TState]] = field(init=False, repr=False)
+
+    def __post_init__(self) -> None:
+        """Build the from_state -> Transition lookup and reject duplicates."""
+        # Duplicate from_states would silently lose transitions, so reject
+        # them up-front.
+        by_from: dict[TState, Transition[TState]] = {}
+        for t in self.transitions:
+            if t.from_state in by_from:
+                raise ValueError(
+                    f"Duplicate transition for from_state {t.from_state!r} in {self.label}"
+                )
+            by_from[t.from_state] = t
+        self._by_from = by_from
+
+    # ---------------------------------------------------------------- queries
+
+    def is_terminal(self, state: TState) -> bool:
+        """Return True if `state` is in the terminal-state set."""
+        return state in self.terminal_states
+
+    def is_complete(self) -> bool:
+        """Return True if the current state is terminal."""
+        return self.is_terminal(self.get_state())
+
+    def get_next_transition(self, state: TState) -> Transition[TState] | None:
+        """Return the legal outgoing transition from `state`, or None."""
+        return self._by_from.get(state)
+
+    def validate_transition(self, from_state: TState, to_state: TState) -> bool:
+        """Return True if `from_state -> to_state` is a legal edge."""
+        t = self._by_from.get(from_state)
+        if t is None:
+            return False
+        return t.to_state == to_state
+
+    # ---------------------------------------------------------------- advance
+
+    def advance(self, actions: dict[TState, Callable[[], None]]) -> TState:
+        """Execute the next transition.
+
+        Reads the current state, looks up the next transition, runs the
+        caller-supplied action (if any), updates state via `apply_state`,
+        invokes the persistence and event hooks, and returns the new state.
+
+        Args:
+            actions: Map of `from_state -> callable`. Missing entries mean
+                the transition is a no-op (state advances without side
+                effects).
+
+        Returns:
+            The new state after the transition.
+
+        Raises:
+            RuntimeError: If the current state is terminal.
+            ValueError: If no transition is registered for the current state.
+
+        """
+        current = self.get_state()
+
+        if self.is_terminal(current):
+            raise RuntimeError(f"Cannot advance {self.label} from terminal state {current.value!r}")
+
+        transition = self._by_from.get(current)
+        if transition is None:
+            raise ValueError(f"No transition defined from {self.label} state {current.value!r}")
+
+        logger.debug(
+            f"[{self.label}] {current.value} -> {transition.to_state.value}: "
+            f"{transition.description}"
+        )
+
+        action = actions.get(current)
+        if action is not None:
+            _t0 = time.monotonic()
+            action()
+            _elapsed = time.monotonic() - _t0
+            logger.info(
+                f"[{self.label}] {current.value} -> {transition.to_state.value}: "
+                f"{transition.description} ({_elapsed:.1f}s)"
+            )
+
+        # Apply the new state, then run persistence + event hooks.
+        self.apply_state(transition.to_state)
+
+        if self.persistence_hook is not None:
+            self.persistence_hook(transition.to_state)
+
+        if self.event_hook is not None:
+            try:
+                self.event_hook(current, transition.to_state, transition.description)
+            except Exception:
+                logger.exception(
+                    f"[{self.label}] event hook raised during "
+                    f"{current.value} -> {transition.to_state.value}"
+                )
+
+        return transition.to_state
+
+    def advance_to_completion(
+        self,
+        actions: dict[TState, Callable[[], None]],
+        *,
+        until_state: TState | None = None,
+        error_state_map: list[tuple[type[BaseException], TState]] | None = None,
+        failure_state: TState | None = None,
+    ) -> TState:
+        """Drive the FSM until a terminal state, `until_state`, or exception.
+
+        Args:
+            actions: `from_state -> callable` map (see `advance`).
+            until_state: Optional state at which to stop early (inclusive).
+                The action that produces `until_state` runs, but no further
+                transitions are executed. The FSM is *not* marked failed.
+            error_state_map: Ordered list of `(exception_type, target_state)`
+                pairs. When an exception of any listed type is raised during
+                a transition, the FSM is moved to the associated target
+                state and persisted before the exception is re-raised. The
+                first matching entry wins (so subclasses should appear
+                before parents).
+            failure_state: Optional fallback state to apply when an
+                exception does not match any entry in `error_state_map`. If
+                omitted, generic failures simply propagate without changing
+                state.
+
+        Returns:
+            The final state on clean completion or `until_state` early exit.
+
+        """
+        try:
+            while not self.is_complete():
+                new_state = self.advance(actions)
+                if until_state is not None and new_state == until_state:
+                    logger.info(f"[{self.label}] Reached --until target state: {until_state.value}")
+                    break
+        except BaseException as exc:
+            mapped: TState | None = None
+            if error_state_map is not None:
+                for exc_type, target in error_state_map:
+                    if isinstance(exc, exc_type):
+                        mapped = target
+                        break
+            if mapped is None and failure_state is not None:
+                mapped = failure_state
+
+            if mapped is not None:
+                logger.warning(
+                    f"[{self.label}] {type(exc).__name__} during "
+                    f"{self.get_state().value} -> applying {mapped.value}"
+                )
+                self.apply_state(mapped)
+                if self.persistence_hook is not None:
+                    self.persistence_hook(mapped)
+            raise
+
+        return self.get_state()
+
+
+__all__ = [
+    "EventHook",
+    "PersistenceHook",
+    "StateMachine",
+    "TState",
+    "Transition",
+]

--- a/src/scylla/e2e/experiment_state_machine.py
+++ b/src/scylla/e2e/experiment_state_machine.py
@@ -13,17 +13,24 @@ State flow for an experiment (6 sequential states):
     -> REPORTS_GENERATED  (generate experiment reports)
   Terminal: COMPLETE | INTERRUPTED | FAILED
 
+Implementation note: the transition table, hook plumbing, and
+advance-to-completion driver live in :mod:`scylla.core.state_machine` as a
+generic ``StateMachine[TState]``. This module composes the generic with the
+experiment-specific state enum, terminal set, and checkpoint persistence;
+the public API (``ExperimentStateMachine``, ``EXPERIMENT_TRANSITION_REGISTRY``,
+``get_next_experiment_transition``, ``is_experiment_terminal_state``,
+``validate_experiment_transition``) is unchanged.
 """
 
 from __future__ import annotations
 
 import logging
-import time
 from collections.abc import Callable
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
 from typing import TYPE_CHECKING
 
+from scylla.core.state_machine import StateMachine, Transition
 from scylla.e2e.models import ExperimentState
 
 if TYPE_CHECKING:
@@ -49,50 +56,40 @@ _EXPERIMENT_TERMINAL_STATES: frozenset[ExperimentState] = frozenset(
 )
 
 
-@dataclass
-class ExperimentTransition:
-    """Describes a single state transition in the experiment state machine.
-
-    Attributes:
-        from_state: State before this transition
-        to_state: State after this transition completes successfully
-        description: Human-readable description for logging
-
-    """
-
-    from_state: ExperimentState
-    to_state: ExperimentState
-    description: str
+# Backwards-compatible alias: pre-port code used ``ExperimentTransition`` as a
+# dataclass. The generic ``Transition[ExperimentState]`` is a drop-in replacement
+# (same field names and types). Keep the alias to avoid breaking importers.
+ExperimentTransition = Transition[ExperimentState]
 
 
 # Registry of all valid experiment transitions
-EXPERIMENT_TRANSITION_REGISTRY: list[ExperimentTransition] = [
-    ExperimentTransition(
+EXPERIMENT_TRANSITION_REGISTRY: list[Transition[ExperimentState]] = [
+    Transition(
         from_state=ExperimentState.INITIALIZING,
         to_state=ExperimentState.DIR_CREATED,
         description="Create experiment directory tree",
     ),
-    ExperimentTransition(
+    Transition(
         from_state=ExperimentState.DIR_CREATED,
         to_state=ExperimentState.REPO_CLONED,
         description="Clone/setup base repository",
     ),
-    ExperimentTransition(
+    Transition(
         from_state=ExperimentState.REPO_CLONED,
         to_state=ExperimentState.TIERS_RUNNING,
         description="Begin tier group execution",
     ),
-    ExperimentTransition(
+    Transition(
         from_state=ExperimentState.TIERS_RUNNING,
         to_state=ExperimentState.TIERS_COMPLETE,
         description="Execute all tier groups",
     ),
-    ExperimentTransition(
+    Transition(
         from_state=ExperimentState.TIERS_COMPLETE,
         to_state=ExperimentState.REPORTS_GENERATED,
         description="Generate experiment reports",
     ),
-    ExperimentTransition(
+    Transition(
         from_state=ExperimentState.REPORTS_GENERATED,
         to_state=ExperimentState.COMPLETE,
         description="Mark experiment complete",
@@ -100,21 +97,21 @@ EXPERIMENT_TRANSITION_REGISTRY: list[ExperimentTransition] = [
 ]
 
 # Build lookup: from_state -> transition
-_EXPERIMENT_TRANSITION_BY_FROM: dict[ExperimentState, ExperimentTransition] = {
+_EXPERIMENT_TRANSITION_BY_FROM: dict[ExperimentState, Transition[ExperimentState]] = {
     t.from_state: t for t in EXPERIMENT_TRANSITION_REGISTRY
 }
 
 
 def get_next_experiment_transition(
     current_state: ExperimentState,
-) -> ExperimentTransition | None:
+) -> Transition[ExperimentState] | None:
     """Get the next transition from the current experiment state.
 
     Args:
         current_state: The current ExperimentState
 
     Returns:
-        ExperimentTransition to execute next, or None if in a terminal/complete state.
+        Transition to execute next, or None if in a terminal/complete state.
 
     """
     return _EXPERIMENT_TRANSITION_BY_FROM.get(current_state)
@@ -164,6 +161,32 @@ class ExperimentStateMachine:
 
     checkpoint: E2ECheckpoint
     checkpoint_path: Path
+    _sm: StateMachine[ExperimentState] = field(init=False, repr=False)
+
+    def __post_init__(self) -> None:
+        """Wire the generic StateMachine with experiment-specific config."""
+        self._sm = StateMachine[ExperimentState](
+            transitions=EXPERIMENT_TRANSITION_REGISTRY,
+            terminal_states=_EXPERIMENT_TERMINAL_STATES,
+            get_state=self.get_state,
+            apply_state=self._apply_state,
+            persistence_hook=self._persist,
+            label="experiment",
+        )
+
+    # -- generic-state-machine adapters --------------------------------------
+
+    def _apply_state(self, new_state: ExperimentState) -> None:
+        """Write the new state into the in-memory checkpoint."""
+        self.checkpoint.experiment_state = new_state.value
+
+    def _persist(self, _new_state: ExperimentState) -> None:
+        """Atomically save the checkpoint to disk after a transition."""
+        from scylla.e2e.checkpoint import save_checkpoint
+
+        save_checkpoint(self.checkpoint, self.checkpoint_path)
+
+    # -- public API ----------------------------------------------------------
 
     def get_state(self) -> ExperimentState:
         """Get the current ExperimentState.
@@ -213,39 +236,7 @@ class ExperimentStateMachine:
             ValueError: If no transition is defined for the current state
 
         """
-        from scylla.e2e.checkpoint import save_checkpoint
-
-        current = self.get_state()
-
-        if is_experiment_terminal_state(current):
-            raise RuntimeError(f"Cannot advance experiment from terminal state {current.value}")
-
-        transition = get_next_experiment_transition(current)
-        if transition is None:
-            raise ValueError(f"No transition defined from experiment state {current.value}")
-
-        logger.debug(
-            f"[experiment] {current.value} -> {transition.to_state.value}: {transition.description}"
-        )
-
-        # Execute the action if provided
-        action = actions.get(current)
-        if action is not None:
-            _t0 = time.monotonic()
-            action()
-            _elapsed = time.monotonic() - _t0
-            logger.info(
-                f"[experiment] {current.value} -> {transition.to_state.value}: "
-                f"{transition.description} ({_elapsed:.1f}s)"
-            )
-
-        # Update state in checkpoint
-        self.checkpoint.experiment_state = transition.to_state.value
-
-        # Save checkpoint atomically
-        save_checkpoint(self.checkpoint, self.checkpoint_path)
-
-        return transition.to_state
+        return self._sm.advance(actions)
 
     def advance_to_completion(
         self,
@@ -254,7 +245,9 @@ class ExperimentStateMachine:
     ) -> ExperimentState:
         """Advance the experiment through all states until COMPLETE is reached.
 
-        On exception, marks experiment as FAILED in the checkpoint.
+        On exception, marks experiment as FAILED in the checkpoint. RateLimitError
+        and ShutdownInterruptedError mark the experiment as INTERRUPTED instead
+        (resumable, not terminal failure).
 
         If until_state is specified, the experiment stops cleanly once that state
         is reached (inclusive): the action that transitions INTO until_state IS
@@ -270,28 +263,15 @@ class ExperimentStateMachine:
             Final ExperimentState (COMPLETE, FAILED, INTERRUPTED, or until_state)
 
         """
-        from scylla.e2e.checkpoint import save_checkpoint
+        from scylla.e2e.rate_limit import RateLimitError
+        from scylla.e2e.shutdown import ShutdownInterruptedError
 
-        try:
-            while not self.is_complete():
-                new_state = self.advance(actions)
-                if until_state is not None and new_state == until_state:
-                    logger.info(
-                        f"[experiment] Reached --until-experiment target state: {until_state.value}"
-                    )
-                    break
-        except Exception as e:
-            from scylla.e2e.rate_limit import RateLimitError
-            from scylla.e2e.shutdown import ShutdownInterruptedError
-
-            if isinstance(e, (RateLimitError, ShutdownInterruptedError)):
-                logger.warning(f"Experiment interrupted in state {self.get_state().value}: {e}")
-                self.checkpoint.experiment_state = ExperimentState.INTERRUPTED.value
-            else:
-                logger.error(f"Experiment failed in state {self.get_state().value}: {e}")
-                self.checkpoint.experiment_state = ExperimentState.FAILED.value
-
-            save_checkpoint(self.checkpoint, self.checkpoint_path)
-            raise
-
-        return self.get_state()
+        return self._sm.advance_to_completion(
+            actions,
+            until_state=until_state,
+            error_state_map=[
+                (RateLimitError, ExperimentState.INTERRUPTED),
+                (ShutdownInterruptedError, ExperimentState.INTERRUPTED),
+            ],
+            failure_state=ExperimentState.FAILED,
+        )

--- a/tests/unit/core/test_state_machine.py
+++ b/tests/unit/core/test_state_machine.py
@@ -1,0 +1,254 @@
+"""Unit tests for the generic StateMachine[TState] in scylla.core.state_machine.
+
+These tests exercise the generic itself with a synthetic state enum, so they
+are independent of any concrete FSM. The experiment-level port is covered by
+``tests/unit/e2e/test_experiment_state_machine.py``.
+"""
+
+from __future__ import annotations
+
+from enum import Enum
+from typing import Any
+
+import pytest
+
+from scylla.core.state_machine import StateMachine, Transition
+
+
+class _S(str, Enum):
+    """Synthetic state enum used by these tests."""
+
+    A = "a"
+    B = "b"
+    C = "c"
+    DONE = "done"
+    FAILED = "failed"
+
+
+def _build(
+    state_ref: list[_S],
+    *,
+    persistence_calls: list[_S] | None = None,
+    event_calls: list[tuple[_S, _S, str]] | None = None,
+) -> StateMachine[_S]:
+    """Build a 3-edge StateMachine wired against `state_ref` as a single-cell store."""
+    transitions = [
+        Transition(from_state=_S.A, to_state=_S.B, description="a->b"),
+        Transition(from_state=_S.B, to_state=_S.C, description="b->c"),
+        Transition(from_state=_S.C, to_state=_S.DONE, description="c->done"),
+    ]
+
+    def apply(s: _S) -> None:
+        state_ref[0] = s
+
+    def persist(s: _S) -> None:
+        if persistence_calls is not None:
+            persistence_calls.append(s)
+
+    def emit(f: _S, t: _S, d: str) -> None:
+        if event_calls is not None:
+            event_calls.append((f, t, d))
+
+    return StateMachine[_S](
+        transitions=transitions,
+        terminal_states=frozenset({_S.DONE, _S.FAILED}),
+        get_state=lambda: state_ref[0],
+        apply_state=apply,
+        persistence_hook=persist,
+        event_hook=emit,
+        label="test",
+    )
+
+
+class TestStateMachineValidation:
+    """Construction-time and query-side validation behavior."""
+
+    def test_rejects_duplicate_from_state(self) -> None:
+        """Duplicate from_state in the transition table is rejected at __post_init__."""
+        with pytest.raises(ValueError, match="Duplicate transition"):
+            StateMachine[_S](
+                transitions=[
+                    Transition(_S.A, _S.B, "a"),
+                    Transition(_S.A, _S.C, "dup"),
+                ],
+                terminal_states=frozenset({_S.DONE}),
+                get_state=lambda: _S.A,
+                apply_state=lambda _s: None,
+            )
+
+    def test_validate_transition_accepts_legal(self) -> None:
+        """Legal edges return True."""
+        sm = _build([_S.A])
+        assert sm.validate_transition(_S.A, _S.B)
+
+    def test_validate_transition_rejects_skip(self) -> None:
+        """Edges that skip states return False."""
+        sm = _build([_S.A])
+        assert not sm.validate_transition(_S.A, _S.C)
+
+    def test_validate_transition_rejects_terminal(self) -> None:
+        """No edges out of terminal states are legal."""
+        sm = _build([_S.A])
+        assert not sm.validate_transition(_S.DONE, _S.A)
+
+    def test_get_next_transition(self) -> None:
+        """get_next_transition returns the registered edge or None."""
+        sm = _build([_S.A])
+        t = sm.get_next_transition(_S.A)
+        assert t is not None
+        assert t.to_state == _S.B
+        assert sm.get_next_transition(_S.DONE) is None
+
+
+class TestStateMachineAdvance:
+    """Behavior of advance() — single-step transitions."""
+
+    def test_advance_runs_action_and_transitions(self) -> None:
+        """advance() runs the registered action then applies the new state."""
+        state = [_S.A]
+        sm = _build(state)
+        called: list[str] = []
+        new = sm.advance({_S.A: lambda: called.append("a")})
+        assert new == _S.B
+        assert called == ["a"]
+        assert state[0] == _S.B
+
+    def test_advance_without_action_still_transitions(self) -> None:
+        """A missing action entry advances state silently (no-op transition)."""
+        state = [_S.A]
+        sm = _build(state)
+        assert sm.advance({}) == _S.B
+        assert state[0] == _S.B
+
+    def test_advance_from_terminal_raises(self) -> None:
+        """Advancing from a terminal state raises RuntimeError."""
+        state = [_S.DONE]
+        sm = _build(state)
+        with pytest.raises(RuntimeError, match="terminal"):
+            sm.advance({})
+
+    def test_advance_unknown_state_raises_value_error(self) -> None:
+        """Advancing from a non-terminal state with no outgoing edge raises ValueError."""
+        sm = StateMachine[_S](
+            transitions=[Transition(_S.A, _S.B, "a")],
+            terminal_states=frozenset(),  # nothing is terminal
+            get_state=lambda: _S.C,  # no edge from C
+            apply_state=lambda _s: None,
+        )
+        with pytest.raises(ValueError, match="No transition"):
+            sm.advance({})
+
+    def test_advance_action_exception_does_not_apply_state(self) -> None:
+        """If the action raises, the state is NOT advanced and persistence is NOT called."""
+        state = [_S.A]
+        persisted: list[_S] = []
+        sm = _build(state, persistence_calls=persisted)
+
+        def boom() -> None:
+            raise RuntimeError("boom")
+
+        with pytest.raises(RuntimeError, match="boom"):
+            sm.advance({_S.A: boom})
+
+        assert state[0] == _S.A
+        assert persisted == []
+
+    def test_advance_invokes_persistence_and_event_hooks(self) -> None:
+        """Both hooks fire once per successful transition, after apply_state."""
+        state = [_S.A]
+        persisted: list[_S] = []
+        events: list[tuple[_S, _S, str]] = []
+        sm = _build(state, persistence_calls=persisted, event_calls=events)
+        sm.advance({})
+        assert persisted == [_S.B]
+        assert events == [(_S.A, _S.B, "a->b")]
+
+    def test_event_hook_exception_does_not_break_advance(self) -> None:
+        """Event-hook exceptions are swallowed; advance still returns the new state."""
+        state = [_S.A]
+
+        def bad_event(_f: _S, _t: _S, _d: str) -> None:
+            raise RuntimeError("event broken")
+
+        sm = StateMachine[_S](
+            transitions=[Transition(_S.A, _S.B, "a")],
+            terminal_states=frozenset({_S.DONE}),
+            get_state=lambda: state[0],
+            apply_state=lambda s: state.__setitem__(0, s),
+            event_hook=bad_event,
+        )
+        assert sm.advance({}) == _S.B
+
+
+class TestStateMachineAdvanceToCompletion:
+    """Behavior of advance_to_completion() — driver loop and error mapping."""
+
+    def test_runs_to_terminal(self) -> None:
+        """The driver walks through every edge until reaching a terminal state."""
+        state = [_S.A]
+        sm = _build(state)
+        assert sm.advance_to_completion({}) == _S.DONE
+
+    def test_stops_at_until_state(self) -> None:
+        """until_state stops the driver as soon as that state is entered."""
+        state = [_S.A]
+        sm = _build(state)
+        assert sm.advance_to_completion({}, until_state=_S.C) == _S.C
+        assert state[0] == _S.C
+
+    def test_error_state_map_first_match_wins(self) -> None:
+        """The first entry matching the exception type wins; failure_state is ignored."""
+        state = [_S.A]
+        sm = _build(state)
+
+        class _MyError(RuntimeError):
+            """Custom error used to exercise error_state_map ordering."""
+
+        def boom() -> None:
+            raise _MyError("x")
+
+        with pytest.raises(_MyError):
+            sm.advance_to_completion(
+                {_S.A: boom},
+                error_state_map=[(_MyError, _S.FAILED)],
+                failure_state=_S.DONE,  # should NOT win (subclass listed first)
+            )
+        assert state[0] == _S.FAILED
+
+    def test_failure_state_used_when_no_map_match(self) -> None:
+        """When no entry in error_state_map matches, failure_state is applied."""
+        state = [_S.A]
+        sm = _build(state)
+
+        def boom() -> None:
+            raise RuntimeError("unmapped")
+
+        with pytest.raises(RuntimeError):
+            sm.advance_to_completion(
+                {_S.A: boom},
+                error_state_map=[(ValueError, _S.DONE)],
+                failure_state=_S.FAILED,
+            )
+        assert state[0] == _S.FAILED
+
+    def test_no_mapping_propagates_without_state_change(self) -> None:
+        """Without error_state_map / failure_state, exceptions propagate as-is."""
+        state = [_S.A]
+        sm = _build(state)
+
+        def boom() -> None:
+            raise RuntimeError("unmapped")
+
+        with pytest.raises(RuntimeError):
+            sm.advance_to_completion({_S.A: boom})
+        # No failure_state -> state untouched at last successful checkpoint.
+        assert state[0] == _S.A
+
+    def test_already_terminal_is_noop(self) -> None:
+        """Calling advance_to_completion on a terminal state is a no-op."""
+        state = [_S.DONE]
+        sm = _build(state)
+        called: list[Any] = []
+        final = sm.advance_to_completion({_S.A: lambda: called.append("x")})
+        assert final == _S.DONE
+        assert called == []


### PR DESCRIPTION
## Summary

Partial fix for #1942 state-machine sprawl. Defines a generic `StateMachine[TState]` in `scylla.core.state_machine` consolidating:

- transition-table validation (rejects illegal edges and duplicate from_states)
- persistence hook (runs after each transition; e.g. atomic checkpoint save)
- event-emission hook (runs after persistence; exceptions are swallowed and logged)
- `advance_to_completion` driver with caller-supplied `error_state_map` so each FSM can map its own exception types to its own resumable/terminal states (e.g. RateLimitError -> INTERRUPTED) without forking the driver.

Ports `experiment_state_machine.py` to use the generic as proof-of-concept. The public API (`ExperimentStateMachine`, `EXPERIMENT_TRANSITION_REGISTRY`, `get_next_experiment_transition`, `is_experiment_terminal_state`, `validate_experiment_transition`, `ExperimentTransition`) is unchanged — verified by the existing 37-test suite, which passes unmodified.

## Tests

- `tests/unit/core/test_state_machine.py` — 18 new tests covering the generic with a synthetic state enum (validation, advance, advance_to_completion, hooks, error mapping).
- `tests/unit/e2e/test_experiment_state_machine.py` — existing 37 tests; pass unmodified, confirming the port preserves behavior.
- Other FSM test suites (`test_state_machine.py`, `test_tier_state_machine.py`, `test_subtest_state_machine.py`, `test_runner_state_machine.py`) continue to pass — they are untouched.

## Deferred (tracked in #1942)

- Port `tier_state_machine.py`
- Port `subtest_state_machine.py`
- Port `state_machine.py` (the run-level FSM)
- Update `docs/dev/adr/state-machine-hierarchy.md` once all four levels are ported

Refs #1942