### PR TITLE
refactor(e2e): consolidate state-machine sprawl onto generic

### DIFF
--- a/pixi.lock
+++ b/pixi.lock
@@ -5,6 +5,8 @@ environments:
     - url: https://conda.anaconda.org/conda-forge/
     indexes:
     - https://pypi.org/simple
+    options:
+      pypi-prerelease-mode: if-necessary-or-explicit
     packages:
       linux-64:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-20_gnu.conda
@@ -131,7 +133,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/ce/e4/dccd7f47c4b64213ac01ef921a1337ee6e30e8c6466046018326977efd95/tzdata-2026.2-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/39/08/aaaad47bc4e9dc8c725e68f9d04865dbcb2052843ff09c97b08904852d84/urllib3-2.6.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/93/89/36722344d1758ec2106f4e8eca980f173cfe8f8d0358c1b77cc5d2e035a4/vl_convert_python-1.9.0.post1.tar.gz
-      - pypi: .
+      - pypi: ./
       osx-64:
       - conda: https://conda.anaconda.org/conda-forge/noarch/attrs-26.1.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/bats-core-1.13.0-h694c41f_0.conda
@@ -255,7 +257,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/ce/e4/dccd7f47c4b64213ac01ef921a1337ee6e30e8c6466046018326977efd95/tzdata-2026.2-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/39/08/aaaad47bc4e9dc8c725e68f9d04865dbcb2052843ff09c97b08904852d84/urllib3-2.6.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/9f/59/e5862245972ff467d38b0eb5ad28154685e23ecabb47e14f2b6962da7b56/vl_convert_python-1.9.0.post1-cp37-abi3-macosx_10_12_x86_64.whl
-      - pypi: .
+      - pypi: ./
       osx-arm64:
       - conda: https://conda.anaconda.org/conda-forge/noarch/attrs-26.1.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/bats-core-1.13.0-hce30654_0.conda
@@ -378,7 +380,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/ce/e4/dccd7f47c4b64213ac01ef921a1337ee6e30e8c6466046018326977efd95/tzdata-2026.2-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/39/08/aaaad47bc4e9dc8c725e68f9d04865dbcb2052843ff09c97b08904852d84/urllib3-2.6.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/62/e6/e7d0b538c2f0daaf120901dc113bd5d5d1fa51a9532fa5ffd90234e8c69e/vl_convert_python-1.9.0.post1-cp37-abi3-macosx_11_0_arm64.whl
-      - pypi: .
+      - pypi: ./
       win-64:
       - conda: https://conda.anaconda.org/conda-forge/noarch/attrs-26.1.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/bats-core-1.13.0-h57928b3_0.conda
@@ -499,12 +501,14 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/ce/e4/dccd7f47c4b64213ac01ef921a1337ee6e30e8c6466046018326977efd95/tzdata-2026.2-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/39/08/aaaad47bc4e9dc8c725e68f9d04865dbcb2052843ff09c97b08904852d84/urllib3-2.6.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/93/89/36722344d1758ec2106f4e8eca980f173cfe8f8d0358c1b77cc5d2e035a4/vl_convert_python-1.9.0.post1.tar.gz
-      - pypi: .
+      - pypi: ./
   docs:
     channels:
     - url: https://conda.anaconda.org/conda-forge/
     indexes:
     - https://pypi.org/simple
+    options:
+      pypi-prerelease-mode: if-necessary-or-explicit
     packages:
       linux-64:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-20_gnu.conda
@@ -660,7 +664,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/ce/e4/dccd7f47c4b64213ac01ef921a1337ee6e30e8c6466046018326977efd95/tzdata-2026.2-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/39/08/aaaad47bc4e9dc8c725e68f9d04865dbcb2052843ff09c97b08904852d84/urllib3-2.6.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/93/89/36722344d1758ec2106f4e8eca980f173cfe8f8d0358c1b77cc5d2e035a4/vl_convert_python-1.9.0.post1.tar.gz
-      - pypi: .
+      - pypi: ./
       osx-64:
       - conda: https://conda.anaconda.org/conda-forge/noarch/attrs-26.1.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/bats-core-1.13.0-h694c41f_0.conda
@@ -805,7 +809,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/ce/e4/dccd7f47c4b64213ac01ef921a1337ee6e30e8c6466046018326977efd95/tzdata-2026.2-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/39/08/aaaad47bc4e9dc8c725e68f9d04865dbcb2052843ff09c97b08904852d84/urllib3-2.6.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/9f/59/e5862245972ff467d38b0eb5ad28154685e23ecabb47e14f2b6962da7b56/vl_convert_python-1.9.0.post1-cp37-abi3-macosx_10_12_x86_64.whl
-      - pypi: .
+      - pypi: ./
       osx-arm64:
       - conda: https://conda.anaconda.org/conda-forge/noarch/attrs-26.1.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/bats-core-1.13.0-hce30654_0.conda
@@ -950,7 +954,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/ce/e4/dccd7f47c4b64213ac01ef921a1337ee6e30e8c6466046018326977efd95/tzdata-2026.2-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/39/08/aaaad47bc4e9dc8c725e68f9d04865dbcb2052843ff09c97b08904852d84/urllib3-2.6.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/62/e6/e7d0b538c2f0daaf120901dc113bd5d5d1fa51a9532fa5ffd90234e8c69e/vl_convert_python-1.9.0.post1-cp37-abi3-macosx_11_0_arm64.whl
-      - pypi: .
+      - pypi: ./
       win-64:
       - conda: https://conda.anaconda.org/conda-forge/noarch/attrs-26.1.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/bats-core-1.13.0-h57928b3_0.conda
@@ -1071,12 +1075,14 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/ce/e4/dccd7f47c4b64213ac01ef921a1337ee6e30e8c6466046018326977efd95/tzdata-2026.2-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/39/08/aaaad47bc4e9dc8c725e68f9d04865dbcb2052843ff09c97b08904852d84/urllib3-2.6.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/93/89/36722344d1758ec2106f4e8eca980f173cfe8f8d0358c1b77cc5d2e035a4/vl_convert_python-1.9.0.post1.tar.gz
-      - pypi: .
+      - pypi: ./
   lint:
     channels:
     - url: https://conda.anaconda.org/conda-forge/
     indexes:
     - https://pypi.org/simple
+    options:
+      pypi-prerelease-mode: if-necessary-or-explicit
     packages:
       linux-64:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-20_gnu.conda
@@ -1202,7 +1208,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/ce/e4/dccd7f47c4b64213ac01ef921a1337ee6e30e8c6466046018326977efd95/tzdata-2026.2-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/39/08/aaaad47bc4e9dc8c725e68f9d04865dbcb2052843ff09c97b08904852d84/urllib3-2.6.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/93/89/36722344d1758ec2106f4e8eca980f173cfe8f8d0358c1b77cc5d2e035a4/vl_convert_python-1.9.0.post1.tar.gz
-      - pypi: .
+      - pypi: ./
       osx-64:
       - conda: https://conda.anaconda.org/conda-forge/noarch/attrs-26.1.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/bzip2-1.0.8-h500dc9f_9.conda
@@ -1325,7 +1331,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/ce/e4/dccd7f47c4b64213ac01ef921a1337ee6e30e8c6466046018326977efd95/tzdata-2026.2-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/39/08/aaaad47bc4e9dc8c725e68f9d04865dbcb2052843ff09c97b08904852d84/urllib3-2.6.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/9f/59/e5862245972ff467d38b0eb5ad28154685e23ecabb47e14f2b6962da7b56/vl_convert_python-1.9.0.post1-cp37-abi3-macosx_10_12_x86_64.whl
-      - pypi: .
+      - pypi: ./
       osx-arm64:
       - conda: https://conda.anaconda.org/conda-forge/noarch/attrs-26.1.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/bzip2-1.0.8-hd037594_9.conda
