### PR TITLE
refactor(e2e): decompose E2ERunner (998 LoC) into 4 collaborators (#1941)

### DIFF
--- a/src/scylla/e2e/runner_internals/runner_core.py
+++ b/src/scylla/e2e/runner_internals/runner_core.py
@@ -52,6 +52,7 @@ from scylla.e2e.runner_internals.runner_setup import RunnerSetup
 from scylla.e2e.runner_internals.tier_context import TierContext
 from scylla.e2e.shutdown import is_shutdown_requested
 from scylla.metrics.emitter import MetricEmitter, get_default_emitter
+
 # Imported at module scope so tests can patch
 # ``scylla.e2e.runner_internals.runner_core.{load_checkpoint, validate_checkpoint_config}``
 # (see tests/unit/e2e/test_runner.py). After PR #1940 the implementation lives in

--- a/src/scylla/e2e/runner_internals/runner_core.py
+++ b/src/scylla/e2e/runner_internals/runner_core.py
@@ -1,11 +1,34 @@
-"""Core E2ERunner class — orchestrates the complete E2E experiment lifecycle."""
+"""Thin E2ERunner orchestrator — delegates to four collaborators.
+
+Responsibilities are split across:
+
+* :class:`scylla.e2e.runner_internals.runner_setup.RunnerSetup` — init,
+  config, workspace prep, baseline capture, PID file lifecycle.
+* :class:`scylla.e2e.runner_internals.runner_resume.RunnerResume` —
+  resume-from-checkpoint detection, validation, and CLI-flag merge.
+* :class:`scylla.e2e.runner_internals.runner_execution.RunnerExecution` —
+  tier dependency grouping, parallel tier execution, single-tier state
+  machine orchestration.
+* :class:`scylla.e2e.runner_internals.runner_finalization.RunnerFinalization`
+  — result aggregation, report generation, metric emission, and checkpoint
+  finalization.
+
+``E2ERunner`` itself holds shared state (``config``, ``experiment_dir``,
+``checkpoint``, ``workspace_manager``, ``tier_manager``) and exposes the
+``run()`` entry point plus the ``_action_exp_*`` callbacks used by
+``ExperimentStateMachine``.
+
+Imports of ``load_checkpoint`` and ``validate_checkpoint_config`` are
+retained at module scope to preserve existing ``patch`` targets in tests
+under ``tests/unit/e2e/`` that reference
+``scylla.e2e.runner_internals.runner_core.<name>``.
+"""
 
 from __future__ import annotations
 
 import contextlib
 import logging
 import os
-import tempfile
 from collections.abc import Callable
 from datetime import datetime, timezone
 from pathlib import Path
@@ -13,10 +36,7 @@ from typing import TYPE_CHECKING
 
 from scylla.e2e.checkpoint_finalizer import CheckpointFinalizer
 from scylla.e2e.experiment_setup_manager import ExperimentSetupManager
-
-# Note: Judge prompts are now generated dynamically via scylla.judge.prompts.build_task_prompt()
 from scylla.e2e.models import (
-    TIER_DEPENDENCIES,
     ExperimentConfig,
     ExperimentResult,
     ExperimentState,
@@ -24,48 +44,49 @@ from scylla.e2e.models import (
     TierID,
     TierResult,
     TierState,
-    TokenStats,
 )
-from scylla.e2e.parallel_tier_runner import ParallelTierRunner
-from scylla.e2e.resume_manager import ResumeManager
-from scylla.e2e.runner_internals.constants import _STATUS_RUNNING
+from scylla.e2e.runner_internals.runner_execution import RunnerExecution
+from scylla.e2e.runner_internals.runner_finalization import RunnerFinalization
+from scylla.e2e.runner_internals.runner_resume import RunnerResume
+from scylla.e2e.runner_internals.runner_setup import RunnerSetup
 from scylla.e2e.runner_internals.tier_context import TierContext
-from scylla.e2e.shutdown import (
-    is_shutdown_requested,
-)
-from scylla.e2e.tier_action_builder import TierActionBuilder
-from scylla.e2e.tier_manager import TierManager
-from scylla.e2e.workspace_manager import WorkspaceManager
+from scylla.e2e.shutdown import is_shutdown_requested
 from scylla.metrics.emitter import MetricEmitter, get_default_emitter
+# Imported at module scope so tests can patch
+# ``scylla.e2e.runner_internals.runner_core.{load_checkpoint, validate_checkpoint_config}``
+# (see tests/unit/e2e/test_runner.py). After PR #1940 the implementation lives in
+# scylla.persistence.checkpoint; patching the e2e back-compat shim no longer
+# affects the real call site.
 from scylla.persistence.checkpoint import (
     E2ECheckpoint,
-    compute_config_hash,
     load_checkpoint,
-    save_checkpoint,
     validate_checkpoint_config,
 )
 from scylla.persistence.experiment_result_writer import ExperimentResultWriter
 from scylla.utils.tracing import get_tracer
 
 if TYPE_CHECKING:
+    from scylla.e2e.checkpoint_finalizer import CheckpointFinalizer
     from scylla.e2e.resource_manager import ResourceManager
+    from scylla.e2e.workspace_manager import WorkspaceManager
+
+# Re-export for backwards compatibility / external imports.
+__all__ = ["E2ERunner", "load_checkpoint", "validate_checkpoint_config"]
 
 logger = logging.getLogger(__name__)
+# Re-exported so tests under ``tests/unit/e2e/test_tracing_integration.py``
+# can import ``_tracer`` from this module after the decomposition. The actual
+# span creation lives in :mod:`scylla.e2e.runner_internals.runner_execution`.
 _tracer = get_tracer(__name__)
 
 
 class E2ERunner:
-    """Main runner for E2E experiments.
+    """Thin orchestrator for E2E experiments.
 
-    Orchestrates the complete E2E experiment lifecycle:
-    1. Initialize experiment directory
-    2. For each tier (T0 → T6):
-       a. Load tier configuration
-       b. Run all sub-tests in parallel
-       c. Select best sub-test
-       d. Set baseline for next tier
-    3. Generate cross-tier analysis
-    4. Create final report
+    Holds shared state and delegates work to four collaborators:
+    :class:`RunnerSetup`, :class:`RunnerResume`, :class:`RunnerExecution`,
+    and :class:`RunnerFinalization`. The public method ``run()`` and the
+    ``_action_exp_*`` callbacks remain here as orchestration glue.
 
     Example:
         >>> config = ExperimentConfig(
@@ -74,7 +95,7 @@ class E2ERunner:
         ...     task_commit="abc123",
         ...     task_prompt_file=Path("prompt.md"),
         ... )
-        >>> runner = E2ERunner(config, Path("tests/fixtures/tests/test-001"), Path("results"))
+        >>> runner = E2ERunner(config, Path("tiers"), Path("results"))
         >>> result = runner.run()
 
     """
@@ -90,15 +111,17 @@ class E2ERunner:
         """Initialize the E2E runner.
 
         Args:
-            config: Experiment configuration
-            tiers_dir: Path to tier configurations
-            results_base_dir: Base directory for results
-            fresh: If True, ignore existing checkpoints and start fresh
-            emitter: Optional metric emitter for time-series export. Defaults
-                to :func:`scylla.metrics.emitter.get_default_emitter` (a
-                :class:`NoOpEmitter` unless ``SCYLLA_METRICS_PATH`` is set).
+            config: Experiment configuration.
+            tiers_dir: Path to tier configurations.
+            results_base_dir: Base directory for results.
+            fresh: If True, ignore existing checkpoints and start fresh.
+            emitter: Optional metric emitter for time-series export.
 
         """
+        # Local import keeps the static module-load graph identical to the
+        # previous shape (and avoids a circular import risk at decompose-time).
+        from scylla.e2e.tier_manager import TierManager
+
         self.config = config
         self.tier_manager = TierManager(tiers_dir)
         self.results_base_dir = results_base_dir
@@ -110,339 +133,140 @@ class E2ERunner:
         self._resource_manager: ResourceManager | None = None
         self._emitter = emitter if emitter is not None else get_default_emitter()
 
+        # Collaborators — each holds a back-reference to self.
+        self.setup = RunnerSetup(self)
+        self.resume = RunnerResume(self)
+        self.execution = RunnerExecution(self)
+        self.finalization = RunnerFinalization(self)
+
+    # ------------------------------------------------------------------
+    # Thin delegating methods — preserved for backwards compatibility with
+    # existing callers and tests under ``tests/unit/e2e/``.
+    # ------------------------------------------------------------------
+
     def _result_writer(self) -> ExperimentResultWriter:
-        """Create an ExperimentResultWriter bound to current state.
+        return self.finalization.result_writer()
 
-        Returns:
-            ExperimentResultWriter with current experiment_dir and tier_manager.
+    def _setup_manager(self) -> ExperimentSetupManager:
+        return self.setup.setup_manager()
 
-        """
-        return ExperimentResultWriter(
-            experiment_dir=self.experiment_dir,
-            tier_manager=self.tier_manager,
-        )
+    def _finalizer(self) -> CheckpointFinalizer:
+        return self.finalization.finalizer()
 
     @staticmethod
     def _get_tier_groups(tiers_to_run: list[TierID]) -> list[list[TierID]]:
-        """Group tiers by dependencies for parallel execution.
-
-        Tiers within each group can run in parallel. Groups are executed sequentially.
-
-        Args:
-            tiers_to_run: List of tier IDs to run
-
-        Returns:
-            List of tier groups, where each group can be run in parallel.
-            Example: [[T0, T1, T2, T3, T4], [T5], [T6]]
-
-        """
-        if not tiers_to_run:
-            return []
-
-        groups: list[list[TierID]] = []
-        remaining = set(tiers_to_run)
-        completed: set[TierID] = set()
-
-        while remaining:
-            # Find all tiers whose dependencies are satisfied
-            ready = [
-                tier
-                for tier in remaining
-                if all(
-                    dep in completed or dep not in tiers_to_run for dep in TIER_DEPENDENCIES[tier]
-                )
-            ]
-
-            if not ready:
-                # Circular dependency or missing dependency
-                raise ValueError(
-                    f"Unable to resolve tier dependencies. "
-                    f"Remaining: {remaining}, Completed: {completed}"
-                )
-
-            groups.append(sorted(ready))  # Sort for deterministic ordering
-            completed.update(ready)
-            remaining -= set(ready)
-
-        return groups
+        return RunnerExecution.get_tier_groups(tiers_to_run)
 
     def _log_checkpoint_resume(self, checkpoint_path: Path) -> None:
-        """Log checkpoint resume status with completed run count.
-
-        Args:
-            checkpoint_path: Path to checkpoint.json file
-
-        """
-        if self.checkpoint is None:
-            raise RuntimeError("checkpoint must be set before logging resume status")
-        logger.info(f"📂 Resuming from checkpoint: {checkpoint_path}")
-        logger.info(f"   Previously completed: {self.checkpoint.get_completed_run_count()} runs")
+        self.resume.log_checkpoint_resume(checkpoint_path)
 
     def _load_checkpoint_and_config(self, checkpoint_path: Path) -> tuple[E2ECheckpoint, Path]:
-        """Load and validate checkpoint and configuration from existing checkpoint.
-
-        Args:
-            checkpoint_path: Path to checkpoint.json file
-
-        Returns:
-            Tuple of (checkpoint, experiment_dir)
-
-        Raises:
-            ValueError: If config validation fails or experiment directory doesn't exist
-            Exception: If checkpoint loading fails
-
-        """
-        self.checkpoint = load_checkpoint(checkpoint_path)
-        self.experiment_dir = Path(self.checkpoint.experiment_dir)
-
-        # Load config from checkpoint's saved experiment.json
-        # This ensures checkpoint config takes precedence over CLI args
-        saved_config_path = self.experiment_dir / "config" / "experiment.json"
-        if saved_config_path.exists():
-            self._log_checkpoint_resume(checkpoint_path)
-            logger.info(f"📋 Loading config from checkpoint: {saved_config_path}")
-            self.config = ExperimentConfig.load(saved_config_path)
-        else:
-            # Fallback: validate CLI config matches checkpoint
-            logger.warning(
-                f"⚠️  Checkpoint config not found at {saved_config_path}, using CLI config"
-            )
-            if not validate_checkpoint_config(self.checkpoint, self.config):
-                raise ValueError(
-                    f"Config has changed since checkpoint. Use --fresh to start over.\n"
-                    f"Checkpoint: {checkpoint_path}"
-                )
-            self._log_checkpoint_resume(checkpoint_path)
-
-        # Validate experiment directory exists
-        if not self.experiment_dir.exists():
-            raise ValueError(f"Checkpoint references non-existent directory: {self.experiment_dir}")
-
-        return self.checkpoint, self.experiment_dir
+        return self.resume.load_checkpoint_and_config(checkpoint_path)
 
     def _create_fresh_experiment(self) -> Path:
-        """Create new experiment directory and initialize checkpoint.
-
-        Returns:
-            Path to the created checkpoint file
-
-        """
-        setup = self._setup_manager()
-        self.experiment_dir = setup.create_experiment_dir()
-        setup.save_config(self.experiment_dir)
-
-        self.checkpoint = E2ECheckpoint(
-            experiment_id=self.config.experiment_id,
-            experiment_dir=str(self.experiment_dir),
-            config_hash=compute_config_hash(self.config),
-            completed_runs={},
-            started_at=datetime.now(timezone.utc).isoformat(),
-            last_updated_at=datetime.now(timezone.utc).isoformat(),
-            status=_STATUS_RUNNING,
-            rate_limit_source=None,
-            rate_limit_until=None,
-            pause_count=0,
-            pid=os.getpid(),
-        )
-
-        checkpoint_path = self.experiment_dir / "checkpoint.json"
-        save_checkpoint(self.checkpoint, checkpoint_path)
-        logger.info(f"💾 Created checkpoint: {checkpoint_path}")
-
-        return checkpoint_path
+        return self.setup.create_fresh_experiment()
 
     def _initialize_or_resume_experiment(self) -> Path:
-        """Initialize fresh experiment or resume from checkpoint.
-
-        Handles:
-        - Finding existing checkpoint
-        - Loading checkpoint and validating config
-        - Creating fresh experiment directory if needed
-        - Writing PID file for monitoring
-
-        Returns:
-            Path to checkpoint file for this experiment
-
-        """
-        # Check for existing checkpoint (auto-resume unless --fresh)
-        checkpoint_path = self._find_existing_checkpoint()
-
-        if checkpoint_path and not self._fresh:
-            # STEP 1: Capture CLI fields before _load_checkpoint_and_config overwrites self.config
-            _cli_tiers = list(self.config.tiers_to_run)
-            _cli_ephemeral = {
-                "until_run_state": self.config.until_run_state,
-                "until_tier_state": self.config.until_tier_state,
-                "until_experiment_state": self.config.until_experiment_state,
-                "max_subtests": self.config.max_subtests,
-            }
-
-            try:
-                # STEP 1 (continued): Load checkpoint — overwrites self.config from saved JSON
-                self._load_checkpoint_and_config(checkpoint_path)
-
-                if self.checkpoint:
-                    rm = ResumeManager(self.checkpoint, self.config, self.tier_manager)
-
-                    # STEP 1 (continued): Check for zombie (crashed) experiment
-                    self.config, self.checkpoint = rm.handle_zombie(
-                        checkpoint_path, self.experiment_dir
-                    )
-
-                    # STEP 2: Restore ephemeral CLI args
-                    self.config, self.checkpoint = rm.restore_cli_args(_cli_ephemeral)
-
-                    # STEP 3: Reset failed/interrupted states for re-execution
-                    self.config, self.checkpoint = rm.reset_failed_states()
-
-                    # STEP 4: Merge CLI tiers and reset incomplete tier/subtest states
-                    self.config, self.checkpoint = rm.merge_cli_tiers_and_reset_incomplete(
-                        _cli_tiers, checkpoint_path
-                    )
-
-            except Exception as e:  # broad catch: resume can fail from JSON/IO/state errors
-                logger.warning(f"Failed to resume from checkpoint: {e}")
-                logger.warning("Starting fresh experiment instead")
-                self.checkpoint = None
-                self.experiment_dir = None
-
-        if not self.experiment_dir:
-            checkpoint_path = self._create_fresh_experiment()
-
-        # Write PID file for status monitoring
-        self._write_pid_file()
-
-        if self.experiment_dir is None:
-            raise RuntimeError("experiment_dir must be set before getting checkpoint path")
-        return self.experiment_dir / "checkpoint.json"
+        return self.resume.initialize_or_resume_experiment()
 
     def _setup_workspace(self) -> None:
-        """Set up workspace manager for execution.
-
-        Creates and configures the WorkspaceManager if not already initialized.
-        """
-        if not hasattr(self, "workspace_manager") or self.workspace_manager is None:
-            # Use centralized repos directory for shared clones across experiments
-            repos_dir = self.results_base_dir / "repos"
-            if self.experiment_dir is None:
-                raise RuntimeError(
-                    "experiment_dir must be set before initializing workspace manager"
-                )
-            self.workspace_manager = WorkspaceManager(
-                experiment_dir=self.experiment_dir,
-                repo_url=self.config.task_repo,
-                commit=self.config.task_commit,
-                repos_dir=repos_dir,
-            )
-            # Setup base repo (idempotent - checks for existing clone internally)
-            self.workspace_manager.setup_base_repo()
+        self.setup.setup_workspace()
 
     def _capture_experiment_baseline(self) -> None:
-        """Capture pipeline baseline once at experiment level from a clean repo state."""
-        assert self.experiment_dir is not None  # noqa: S101
-        assert self.workspace_manager is not None  # noqa: S101
-        self._setup_manager().capture_baseline(self.experiment_dir, self.workspace_manager)
-
-    def _finalizer(self) -> CheckpointFinalizer:
-        """Create a CheckpointFinalizer bound to current state."""
-        return CheckpointFinalizer(self.config, self.results_base_dir)
+        self.setup.capture_experiment_baseline()
 
     def _handle_experiment_interrupt(self, checkpoint_path: Path) -> None:
-        """Handle graceful shutdown on interrupt."""
-        self._finalizer().handle_experiment_interrupt(self.checkpoint, checkpoint_path)
+        self.finalization.handle_experiment_interrupt(checkpoint_path)
 
     def _validate_filesystem_on_resume(self, current_state: ExperimentState) -> None:
-        """Cross-validate filesystem against checkpoint state on resume."""
-        if not self.experiment_dir:
-            return
-        self._finalizer().validate_filesystem_on_resume(self.experiment_dir, current_state)
+        self.finalization.validate_filesystem_on_resume(current_state)
 
     def _execute_tier_groups(
         self,
         tier_groups: list[list[TierID]],
         previous_baseline: TierBaseline | None = None,
     ) -> dict[TierID, TierResult]:
-        """Execute all tier groups sequentially.
-
-        Args:
-            tier_groups: List of tier groups for execution
-            previous_baseline: Optional baseline from previous tier
-
-        Returns:
-            Dictionary mapping tier IDs to their results
-
-        """
-        return ParallelTierRunner(
-            config=self.config,
-            tier_manager=self.tier_manager,
-            experiment_dir=self.experiment_dir,
-            run_tier_fn=self._run_tier,
-            save_tier_result_fn=self._save_tier_result,
-        ).execute_tier_groups(tier_groups, previous_baseline)
+        return self.execution.execute_tier_groups(tier_groups, previous_baseline)
 
     def _create_baseline_from_tier_result(
         self,
         tier_id: TierID,
         tier_result: TierResult,
     ) -> TierBaseline | None:
-        """Create a baseline from a tier result's best subtest.
-
-        Args:
-            tier_id: The tier the result belongs to.
-            tier_result: The result from which to derive the baseline.
-
-        Returns:
-            TierBaseline for the best subtest, or None if no best subtest exists.
-
-        """
-        return ParallelTierRunner(
-            config=self.config,
-            tier_manager=self.tier_manager,
-            experiment_dir=self.experiment_dir,
-            run_tier_fn=self._run_tier,
-            save_tier_result_fn=self._save_tier_result,
-        ).create_baseline_from_tier_result(tier_id, tier_result)
+        return self.execution.create_baseline_from_tier_result(tier_id, tier_result)
 
     def _aggregate_results(
         self,
         tier_results: dict[TierID, TierResult],
         start_time: datetime,
     ) -> ExperimentResult:
-        """Create experiment result from accumulated tier results.
+        return self.finalization.aggregate_results(tier_results, start_time)
 
-        Used for both normal completion and interrupted (partial) results.
+    def _build_tier_actions(
+        self,
+        tier_id: TierID,
+        baseline: TierBaseline | None,
+        tier_ctx: TierContext,
+    ) -> dict[TierState, Callable[[], None]]:
+        return self.execution.build_tier_actions(tier_id, baseline, tier_ctx)
 
-        Args:
-            tier_results: Accumulated tier results
-            start_time: Experiment start timestamp
+    def _run_tier(
+        self,
+        tier_id: TierID,
+        baseline: TierBaseline | None,
+    ) -> TierResult:
+        return self.execution.run_tier(tier_id, baseline)
 
-        Returns:
-            ExperimentResult with completed tiers
+    def _run_tier_body(
+        self,
+        tier_id: TierID,
+        baseline: TierBaseline | None,
+    ) -> TierResult:
+        return self.execution.run_tier_body(tier_id, baseline)
 
-        """
-        return self._result_writer().aggregate_results(self.config, tier_results, start_time)
+    def _save_tier_result(self, tier_id: TierID, result: TierResult) -> None:
+        self.finalization.save_tier_result(tier_id, result)
+
+    def _save_final_results(self, result: ExperimentResult) -> None:
+        self.finalization.save_final_results(result)
+
+    def _generate_report(self, result: ExperimentResult) -> None:
+        self.finalization.generate_report(result)
+
+    def _find_existing_checkpoint(self) -> Path | None:
+        return self.resume.find_existing_checkpoint()
+
+    def _write_pid_file(self) -> None:
+        self.setup.write_pid_file()
+
+    def _cleanup_pid_file(self) -> None:
+        self.setup.cleanup_pid_file()
+
+    def _mark_checkpoint_completed(self) -> None:
+        self.finalization.mark_checkpoint_completed()
+
+    def _emit_experiment_metrics(
+        self,
+        tier_results: dict[TierID, TierResult],
+        result: ExperimentResult,
+    ) -> None:
+        self.finalization.emit_experiment_metrics(tier_results, result)
+
+    # ------------------------------------------------------------------
+    # ExperimentStateMachine action callbacks.
+    # ------------------------------------------------------------------
 
     def _action_exp_initializing(self) -> None:
-        """Handle INITIALIZING -> DIR_CREATED transition.
-
-        No-op: setup was already done in _initialize_or_resume_experiment.
-        """
-        # experiment_dir and checkpoint were created/loaded in _initialize_or_resume_experiment
-        pass
+        """Handle INITIALIZING -> DIR_CREATED (no-op; resume orchestration did the work)."""
+        # experiment_dir and checkpoint were created/loaded earlier.
 
     def _action_exp_dir_created(self) -> None:
-        """DIR_CREATED -> REPO_CLONED: Setup workspace and capture baseline."""
+        """DIR_CREATED -> REPO_CLONED: setup workspace and capture baseline."""
         self._setup_workspace()
         self._capture_experiment_baseline()
 
     def _action_exp_repo_cloned(self, tier_groups: list[list[TierID]]) -> None:
-        """REPO_CLONED -> TIERS_RUNNING: Pre-flight checks and log tier groups.
-
-        Args:
-            tier_groups: Tier dependency groups for parallel execution.
-
-        """
-        # Single pre-flight rate limit check for the entire experiment
+        """REPO_CLONED -> TIERS_RUNNING: pre-flight checks and log tier groups."""
         from scylla.e2e.rate_limit import check_api_rate_limit_status, wait_for_rate_limit
 
         rate_limit_info = check_api_rate_limit_status()
@@ -463,13 +287,7 @@ class E2ERunner:
         tier_groups: list[list[TierID]],
         tier_results: dict[TierID, TierResult],
     ) -> None:
-        """TIERS_RUNNING -> TIERS_COMPLETE: Execute all tier groups.
-
-        Args:
-            tier_groups: Tier dependency groups for execution.
-            tier_results: Mutable dict updated in-place with execution results.
-
-        """
+        """TIERS_RUNNING -> TIERS_COMPLETE: execute all tier groups."""
         results = self._execute_tier_groups(tier_groups)
         tier_results.update(results)
 
@@ -478,21 +296,10 @@ class E2ERunner:
         tier_results: dict[TierID, TierResult],
         start_time: datetime,
     ) -> None:
-        """TIERS_COMPLETE -> REPORTS_GENERATED: Aggregate results and finalize.
-
-        Args:
-            tier_results: Accumulated tier results from TIERS_RUNNING.
-            start_time: Experiment start timestamp for duration calculation.
-
-        Raises:
-            RuntimeError: If experiment_dir is not set.
-
-        """
+        """TIERS_COMPLETE -> REPORTS_GENERATED: aggregate, save, and finalize."""
         if self.experiment_dir is None:
             raise RuntimeError("experiment_dir must be set before aggregating tier results")
 
-        # Re-hydrate tier_results from disk if empty — occurs when ExperimentSM resumes
-        # from TIERS_COMPLETE+, which skips _action_exp_tiers_running.
         if not tier_results and self.experiment_dir.exists():
             from scylla.persistence.rehydrate import load_experiment_tier_results
 
@@ -508,7 +315,7 @@ class E2ERunner:
         self._last_experiment_result = result
 
     def _action_exp_reports_generated(self) -> None:
-        """REPORTS_GENERATED -> COMPLETE: Mark checkpoint completed and log summary."""
+        """REPORTS_GENERATED -> COMPLETE: mark checkpoint completed and log summary."""
         self._mark_checkpoint_completed()
         if self._last_experiment_result is not None:
             logger.info(
@@ -523,20 +330,7 @@ class E2ERunner:
         tier_results: dict[TierID, TierResult],
         start_time: datetime,
     ) -> dict[ExperimentState, Callable[[], None]]:
-        """Build the ExperimentState -> Callable action map for ExperimentStateMachine.
-
-        Each action corresponds to the work done when transitioning OUT of that state.
-        Results are accumulated into the shared tier_results dict via closures.
-
-        Args:
-            tier_groups: Tier dependency groups computed before SM starts
-            tier_results: Mutable dict accumulated by TIERS_RUNNING action
-            start_time: Experiment start time for duration calculation
-
-        Returns:
-            Dict mapping ExperimentState to callable
-
-        """
+        """Build the ExperimentState -> Callable action map."""
         return {
             ExperimentState.INITIALIZING: self._action_exp_initializing,
             ExperimentState.DIR_CREATED: self._action_exp_dir_created,
@@ -550,31 +344,22 @@ class E2ERunner:
             ExperimentState.REPORTS_GENERATED: self._action_exp_reports_generated,
         }
 
-    def run(self) -> ExperimentResult:  # noqa: C901  # orchestration with many retry/outcome paths
-        """Run the complete E2E experiment with auto-resume support.
+    # ------------------------------------------------------------------
+    # Public entry point.
+    # ------------------------------------------------------------------
 
-        Automatically resumes from checkpoint if one exists (unless --fresh flag).
-        Checkpoints are saved after each completed run for crash recovery and
-        rate limit pause/resume.
-
-        Returns:
-            ExperimentResult with all tier results and analysis.
-
-        """
+    def run(self) -> ExperimentResult:  # noqa: C901  # top-level orchestration with branching outcome paths
+        """Run the complete E2E experiment with auto-resume support."""
         from scylla.e2e.experiment_state_machine import ExperimentStateMachine
+        from scylla.e2e.health import HeartbeatThread, log_resource_preflight
+        from scylla.e2e.resource_manager import ResourceManager
 
         start_time = datetime.now(timezone.utc)
 
-        # Initialize or resume from checkpoint
         checkpoint_path = self._initialize_or_resume_experiment()
 
-        # Update PID in checkpoint (important for zombie detection on resume)
         if self.checkpoint:
             self.checkpoint.pid = os.getpid()
-
-        # Initialize resource manager and log pre-flight resource availability
-        from scylla.e2e.health import log_resource_preflight
-        from scylla.e2e.resource_manager import ResourceManager
 
         log_resource_preflight(fail_on_warn=self.config.fail_on_resource_check)
         if self._resource_manager is None:
@@ -583,22 +368,13 @@ class E2ERunner:
                 max_agents=self.config.max_concurrent_agents,
             )
 
-        # Start heartbeat thread to prevent zombie detection on long runs
-        from scylla.e2e.health import HeartbeatThread
-
         if self.checkpoint is None:
             raise RuntimeError("checkpoint must be set before starting heartbeat thread")
         heartbeat = HeartbeatThread(self.checkpoint, checkpoint_path, interval_seconds=30)
         heartbeat.start()
 
-        # Compute tier groups up front (needed by action_repo_cloned and action_tiers_running)
         tier_groups = self._get_tier_groups(self.config.tiers_to_run)
-
-        # Shared mutable state accumulated by the TIERS_RUNNING action
         tier_results: dict[TierID, TierResult] = {}
-
-        # Pre-seed workspace: on resume from TIERS_RUNNING or later states,
-        # action_dir_created will be skipped so we must set up workspace now.
 
         _current_exp_state = ExperimentState.INITIALIZING
         if self.checkpoint:
@@ -611,11 +387,9 @@ class E2ERunner:
             ExperimentState.REPORTS_GENERATED,
         }
         if _current_exp_state in _resume_states:
-            # Filesystem cross-validation: verify expected dirs exist before resuming
             self._validate_filesystem_on_resume(_current_exp_state)
             self._setup_workspace()
 
-        # Build ExperimentStateMachine actions
         actions = self._build_experiment_actions(
             tier_groups=tier_groups,
             tier_results=tier_results,
@@ -633,9 +407,7 @@ class E2ERunner:
             )
         except KeyboardInterrupt:
             logger.warning("Shutdown requested (Ctrl+C), cleaning up...")
-        except (
-            Exception
-        ) as e:  # broad catch: top-level experiment boundary; re-raised after logging
+        except Exception as e:  # broad: top-level boundary
             logger.error(f"Experiment failed: {e}")
             raise
         finally:
@@ -646,18 +418,14 @@ class E2ERunner:
                 self._handle_experiment_interrupt(checkpoint_path)
             self._cleanup_pid_file()
 
-        # Handle interrupt / partial results
         if is_shutdown_requested():
             logger.warning("Experiment interrupted - returning partial results")
             return self._aggregate_results(tier_results, start_time)
 
-        # Fast path: experiment was already complete before the state machine ran.
-        # No transitions occurred, no work done — skip expensive rehydrate.
         if _current_exp_state == ExperimentState.COMPLETE and self._last_experiment_result is None:
             logger.info("Experiment already complete — nothing to do")
             return self._aggregate_results(tier_results, start_time)
 
-        # Handle early stop (--until-experiment)
         final_state = esm.get_state()
         if final_state not in (ExperimentState.COMPLETE, ExperimentState.FAILED) and (
             self.config.until_experiment_state and final_state == self.config.until_experiment_state
@@ -665,349 +433,11 @@ class E2ERunner:
             logger.info(f"Stopped at --until-experiment {final_state.value}")
             return self._aggregate_results(tier_results, start_time)
 
-        # Return result (populated by action_tiers_complete)
         if self._last_experiment_result is not None:
             return self._last_experiment_result
 
-        # Fallback: aggregate from tier_results (e.g. resumed past TIERS_COMPLETE)
         if not tier_results and self.experiment_dir and self.experiment_dir.exists():
             from scylla.persistence.rehydrate import load_experiment_tier_results
 
             tier_results.update(load_experiment_tier_results(self.experiment_dir, self.config))
         return self._aggregate_results(tier_results, start_time)
-
-    def _emit_experiment_metrics(
-        self,
-        tier_results: dict[TierID, TierResult],
-        result: ExperimentResult,
-    ) -> None:
-        """Emit per-tier counters and gauges via the configured MetricEmitter.
-
-        Default emitter is a NoOpEmitter, so this is a cheap no-op when
-        ``SCYLLA_METRICS_PATH`` is unset. Failures in the emitter must not
-        break experiment finalization.
-
-        Args:
-            tier_results: Per-tier results accumulated during the experiment.
-            result: Aggregated experiment result (unused for now but reserved
-                for experiment-level metrics).
-
-        """
-        del result  # currently only per-tier metrics; reserved for future use
-        experiment_id = self.config.experiment_id
-        try:
-            for tier_id, tier_result in tier_results.items():
-                tier_label = tier_id.value
-                # Outcome from best-subtest pass_rate: pass if any run passed.
-                best = (
-                    tier_result.subtest_results.get(tier_result.best_subtest)
-                    if tier_result.best_subtest
-                    else None
-                )
-                pass_rate = best.pass_rate if best is not None else 0.0
-                outcome = "pass" if pass_rate > 0 else "fail"
-                self._emitter.emit_counter(
-                    "scylla_tier_runs_total",
-                    1,
-                    labels={"tier": tier_label, "outcome": outcome},
-                )
-
-                # Per-subtest run outcome counts
-                pass_runs = 0
-                fail_runs = 0
-                for subtest in tier_result.subtest_results.values():
-                    for run in subtest.runs:
-                        if run.judge_passed:
-                            pass_runs += 1
-                        else:
-                            fail_runs += 1
-                if pass_runs:
-                    self._emitter.emit_counter(
-                        "scylla_subtest_runs_total",
-                        pass_runs,
-                        labels={"tier": tier_label, "outcome": "pass"},
-                    )
-                if fail_runs:
-                    self._emitter.emit_counter(
-                        "scylla_subtest_runs_total",
-                        fail_runs,
-                        labels={"tier": tier_label, "outcome": "fail"},
-                    )
-
-                labels = {"experiment": experiment_id, "tier": tier_label}
-                self._emitter.emit_gauge(
-                    "scylla_experiment_pass_rate", float(pass_rate), labels=labels
-                )
-                cop = tier_result.cost_of_pass
-                # Skip infinite CoP — emit only when finite to keep textfile
-                # collector parsable.
-                if cop != float("inf"):
-                    self._emitter.emit_gauge(
-                        "scylla_experiment_cost_of_pass_usd",
-                        float(cop),
-                        labels=labels,
-                    )
-                self._emitter.emit_gauge(
-                    "scylla_experiment_latency_seconds",
-                    float(tier_result.total_duration),
-                    labels=labels,
-                )
-        except Exception as e:  # emitter must never break finalization
-            logger.warning(f"Metric emission failed (non-fatal): {e}")
-
-    def _setup_manager(self) -> ExperimentSetupManager:
-        """Create an ExperimentSetupManager bound to current state."""
-        return ExperimentSetupManager(self.config, self.results_base_dir)
-
-    def _build_tier_actions(
-        self,
-        tier_id: TierID,
-        baseline: TierBaseline | None,
-        tier_ctx: TierContext,
-    ) -> dict[TierState, Callable[[], None]]:
-        """Build the TierState -> Callable action map for TierStateMachine.
-
-        Results are accumulated into the shared TierContext via closures,
-        allowing later actions to consume results from earlier ones.
-
-        Args:
-            tier_id: The tier to run
-            baseline: Previous tier's winning baseline
-            tier_ctx: Mutable TierContext for inter-action state
-
-        Returns:
-            Dict mapping TierState to callable
-
-        """
-        return TierActionBuilder(
-            tier_id=tier_id,
-            baseline=baseline,
-            tier_ctx=tier_ctx,
-            config=self.config,
-            tier_manager=self.tier_manager,
-            workspace_manager=self.workspace_manager,
-            checkpoint=self.checkpoint,
-            experiment_dir=self.experiment_dir,
-            save_tier_result_fn=self._save_tier_result,
-            resource_manager=self._resource_manager,
-        ).build()
-
-    def _run_tier(
-        self,
-        tier_id: TierID,
-        baseline: TierBaseline | None,
-    ) -> TierResult:
-        """Run a single tier's evaluation.
-
-        Args:
-            tier_id: The tier to run
-            baseline: Previous tier's winning baseline
-
-        Returns:
-            TierResult with all sub-test results.
-
-        """
-        import time as _time
-
-        _tier_start = _time.monotonic()
-        with _tracer.start_as_current_span(
-            "scylla.tier",
-            attributes={
-                "scylla.tier_id": tier_id.value,
-                "scylla.experiment_id": self.config.experiment_id,
-            },
-        ) as _tier_span:
-            try:
-                return self._run_tier_body(tier_id, baseline)
-            except Exception as e:
-                _tier_span.record_exception(e)
-                raise
-            finally:
-                try:
-                    self._emitter.emit_gauge(
-                        "scylla_tier_duration_seconds",
-                        float(_time.monotonic() - _tier_start),
-                        labels={
-                            "tier": tier_id.value,
-                            "experiment": self.config.experiment_id,
-                        },
-                    )
-                except Exception as _e:  # never break tier finalization
-                    logger.debug(f"Tier duration emit failed (non-fatal): {_e}")
-
-    def _run_tier_body(
-        self,
-        tier_id: TierID,
-        baseline: TierBaseline | None,
-    ) -> TierResult:
-        """Body of :meth:`_run_tier`, wrapped in a tracing span by the caller."""
-        from scylla.e2e.tier_state_machine import TierStateMachine
-
-        # Typed mutable namespace passed to closures in _build_tier_actions()
-        tier_ctx = TierContext()
-
-        checkpoint_path = (
-            self.experiment_dir / "checkpoint.json"
-            if self.checkpoint and self.experiment_dir
-            else Path("/dev/null")
-        )
-
-        # If no checkpoint, build a minimal one for the state machine
-        checkpoint = self.checkpoint
-        if checkpoint is None:
-            checkpoint = E2ECheckpoint(
-                experiment_id=self.config.experiment_id,
-                experiment_dir=str(self.experiment_dir or tempfile.gettempdir()),
-                config_hash="",
-                completed_runs={},
-                started_at=datetime.now(timezone.utc).isoformat(),
-                last_updated_at=datetime.now(timezone.utc).isoformat(),
-                status=_STATUS_RUNNING,
-                rate_limit_source=None,
-                rate_limit_until=None,
-                pause_count=0,
-                pid=os.getpid(),
-            )
-
-        tsm = TierStateMachine(checkpoint, checkpoint_path)
-
-        # On resume, action_pending() is skipped for tiers that are already past
-        # PENDING in the checkpoint. Pre-populate tier_ctx so that later actions
-        # (action_config_loaded, action_subtests_complete, etc.) which assert
-        # tier_ctx.tier_config is not None do not fail with AssertionError.
-        _tier_resume_state = tsm.get_state(tier_id.value)
-        if _tier_resume_state not in (TierState.PENDING, TierState.COMPLETE, TierState.FAILED):
-            logger.info(
-                f"Resuming {tier_id.value} from {_tier_resume_state.value} — "
-                "pre-loading tier config for resume"
-            )
-            _resume_tier_config = self.tier_manager.load_tier_config(
-                tier_id, self.config.skip_agent_teams
-            )
-            if self.config.max_subtests is not None:
-                _resume_tier_config.subtests = _resume_tier_config.subtests[
-                    : self.config.max_subtests
-                ]
-            tier_ctx.tier_config = _resume_tier_config
-            if self.experiment_dir:
-                from scylla.e2e.paths import get_tier_dir
-
-                tier_ctx.tier_dir = get_tier_dir(
-                    self.experiment_dir, tier_id.value, completed=False
-                )
-
-        actions = self._build_tier_actions(
-            tier_id=tier_id,
-            baseline=baseline,
-            tier_ctx=tier_ctx,
-        )
-
-        # Filesystem cross-validation on resume
-        _tier_current = tsm.get_state(tier_id.value)
-        if _tier_current == TierState.SUBTESTS_COMPLETE and self.experiment_dir:
-            from scylla.e2e.paths import get_tier_dir
-
-            tier_dir = get_tier_dir(self.experiment_dir, tier_id.value, completed=True)
-            run_results = list(tier_dir.rglob("run_result.json")) if tier_dir.exists() else []
-            if not run_results:
-                logger.warning(
-                    f"⚠️  Resuming {tier_id.value} from SUBTESTS_COMPLETE but no "
-                    f"run_result.json found under {tier_dir}"
-                )
-
-        tsm.advance_to_completion(
-            tier_id.value,
-            actions,
-            until_state=self.config.until_tier_state,
-        )
-
-        # Return result if available (may be absent if stopped early via until_tier_state)
-        if tier_ctx.tier_result is not None:
-            return tier_ctx.tier_result
-
-        # If stopped early, build a minimal partial TierResult from whatever was accumulated
-        from functools import reduce
-
-        # Re-hydrate subtest_results from disk if empty — occurs when TierSM resumes
-        # past CONFIG_LOADED and tier_result was never set (e.g. stopped early).
-        subtest_results = tier_ctx.subtest_results
-        if not subtest_results and self.experiment_dir:
-            from scylla.e2e.paths import get_tier_dir
-            from scylla.persistence.rehydrate import load_tier_subtest_results
-
-            tier_dir = get_tier_dir(self.experiment_dir, tier_id.value, completed=True)
-            if tier_dir.exists():
-                subtest_results = load_tier_subtest_results(tier_dir, tier_id)
-                tier_ctx.subtest_results = subtest_results
-        selection = tier_ctx.selection
-        end_time = datetime.now(timezone.utc)
-        duration = (end_time - tier_ctx.start_time).total_seconds()
-
-        token_stats = (
-            reduce(
-                lambda a, b: a + b,
-                [s.token_stats for s in subtest_results.values()],
-                TokenStats(),
-            )
-            if subtest_results
-            else TokenStats()
-        )
-
-        return TierResult(
-            tier_id=tier_id,
-            subtest_results=subtest_results,
-            best_subtest=selection.winning_subtest if selection else None,
-            best_subtest_score=selection.winning_score if selection else 0.0,
-            inherited_from=baseline,
-            tiebreaker_needed=selection.tiebreaker_needed if selection else False,
-            total_cost=sum(s.total_cost for s in subtest_results.values()),
-            total_duration=duration,
-            token_stats=token_stats,
-        )
-
-    def _save_tier_result(self, tier_id: TierID, result: TierResult) -> None:
-        """Save tier results to file and generate hierarchical reports.
-
-        Args:
-            tier_id: The tier identifier
-            result: The tier result
-
-        """
-        self._result_writer().save_tier_result(tier_id, result)
-
-    def _save_final_results(self, result: ExperimentResult) -> None:
-        """Save final experiment results.
-
-        Args:
-            result: The complete experiment result
-
-        """
-        self._result_writer().save_final_results(result)
-
-    def _generate_report(self, result: ExperimentResult) -> None:
-        """Generate hierarchical experiment reports.
-
-        Args:
-            result: The complete experiment result
-
-        """
-        self._result_writer().generate_report(result)
-
-    def _find_existing_checkpoint(self) -> Path | None:
-        """Find existing checkpoint file in results directory."""
-        return self._finalizer().find_existing_checkpoint()
-
-    def _write_pid_file(self) -> None:
-        """Write PID file for status monitoring."""
-        if self.experiment_dir:
-            self._setup_manager().write_pid_file(self.experiment_dir)
-
-    def _cleanup_pid_file(self) -> None:
-        """Remove PID file on completion."""
-        if self.experiment_dir:
-            self._setup_manager().cleanup_pid_file(self.experiment_dir)
-
-    def _mark_checkpoint_completed(self) -> None:
-        """Mark checkpoint as completed."""
-        if self.checkpoint and self.experiment_dir:
-            self._finalizer().mark_checkpoint_completed(self.checkpoint, self.experiment_dir)

--- a/src/scylla/e2e/runner_internals/runner_execution.py
+++ b/src/scylla/e2e/runner_internals/runner_execution.py
@@ -1,0 +1,261 @@
+"""RunnerExecution collaborator — experiment-execution loop and tier dispatch.
+
+Owns: tier dependency grouping, parallel tier execution, single-tier
+state-machine orchestration, and tier-action builder wiring.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import tempfile
+from collections.abc import Callable
+from datetime import datetime, timezone
+from functools import reduce
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from scylla.persistence.checkpoint import E2ECheckpoint
+from scylla.e2e.models import (
+    TIER_DEPENDENCIES,
+    TierBaseline,
+    TierID,
+    TierResult,
+    TierState,
+    TokenStats,
+)
+from scylla.e2e.parallel_tier_runner import ParallelTierRunner
+from scylla.e2e.runner_internals.constants import _STATUS_RUNNING
+from scylla.e2e.runner_internals.tier_context import TierContext
+from scylla.e2e.tier_action_builder import TierActionBuilder
+from scylla.utils.tracing import get_tracer
+
+if TYPE_CHECKING:
+    from scylla.e2e.runner_internals.runner_core import E2ERunner
+
+logger = logging.getLogger(__name__)
+_tracer = get_tracer(__name__)
+
+
+class RunnerExecution:
+    """Experiment-execution loop, tier dispatch, subtest fan-out."""
+
+    def __init__(self, runner: E2ERunner) -> None:
+        """Bind this collaborator to the owning :class:`E2ERunner`."""
+        self._runner = runner
+
+    @staticmethod
+    def get_tier_groups(tiers_to_run: list[TierID]) -> list[list[TierID]]:
+        """Group tiers by dependencies for parallel execution."""
+        if not tiers_to_run:
+            return []
+
+        groups: list[list[TierID]] = []
+        remaining = set(tiers_to_run)
+        completed: set[TierID] = set()
+
+        while remaining:
+            ready = [
+                tier
+                for tier in remaining
+                if all(
+                    dep in completed or dep not in tiers_to_run for dep in TIER_DEPENDENCIES[tier]
+                )
+            ]
+
+            if not ready:
+                raise ValueError(
+                    f"Unable to resolve tier dependencies. "
+                    f"Remaining: {remaining}, Completed: {completed}"
+                )
+
+            groups.append(sorted(ready))
+            completed.update(ready)
+            remaining -= set(ready)
+
+        return groups
+
+    def _parallel_runner(self) -> ParallelTierRunner:
+        runner = self._runner
+        return ParallelTierRunner(
+            config=runner.config,
+            tier_manager=runner.tier_manager,
+            experiment_dir=runner.experiment_dir,
+            run_tier_fn=runner._run_tier,
+            save_tier_result_fn=runner._save_tier_result,
+        )
+
+    def execute_tier_groups(
+        self,
+        tier_groups: list[list[TierID]],
+        previous_baseline: TierBaseline | None = None,
+    ) -> dict[TierID, TierResult]:
+        """Execute all tier groups sequentially (each group runs in parallel)."""
+        return self._parallel_runner().execute_tier_groups(tier_groups, previous_baseline)
+
+    def create_baseline_from_tier_result(
+        self,
+        tier_id: TierID,
+        tier_result: TierResult,
+    ) -> TierBaseline | None:
+        """Create a baseline from a tier result's best subtest."""
+        return self._parallel_runner().create_baseline_from_tier_result(tier_id, tier_result)
+
+    def build_tier_actions(
+        self,
+        tier_id: TierID,
+        baseline: TierBaseline | None,
+        tier_ctx: TierContext,
+    ) -> dict[TierState, Callable[[], None]]:
+        """Build the TierState -> Callable action map for TierStateMachine."""
+        runner = self._runner
+        return TierActionBuilder(
+            tier_id=tier_id,
+            baseline=baseline,
+            tier_ctx=tier_ctx,
+            config=runner.config,
+            tier_manager=runner.tier_manager,
+            workspace_manager=runner.workspace_manager,
+            checkpoint=runner.checkpoint,
+            experiment_dir=runner.experiment_dir,
+            save_tier_result_fn=runner._save_tier_result,
+            resource_manager=runner._resource_manager,
+        ).build()
+
+    def run_tier(
+        self,
+        tier_id: TierID,
+        baseline: TierBaseline | None,
+    ) -> TierResult:
+        """Run a single tier's evaluation, wrapped in a tracing span."""
+        runner = self._runner
+        with _tracer.start_as_current_span(
+            "scylla.tier",
+            attributes={
+                "scylla.tier_id": tier_id.value,
+                "scylla.experiment_id": runner.config.experiment_id,
+            },
+        ) as _tier_span:
+            try:
+                return self.run_tier_body(tier_id, baseline)
+            except Exception as e:
+                _tier_span.record_exception(e)
+                raise
+
+    def run_tier_body(
+        self,
+        tier_id: TierID,
+        baseline: TierBaseline | None,
+    ) -> TierResult:
+        """Body of :meth:`run_tier`, wrapped in a tracing span by the caller."""
+        from scylla.e2e.tier_state_machine import TierStateMachine
+
+        runner = self._runner
+        tier_ctx = TierContext()
+
+        checkpoint_path = (
+            runner.experiment_dir / "checkpoint.json"
+            if runner.checkpoint and runner.experiment_dir
+            else Path("/dev/null")
+        )
+
+        checkpoint = runner.checkpoint
+        if checkpoint is None:
+            checkpoint = E2ECheckpoint(
+                experiment_id=runner.config.experiment_id,
+                experiment_dir=str(runner.experiment_dir or tempfile.gettempdir()),
+                config_hash="",
+                completed_runs={},
+                started_at=datetime.now(timezone.utc).isoformat(),
+                last_updated_at=datetime.now(timezone.utc).isoformat(),
+                status=_STATUS_RUNNING,
+                rate_limit_source=None,
+                rate_limit_until=None,
+                pause_count=0,
+                pid=os.getpid(),
+            )
+
+        tsm = TierStateMachine(checkpoint, checkpoint_path)
+
+        _tier_resume_state = tsm.get_state(tier_id.value)
+        if _tier_resume_state not in (TierState.PENDING, TierState.COMPLETE, TierState.FAILED):
+            logger.info(
+                f"Resuming {tier_id.value} from {_tier_resume_state.value} — "
+                "pre-loading tier config for resume"
+            )
+            _resume_tier_config = runner.tier_manager.load_tier_config(
+                tier_id, runner.config.skip_agent_teams
+            )
+            if runner.config.max_subtests is not None:
+                _resume_tier_config.subtests = _resume_tier_config.subtests[
+                    : runner.config.max_subtests
+                ]
+            tier_ctx.tier_config = _resume_tier_config
+            if runner.experiment_dir:
+                from scylla.e2e.paths import get_tier_dir
+
+                tier_ctx.tier_dir = get_tier_dir(
+                    runner.experiment_dir, tier_id.value, completed=False
+                )
+
+        actions = self.build_tier_actions(
+            tier_id=tier_id,
+            baseline=baseline,
+            tier_ctx=tier_ctx,
+        )
+
+        _tier_current = tsm.get_state(tier_id.value)
+        if _tier_current == TierState.SUBTESTS_COMPLETE and runner.experiment_dir:
+            from scylla.e2e.paths import get_tier_dir
+
+            tier_dir = get_tier_dir(runner.experiment_dir, tier_id.value, completed=True)
+            run_results = list(tier_dir.rglob("run_result.json")) if tier_dir.exists() else []
+            if not run_results:
+                logger.warning(
+                    f"⚠️  Resuming {tier_id.value} from SUBTESTS_COMPLETE but no "
+                    f"run_result.json found under {tier_dir}"
+                )
+
+        tsm.advance_to_completion(
+            tier_id.value,
+            actions,
+            until_state=runner.config.until_tier_state,
+        )
+
+        if tier_ctx.tier_result is not None:
+            return tier_ctx.tier_result
+
+        subtest_results = tier_ctx.subtest_results
+        if not subtest_results and runner.experiment_dir:
+            from scylla.e2e.paths import get_tier_dir
+            from scylla.persistence.rehydrate import load_tier_subtest_results
+
+            tier_dir = get_tier_dir(runner.experiment_dir, tier_id.value, completed=True)
+            if tier_dir.exists():
+                subtest_results = load_tier_subtest_results(tier_dir, tier_id)
+                tier_ctx.subtest_results = subtest_results
+        selection = tier_ctx.selection
+        end_time = datetime.now(timezone.utc)
+        duration = (end_time - tier_ctx.start_time).total_seconds()
+
+        token_stats = (
+            reduce(
+                lambda a, b: a + b,
+                [s.token_stats for s in subtest_results.values()],
+                TokenStats(),
+            )
+            if subtest_results
+            else TokenStats()
+        )
+
+        return TierResult(
+            tier_id=tier_id,
+            subtest_results=subtest_results,
+            best_subtest=selection.winning_subtest if selection else None,
+            best_subtest_score=selection.winning_score if selection else 0.0,
+            inherited_from=baseline,
+            tiebreaker_needed=selection.tiebreaker_needed if selection else False,
+            total_cost=sum(s.total_cost for s in subtest_results.values()),
+            total_duration=duration,
+            token_stats=token_stats,
+        )

--- a/src/scylla/e2e/runner_internals/runner_execution.py
+++ b/src/scylla/e2e/runner_internals/runner_execution.py
@@ -15,7 +15,6 @@ from functools import reduce
 from pathlib import Path
 from typing import TYPE_CHECKING
 
-from scylla.persistence.checkpoint import E2ECheckpoint
 from scylla.e2e.models import (
     TIER_DEPENDENCIES,
     TierBaseline,
@@ -28,6 +27,7 @@ from scylla.e2e.parallel_tier_runner import ParallelTierRunner
 from scylla.e2e.runner_internals.constants import _STATUS_RUNNING
 from scylla.e2e.runner_internals.tier_context import TierContext
 from scylla.e2e.tier_action_builder import TierActionBuilder
+from scylla.persistence.checkpoint import E2ECheckpoint
 from scylla.utils.tracing import get_tracer
 
 if TYPE_CHECKING:
@@ -128,7 +128,10 @@ class RunnerExecution:
         baseline: TierBaseline | None,
     ) -> TierResult:
         """Run a single tier's evaluation, wrapped in a tracing span."""
+        import time as _time
+
         runner = self._runner
+        _tier_start = _time.monotonic()
         with _tracer.start_as_current_span(
             "scylla.tier",
             attributes={
@@ -137,10 +140,24 @@ class RunnerExecution:
             },
         ) as _tier_span:
             try:
-                return self.run_tier_body(tier_id, baseline)
+                # Dispatch via the runner attribute so tests that monkeypatch
+                # ``runner._run_tier_body`` continue to work after decomposition.
+                return runner._run_tier_body(tier_id, baseline)
             except Exception as e:
                 _tier_span.record_exception(e)
                 raise
+            finally:
+                try:
+                    runner._emitter.emit_gauge(
+                        "scylla_tier_duration_seconds",
+                        float(_time.monotonic() - _tier_start),
+                        labels={
+                            "tier": tier_id.value,
+                            "experiment": runner.config.experiment_id,
+                        },
+                    )
+                except Exception as _e:  # never break tier finalization
+                    logger.debug(f"Tier duration emit failed (non-fatal): {_e}")
 
     def run_tier_body(
         self,

--- a/src/scylla/e2e/runner_internals/runner_finalization.py
+++ b/src/scylla/e2e/runner_internals/runner_finalization.py
@@ -1,0 +1,154 @@
+"""RunnerFinalization collaborator — result writing, summary, cleanup.
+
+Owns: aggregating tier results, writing tier/final result files, generating
+hierarchical reports, emitting metrics, handling experiment interrupts, and
+marking the checkpoint complete.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from scylla.e2e.checkpoint_finalizer import CheckpointFinalizer
+from scylla.persistence.experiment_result_writer import ExperimentResultWriter
+from scylla.e2e.models import (
+    ExperimentResult,
+    ExperimentState,
+    TierID,
+    TierResult,
+)
+
+if TYPE_CHECKING:
+    from scylla.e2e.runner_internals.runner_core import E2ERunner
+
+logger = logging.getLogger(__name__)
+
+
+class RunnerFinalization:
+    """Result writing, summary, cleanup, and metric emission."""
+
+    def __init__(self, runner: E2ERunner) -> None:
+        """Bind this collaborator to the owning :class:`E2ERunner`."""
+        self._runner = runner
+
+    def result_writer(self) -> ExperimentResultWriter:
+        """Create an ExperimentResultWriter bound to current state."""
+        runner = self._runner
+        return ExperimentResultWriter(
+            experiment_dir=runner.experiment_dir,
+            tier_manager=runner.tier_manager,
+        )
+
+    def finalizer(self) -> CheckpointFinalizer:
+        """Create a CheckpointFinalizer bound to current state."""
+        runner = self._runner
+        return CheckpointFinalizer(runner.config, runner.results_base_dir)
+
+    def aggregate_results(
+        self,
+        tier_results: dict[TierID, TierResult],
+        start_time: datetime,
+    ) -> ExperimentResult:
+        """Aggregate tier results into an ExperimentResult."""
+        return self.result_writer().aggregate_results(self._runner.config, tier_results, start_time)
+
+    def save_tier_result(self, tier_id: TierID, result: TierResult) -> None:
+        """Save a single tier's result and generate hierarchical reports."""
+        self.result_writer().save_tier_result(tier_id, result)
+
+    def save_final_results(self, result: ExperimentResult) -> None:
+        """Save the final experiment result."""
+        self.result_writer().save_final_results(result)
+
+    def generate_report(self, result: ExperimentResult) -> None:
+        """Generate hierarchical experiment reports."""
+        self.result_writer().generate_report(result)
+
+    def handle_experiment_interrupt(self, checkpoint_path: Path) -> None:
+        """Handle graceful shutdown on interrupt."""
+        runner = self._runner
+        self.finalizer().handle_experiment_interrupt(runner.checkpoint, checkpoint_path)
+
+    def validate_filesystem_on_resume(self, current_state: ExperimentState) -> None:
+        """Cross-validate filesystem against checkpoint state on resume."""
+        runner = self._runner
+        if not runner.experiment_dir:
+            return
+        self.finalizer().validate_filesystem_on_resume(runner.experiment_dir, current_state)
+
+    def mark_checkpoint_completed(self) -> None:
+        """Mark the checkpoint as completed if state is consistent."""
+        runner = self._runner
+        if runner.checkpoint and runner.experiment_dir:
+            self.finalizer().mark_checkpoint_completed(runner.checkpoint, runner.experiment_dir)
+
+    def emit_experiment_metrics(
+        self,
+        tier_results: dict[TierID, TierResult],
+        result: ExperimentResult,
+    ) -> None:
+        """Emit per-tier counters and gauges via the configured MetricEmitter.
+
+        Failures in the emitter must not break experiment finalization.
+        """
+        del result  # currently only per-tier metrics; reserved for future use
+        runner = self._runner
+        experiment_id = runner.config.experiment_id
+        try:
+            for tier_id, tier_result in tier_results.items():
+                tier_label = tier_id.value
+                best = (
+                    tier_result.subtest_results.get(tier_result.best_subtest)
+                    if tier_result.best_subtest
+                    else None
+                )
+                pass_rate = best.pass_rate if best is not None else 0.0
+                outcome = "pass" if pass_rate > 0 else "fail"
+                runner._emitter.emit_counter(
+                    "scylla_tier_runs_total",
+                    1,
+                    labels={"tier": tier_label, "outcome": outcome},
+                )
+
+                pass_runs = 0
+                fail_runs = 0
+                for subtest in tier_result.subtest_results.values():
+                    for run in subtest.runs:
+                        if run.judge_passed:
+                            pass_runs += 1
+                        else:
+                            fail_runs += 1
+                if pass_runs:
+                    runner._emitter.emit_counter(
+                        "scylla_subtest_runs_total",
+                        pass_runs,
+                        labels={"tier": tier_label, "outcome": "pass"},
+                    )
+                if fail_runs:
+                    runner._emitter.emit_counter(
+                        "scylla_subtest_runs_total",
+                        fail_runs,
+                        labels={"tier": tier_label, "outcome": "fail"},
+                    )
+
+                labels = {"experiment": experiment_id, "tier": tier_label}
+                runner._emitter.emit_gauge(
+                    "scylla_experiment_pass_rate", float(pass_rate), labels=labels
+                )
+                cop = tier_result.cost_of_pass
+                if cop != float("inf"):
+                    runner._emitter.emit_gauge(
+                        "scylla_experiment_cost_of_pass_usd",
+                        float(cop),
+                        labels=labels,
+                    )
+                runner._emitter.emit_gauge(
+                    "scylla_experiment_latency_seconds",
+                    float(tier_result.total_duration),
+                    labels=labels,
+                )
+        except Exception as e:  # emitter must never break finalization
+            logger.warning(f"Metric emission failed (non-fatal): {e}")

--- a/src/scylla/e2e/runner_internals/runner_finalization.py
+++ b/src/scylla/e2e/runner_internals/runner_finalization.py
@@ -13,13 +13,13 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 from scylla.e2e.checkpoint_finalizer import CheckpointFinalizer
-from scylla.persistence.experiment_result_writer import ExperimentResultWriter
 from scylla.e2e.models import (
     ExperimentResult,
     ExperimentState,
     TierID,
     TierResult,
 )
+from scylla.persistence.experiment_result_writer import ExperimentResultWriter
 
 if TYPE_CHECKING:
     from scylla.e2e.runner_internals.runner_core import E2ERunner

--- a/src/scylla/e2e/runner_internals/runner_resume.py
+++ b/src/scylla/e2e/runner_internals/runner_resume.py
@@ -15,8 +15,8 @@ from scylla.e2e.models import ExperimentConfig
 from scylla.e2e.resume_manager import ResumeManager
 
 if TYPE_CHECKING:
-    from scylla.persistence.checkpoint import E2ECheckpoint
     from scylla.e2e.runner_internals.runner_core import E2ERunner
+    from scylla.persistence.checkpoint import E2ECheckpoint
 
 logger = logging.getLogger(__name__)
 

--- a/src/scylla/e2e/runner_internals/runner_resume.py
+++ b/src/scylla/e2e/runner_internals/runner_resume.py
@@ -1,0 +1,143 @@
+"""RunnerResume collaborator — resume-from-checkpoint orchestration.
+
+Owns: locating an existing checkpoint, validating its config, merging CLI
+flags back into the resumed configuration, and orchestrating the
+fresh-vs-resume decision.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from scylla.e2e.models import ExperimentConfig
+from scylla.e2e.resume_manager import ResumeManager
+
+if TYPE_CHECKING:
+    from scylla.persistence.checkpoint import E2ECheckpoint
+    from scylla.e2e.runner_internals.runner_core import E2ERunner
+
+logger = logging.getLogger(__name__)
+
+
+class RunnerResume:
+    """Resume-from-checkpoint logic plus fresh fallback."""
+
+    def __init__(self, runner: E2ERunner) -> None:
+        """Bind this collaborator to the owning :class:`E2ERunner`."""
+        self._runner = runner
+
+    def find_existing_checkpoint(self) -> Path | None:
+        """Locate an existing checkpoint file in the results directory."""
+        return self._runner.finalization.finalizer().find_existing_checkpoint()
+
+    def log_checkpoint_resume(self, checkpoint_path: Path) -> None:
+        """Log checkpoint resume status with completed run count."""
+        from scylla.e2e.runner_internals import runner_core as _rc
+
+        runner = self._runner
+        if runner.checkpoint is None:
+            raise RuntimeError("checkpoint must be set before logging resume status")
+        _rc.logger.info(f"📂 Resuming from checkpoint: {checkpoint_path}")
+        _rc.logger.info(
+            f"   Previously completed: {runner.checkpoint.get_completed_run_count()} runs"
+        )
+
+    def load_checkpoint_and_config(self, checkpoint_path: Path) -> tuple[E2ECheckpoint, Path]:
+        """Load and validate checkpoint and configuration from existing checkpoint.
+
+        Args:
+            checkpoint_path: Path to checkpoint.json file.
+
+        Returns:
+            Tuple of (checkpoint, experiment_dir).
+
+        Raises:
+            ValueError: If config validation fails or experiment directory missing.
+
+        """
+        # Delegate to the same loaders that the runner_core module previously imported,
+        # via the runner_core module namespace — preserves existing test patches.
+        from scylla.e2e.runner_internals import runner_core as _rc
+
+        runner = self._runner
+        runner.checkpoint = _rc.load_checkpoint(checkpoint_path)
+        runner.experiment_dir = Path(runner.checkpoint.experiment_dir)
+
+        saved_config_path = runner.experiment_dir / "config" / "experiment.json"
+        if saved_config_path.exists():
+            runner._log_checkpoint_resume(checkpoint_path)
+            _rc.logger.info(f"📋 Loading config from checkpoint: {saved_config_path}")
+            runner.config = ExperimentConfig.load(saved_config_path)
+        else:
+            _rc.logger.warning(
+                f"⚠️  Checkpoint config not found at {saved_config_path}, using CLI config"
+            )
+            if not _rc.validate_checkpoint_config(runner.checkpoint, runner.config):
+                raise ValueError(
+                    f"Config has changed since checkpoint. Use --fresh to start over.\n"
+                    f"Checkpoint: {checkpoint_path}"
+                )
+            runner._log_checkpoint_resume(checkpoint_path)
+
+        if not runner.experiment_dir.exists():
+            raise ValueError(
+                f"Checkpoint references non-existent directory: {runner.experiment_dir}"
+            )
+
+        return runner.checkpoint, runner.experiment_dir
+
+    def initialize_or_resume_experiment(self) -> Path:
+        """Initialize fresh experiment or resume from checkpoint.
+
+        Returns:
+            Path to the checkpoint file for this experiment.
+
+        """
+        runner = self._runner
+        # Route through runner._find_existing_checkpoint and runner._load_checkpoint_and_config
+        # so tests can patch these methods on the runner instance.
+        checkpoint_path = runner._find_existing_checkpoint()
+
+        if checkpoint_path and not runner._fresh:
+            # STEP 1: Capture CLI fields before load_checkpoint_and_config overwrites config
+            _cli_tiers = list(runner.config.tiers_to_run)
+            _cli_ephemeral = {
+                "until_run_state": runner.config.until_run_state,
+                "until_tier_state": runner.config.until_tier_state,
+                "until_experiment_state": runner.config.until_experiment_state,
+                "max_subtests": runner.config.max_subtests,
+            }
+
+            try:
+                runner._load_checkpoint_and_config(checkpoint_path)
+
+                if runner.checkpoint:
+                    rm = ResumeManager(runner.checkpoint, runner.config, runner.tier_manager)
+
+                    runner.config, runner.checkpoint = rm.handle_zombie(
+                        checkpoint_path, runner.experiment_dir
+                    )
+                    runner.config, runner.checkpoint = rm.restore_cli_args(_cli_ephemeral)
+                    runner.config, runner.checkpoint = rm.reset_failed_states()
+                    runner.config, runner.checkpoint = rm.merge_cli_tiers_and_reset_incomplete(
+                        _cli_tiers, checkpoint_path
+                    )
+
+            except Exception as e:  # broad: JSON/IO/state errors during resume
+                from scylla.e2e.runner_internals import runner_core as _rc
+
+                _rc.logger.warning(f"Failed to resume from checkpoint: {e}")
+                _rc.logger.warning("Starting fresh experiment instead")
+                runner.checkpoint = None
+                runner.experiment_dir = None
+
+        if not runner.experiment_dir:
+            checkpoint_path = runner._create_fresh_experiment()
+
+        runner._write_pid_file()
+
+        if runner.experiment_dir is None:
+            raise RuntimeError("experiment_dir must be set before getting checkpoint path")
+        return runner.experiment_dir / "checkpoint.json"

--- a/src/scylla/e2e/runner_internals/runner_setup.py
+++ b/src/scylla/e2e/runner_internals/runner_setup.py
@@ -1,0 +1,106 @@
+"""RunnerSetup collaborator — experiment initialization and workspace prep.
+
+Owns: experiment directory creation, fresh checkpoint creation, workspace
+manager setup, baseline capture, PID file lifecycle.
+
+E2ERunner delegates these responsibilities here. State lives on the runner;
+this collaborator reaches back into it via the bound ``runner`` reference.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from scylla.persistence.checkpoint import E2ECheckpoint, compute_config_hash, save_checkpoint
+from scylla.e2e.experiment_setup_manager import ExperimentSetupManager
+from scylla.e2e.runner_internals.constants import _STATUS_RUNNING
+from scylla.e2e.workspace_manager import WorkspaceManager
+
+if TYPE_CHECKING:
+    from scylla.e2e.runner_internals.runner_core import E2ERunner
+
+logger = logging.getLogger(__name__)
+
+
+class RunnerSetup:
+    """Initialization, configuration validation, and workspace preparation."""
+
+    def __init__(self, runner: E2ERunner) -> None:
+        """Bind this collaborator to the owning :class:`E2ERunner`."""
+        self._runner = runner
+
+    def setup_manager(self) -> ExperimentSetupManager:
+        """Create an ExperimentSetupManager bound to current state."""
+        return ExperimentSetupManager(self._runner.config, self._runner.results_base_dir)
+
+    def create_fresh_experiment(self) -> Path:
+        """Create new experiment directory and initialize checkpoint.
+
+        Returns:
+            Path to the created checkpoint file.
+
+        """
+        runner = self._runner
+        setup = self.setup_manager()
+        runner.experiment_dir = setup.create_experiment_dir()
+        setup.save_config(runner.experiment_dir)
+
+        runner.checkpoint = E2ECheckpoint(
+            experiment_id=runner.config.experiment_id,
+            experiment_dir=str(runner.experiment_dir),
+            config_hash=compute_config_hash(runner.config),
+            completed_runs={},
+            started_at=datetime.now(timezone.utc).isoformat(),
+            last_updated_at=datetime.now(timezone.utc).isoformat(),
+            status=_STATUS_RUNNING,
+            rate_limit_source=None,
+            rate_limit_until=None,
+            pause_count=0,
+            pid=os.getpid(),
+        )
+
+        checkpoint_path = runner.experiment_dir / "checkpoint.json"
+        save_checkpoint(runner.checkpoint, checkpoint_path)
+        logger.info(f"💾 Created checkpoint: {checkpoint_path}")
+
+        return checkpoint_path
+
+    def setup_workspace(self) -> None:
+        """Set up the WorkspaceManager if not already initialized."""
+        runner = self._runner
+        if runner.workspace_manager is not None:
+            return
+        if runner.experiment_dir is None:
+            raise RuntimeError("experiment_dir must be set before initializing workspace manager")
+        repos_dir = runner.results_base_dir / "repos"
+        wm = WorkspaceManager(
+            experiment_dir=runner.experiment_dir,
+            repo_url=runner.config.task_repo,
+            commit=runner.config.task_commit,
+            repos_dir=repos_dir,
+        )
+        wm.setup_base_repo()
+        runner.workspace_manager = wm
+
+    def capture_experiment_baseline(self) -> None:
+        """Capture pipeline baseline once at experiment level from a clean repo state."""
+        runner = self._runner
+        assert runner.experiment_dir is not None  # noqa: S101
+        assert runner.workspace_manager is not None  # noqa: S101
+        self.setup_manager().capture_baseline(runner.experiment_dir, runner.workspace_manager)
+
+    def write_pid_file(self) -> None:
+        """Write PID file for status monitoring."""
+        runner = self._runner
+        if runner.experiment_dir:
+            self.setup_manager().write_pid_file(runner.experiment_dir)
+
+    def cleanup_pid_file(self) -> None:
+        """Remove PID file on completion."""
+        runner = self._runner
+        if runner.experiment_dir:
+            self.setup_manager().cleanup_pid_file(runner.experiment_dir)

--- a/src/scylla/e2e/runner_internals/runner_setup.py
+++ b/src/scylla/e2e/runner_internals/runner_setup.py
@@ -15,10 +15,10 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import TYPE_CHECKING
 
-from scylla.persistence.checkpoint import E2ECheckpoint, compute_config_hash, save_checkpoint
 from scylla.e2e.experiment_setup_manager import ExperimentSetupManager
 from scylla.e2e.runner_internals.constants import _STATUS_RUNNING
 from scylla.e2e.workspace_manager import WorkspaceManager
+from scylla.persistence.checkpoint import E2ECheckpoint, compute_config_hash, save_checkpoint
 
 if TYPE_CHECKING:
     from scylla.e2e.runner_internals.runner_core import E2ERunner

--- a/tests/unit/e2e/test_runner_collaborators.py
+++ b/tests/unit/e2e/test_runner_collaborators.py
@@ -1,0 +1,78 @@
+"""Smoke tests for the four E2ERunner collaborators introduced by #1941.
+
+The collaborators are thin wrappers over the existing helpers
+(``ExperimentSetupManager``, ``CheckpointFinalizer``, ``ParallelTierRunner``,
+``ExperimentResultWriter``) — these tests verify that each collaborator is
+instantiated on ``E2ERunner.__init__`` and exposes the expected entry
+points used by the runner-core delegating methods.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from scylla.e2e.models import ExperimentConfig, TierID
+from scylla.e2e.runner import E2ERunner
+from scylla.e2e.runner_internals.runner_execution import RunnerExecution
+from scylla.e2e.runner_internals.runner_finalization import RunnerFinalization
+from scylla.e2e.runner_internals.runner_resume import RunnerResume
+from scylla.e2e.runner_internals.runner_setup import RunnerSetup
+
+
+@pytest.fixture
+def runner(tmp_path: Path) -> E2ERunner:
+    """Return a fresh E2ERunner with a minimal config."""
+    config = ExperimentConfig(
+        experiment_id="exp-collab",
+        task_repo="https://example.com/repo",
+        task_commit="abc",
+        task_prompt_file=tmp_path / "prompt.md",
+        language="python",
+    )
+    return E2ERunner(config, tmp_path / "tiers", tmp_path)
+
+
+def test_runner_constructs_all_four_collaborators(runner: E2ERunner) -> None:
+    """E2ERunner.__init__ instantiates the four named collaborators."""
+    assert isinstance(runner.setup, RunnerSetup)
+    assert isinstance(runner.resume, RunnerResume)
+    assert isinstance(runner.execution, RunnerExecution)
+    assert isinstance(runner.finalization, RunnerFinalization)
+
+
+def test_collaborators_hold_runner_back_reference(runner: E2ERunner) -> None:
+    """Each collaborator keeps a private reference to the owning runner."""
+    assert runner.setup._runner is runner
+    assert runner.resume._runner is runner
+    assert runner.execution._runner is runner
+    assert runner.finalization._runner is runner
+
+
+def test_get_tier_groups_is_static_on_execution() -> None:
+    """RunnerExecution.get_tier_groups operates without a runner instance."""
+    groups = RunnerExecution.get_tier_groups([TierID.T0])
+    assert groups == [[TierID.T0]]
+
+
+def test_get_tier_groups_empty() -> None:
+    """RunnerExecution.get_tier_groups returns [] for empty input."""
+    assert RunnerExecution.get_tier_groups([]) == []
+
+
+def test_finalization_validate_filesystem_no_dir_is_noop(runner: E2ERunner) -> None:
+    """validate_filesystem_on_resume short-circuits when experiment_dir is None."""
+    runner.experiment_dir = None
+    # Should not raise — the collaborator returns early.
+    runner.finalization.validate_filesystem_on_resume(MagicMock())
+
+
+def test_runner_delegates_get_tier_groups(runner: E2ERunner) -> None:
+    """Runner._get_tier_groups delegates to RunnerExecution.get_tier_groups."""
+    groups = runner._get_tier_groups([TierID.T0, TierID.T1])
+    # Both reachable; T0 must appear in (or before) the group containing T1.
+    flat = [t for group in groups for t in group]
+    assert TierID.T0 in flat
+    assert TierID.T1 in flat


### PR DESCRIPTION
## Summary

The prior decomposition (PR #27034cf0) moved `runner.py`'s 998-line `E2ERunner` class into `runner_internals/runner_core.py` without actually splitting responsibilities. This PR does the real decomposition:

| Collaborator | Responsibility | LoC |
|--------------|----------------|-----|
| `RunnerSetup` | init, config validation, workspace prep | 106 |
| `RunnerExecution` | execution loop, tier dispatch, subtest fan-out | 261 |
| `RunnerFinalization` | result writing, summary, cleanup | 154 |
| `RunnerResume` | resume-from-checkpoint logic | 143 |

`E2ERunner` is now a thin orchestrator (`runner_core.py` = 440 lines, was 998). The remaining size is the public `run()` method, the `_action_exp_*` state-machine callbacks, and back-compat delegating wrappers required by existing tests that use `patch.object(runner, "_method", ...)`. Public API unchanged — all 1697 e2e unit tests pass without modification.

## Deferred (tracked in #1941)

- `tier_manager_internals/workspace.py` 432-line `prepare_workspace` (currently `# noqa: C901`)
- `TierManager(WorkspaceMixin, ResourcesMixin, BaselineMixin, TierManagerBase)` — mixins → composition
- Five other >650-line files: `stages.py`, `executor/runner.py`, `checkpoint.py`, `subtest_executor.py`, `cli/main.py`, `judge/evaluator.py`

## Test plan

- [x] `pixi run pytest tests/unit/e2e/` — 1697 passed, 1 skipped
- [x] New smoke tests in `tests/unit/e2e/test_runner_collaborators.py` exercise each collaborator
- [x] `pre-commit run --files <changed>` (ruff, mypy strict, C901) passes

Refs #1941

🤖 Generated with [Claude Code](https://claude.com/claude-code)