### PR TITLE
feat(observability): wire 5 high-value call sites to OTel + Prometheus (#1949)

### DIFF
--- a/src/scylla/e2e/checkpoint.py
+++ b/src/scylla/e2e/checkpoint.py
@@ -23,10 +23,14 @@ from typing import TYPE_CHECKING, Any
 
 from pydantic import BaseModel, Field
 
+from scylla.metrics.emitter import get_default_emitter
+from scylla.utils.tracing import get_tracer
+
 if TYPE_CHECKING:
     from scylla.e2e.models import ExperimentConfig
 
 logger = logging.getLogger(__name__)
+_tracer = get_tracer(__name__)
 
 
 class CheckpointError(Exception):
@@ -522,7 +526,17 @@ def save_checkpoint(checkpoint: E2ECheckpoint, path: Path) -> None:
         CheckpointError: If save fails
 
     """
-    with _checkpoint_write_lock:
+    import time as _time
+
+    _save_start = _time.monotonic()
+    _outcome = "error"
+    with (
+        _checkpoint_write_lock,
+        _tracer.start_as_current_span(
+            "scylla.checkpoint.save",
+            attributes={"scylla.experiment_id": checkpoint.experiment_id},
+        ) as _span,
+    ):
         try:
             # Update timestamp
             checkpoint.last_updated_at = datetime.now(timezone.utc).isoformat()
@@ -540,9 +554,27 @@ def save_checkpoint(checkpoint: E2ECheckpoint, path: Path) -> None:
 
             # Atomic rename — each writer has a unique temp file (PID+TID)
             temp_path.replace(path)
+            _outcome = "ok"
 
         except OSError as e:
+            _span.record_exception(e)
             raise CheckpointError(f"Failed to save checkpoint to {path}: {e}") from e
+        finally:
+            try:
+                emitter = get_default_emitter()
+                labels = {"experiment": checkpoint.experiment_id}
+                emitter.emit_gauge(
+                    "scylla_checkpoint_save_duration_seconds",
+                    float(_time.monotonic() - _save_start),
+                    labels=labels,
+                )
+                emitter.emit_counter(
+                    "scylla_checkpoint_save_total",
+                    1,
+                    labels={**labels, "outcome": _outcome},
+                )
+            except Exception as _e:  # never break checkpoint save
+                logger.debug(f"Checkpoint metric emission failed (non-fatal): {_e}")
 
 
 def load_checkpoint(path: Path) -> E2ECheckpoint:

--- a/src/scylla/e2e/judge_runner.py
+++ b/src/scylla/e2e/judge_runner.py
@@ -182,8 +182,11 @@ def _run_judge(  # noqa: C901  # multi-judge consensus with rate-limit/error bra
 
         # Use the LLM judge for proper evaluation
         try:
+            import time as _time
+
+            _judge_start = _time.monotonic()
             with _tracer.start_as_current_span(
-                "scylla.judge",
+                "scylla.judge.call",
                 attributes={
                     "scylla.judge_model": model,
                     "scylla.judge_number": judge_num,
@@ -204,6 +207,15 @@ def _run_judge(  # noqa: C901  # multi-judge consensus with rate-limit/error bra
                 except Exception as _exc:
                     _judge_span.record_exception(_exc)
                     raise
+                finally:
+                    try:
+                        _emitter.emit_gauge(
+                            "scylla_judge_call_duration_seconds",
+                            float(_time.monotonic() - _judge_start),
+                            labels={"model": model},
+                        )
+                    except Exception as _e:  # never break judge call
+                        logger.debug(f"Judge duration emit failed (non-fatal): {_e}")
 
             # Store individual judge result
             judge_summary = JudgeResultSummary(

--- a/src/scylla/e2e/runner_internals/runner_core.py
+++ b/src/scylla/e2e/runner_internals/runner_core.py
@@ -807,6 +807,9 @@ class E2ERunner:
             TierResult with all sub-test results.
 
         """
+        import time as _time
+
+        _tier_start = _time.monotonic()
         with _tracer.start_as_current_span(
             "scylla.tier",
             attributes={
@@ -819,6 +822,18 @@ class E2ERunner:
             except Exception as e:
                 _tier_span.record_exception(e)
                 raise
+            finally:
+                try:
+                    self._emitter.emit_gauge(
+                        "scylla_tier_duration_seconds",
+                        float(_time.monotonic() - _tier_start),
+                        labels={
+                            "tier": tier_id.value,
+                            "experiment": self.config.experiment_id,
+                        },
+                    )
+                except Exception as _e:  # never break tier finalization
+                    logger.debug(f"Tier duration emit failed (non-fatal): {_e}")
 
     def _run_tier_body(
         self,

--- a/src/scylla/e2e/stages.py
+++ b/src/scylla/e2e/stages.py
@@ -89,10 +89,12 @@ from scylla.e2e.stage_process_metrics import (
 from scylla.e2e.stage_process_metrics import (
     _parse_diff_numstat_output as _parse_diff_numstat_output,
 )
+from scylla.metrics.emitter import get_default_emitter
 from scylla.metrics.process import (
     ChangeResult,
     ProgressStep,
 )
+from scylla.utils.tracing import get_tracer
 
 if TYPE_CHECKING:
     from scylla.adapters.base import AdapterConfig, AdapterResult
@@ -106,6 +108,7 @@ if TYPE_CHECKING:
     from scylla.e2e.workspace_manager import WorkspaceManager
 
 logger = logging.getLogger(__name__)
+_tracer = get_tracer(__name__)
 
 # Fallback lock for pipeline serialization when no ResourceManager is configured.
 # Prefer ctx.resource_manager.pipeline_slot() when available.
@@ -559,6 +562,10 @@ def stage_execute_agent(ctx: RunContext) -> None:
     If ctx.agent_result is already set (resume), this is a no-op.
     Otherwise, runs via replay.sh and saves all agent artifacts.
 
+    Wraps execution in an OTel span (``scylla.adapter.call``) and emits
+    ``scylla_adapter_call_duration_seconds`` and ``scylla_adapter_tokens_total``
+    via the default MetricEmitter. Both are no-ops when env vars are unset.
+
     Args:
         ctx: Run context (mutates ctx.agent_result, ctx.agent_duration, ctx.agent_ran)
 
@@ -568,6 +575,60 @@ def stage_execute_agent(ctx: RunContext) -> None:
         logger.debug(f"Skipping agent execution for run {ctx.run_number} (resumed)")
         return
 
+    with _tracer.start_as_current_span(
+        "scylla.adapter.call",
+        attributes={
+            "scylla.tier_id": ctx.tier_id.value,
+            "scylla.subtest_id": ctx.subtest.id,
+            "scylla.run_num": ctx.run_number,
+            "scylla.adapter": ctx.adapter.get_name(),
+            "scylla.model": ctx.config.models[0] if ctx.config.models else "",
+        },
+    ) as _adapter_span:
+        try:
+            _stage_execute_agent_body(ctx)
+        except Exception as _exc:
+            _adapter_span.record_exception(_exc)
+            raise
+        finally:
+            _emit_adapter_metrics(ctx)
+
+
+def _emit_adapter_metrics(ctx: RunContext) -> None:
+    """Emit adapter call duration + token counters. Best-effort, never raises."""
+    try:
+        emitter = get_default_emitter()
+        labels = {
+            "tier": ctx.tier_id.value,
+            "subtest": ctx.subtest.id,
+            "model": ctx.config.models[0] if ctx.config.models else "",
+        }
+        if ctx.agent_duration is not None:
+            emitter.emit_gauge(
+                "scylla_adapter_call_duration_seconds",
+                float(ctx.agent_duration),
+                labels=labels,
+            )
+        if ctx.agent_result is not None:
+            tok = ctx.agent_result.token_stats
+            if tok.input_tokens:
+                emitter.emit_counter(
+                    "scylla_adapter_tokens_total",
+                    int(tok.input_tokens),
+                    labels={**labels, "kind": "input"},
+                )
+            if tok.output_tokens:
+                emitter.emit_counter(
+                    "scylla_adapter_tokens_total",
+                    int(tok.output_tokens),
+                    labels={**labels, "kind": "output"},
+                )
+    except Exception as e:  # emitter must never break the run
+        logger.debug(f"Adapter metric emission failed (non-fatal): {e}")
+
+
+def _stage_execute_agent_body(ctx: RunContext) -> None:
+    """Body of :func:`stage_execute_agent`, wrapped in a tracing span by caller."""
     from scylla.adapters.base import AdapterResult
     from scylla.e2e.agent_runner import (
         _create_agent_model_md,

--- a/src/scylla/e2e/subtest_executor.py
+++ b/src/scylla/e2e/subtest_executor.py
@@ -59,6 +59,7 @@ from scylla.e2e.workspace_setup import (
     _move_to_failed,
     _setup_workspace,
 )
+from scylla.metrics.emitter import get_default_emitter
 from scylla.utils.tracing import get_tracer
 
 if TYPE_CHECKING:
@@ -85,6 +86,30 @@ __all__ = [
     "_setup_workspace",
     "aggregate_run_results",
 ]
+
+
+def _emit_subtest_metrics(
+    tier_id: str,
+    subtest_id: str,
+    duration_seconds: float,
+    outcome: str,
+) -> None:
+    """Emit subtest duration gauge + outcome counter. Best-effort, never raises."""
+    try:
+        emitter = get_default_emitter()
+        labels = {"tier": tier_id, "subtest": subtest_id}
+        emitter.emit_gauge(
+            "scylla_subtest_duration_seconds",
+            float(duration_seconds),
+            labels=labels,
+        )
+        emitter.emit_counter(
+            "scylla_subtest_outcome_total",
+            1,
+            labels={**labels, "outcome": outcome},
+        )
+    except Exception as e:  # emitter must never break subtest execution
+        logger.debug(f"Subtest metric emission failed (non-fatal): {e}")
 
 
 def _restore_run_context(ctx: Any, current_state: str) -> None:
@@ -396,6 +421,10 @@ class SubTestExecutor:
             SubTestResult with aggregated metrics.
 
         """
+        import time as _time
+
+        _subtest_start = _time.monotonic()
+        _outcome = "error"
         with _tracer.start_as_current_span(
             "scylla.subtest",
             attributes={
@@ -405,7 +434,7 @@ class SubTestExecutor:
             },
         ) as _subtest_span:
             try:
-                return self._run_subtest_body(
+                _result = self._run_subtest_body(
                     tier_id=tier_id,
                     tier_config=tier_config,
                     subtest=subtest,
@@ -416,9 +445,18 @@ class SubTestExecutor:
                     coordinator=coordinator,
                     experiment_dir=experiment_dir,
                 )
+                _outcome = "pass" if _result.pass_rate > 0 else "fail"
+                return _result
             except Exception as _exc:
                 _subtest_span.record_exception(_exc)
                 raise
+            finally:
+                _emit_subtest_metrics(
+                    tier_id=tier_id.value,
+                    subtest_id=subtest.id,
+                    duration_seconds=_time.monotonic() - _subtest_start,
+                    outcome=_outcome,
+                )
 
     def _run_subtest_body(  # noqa: C901  # orchestration with many retry/outcome paths
         self,

--- a/tests/unit/e2e/test_stages.py
+++ b/tests/unit/e2e/test_stages.py
@@ -1134,7 +1134,13 @@ class TestStageExecuteAgentStdinDevNull:
         """
         import inspect
 
-        source = inspect.getsource(stage_execute_agent)
+        # stage_execute_agent is a thin tracing/metrics wrapper; the Popen call
+        # lives in _stage_execute_agent_body. Inspect both to guard against drift.
+        from scylla.e2e.stages import _stage_execute_agent_body
+
+        source = inspect.getsource(stage_execute_agent) + inspect.getsource(
+            _stage_execute_agent_body
+        )
         assert "stdin=subprocess.DEVNULL" in source, (
             "stage_execute_agent must use stdin=subprocess.DEVNULL in Popen "
             "to prevent TTY sharing and signal delivery issues"

--- a/tests/unit/metrics/test_emitter_wiring_sites.py
+++ b/tests/unit/metrics/test_emitter_wiring_sites.py
@@ -1,0 +1,249 @@
+"""Tests for the 5 high-value call sites instrumented in #1949.
+
+Validates that each instrumentation point emits the expected metric name(s)
+to the default :class:`MetricEmitter`, and that emission failures are
+swallowed (never break the wrapped operation).
+
+Sites covered:
+    1. Tier start/end             -> ``scylla_tier_duration_seconds``
+    2. Subtest start/end          -> ``scylla_subtest_duration_seconds`` +
+                                     ``scylla_subtest_outcome_total``
+    3. Judge call                 -> ``scylla_judge_call_duration_seconds``
+    4. Adapter call               -> ``scylla_adapter_call_duration_seconds`` +
+                                     ``scylla_adapter_tokens_total``
+    5. Checkpoint save            -> ``scylla_checkpoint_save_duration_seconds`` +
+                                     ``scylla_checkpoint_save_total``
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TYPE_CHECKING
+from unittest.mock import MagicMock
+
+import pytest
+
+from scylla.metrics.emitter import MetricEmitter, NoOpEmitter
+
+if TYPE_CHECKING:
+    pass
+
+
+class RecordingEmitter(MetricEmitter):
+    """Capture emit calls for assertions."""
+
+    def __init__(self) -> None:
+        """Initialize with empty call lists."""
+        self.counters: list[tuple[str, int, dict[str, str] | None]] = []
+        self.gauges: list[tuple[str, float, dict[str, str] | None]] = []
+
+    def emit_counter(
+        self,
+        name: str,
+        value: int,
+        labels: dict[str, str] | None = None,
+    ) -> None:
+        """Record a counter call."""
+        self.counters.append((name, value, labels))
+
+    def emit_gauge(
+        self,
+        name: str,
+        value: float,
+        labels: dict[str, str] | None = None,
+    ) -> None:
+        """Record a gauge call."""
+        self.gauges.append((name, value, labels))
+
+
+# ---------------------------------------------------------------------------
+# Subtest site
+# ---------------------------------------------------------------------------
+
+
+def test_subtest_metrics_emit_duration_and_outcome(monkeypatch: pytest.MonkeyPatch) -> None:
+    """``_emit_subtest_metrics`` writes duration + outcome via default emitter."""
+    from scylla.e2e import subtest_executor
+
+    rec = RecordingEmitter()
+    monkeypatch.setattr(subtest_executor, "get_default_emitter", lambda: rec)
+
+    subtest_executor._emit_subtest_metrics(
+        tier_id="T0",
+        subtest_id="s1",
+        duration_seconds=1.5,
+        outcome="pass",
+    )
+
+    gauge_names = {g[0] for g in rec.gauges}
+    counter_names = {c[0] for c in rec.counters}
+    assert "scylla_subtest_duration_seconds" in gauge_names
+    assert "scylla_subtest_outcome_total" in counter_names
+
+    # Outcome label present.
+    outcome_calls = [c for c in rec.counters if c[0] == "scylla_subtest_outcome_total"]
+    assert outcome_calls[0][2] == {"tier": "T0", "subtest": "s1", "outcome": "pass"}
+
+
+def test_subtest_metrics_swallow_emitter_errors(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Emitter exceptions inside ``_emit_subtest_metrics`` must not propagate."""
+    from scylla.e2e import subtest_executor
+
+    class Boom(NoOpEmitter):
+        def emit_gauge(self, *a: object, **k: object) -> None:
+            raise RuntimeError("boom")
+
+    monkeypatch.setattr(subtest_executor, "get_default_emitter", lambda: Boom())
+    # Should not raise.
+    subtest_executor._emit_subtest_metrics(
+        tier_id="T0", subtest_id="s1", duration_seconds=0.1, outcome="fail"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Adapter (stages) site
+# ---------------------------------------------------------------------------
+
+
+def test_adapter_metrics_emit_duration_and_tokens(monkeypatch: pytest.MonkeyPatch) -> None:
+    """``_emit_adapter_metrics`` emits duration gauge + input/output token counters."""
+    from scylla.adapters.base import AdapterResult, AdapterTokenStats
+    from scylla.e2e import stages
+
+    rec = RecordingEmitter()
+    monkeypatch.setattr(stages, "get_default_emitter", lambda: rec)
+
+    # Build a minimal stand-in for RunContext with just the fields the emitter reads.
+    ctx = MagicMock()
+    ctx.tier_id.value = "T0"
+    ctx.subtest.id = "s1"
+    ctx.config.models = ["claude-sonnet-4-6"]
+    ctx.agent_duration = 12.34
+    ctx.agent_result = AdapterResult(
+        exit_code=0,
+        token_stats=AdapterTokenStats(input_tokens=100, output_tokens=50),
+    )
+
+    stages._emit_adapter_metrics(ctx)
+
+    gauge_names = {g[0] for g in rec.gauges}
+    assert "scylla_adapter_call_duration_seconds" in gauge_names
+
+    token_calls = [c for c in rec.counters if c[0] == "scylla_adapter_tokens_total"]
+    kinds = {(c[2] or {}).get("kind") for c in token_calls}
+    assert kinds == {"input", "output"}
+
+
+def test_adapter_metrics_skip_when_no_result(monkeypatch: pytest.MonkeyPatch) -> None:
+    """When agent_result is None, only duration may be emitted (no token counters)."""
+    from scylla.e2e import stages
+
+    rec = RecordingEmitter()
+    monkeypatch.setattr(stages, "get_default_emitter", lambda: rec)
+
+    ctx = MagicMock()
+    ctx.tier_id.value = "T0"
+    ctx.subtest.id = "s1"
+    ctx.config.models = ["m"]
+    ctx.agent_duration = None
+    ctx.agent_result = None
+
+    stages._emit_adapter_metrics(ctx)
+
+    # No token counters when no result.
+    assert not [c for c in rec.counters if c[0] == "scylla_adapter_tokens_total"]
+
+
+# ---------------------------------------------------------------------------
+# Checkpoint save site
+# ---------------------------------------------------------------------------
+
+
+def test_checkpoint_save_emits_metrics(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """``save_checkpoint`` emits duration + outcome on success."""
+    from scylla.e2e import checkpoint as checkpoint_mod
+    from scylla.e2e.checkpoint import E2ECheckpoint, save_checkpoint
+
+    rec = RecordingEmitter()
+    monkeypatch.setattr(checkpoint_mod, "get_default_emitter", lambda: rec)
+
+    ckpt = E2ECheckpoint(
+        experiment_id="exp-test",
+        experiment_dir=str(tmp_path),
+        config_hash="abc",
+        completed_runs={},
+        started_at="2026-01-01T00:00:00+00:00",
+        last_updated_at="2026-01-01T00:00:00+00:00",
+        status="running",
+        rate_limit_source=None,
+        rate_limit_until=None,
+        pause_count=0,
+        pid=1234,
+    )
+    save_checkpoint(ckpt, tmp_path / "checkpoint.json")
+
+    gauge_names = {g[0] for g in rec.gauges}
+    counter_names = {c[0] for c in rec.counters}
+    assert "scylla_checkpoint_save_duration_seconds" in gauge_names
+    assert "scylla_checkpoint_save_total" in counter_names
+
+    save_calls = [c for c in rec.counters if c[0] == "scylla_checkpoint_save_total"]
+    assert (save_calls[0][2] or {}).get("outcome") == "ok"
+
+
+# ---------------------------------------------------------------------------
+# Tier site
+# ---------------------------------------------------------------------------
+
+
+def test_tier_duration_emitted_in_run_tier(monkeypatch: pytest.MonkeyPatch) -> None:
+    """``_run_tier`` emits ``scylla_tier_duration_seconds`` via ``self._emitter``.
+
+    We exercise the duration emission path by invoking ``_run_tier`` with a
+    stubbed ``_run_tier_body``.
+    """
+    from scylla.e2e.models import ExperimentConfig, TierID
+    from scylla.e2e.runner import E2ERunner
+
+    rec = RecordingEmitter()
+    config = ExperimentConfig(
+        experiment_id="exp-test",
+        task_repo="https://example/repo",
+        task_commit="abc",
+        task_prompt_file=Path("prompt.md"),
+        language="python",
+    )
+    runner = E2ERunner(
+        config=config,
+        tiers_dir=Path("/tmp"),
+        results_base_dir=Path("/tmp"),
+        emitter=rec,
+    )
+
+    # Stub the body so we don't need real tier execution.
+    monkeypatch.setattr(runner, "_run_tier_body", lambda tier, baseline: MagicMock())
+
+    runner._run_tier(TierID.T0, baseline=None)
+
+    gauge_names = {g[0] for g in rec.gauges}
+    assert "scylla_tier_duration_seconds" in gauge_names
+    duration_calls = [g for g in rec.gauges if g[0] == "scylla_tier_duration_seconds"]
+    assert (duration_calls[0][2] or {}).get("tier") == "T0"
+
+
+# ---------------------------------------------------------------------------
+# Judge call site (duration metric is emitted via the existing _emitter)
+# ---------------------------------------------------------------------------
+
+
+def test_judge_call_duration_metric_name_used() -> None:
+    """The judge_runner module references the correct duration metric name.
+
+    Source-level guard against rename drift — a full end-to-end exercise of
+    ``_run_judge`` is covered elsewhere in ``test_emitter_wiring.py``.
+    """
+    from scylla.e2e import judge_runner
+
+    source = Path(judge_runner.__file__).read_text()
+    assert "scylla_judge_call_duration_seconds" in source
+    assert "scylla.judge.call" in source


### PR DESCRIPTION
## Summary

First slice of #1949. The observability scaffolding from PRs #1921-#1933 was un-wired — turning on \`SCYLLA_OTEL_EXPORTER\` and \`SCYLLA_METRICS_PATH\` produced little signal. This PR instruments 5 high-value sites:

| Site | Span | Metric(s) |
|------|------|-----------|
| Tier start/end | \`scylla.tier\` | \`scylla_tier_duration_seconds\` gauge |
| Subtest start/end | \`scylla.subtest\` | \`scylla_subtest_duration_seconds\`, \`scylla_subtest_outcome_total\` |
| Judge call | \`scylla.judge.call\` | \`scylla_judge_call_duration_seconds\` (plus existing \`scylla_judge_evaluations_total\`) |
| Adapter call | \`scylla.adapter.call\` | \`scylla_adapter_call_duration_seconds\`, \`scylla_adapter_tokens_total{kind=input\|output}\` |
| Checkpoint save | \`scylla.checkpoint.save\` | \`scylla_checkpoint_save_duration_seconds\`, \`scylla_checkpoint_save_total{outcome=ok\|error}\` |

All instrumentation is no-op when env vars are unset. Emission failures are swallowed by best-effort \`try/except\` blocks so observability never breaks the wrapped operation.

## Notes on API

- The scaffolding only exposes \`emit_counter\` / \`emit_gauge\` (no \`observe_histogram\`). Durations are emitted as gauges per the existing pattern in \`runner_core._emit_experiment_metrics\`.
- Judge token counters were not added in this slice — \`JudgeResult\` does not currently expose token counts. Deferred.
- The existing \`scylla.judge\` span name was changed to \`scylla.judge.call\` to match the issue's instrumentation map.

## Deferred (tracked in #1949)

- Rate-limit pause instrumentation
- Container start/stop instrumentation
- Error-class dispatch instrumentation
- Top-level experiment lifecycle instrumentation
- Judge token counters (requires plumbing through \`run_llm_judge\`)
- \`docs/dev/tracing.md\` instrumentation map (will land after all sites are wired)

## Test Plan

- [x] New unit tests in \`tests/unit/metrics/test_emitter_wiring_sites.py\` (7 tests) assert each site emits its expected metric name via a recording emitter and that errors are swallowed
- [x] Existing \`test_popen_uses_stdin_devnull\` source-inspection guard updated to follow the new wrapper/body split in \`stage_execute_agent\`
- [x] Full \`tests/unit/{metrics,utils,e2e}\` suite: 2005 passed, 3 skipped
- [x] \`pre-commit run\` green (ruff, mypy strict, complexity)

Refs #1949

🤖 Generated with [Claude Code](https://claude.com/claude-code)