@@ -1447,7 +1453,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/ce/e4/dccd7f47c4b64213ac01ef921a1337ee6e30e8c6466046018326977efd95/tzdata-2026.2-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/39/08/aaaad47bc4e9dc8c725e68f9d04865dbcb2052843ff09c97b08904852d84/urllib3-2.6.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/62/e6/e7d0b538c2f0daaf120901dc113bd5d5d1fa51a9532fa5ffd90234e8c69e/vl_convert_python-1.9.0.post1-cp37-abi3-macosx_11_0_arm64.whl
-      - pypi: .
+      - pypi: ./
       win-64:
       - conda: https://conda.anaconda.org/conda-forge/noarch/attrs-26.1.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/bzip2-1.0.8-h0ad9c76_9.conda
@@ -1567,7 +1573,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/ce/e4/dccd7f47c4b64213ac01ef921a1337ee6e30e8c6466046018326977efd95/tzdata-2026.2-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/39/08/aaaad47bc4e9dc8c725e68f9d04865dbcb2052843ff09c97b08904852d84/urllib3-2.6.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/93/89/36722344d1758ec2106f4e8eca980f173cfe8f8d0358c1b77cc5d2e035a4/vl_convert_python-1.9.0.post1.tar.gz
-      - pypi: .
+      - pypi: ./
 packages:
 - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-20_gnu.conda
   build_number: 20
@@ -1671,7 +1677,7 @@ packages:
   - pyyaml>=5.3.1
   - stevedore>=1.20.0
   - rich
-  - colorama>=0.3.9 ; platform_system == 'Windows'
+  - colorama>=0.3.9 ; sys_platform == 'win32'
   - pyyaml ; extra == 'yaml'
   - tomli>=1.1.0 ; python_full_version < '3.11' and extra == 'toml'
   - gitpython>=3.1.30 ; extra == 'baseline'
@@ -1957,7 +1963,7 @@ packages:
   version: 8.3.3
   sha256: a2bf429bb3033c89fa4936ffb35d5cb471e3719e1f3c8a7c3fff0b8314305613
   requires_dist:
-  - colorama ; platform_system == 'Windows'
+  - colorama ; sys_platform == 'win32'
   requires_python: '>=3.10'
 - conda: https://conda.anaconda.org/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_1.conda
   sha256: ab29d57dc70786c1269633ba3dff20288b81664d3ff8d21af995742e2bb03287
@@ -4569,7 +4575,7 @@ packages:
   - typing-extensions>=4.14.1
   - typing-inspection>=0.4.2
   - email-validator>=2.0.0 ; extra == 'email'
-  - tzdata ; python_full_version >= '3.9' and platform_system == 'Windows' and extra == 'timezone'
+  - tzdata ; python_full_version >= '3.9' and sys_platform == 'win32' and extra == 'timezone'
   requires_python: '>=3.9'
 - pypi: https://files.pythonhosted.org/packages/40/1f/f1eb9eb350e795d1af8586289746f5c5677d16043040d63710e22abc43c9/pydantic_core-2.46.4-cp314-cp314t-win_amd64.whl
   name: pydantic-core
@@ -5312,7 +5318,7 @@ packages:
   - ruff>=0.12.0 ; extra == 'dev'
   - cython-lint>=0.12.2 ; extra == 'dev'
   requires_python: '>=3.11'
-- pypi: .
+- pypi: ./
   name: scylla
   version: 0.1.0
   sha256: 33668a51752c9cf2a81334ff5c209996c1b5dbc44c97c9753d0222cd05d6fd0d
@@ -5340,7 +5346,6 @@ packages:
   - statsmodels>=0.14,<1 ; extra == 'analysis'
   - jsonschema>=4.0,<5 ; extra == 'analysis'
   requires_python: '>=3.10'
-  editable: true
 - pypi: https://files.pythonhosted.org/packages/83/11/00d3c3dfc25ad54e731d91449895a79e4bf2384dc3ac01809010ba88f6d5/seaborn-0.13.2-py3-none-any.whl
   name: seaborn
   version: 0.13.2

--- a/pixi.lock
+++ b/pixi.lock
@@ -5,8 +5,6 @@ environments:
     - url: https://conda.anaconda.org/conda-forge/
     indexes:
     - https://pypi.org/simple
-    options:
-      pypi-prerelease-mode: if-necessary-or-explicit
     packages:
       linux-64:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-20_gnu.conda
@@ -133,7 +131,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/ce/e4/dccd7f47c4b64213ac01ef921a1337ee6e30e8c6466046018326977efd95/tzdata-2026.2-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/39/08/aaaad47bc4e9dc8c725e68f9d04865dbcb2052843ff09c97b08904852d84/urllib3-2.6.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/93/89/36722344d1758ec2106f4e8eca980f173cfe8f8d0358c1b77cc5d2e035a4/vl_convert_python-1.9.0.post1.tar.gz
-      - pypi: ./
+      - pypi: .
       osx-64:
       - conda: https://conda.anaconda.org/conda-forge/noarch/attrs-26.1.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/bats-core-1.13.0-h694c41f_0.conda
@@ -257,7 +255,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/ce/e4/dccd7f47c4b64213ac01ef921a1337ee6e30e8c6466046018326977efd95/tzdata-2026.2-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/39/08/aaaad47bc4e9dc8c725e68f9d04865dbcb2052843ff09c97b08904852d84/urllib3-2.6.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/9f/59/e5862245972ff467d38b0eb5ad28154685e23ecabb47e14f2b6962da7b56/vl_convert_python-1.9.0.post1-cp37-abi3-macosx_10_12_x86_64.whl
-      - pypi: ./
+      - pypi: .
       osx-arm64:
       - conda: https://conda.anaconda.org/conda-forge/noarch/attrs-26.1.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/bats-core-1.13.0-hce30654_0.conda
@@ -380,7 +378,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/ce/e4/dccd7f47c4b64213ac01ef921a1337ee6e30e8c6466046018326977efd95/tzdata-2026.2-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/39/08/aaaad47bc4e9dc8c725e68f9d04865dbcb2052843ff09c97b08904852d84/urllib3-2.6.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/62/e6/e7d0b538c2f0daaf120901dc113bd5d5d1fa51a9532fa5ffd90234e8c69e/vl_convert_python-1.9.0.post1-cp37-abi3-macosx_11_0_arm64.whl
-      - pypi: ./
+      - pypi: .
       win-64:
       - conda: https://conda.anaconda.org/conda-forge/noarch/attrs-26.1.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/bats-core-1.13.0-h57928b3_0.conda
@@ -501,14 +499,12 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/ce/e4/dccd7f47c4b64213ac01ef921a1337ee6e30e8c6466046018326977efd95/tzdata-2026.2-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/39/08/aaaad47bc4e9dc8c725e68f9d04865dbcb2052843ff09c97b08904852d84/urllib3-2.6.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/93/89/36722344d1758ec2106f4e8eca980f173cfe8f8d0358c1b77cc5d2e035a4/vl_convert_python-1.9.0.post1.tar.gz
-      - pypi: ./
+      - pypi: .
   docs:
     channels:
     - url: https://conda.anaconda.org/conda-forge/
     indexes:
     - https://pypi.org/simple
-    options:
-      pypi-prerelease-mode: if-necessary-or-explicit
     packages:
       linux-64:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-20_gnu.conda
@@ -664,7 +660,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/ce/e4/dccd7f47c4b64213ac01ef921a1337ee6e30e8c6466046018326977efd95/tzdata-2026.2-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/39/08/aaaad47bc4e9dc8c725e68f9d04865dbcb2052843ff09c97b08904852d84/urllib3-2.6.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/93/89/36722344d1758ec2106f4e8eca980f173cfe8f8d0358c1b77cc5d2e035a4/vl_convert_python-1.9.0.post1.tar.gz
-      - pypi: ./
+      - pypi: .
       osx-64:
       - conda: https://conda.anaconda.org/conda-forge/noarch/attrs-26.1.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/bats-core-1.13.0-h694c41f_0.conda
@@ -809,7 +805,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/ce/e4/dccd7f47c4b64213ac01ef921a1337ee6e30e8c6466046018326977efd95/tzdata-2026.2-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/39/08/aaaad47bc4e9dc8c725e68f9d04865dbcb2052843ff09c97b08904852d84/urllib3-2.6.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/9f/59/e5862245972ff467d38b0eb5ad28154685e23ecabb47e14f2b6962da7b56/vl_convert_python-1.9.0.post1-cp37-abi3-macosx_10_12_x86_64.whl
-      - pypi: ./
+      - pypi: .
       osx-arm64:
       - conda: https://conda.anaconda.org/conda-forge/noarch/attrs-26.1.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/bats-core-1.13.0-hce30654_0.conda
@@ -954,7 +950,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/ce/e4/dccd7f47c4b64213ac01ef921a1337ee6e30e8c6466046018326977efd95/tzdata-2026.2-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/39/08/aaaad47bc4e9dc8c725e68f9d04865dbcb2052843ff09c97b08904852d84/urllib3-2.6.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/62/e6/e7d0b538c2f0daaf120901dc113bd5d5d1fa51a9532fa5ffd90234e8c69e/vl_convert_python-1.9.0.post1-cp37-abi3-macosx_11_0_arm64.whl
-      - pypi: ./
+      - pypi: .
       win-64:
       - conda: https://conda.anaconda.org/conda-forge/noarch/attrs-26.1.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/bats-core-1.13.0-h57928b3_0.conda
@@ -1075,14 +1071,12 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/ce/e4/dccd7f47c4b64213ac01ef921a1337ee6e30e8c6466046018326977efd95/tzdata-2026.2-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/39/08/aaaad47bc4e9dc8c725e68f9d04865dbcb2052843ff09c97b08904852d84/urllib3-2.6.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/93/89/36722344d1758ec2106f4e8eca980f173cfe8f8d0358c1b77cc5d2e035a4/vl_convert_python-1.9.0.post1.tar.gz
-      - pypi: ./
+      - pypi: .
   lint:
     channels:
     - url: https://conda.anaconda.org/conda-forge/
     indexes:
     - https://pypi.org/simple
-    options:
-      pypi-prerelease-mode: if-necessary-or-explicit
     packages:
       linux-64:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-20_gnu.conda
@@ -1208,7 +1202,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/ce/e4/dccd7f47c4b64213ac01ef921a1337ee6e30e8c6466046018326977efd95/tzdata-2026.2-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/39/08/aaaad47bc4e9dc8c725e68f9d04865dbcb2052843ff09c97b08904852d84/urllib3-2.6.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/93/89/36722344d1758ec2106f4e8eca980f173cfe8f8d0358c1b77cc5d2e035a4/vl_convert_python-1.9.0.post1.tar.gz
-      - pypi: ./
+      - pypi: .
       osx-64:
       - conda: https://conda.anaconda.org/conda-forge/noarch/attrs-26.1.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/bzip2-1.0.8-h500dc9f_9.conda
@@ -1331,7 +1325,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/ce/e4/dccd7f47c4b64213ac01ef921a1337ee6e30e8c6466046018326977efd95/tzdata-2026.2-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/39/08/aaaad47bc4e9dc8c725e68f9d04865dbcb2052843ff09c97b08904852d84/urllib3-2.6.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/9f/59/e5862245972ff467d38b0eb5ad28154685e23ecabb47e14f2b6962da7b56/vl_convert_python-1.9.0.post1-cp37-abi3-macosx_10_12_x86_64.whl
-      - pypi: ./
+      - pypi: .
       osx-arm64:
       - conda: https://conda.anaconda.org/conda-forge/noarch/attrs-26.1.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/bzip2-1.0.8-hd037594_9.conda
@@ -1453,7 +1447,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/ce/e4/dccd7f47c4b64213ac01ef921a1337ee6e30e8c6466046018326977efd95/tzdata-2026.2-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/39/08/aaaad47bc4e9dc8c725e68f9d04865dbcb2052843ff09c97b08904852d84/urllib3-2.6.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/62/e6/e7d0b538c2f0daaf120901dc113bd5d5d1fa51a9532fa5ffd90234e8c69e/vl_convert_python-1.9.0.post1-cp37-abi3-macosx_11_0_arm64.whl
-      - pypi: ./
+      - pypi: .
       win-64:
       - conda: https://conda.anaconda.org/conda-forge/noarch/attrs-26.1.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/bzip2-1.0.8-h0ad9c76_9.conda
@@ -1573,7 +1567,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/ce/e4/dccd7f47c4b64213ac01ef921a1337ee6e30e8c6466046018326977efd95/tzdata-2026.2-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/39/08/aaaad47bc4e9dc8c725e68f9d04865dbcb2052843ff09c97b08904852d84/urllib3-2.6.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/93/89/36722344d1758ec2106f4e8eca980f173cfe8f8d0358c1b77cc5d2e035a4/vl_convert_python-1.9.0.post1.tar.gz
-      - pypi: ./
+      - pypi: .
 packages:
 - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-20_gnu.conda
   build_number: 20
@@ -1677,7 +1671,7 @@ packages:
   - pyyaml>=5.3.1
   - stevedore>=1.20.0
   - rich
-  - colorama>=0.3.9 ; sys_platform == 'win32'
+  - colorama>=0.3.9 ; platform_system == 'Windows'
   - pyyaml ; extra == 'yaml'
   - tomli>=1.1.0 ; python_full_version < '3.11' and extra == 'toml'
   - gitpython>=3.1.30 ; extra == 'baseline'
@@ -1963,7 +1957,7 @@ packages:
   version: 8.3.3
   sha256: a2bf429bb3033c89fa4936ffb35d5cb471e3719e1f3c8a7c3fff0b8314305613
   requires_dist:
-  - colorama ; sys_platform == 'win32'
+  - colorama ; platform_system == 'Windows'
   requires_python: '>=3.10'
 - conda: https://conda.anaconda.org/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_1.conda
   sha256: ab29d57dc70786c1269633ba3dff20288b81664d3ff8d21af995742e2bb03287
@@ -4575,7 +4569,7 @@ packages:
   - typing-extensions>=4.14.1
   - typing-inspection>=0.4.2
   - email-validator>=2.0.0 ; extra == 'email'
-  - tzdata ; python_full_version >= '3.9' and sys_platform == 'win32' and extra == 'timezone'
+  - tzdata ; python_full_version >= '3.9' and platform_system == 'Windows' and extra == 'timezone'
   requires_python: '>=3.9'
 - pypi: https://files.pythonhosted.org/packages/40/1f/f1eb9eb350e795d1af8586289746f5c5677d16043040d63710e22abc43c9/pydantic_core-2.46.4-cp314-cp314t-win_amd64.whl
   name: pydantic-core
@@ -5318,7 +5312,7 @@ packages:
   - ruff>=0.12.0 ; extra == 'dev'
   - cython-lint>=0.12.2 ; extra == 'dev'
   requires_python: '>=3.11'
-- pypi: ./
+- pypi: .
   name: scylla
   version: 0.1.0
   sha256: 33668a51752c9cf2a81334ff5c209996c1b5dbc44c97c9753d0222cd05d6fd0d
@@ -5346,6 +5340,7 @@ packages:
   - statsmodels>=0.14,<1 ; extra == 'analysis'
   - jsonschema>=4.0,<5 ; extra == 'analysis'
   requires_python: '>=3.10'
+  editable: true
 - pypi: https://files.pythonhosted.org/packages/83/11/00d3c3dfc25ad54e731d91449895a79e4bf2384dc3ac01809010ba88f6d5/seaborn-0.13.2-py3-none-any.whl
   name: seaborn
   version: 0.13.2

--- a/src/scylla/core/state_machine.py
+++ b/src/scylla/core/state_machine.py
@@ -262,29 +262,45 @@ class StateMachine(Generic[TState]):
                 )
                 return self.get_state()
 
-            matched = False
-            mapped: TState | None = None
-            if error_state_map is not None:
-                for exc_type, target in error_state_map:
-                    if isinstance(exc, exc_type):
-                        matched = True
-                        mapped = target
-                        break
-
-            if not matched and failure_state is not None:
-                mapped = failure_state
-
-            if mapped is not None:
-                logger.warning(
-                    f"[{self.label}] {type(exc).__name__} during "
-                    f"{self.get_state().value} -> applying {mapped.value}"
-                )
-                self.apply_state(mapped)
-                if self.persistence_hook is not None:
-                    self.persistence_hook(mapped)
+            self._handle_advance_exception(exc, error_state_map, failure_state)
             raise
 
         return self.get_state()
+
+    def _handle_advance_exception(
+        self,
+        exc: BaseException,
+        error_state_map: list[tuple[type[BaseException], TState | None]] | None,
+        failure_state: TState | None,
+    ) -> None:
+        """Apply the mapped error/failure state (if any) before the caller re-raises.
+
+        Resolves the target state via `error_state_map` precedence, falling back to
+        `failure_state`. When a concrete target is resolved it is applied and persisted.
+        """
+        mapped = self._resolve_error_state(exc, error_state_map, failure_state)
+        if mapped is None:
+            return
+        logger.warning(
+            f"[{self.label}] {type(exc).__name__} during "
+            f"{self.get_state().value} -> applying {mapped.value}"
+        )
+        self.apply_state(mapped)
+        if self.persistence_hook is not None:
+            self.persistence_hook(mapped)
+
+    @staticmethod
+    def _resolve_error_state(
+        exc: BaseException,
+        error_state_map: list[tuple[type[BaseException], TState | None]] | None,
+        failure_state: TState | None,
+    ) -> TState | None:
+        """Return the target state for `exc`, or None to leave state unchanged."""
+        if error_state_map is not None:
+            for exc_type, target in error_state_map:
+                if isinstance(exc, exc_type):
+                    return target
+        return failure_state
 
 
 __all__ = [

--- a/src/scylla/core/state_machine.py
+++ b/src/scylla/core/state_machine.py
@@ -208,10 +208,22 @@ class StateMachine(Generic[TState]):
         actions: dict[TState, Callable[[], None]],
         *,
         until_state: TState | None = None,
-        error_state_map: list[tuple[type[BaseException], TState]] | None = None,
+        error_state_map: list[tuple[type[BaseException], TState | None]] | None = None,
         failure_state: TState | None = None,
+        swallow_types: tuple[type[BaseException], ...] = (),
     ) -> TState:
         """Drive the FSM until a terminal state, `until_state`, or exception.
+
+        Exceptions are handled with the following precedence:
+        1. `swallow_types`: Exception is caught, logged at info level, and the
+           current state is returned normally without state change.
+        2. `error_state_map`: If the exception matches an entry, the FSM is moved
+           to the mapped `target_state`. If `target_state` is None, no state change
+           occurs (the exception is re-raised unchanged). If `target_state` is
+           concrete, it is applied and persisted before re-raising.
+        3. `failure_state`: If no `error_state_map` entry matches, `failure_state`
+           (if provided) is applied and persisted before re-raising.
+        4. Unhandled exceptions propagate without state change.
 
         Args:
             actions: `from_state -> callable` map (see `advance`).
@@ -220,14 +232,18 @@ class StateMachine(Generic[TState]):
                 transitions are executed. The FSM is *not* marked failed.
             error_state_map: Ordered list of `(exception_type, target_state)`
                 pairs. When an exception of any listed type is raised during
-                a transition, the FSM is moved to the associated target
-                state and persisted before the exception is re-raised. The
-                first matching entry wins (so subclasses should appear
-                before parents).
-            failure_state: Optional fallback state to apply when an
-                exception does not match any entry in `error_state_map`. If
-                omitted, generic failures simply propagate without changing
-                state.
+                a transition, the FSM is moved to the associated target_state
+                and persisted before the exception is re-raised. If
+                target_state is None, the state is left unchanged. The first
+                matching entry wins (so subclasses should appear before parents).
+            failure_state: Optional fallback state to apply when an exception
+                does not match any entry in `error_state_map`. If omitted,
+                exceptions not in the map propagate without changing state.
+            swallow_types: Tuple of exception types to catch and suppress
+                without state change. These are checked before error_state_map,
+                so swallowed exceptions never trigger the error map. Caught
+                exceptions are logged at info level and the current state is
+                returned normally.
 
         Returns:
             The final state on clean completion or `until_state` early exit.
@@ -240,13 +256,22 @@ class StateMachine(Generic[TState]):
                     logger.info(f"[{self.label}] Reached --until target state: {until_state.value}")
                     break
         except BaseException as exc:
+            if swallow_types and isinstance(exc, swallow_types):
+                logger.info(
+                    f"[{self.label}] Swallowed {type(exc).__name__} at {self.get_state().value}"
+                )
+                return self.get_state()
+
+            matched = False
             mapped: TState | None = None
             if error_state_map is not None:
                 for exc_type, target in error_state_map:
                     if isinstance(exc, exc_type):
+                        matched = True
                         mapped = target
                         break
-            if mapped is None and failure_state is not None:
+
+            if not matched and failure_state is not None:
                 mapped = failure_state
 
             if mapped is not None:

--- a/src/scylla/e2e/state_machine.py
+++ b/src/scylla/e2e/state_machine.py
@@ -30,12 +30,13 @@ State flow for a single run (18 sequential states):
 from __future__ import annotations
 
 import logging
-import time
 from collections.abc import Callable
 from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING
 
+from scylla.core.state_machine import StateMachine as GenericStateMachine
+from scylla.core.state_machine import Transition
 from scylla.e2e.models import RunState
 
 if TYPE_CHECKING:
@@ -90,112 +91,100 @@ def is_at_or_past_state(current: RunState, target: RunState) -> bool:
     return cur_idx >= tgt_idx
 
 
-@dataclass
-class StateTransition:
-    """Describes a single state transition in the run state machine.
-
-    Attributes:
-        from_state: State before this transition
-        to_state: State after this transition completes successfully
-        description: Human-readable description for logging
-
-    """
-
-    from_state: RunState
-    to_state: RunState
-    description: str
+# Type alias for run transitions using the generic Transition
+StateTransition = Transition[RunState]
 
 
 # Registry of all valid transitions.
 # Actions (the callables that perform the work) are injected at runtime
 # by callers who hold references to the appropriate stage functions.
 TRANSITION_REGISTRY: list[StateTransition] = [
-    StateTransition(
+    Transition(
         from_state=RunState.PENDING,
         to_state=RunState.DIR_STRUCTURE_CREATED,
         description="Create run_NN/, agent/, judge/ directories",
     ),
-    StateTransition(
+    Transition(
         from_state=RunState.DIR_STRUCTURE_CREATED,
         to_state=RunState.WORKTREE_CREATED,
         description="Create git worktree",
     ),
-    StateTransition(
+    Transition(
         from_state=RunState.WORKTREE_CREATED,
         to_state=RunState.SYMLINKS_APPLIED,
         description="Symlink tier resources to workspace",
     ),
-    StateTransition(
+    Transition(
         from_state=RunState.SYMLINKS_APPLIED,
         to_state=RunState.CONFIG_COMMITTED,
         description="Write CLAUDE.md and settings.json, git commit",
     ),
-    StateTransition(
+    Transition(
         from_state=RunState.CONFIG_COMMITTED,
         to_state=RunState.BASELINE_CAPTURED,
         description="Capture pipeline baseline (compileall, ruff, pytest, pre-commit)",
     ),
-    StateTransition(
+    Transition(
         from_state=RunState.BASELINE_CAPTURED,
         to_state=RunState.PROMPT_WRITTEN,
         description="Write task_prompt.md, inject thinking keyword if configured",
     ),
-    StateTransition(
+    Transition(
         from_state=RunState.PROMPT_WRITTEN,
         to_state=RunState.REPLAY_GENERATED,
         description="Build adapter command, generate replay.sh",
     ),
-    StateTransition(
+    Transition(
         from_state=RunState.REPLAY_GENERATED,
         to_state=RunState.AGENT_COMPLETE,
         description="Execute agent in isolated workspace",
     ),
-    StateTransition(
+    Transition(
         from_state=RunState.AGENT_COMPLETE,
         to_state=RunState.AGENT_CHANGES_COMMITTED,
         description="Commit agent changes to worktree branch",
     ),
-    StateTransition(
+    Transition(
         from_state=RunState.AGENT_CHANGES_COMMITTED,
         to_state=RunState.DIFF_CAPTURED,
         description="Capture git diff and workspace state",
     ),
-    StateTransition(
+    Transition(
         from_state=RunState.DIFF_CAPTURED,
         to_state=RunState.PROMOTED_TO_COMPLETED,
         description="Move run directory from in_progress/ to completed/",
     ),
-    StateTransition(
+    Transition(
         from_state=RunState.PROMOTED_TO_COMPLETED,
         to_state=RunState.JUDGE_PIPELINE_RUN,
         description="Run build pipeline on agent-modified workspace",
     ),
-    StateTransition(
+    Transition(
         from_state=RunState.JUDGE_PIPELINE_RUN,
         to_state=RunState.JUDGE_PROMPT_BUILT,
         description="Assemble judge prompt with all context",
     ),
-    StateTransition(
+    Transition(
         from_state=RunState.JUDGE_PROMPT_BUILT,
         to_state=RunState.JUDGE_COMPLETE,
         description="Execute Claude CLI judge(s), compute consensus",
     ),
-    StateTransition(
+    Transition(
         from_state=RunState.JUDGE_COMPLETE,
         to_state=RunState.RUN_FINALIZED,
         description="Build E2ERunResult, save run_result.json",
     ),
-    StateTransition(
+    Transition(
         from_state=RunState.RUN_FINALIZED,
         to_state=RunState.REPORT_WRITTEN,
         description="Generate report.md and report.json",
     ),
-    StateTransition(
+    Transition(
         from_state=RunState.REPORT_WRITTEN,
         to_state=RunState.CHECKPOINTED,
         description="Save checkpoint (no-op — auto-saved after each transition)",
     ),
-    StateTransition(
+    Transition(
         from_state=RunState.CHECKPOINTED,
         to_state=RunState.WORKTREE_CLEANED,
         description="Remove worktree for passed runs",
@@ -247,8 +236,8 @@ def validate_transition(from_state: RunState, to_state: RunState) -> bool:
 class StateMachine:
     """Manages state transitions for a single run with checkpoint persistence.
 
-    Each call to advance() executes the next action, updates the run state
-    in the checkpoint, and saves the checkpoint atomically.
+    Delegates to the generic StateMachine[RunState] for each run, constructing
+    a transient instance per call via _sm_for(tier_id, subtest_id, run_num).
 
     Usage:
         sm = StateMachine(checkpoint, checkpoint_path)
@@ -300,6 +289,38 @@ class StateMachine:
         """
         return is_terminal_state(self.get_state(tier_id, subtest_id, run_num))
 
+    def _sm_for(self, tier_id: str, subtest_id: str, run_num: int) -> GenericStateMachine[RunState]:
+        """Construct a transient StateMachine instance for a run.
+
+        Each call creates a fresh instance with closures capturing tier_id, subtest_id,
+        and run_num, so state access is correctly scoped to the specific run.
+
+        Args:
+            tier_id: Tier identifier
+            subtest_id: Subtest identifier
+            run_num: Run number (1-based)
+
+        Returns:
+            A StateMachine[RunState] configured for this run
+
+        """
+        from scylla.persistence.checkpoint import save_checkpoint
+
+        def apply(state: RunState) -> None:
+            self.checkpoint.set_run_state(tier_id, subtest_id, run_num, state.value)
+
+        def persist(_state: RunState) -> None:
+            save_checkpoint(self.checkpoint, self.checkpoint_path)
+
+        return GenericStateMachine[RunState](
+            transitions=TRANSITION_REGISTRY,
+            terminal_states=_TERMINAL_STATES,
+            get_state=lambda: self.get_state(tier_id, subtest_id, run_num),
+            apply_state=apply,
+            persistence_hook=persist,
+            label=f"run[{tier_id}/{subtest_id}/run_{run_num:02d}]",
+        )
+
     def advance(
         self,
         tier_id: str,
@@ -309,11 +330,7 @@ class StateMachine:
     ) -> RunState:
         """Advance the run by one state transition.
 
-        1. Reads the current state from the checkpoint.
-        2. Looks up the next transition in the registry.
-        3. Executes the transition action (if provided).
-        4. Updates the checkpoint state.
-        5. Saves the checkpoint atomically.
+        Delegates to the generic StateMachine.advance().
 
         Args:
             tier_id: Tier identifier
@@ -331,47 +348,8 @@ class StateMachine:
             ValueError: If no transition is defined for the current state
 
         """
-        from scylla.persistence.checkpoint import save_checkpoint
-
-        current = self.get_state(tier_id, subtest_id, run_num)
-
-        if is_terminal_state(current):
-            raise RuntimeError(
-                f"Cannot advance run {tier_id}/{subtest_id}/run_{run_num:02d} "
-                f"from terminal state {current.value}"
-            )
-
-        transition = get_next_transition(current)
-        if transition is None:
-            raise ValueError(
-                f"No transition defined from state {current.value} "
-                f"for run {tier_id}/{subtest_id}/run_{run_num:02d}"
-            )
-
-        logger.debug(
-            f"[{tier_id}/{subtest_id}/run_{run_num:02d}] "
-            f"{current.value} -> {transition.to_state.value}: {transition.description}"
-        )
-
-        # Execute the action if provided
-        action = actions.get(current)
-        if action is not None:
-            _t0 = time.monotonic()
-            action()
-            _elapsed = time.monotonic() - _t0
-            logger.info(
-                f"[{tier_id}/{subtest_id}/run_{run_num:02d}] "
-                f"{current.value} -> {transition.to_state.value}: "
-                f"{transition.description} ({_elapsed:.1f}s)"
-            )
-
-        # Update state in checkpoint
-        self.checkpoint.set_run_state(tier_id, subtest_id, run_num, transition.to_state.value)
-
-        # Save checkpoint atomically
-        save_checkpoint(self.checkpoint, self.checkpoint_path)
-
-        return transition.to_state
+        sm = self._sm_for(tier_id, subtest_id, run_num)
+        return sm.advance(actions)
 
     def advance_to_completion(
         self,
@@ -383,8 +361,8 @@ class StateMachine:
     ) -> RunState:
         """Advance the run through all states until a terminal state is reached.
 
-        Useful for running a complete run from start or resuming from any state.
-        On exception, the run is marked as FAILED in the checkpoint.
+        Delegates to the generic StateMachine.advance_to_completion() with
+        run-specific exception handling.
 
         If until_state is specified, the run stops cleanly once that state is
         reached (inclusive): the action that transitions INTO until_state IS
@@ -405,7 +383,6 @@ class StateMachine:
         """
         from scylla.e2e.rate_limit import RateLimitError
         from scylla.e2e.shutdown import ShutdownInterruptedError
-        from scylla.persistence.checkpoint import save_checkpoint
 
         # Early return if already at or past the --until target state
         if until_state is not None:
@@ -418,35 +395,13 @@ class StateMachine:
                 )
                 return current
 
-        try:
-            while not self.is_complete(tier_id, subtest_id, run_num):
-                new_state = self.advance(tier_id, subtest_id, run_num, actions)
-                if until_state is not None and new_state == until_state:
-                    logger.info(
-                        f"[{tier_id}/{subtest_id}/run_{run_num:02d}] "
-                        f"Reached --until target state: {until_state.value}"
-                    )
-                    break
-        except RateLimitError:
-            self.checkpoint.set_run_state(tier_id, subtest_id, run_num, RunState.RATE_LIMITED.value)
-            save_checkpoint(self.checkpoint, self.checkpoint_path)
-            raise
-        except ShutdownInterruptedError:
-            # Ctrl+C interrupted this run mid-stage — leave it at its last successfully
-            # checkpointed state so it can be cleanly resumed on the next invocation.
-            current = self.get_state(tier_id, subtest_id, run_num)
-            logger.warning(
-                f"[{tier_id}/{subtest_id}/run_{run_num:02d}] "
-                f"Shutdown interrupted at {current.value} — run left resumable (not FAILED)"
-            )
-            raise
-        except Exception as e:
-            logger.error(
-                f"Run {tier_id}/{subtest_id}/run_{run_num:02d} failed in state "
-                f"{self.get_state(tier_id, subtest_id, run_num).value}: {e}"
-            )
-            self.checkpoint.set_run_state(tier_id, subtest_id, run_num, RunState.FAILED.value)
-            save_checkpoint(self.checkpoint, self.checkpoint_path)
-            raise
-
-        return self.get_state(tier_id, subtest_id, run_num)
+        sm = self._sm_for(tier_id, subtest_id, run_num)
+        return sm.advance_to_completion(
+            actions,
+            until_state=until_state,
+            error_state_map=[
+                (RateLimitError, RunState.RATE_LIMITED),
+                (ShutdownInterruptedError, None),
+            ],
+            failure_state=RunState.FAILED,
+        )

--- a/src/scylla/e2e/subtest_state_machine.py
+++ b/src/scylla/e2e/subtest_state_machine.py
@@ -15,12 +15,12 @@ State flow for a single subtest (3 sequential states):
 from __future__ import annotations
 
 import logging
-import time
 from collections.abc import Callable
 from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING
 
+from scylla.core.state_machine import StateMachine, Transition
 from scylla.e2e.models import SubtestState
 
 if TYPE_CHECKING:
@@ -50,36 +50,22 @@ _SUBTEST_TERMINAL_STATES: frozenset[SubtestState] = frozenset(
     [SubtestState.AGGREGATED, SubtestState.FAILED]
 )
 
-
-@dataclass
-class SubtestTransition:
-    """Describes a single state transition in the subtest state machine.
-
-    Attributes:
-        from_state: State before this transition
-        to_state: State after this transition completes successfully
-        description: Human-readable description for logging
-
-    """
-
-    from_state: SubtestState
-    to_state: SubtestState
-    description: str
-
+# Type alias for subtest transitions using the generic Transition
+SubtestTransition = Transition[SubtestState]
 
 # Registry of all valid subtest transitions
 SUBTEST_TRANSITION_REGISTRY: list[SubtestTransition] = [
-    SubtestTransition(
+    Transition(
         from_state=SubtestState.PENDING,
         to_state=SubtestState.RUNS_IN_PROGRESS,
         description="Start subtest runs",
     ),
-    SubtestTransition(
+    Transition(
         from_state=SubtestState.RUNS_IN_PROGRESS,
         to_state=SubtestState.RUNS_COMPLETE,
         description="All runs finished",
     ),
-    SubtestTransition(
+    Transition(
         from_state=SubtestState.RUNS_COMPLETE,
         to_state=SubtestState.AGGREGATED,
         description="Aggregate run results",
@@ -131,8 +117,8 @@ def validate_subtest_transition(from_state: SubtestState, to_state: SubtestState
 class SubtestStateMachine:
     """Manages state transitions for a single subtest with checkpoint persistence.
 
-    Each call to advance() executes the next action, updates the subtest state
-    in the checkpoint, and saves the checkpoint atomically.
+    Delegates to the generic StateMachine[SubtestState] for each subtest, constructing
+    a transient instance per call via _sm_for(tier_id, subtest_id).
 
     Usage:
         ssm = SubtestStateMachine(checkpoint, checkpoint_path)
@@ -183,6 +169,37 @@ class SubtestStateMachine:
         """
         return is_subtest_terminal_state(self.get_state(tier_id, subtest_id))
 
+    def _sm_for(self, tier_id: str, subtest_id: str) -> StateMachine[SubtestState]:
+        """Construct a transient StateMachine instance for a subtest.
+
+        Each call creates a fresh instance with closures capturing tier_id and subtest_id,
+        so state access is correctly scoped to the specific subtest.
+
+        Args:
+            tier_id: Tier identifier
+            subtest_id: Subtest identifier
+
+        Returns:
+            A StateMachine[SubtestState] configured for this subtest
+
+        """
+        from scylla.persistence.checkpoint import save_checkpoint
+
+        def apply(state: SubtestState) -> None:
+            self.checkpoint.set_subtest_state(tier_id, subtest_id, state.value)
+
+        def persist(_state: SubtestState) -> None:
+            save_checkpoint(self.checkpoint, self.checkpoint_path)
+
+        return StateMachine[SubtestState](
+            transitions=SUBTEST_TRANSITION_REGISTRY,
+            terminal_states=_SUBTEST_TERMINAL_STATES,
+            get_state=lambda: self.get_state(tier_id, subtest_id),
+            apply_state=apply,
+            persistence_hook=persist,
+            label=f"subtest[{tier_id}/{subtest_id}]",
+        )
+
     def advance(
         self,
         tier_id: str,
@@ -191,11 +208,8 @@ class SubtestStateMachine:
     ) -> SubtestState:
         """Advance the subtest by one state transition.
 
-        1. Reads the current state from the checkpoint.
-        2. Looks up the next transition in the registry.
-        3. Executes the transition action (if provided).
-        4. Updates the checkpoint state.
-        5. Saves the checkpoint atomically.
+        Delegates to the generic StateMachine.advance(), wrapping actions to
+        intercept UntilHaltError and force RUNS_IN_PROGRESS state before re-raising.
 
         Args:
             tier_id: Tier identifier
@@ -210,6 +224,7 @@ class SubtestStateMachine:
         Raises:
             RuntimeError: If already in a terminal state
             ValueError: If no transition is defined for the current state
+            UntilHaltError: If the action raises UntilHaltError (state is advanced to next)
 
         """
         from scylla.persistence.checkpoint import save_checkpoint
@@ -233,35 +248,29 @@ class SubtestStateMachine:
             f"{transition.to_state.value}: {transition.description}"
         )
 
-        # Execute the action if provided
         halt_error: UntilHaltError | None = None
         action = actions.get(current)
         if action is not None:
-            _t0 = time.monotonic()
             try:
                 action()
             except UntilHaltError as _e:
-                # --until stopped runs mid-action; still transition the state so
-                # we land in RUNS_IN_PROGRESS (resumable) rather than staying at PENDING.
                 halt_error = _e
-            _elapsed = time.monotonic() - _t0
-            logger.info(
-                f"[{tier_id}/{subtest_id}] {current.value} -> {transition.to_state.value}: "
-                f"{transition.description} ({_elapsed:.1f}s)"
-            )
+                logger.info(
+                    f"[{tier_id}/{subtest_id}] {current.value} -> {transition.to_state.value}: "
+                    f"{transition.description} (UntilHaltError)"
+                )
+            else:
+                logger.info(
+                    f"[{tier_id}/{subtest_id}] {current.value} -> {transition.to_state.value}: "
+                    f"{transition.description}"
+                )
 
-        # Update state in checkpoint.
-        # If UntilHaltError was raised, runs are incomplete — always save RUNS_IN_PROGRESS
-        # regardless of which transition was in progress (PENDING->RUNS_IN_PROGRESS or
-        # RUNS_IN_PROGRESS->RUNS_COMPLETE).  This ensures the next invocation resumes
-        # from RUNS_IN_PROGRESS and re-executes the run loop, not _aggregate().
         if halt_error is not None:
             saved_state = SubtestState.RUNS_IN_PROGRESS
         else:
             saved_state = transition.to_state
-        self.checkpoint.set_subtest_state(tier_id, subtest_id, saved_state.value)
 
-        # Save checkpoint atomically
+        self.checkpoint.set_subtest_state(tier_id, subtest_id, saved_state.value)
         save_checkpoint(self.checkpoint, self.checkpoint_path)
 
         if halt_error is not None:
@@ -278,8 +287,8 @@ class SubtestStateMachine:
     ) -> SubtestState:
         """Advance the subtest through all states until AGGREGATED is reached.
 
-        Useful for running a complete subtest from start or resuming from any state.
-        On exception, marks the subtest as FAILED in the checkpoint and re-raises.
+        Handles UntilHaltError specially: caught and logged without marking FAILED.
+        ShutdownInterruptedError leaves state unchanged and re-raises.
 
         If until_state is specified, the subtest stops cleanly once that state is
         reached (inclusive): the action that transitions INTO until_state IS
@@ -310,13 +319,8 @@ class SubtestStateMachine:
                     )
                     break
         except UntilHaltError as e:
-            # --until stopped runs before they reached a terminal state.
-            # Leave the subtest in RUNS_IN_PROGRESS so it can be resumed later.
-            # Do NOT mark as FAILED — this is intentional early termination.
             logger.info(f"[{tier_id}/{subtest_id}] {e}")
         except ShutdownInterruptedError:
-            # Ctrl+C interrupted this subtest — leave it in RUNS_IN_PROGRESS so it
-            # can be cleanly resumed on the next invocation.  Do NOT mark as FAILED.
             current = self.get_state(tier_id, subtest_id)
             logger.warning(
                 f"[{tier_id}/{subtest_id}] Shutdown interrupted at {current.value} "

--- a/src/scylla/e2e/tier_state_machine.py
+++ b/src/scylla/e2e/tier_state_machine.py
@@ -18,12 +18,12 @@ State flow for a single tier (6 sequential states):
 from __future__ import annotations
 
 import logging
-import time
 from collections.abc import Callable
 from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING
 
+from scylla.core.state_machine import StateMachine, Transition
 from scylla.e2e.models import TierState
 
 if TYPE_CHECKING:
@@ -46,51 +46,37 @@ _TIER_STATE_SEQUENCE: list[TierState] = [
 # Terminal states — do not advance further
 _TIER_TERMINAL_STATES: frozenset[TierState] = frozenset([TierState.COMPLETE, TierState.FAILED])
 
-
-@dataclass
-class TierTransition:
-    """Describes a single state transition in the tier state machine.
-
-    Attributes:
-        from_state: State before this transition
-        to_state: State after this transition completes successfully
-        description: Human-readable description for logging
-
-    """
-
-    from_state: TierState
-    to_state: TierState
-    description: str
-
+# Type alias for tier transitions using the generic Transition
+TierTransition = Transition[TierState]
 
 # Registry of all valid tier transitions
 TIER_TRANSITION_REGISTRY: list[TierTransition] = [
-    TierTransition(
+    Transition(
         from_state=TierState.PENDING,
         to_state=TierState.CONFIG_LOADED,
         description="Load tier config YAML",
     ),
-    TierTransition(
+    Transition(
         from_state=TierState.CONFIG_LOADED,
         to_state=TierState.SUBTESTS_RUNNING,
         description="Start subtest execution",
     ),
-    TierTransition(
+    Transition(
         from_state=TierState.SUBTESTS_RUNNING,
         to_state=TierState.SUBTESTS_COMPLETE,
         description="Execute all subtests",
     ),
-    TierTransition(
+    Transition(
         from_state=TierState.SUBTESTS_COMPLETE,
         to_state=TierState.BEST_SELECTED,
         description="Select best subtest by CoP",
     ),
-    TierTransition(
+    Transition(
         from_state=TierState.BEST_SELECTED,
         to_state=TierState.REPORTS_GENERATED,
         description="Generate tier reports",
     ),
-    TierTransition(
+    Transition(
         from_state=TierState.REPORTS_GENERATED,
         to_state=TierState.COMPLETE,
         description="Mark tier complete",
@@ -142,8 +128,8 @@ def validate_tier_transition(from_state: TierState, to_state: TierState) -> bool
 class TierStateMachine:
     """Manages state transitions for a single tier with checkpoint persistence.
 
-    Each call to advance() executes the next action, updates the tier state
-    in the checkpoint, and saves the checkpoint atomically.
+    Delegates to the generic StateMachine[TierState] for each tier, constructing
+    a transient instance per call via _sm_for(tier_id).
 
     Usage:
         tsm = TierStateMachine(checkpoint, checkpoint_path)
@@ -191,6 +177,36 @@ class TierStateMachine:
         """
         return is_tier_terminal_state(self.get_state(tier_id))
 
+    def _sm_for(self, tier_id: str) -> StateMachine[TierState]:
+        """Construct a transient StateMachine instance for a tier.
+
+        Each call creates a fresh instance with closures capturing tier_id,
+        so state access is correctly scoped to the specific tier.
+
+        Args:
+            tier_id: Tier identifier
+
+        Returns:
+            A StateMachine[TierState] configured for this tier
+
+        """
+        from scylla.persistence.checkpoint import save_checkpoint
+
+        def apply(state: TierState) -> None:
+            self.checkpoint.set_tier_state(tier_id, state.value)
+
+        def persist(_state: TierState) -> None:
+            save_checkpoint(self.checkpoint, self.checkpoint_path)
+
+        return StateMachine[TierState](
+            transitions=TIER_TRANSITION_REGISTRY,
+            terminal_states=_TIER_TERMINAL_STATES,
+            get_state=lambda: self.get_state(tier_id),
+            apply_state=apply,
+            persistence_hook=persist,
+            label=f"tier[{tier_id}]",
+        )
+
     def advance(
         self,
         tier_id: str,
@@ -198,11 +214,7 @@ class TierStateMachine:
     ) -> TierState:
         """Advance the tier by one state transition.
 
-        1. Reads the current state from the checkpoint.
-        2. Looks up the next transition in the registry.
-        3. Executes the transition action (if provided).
-        4. Updates the checkpoint state.
-        5. Saves the checkpoint atomically.
+        Delegates to the generic StateMachine.advance().
 
         Args:
             tier_id: Tier identifier
@@ -218,41 +230,8 @@ class TierStateMachine:
             ValueError: If no transition is defined for the current state
 
         """
-        from scylla.persistence.checkpoint import save_checkpoint
-
-        current = self.get_state(tier_id)
-
-        if is_tier_terminal_state(current):
-            raise RuntimeError(f"Cannot advance tier {tier_id} from terminal state {current.value}")
-
-        transition = get_next_tier_transition(current)
-        if transition is None:
-            raise ValueError(
-                f"No transition defined from tier state {current.value} for tier {tier_id}"
-            )
-
-        logger.debug(
-            f"[{tier_id}] {current.value} -> {transition.to_state.value}: {transition.description}"
-        )
-
-        # Execute the action if provided
-        action = actions.get(current)
-        if action is not None:
-            _t0 = time.monotonic()
-            action()
-            _elapsed = time.monotonic() - _t0
-            logger.info(
-                f"[{tier_id}] {current.value} -> {transition.to_state.value}: "
-                f"{transition.description} ({_elapsed:.1f}s)"
-            )
-
-        # Update state in checkpoint
-        self.checkpoint.set_tier_state(tier_id, transition.to_state.value)
-
-        # Save checkpoint atomically
-        save_checkpoint(self.checkpoint, self.checkpoint_path)
-
-        return transition.to_state
+        sm = self._sm_for(tier_id)
+        return sm.advance(actions)
 
     def advance_to_completion(
         self,
@@ -262,14 +241,12 @@ class TierStateMachine:
     ) -> TierState:
         """Advance the tier through all states until COMPLETE is reached.
 
-        Useful for running a complete tier from start or resuming from any state.
+        Delegates to the generic StateMachine.advance_to_completion() with
+        tier-specific error handling.
+
         On exception, the tier is marked as FAILED in the checkpoint before the
         exception re-raises, enabling the experiment level to detect and continue
         with remaining tiers (partial-failure semantics).
-
-        If until_state is specified, the tier stops cleanly once that state is
-        reached (inclusive): the action that transitions INTO until_state IS
-        executed, but no further transitions run.
 
         Args:
             tier_id: Tier identifier
@@ -282,40 +259,16 @@ class TierStateMachine:
             Final TierState (COMPLETE or until_state)
 
         """
-        try:
-            while not self.is_complete(tier_id):
-                new_state = self.advance(tier_id, actions)
-                if until_state is not None and new_state == until_state:
-                    logger.info(
-                        f"[{tier_id}] Reached --until-tier target state: {until_state.value}"
-                    )
-                    break
-        except Exception as e:
-            from scylla.e2e.rate_limit import RateLimitError
-            from scylla.e2e.shutdown import ShutdownInterruptedError
-            from scylla.persistence.checkpoint import save_checkpoint
+        from scylla.e2e.rate_limit import RateLimitError
+        from scylla.e2e.shutdown import ShutdownInterruptedError
 
-            if isinstance(e, ShutdownInterruptedError):
-                # Ctrl+C interrupted this tier — leave it at CONFIG_LOADED (resumable)
-                # rather than FAILED so the next invocation can continue where we left off.
-                current = self.get_state(tier_id)
-                logger.warning(
-                    f"[{tier_id}] Shutdown interrupted at {current.value} "
-                    "— tier left at config_loaded (not FAILED)"
-                )
-                self.checkpoint.set_tier_state(tier_id, TierState.CONFIG_LOADED.value)
-                save_checkpoint(self.checkpoint, self.checkpoint_path)
-                raise
-
-            if isinstance(e, RateLimitError):
-                # Rate limits propagate to experiment level by design;
-                # TierState has no INTERRUPTED state.
-                logger.warning(
-                    f"[{tier_id}] Rate limit encountered in tier state machine: {e}. "
-                    "Marking tier as FAILED — rate limit handling occurs at experiment level."
-                )
-            self.checkpoint.set_tier_state(tier_id, TierState.FAILED.value)
-            save_checkpoint(self.checkpoint, self.checkpoint_path)
-            raise
-
-        return self.get_state(tier_id)
+        sm = self._sm_for(tier_id)
+        return sm.advance_to_completion(
+            actions,
+            until_state=until_state,
+            error_state_map=[
+                (ShutdownInterruptedError, TierState.CONFIG_LOADED),
+                (RateLimitError, TierState.FAILED),
+            ],
+            failure_state=TierState.FAILED,
+        )

--- a/tests/unit/core/test_state_machine.py
+++ b/tests/unit/core/test_state_machine.py
@@ -263,15 +263,15 @@ class TestAdvanceToCompletionNewBehaviors:
         persistence_calls: list[_S] = []
         sm = _build(state, persistence_calls=persistence_calls)
 
-        class _SwallowMe(RuntimeError):
+        class _SwallowMeError(RuntimeError):
             """Custom error to be swallowed."""
 
         def boom() -> None:
-            raise _SwallowMe("swallow me")
+            raise _SwallowMeError("swallow me")
 
         final = sm.advance_to_completion(
             {_S.A: boom},
-            swallow_types=(_SwallowMe,),
+            swallow_types=(_SwallowMeError,),
         )
         # Swallowed exception returns current state without state change.
         assert final == _S.A
@@ -287,16 +287,16 @@ class TestAdvanceToCompletionNewBehaviors:
         persistence_calls: list[_S] = []
         sm = _build(state, persistence_calls=persistence_calls)
 
-        class _SwallowMe(RuntimeError):
+        class _SwallowMeError(RuntimeError):
             """Custom error that matches both swallow_types and error_state_map."""
 
         def boom() -> None:
-            raise _SwallowMe("swallow me")
+            raise _SwallowMeError("swallow me")
 
         final = sm.advance_to_completion(
             {_S.A: boom},
-            swallow_types=(_SwallowMe,),
-            error_state_map=[(_SwallowMe, _S.FAILED)],
+            swallow_types=(_SwallowMeError,),
+            error_state_map=[(_SwallowMeError, _S.FAILED)],
         )
         # swallow_types takes precedence; no state change, no error_state_map application.
         assert final == _S.A

--- a/tests/unit/core/test_state_machine.py
+++ b/tests/unit/core/test_state_machine.py
@@ -252,3 +252,96 @@ class TestStateMachineAdvanceToCompletion:
         final = sm.advance_to_completion({_S.A: lambda: called.append("x")})
         assert final == _S.DONE
         assert called == []
+
+
+class TestAdvanceToCompletionNewBehaviors:
+    """Tests for the new swallow_types and target=None features."""
+
+    def test_advance_to_completion_swallow_type_returns_current_state_unchanged(self) -> None:
+        """swallow_types exceptions are caught, logged, and return current state unchanged."""
+        state = [_S.A]
+        persistence_calls: list[_S] = []
+        sm = _build(state, persistence_calls=persistence_calls)
+
+        class _SwallowMe(RuntimeError):
+            """Custom error to be swallowed."""
+
+        def boom() -> None:
+            raise _SwallowMe("swallow me")
+
+        final = sm.advance_to_completion(
+            {_S.A: boom},
+            swallow_types=(_SwallowMe,),
+        )
+        # Swallowed exception returns current state without state change.
+        assert final == _S.A
+        assert state[0] == _S.A
+        # No persistence hook called.
+        assert persistence_calls == []
+
+    def test_advance_to_completion_swallow_type_takes_precedence_over_error_map(
+        self,
+    ) -> None:
+        """swallow_types takes precedence over error_state_map."""
+        state = [_S.A]
+        persistence_calls: list[_S] = []
+        sm = _build(state, persistence_calls=persistence_calls)
+
+        class _SwallowMe(RuntimeError):
+            """Custom error that matches both swallow_types and error_state_map."""
+
+        def boom() -> None:
+            raise _SwallowMe("swallow me")
+
+        final = sm.advance_to_completion(
+            {_S.A: boom},
+            swallow_types=(_SwallowMe,),
+            error_state_map=[(_SwallowMe, _S.FAILED)],
+        )
+        # swallow_types takes precedence; no state change, no error_state_map application.
+        assert final == _S.A
+        assert state[0] == _S.A
+        assert persistence_calls == []
+
+    def test_advance_to_completion_error_state_map_target_none_re_raises_without_state_change(
+        self,
+    ) -> None:
+        """error_state_map with target=None re-raises without changing state."""
+        state = [_S.A]
+        persistence_calls: list[_S] = []
+        sm = _build(state, persistence_calls=persistence_calls)
+
+        def boom() -> None:
+            raise RuntimeError("no state change")
+
+        # target=None in the error_state_map means "matched but don't apply state".
+        with pytest.raises(RuntimeError, match="no state change"):
+            sm.advance_to_completion(
+                {_S.A: boom},
+                error_state_map=[(RuntimeError, None)],
+                failure_state=_S.FAILED,
+            )
+        # Exception matched with target=None: state untouched, no persistence.
+        assert state[0] == _S.A
+        assert persistence_calls == []
+
+    def test_advance_to_completion_error_state_map_target_concrete_applies_state_then_re_raises(
+        self,
+    ) -> None:
+        """error_state_map with concrete target applies state and persistence before re-raising."""
+        state = [_S.A]
+        persistence_calls: list[_S] = []
+        sm = _build(state, persistence_calls=persistence_calls)
+
+        def boom() -> None:
+            raise RuntimeError("apply state")
+
+        # target=_S.FAILED in the error_state_map means "matched, apply state, then re-raise".
+        with pytest.raises(RuntimeError, match="apply state"):
+            sm.advance_to_completion(
+                {_S.A: boom},
+                error_state_map=[(RuntimeError, _S.FAILED)],
+            )
+        # Exception matched with concrete target: state applied, persistence called.
+        assert state[0] == _S.FAILED
+        assert persistence_calls == [_S.FAILED]


### PR DESCRIPTION
## Summary

Consolidates four independent state-machine implementations (experiment, tier, subtest, run) onto the single generic `StateMachine[TState]` in `src/scylla/core/state_machine.py`, eliminating ~300–400 LoC of duplicated transition validation, exception handling, and state persistence.

## Changes

- **Extend generic StateMachine** with `target=None` error-state semantics and `swallow_types` exception precedence (two backward-compatible params)
- **Port tier_state_machine.py**: `TierTransition` → `Transition[TierState]` alias; `advance_to_completion` delegates via `_sm_for(tier_id)` transient instance
- **Port subtest_state_machine.py**: preserve `UntilHaltError` swallowing in `advance_to_completion`; `advance()` still handles `UntilHaltError` inline to force `RUNS_IN_PROGRESS` state before re-raising
- **Port state_machine.py** (run FSM): add `_sm_for(tier_id, subtest_id, run_num)` transient constructor; delegate `advance_to_completion` with `RateLimitError` and `ShutdownInterruptedError` error-map entries
- **Add 5 new unit tests** to `test_state_machine.py` covering `target=None` and `swallow_types` behaviors; all 179 existing e2e FSM tests pass
- **Per-FSM error handling contracts** verified line-by-line (tier `CONFIG_LOADED` reset, run `RATE_LIMITED` state, subtest `UntilHaltError` swallow)

## Test Plan

- [x] All 179 existing e2e FSM tests pass (tier: 34, subtest: 52, run: 50, runner: 43)
- [x] 5 new generic state machine tests for `target=None` and `swallow_types` pass
- [x] All pre-commit hooks pass (ruff, mypy, bandit, shellcheck, etc.)
- [x] Commit is cryptographically signed
- [x] Closing #1942

Closes #1942"