### PR TITLE
feat(observability): wire OTel spans and Prometheus metrics at call sites (#1949)

### DIFF
--- a/docs/dev/metrics-emitter.md
+++ b/docs/dev/metrics-emitter.md
@@ -5,9 +5,8 @@ abstraction that lets an operator forward ProjectScylla experiment metrics
 (pass rates, Cost-of-Pass, latency, etc.) into a queryable time-series
 database (TSDB) such as Prometheus or VictoriaMetrics.
 
-> **Status: opt-in scaffolding.** No existing metric-computation site is
-> wired to an emitter yet. Wiring is tracked as a follow-up under issue
-> [#1888](https://github.com/HomericIntelligence/ProjectScylla/issues/1888).
+See `docs/dev/tracing.md` for the complete **Instrumentation Map** listing
+every wired call site with its span, counter, histogram, and labels.
 
 ## API
 
@@ -17,16 +16,34 @@ from scylla.metrics.emitter import get_default_emitter
 emitter = get_default_emitter()
 emitter.emit_counter("scylla_runs_total", 1, labels={"tier": "T2"})
 emitter.emit_gauge("scylla_pass_rate", 0.67, labels={"tier": "T2"})
+emitter.emit_histogram("scylla_latency_seconds", 1.23, labels={"tier": "T2"})
 ```
 
-- `MetricEmitter` — abstract base class with `emit_counter` and
-  `emit_gauge`. (Histograms are intentionally out of scope for v1.)
+- `MetricEmitter` — abstract base class with `emit_counter`, `emit_gauge`,
+  and `emit_histogram`. The base `emit_histogram` is a silent no-op so
+  existing operator-implemented subclasses continue to work without changes.
 - `NoOpEmitter` — drops every sample. **Default**.
 - `PrometheusTextfileEmitter(path)` — writes Prometheus textfile-collector
   format to `path` using an atomic `write tmp + os.replace` cycle.
 - `get_default_emitter()` — returns a `PrometheusTextfileEmitter` if the
   environment variable `SCYLLA_METRICS_PATH` is set, otherwise a
   `NoOpEmitter`.
+
+### Histogram bucket boundaries
+
+`PrometheusTextfileEmitter` uses fixed bucket boundaries (in seconds):
+
+```
+0.1, 0.5, 1.0, 2.0, 5.0, 10.0, 30.0, 60.0, +Inf
+```
+
+Histograms are stored separately from counters/gauges in `_histograms` and
+rendered as canonical Prometheus blocks in the textfile so repeated
+observations never produce duplicate `_bucket` lines.
+
+**Operator-implemented subclasses:** The base `emit_histogram` is a silent
+no-op. Existing custom emitter subclasses continue to work, but histogram
+observations are silently dropped until the operator overrides the method.
 
 ## Output format
 
@@ -78,12 +95,9 @@ both POSIX and Windows when source and destination share a filesystem.
 The textfile collector therefore sees either the previous full snapshot
 or the new full snapshot — never a partially written line.
 
-## What this PR does **not** do
+## What this module does **not** do
 
 - Does **not** add any new runtime dependency (no `prometheus_client`,
   no `statsd`).
-- Does **not** modify any existing metric-computation site. Wiring
-  `emit_counter` / `emit_gauge` calls into the experiment runner,
-  judge, or aggregator is out of scope; see the #1888 follow-up.
 - Does **not** prescribe a TSDB topology. Choosing Prometheus vs.
   VictoriaMetrics vs. another backend is an operator decision.

--- a/docs/dev/tracing.md
+++ b/docs/dev/tracing.md
@@ -81,16 +81,56 @@ Child spans below this root cover the rest of the runtime — see
 Beyond the single root `scylla.experiment.run` span, the runtime emits
 child spans at every meaningful execution boundary. The full hierarchy is:
 
-| Span name              | Emitted by                                        | Attributes                                                                                       |
-|------------------------|---------------------------------------------------|--------------------------------------------------------------------------------------------------|
-| `scylla.experiment.run` | `src/scylla/cli/main.py`                          | `experiment.test_id`, `experiment.model`, `experiment.runs_per_tier`, `experiment.tiers`         |
-| `scylla.tier`          | `src/scylla/e2e/runner_internals/runner_core.py`  | `scylla.tier_id`, `scylla.experiment_id`                                                         |
-| `scylla.subtest`       | `src/scylla/e2e/subtest_executor.py`              | `scylla.tier_id`, `scylla.subtest_id`, `scylla.experiment_id`                                    |
-| `scylla.run`           | `src/scylla/e2e/subtest_executor.py`              | `scylla.tier_id`, `scylla.subtest_id`, `scylla.run_num`, `scylla.experiment_id`                  |
-| `scylla.judge`         | `src/scylla/e2e/judge_runner.py`                  | `scylla.judge_model`, `scylla.judge_number`                                                      |
+| Span name                        | Emitted by                                        | Attributes                                                                                       |
+|----------------------------------|---------------------------------------------------|--------------------------------------------------------------------------------------------------|
+| `scylla.experiment.run`          | `src/scylla/cli/main.py`                          | `experiment.test_id`, `experiment.model`, `experiment.runs_per_tier`, `experiment.tiers`         |
+| `scylla.tier`                    | `src/scylla/e2e/runner_internals/runner_core.py`  | `scylla.tier_id`, `scylla.experiment_id`                                                         |
+| `scylla.subtest`                 | `src/scylla/e2e/subtest_executor.py`              | `scylla.tier_id`, `scylla.subtest_id`, `scylla.experiment_id`                                    |
+| `scylla.run`                     | `src/scylla/e2e/subtest_executor.py`              | `scylla.tier_id`, `scylla.subtest_id`, `scylla.run_num`, `scylla.experiment_id`                  |
+| `scylla.judge`                   | `src/scylla/e2e/judge_runner.py`                  | `scylla.judge_model`, `scylla.judge_number`                                                      |
+| `scylla.container.run`           | `src/scylla/executor/docker.py`                   | `scylla.image`, `scylla.container_id`, `scylla.exit_code`                                        |
+| `scylla.container.run_detached`  | `src/scylla/executor/docker.py`                   | `scylla.image`, `scylla.container_id`                                                            |
+| `scylla.container.stop`          | `src/scylla/executor/docker.py`                   | `scylla.container_id`                                                                            |
+| `scylla.rate_limit.pause`        | `src/scylla/e2e/rate_limit.py`                    | `scylla.reason`, `scylla.retry_after_seconds`                                                    |
 
 Failures at any level call `span.record_exception(exc)` before re-raising,
 so spans carry exception events even when the run itself fails.
+
+## Instrumentation Map
+
+Every actively-wired call site, with its span, counter, histogram, labels, and source file.
+
+| Instrumentation Point | Span | Counter | Histogram | Labels | Source File |
+|-----------------------|------|---------|-----------|--------|-------------|
+| Experiment run (root) | `scylla.experiment.run` | — | — | `experiment.test_id`, `experiment.model` | `src/scylla/cli/main.py` |
+| Tier start/end | `scylla.tier` | `scylla_tier_runs_total` | — | `tier`, `outcome`, `experiment` | `src/scylla/e2e/runner_internals/runner_finalization.py` |
+| Subtest start/end | `scylla.subtest` | `scylla_subtest_runs_total` | — | `tier`, `outcome` | `src/scylla/e2e/subtest_executor.py` |
+| Run start/end | `scylla.run` | `scylla_experiment_pass_rate` (gauge) | — | `tier`, `outcome` | `src/scylla/e2e/subtest_executor.py` |
+| Judge call | `scylla.judge` | `scylla_judge_evaluations_total` | `scylla_judge_call_seconds` | `model` | `src/scylla/e2e/judge_runner.py` |
+| Adapter call | — | — | `scylla_adapter_call_seconds` | `tier`, `subtest`, `model` | `src/scylla/e2e/stages.py` |
+| Checkpoint save | — | `scylla_checkpoint_save_total` | `scylla_checkpoint_save_seconds` | `experiment`, `outcome` | `src/scylla/persistence/checkpoint.py` |
+| Rate-limit pause | `scylla.rate_limit.pause` | `scylla_rate_limit_pauses_total` | `scylla_rate_limit_pause_seconds` | `reason` | `src/scylla/e2e/rate_limit.py` |
+| Container run | `scylla.container.run` | `scylla_container_lifecycle_total` | `scylla_container_run_seconds` | `event`, `image` | `src/scylla/executor/docker.py` |
+| Container stop | `scylla.container.stop` | `scylla_container_lifecycle_total` | `scylla_container_stop_seconds` | `event` | `src/scylla/executor/docker.py` |
+| Error dispatch | — | `scylla_errors_total` | — | `error_class`, `tier` | `src/scylla/e2e/parallel_executor.py`, `src/scylla/e2e/subtest_executor.py` |
+| Config startup | — | — (gauge) | — | — | `src/scylla/cli/main.py` |
+
+## Troubleshooting
+
+**Empty textfile (`$SCYLLA_METRICS_PATH`):**
+
+- Check that `SCYLLA_METRICS_PATH` is set and the parent directory is writable.
+- Check that the process has write permission: `touch $SCYLLA_METRICS_PATH`.
+
+**Missing `trace_id` / `span_id` in JSON logs:**
+
+- Verify `opentelemetry-api` is installed: `pip show opentelemetry-api`.
+- Confirm `SCYLLA_OTEL_EXPORTER` is set (even to `console`) — the trace fields are injected only when an active span exists.
+
+**Traces and logs not correlated:**
+
+- Set both `SCYLLA_OTEL_EXPORTER` and `SCYLLA_JSON_LOGS=1` together. The JSON formatter injects `trace_id`/`span_id` from the currently active OTel span; if tracing is not configured there is no active span to read.
+- Verify the same process sets both env vars (not split across a shell wrapper and the subprocess).
 
 > **Cardinality note.** `scylla.subtest_id` is recorded as a span attribute
 > only — never as a metric label. The OTLP collector budgets cardinality

--- a/src/scylla/cli/main.py
+++ b/src/scylla/cli/main.py
@@ -1,6 +1,7 @@
 """Command-line interface for ProjectScylla."""
 
 import json
+import os
 import statistics
 import sys
 from datetime import datetime, timezone
@@ -12,6 +13,7 @@ import click
 from scylla import __version__
 from scylla.config import DEFAULT_JUDGE_MODEL, ConfigLoader
 from scylla.e2e.orchestrator import EvalOrchestrator, OrchestratorConfig
+from scylla.metrics.emitter import get_default_emitter
 from scylla.reporting import (
     HtmlReportGenerator,
     JsonReportGenerator,
@@ -53,6 +55,19 @@ def cli() -> None:
     # Opt-in OpenTelemetry tracing via SCYLLA_OTEL_EXPORTER=console|otlp.
     # When unset, this is a no-op and no SDK imports happen.
     configure_tracing()
+    # Emit one-shot startup gauges so operators can verify observability is active.
+    try:
+        _startup_emitter = get_default_emitter()
+        _startup_emitter.emit_gauge(
+            "scylla_config_otel_enabled",
+            1.0 if os.environ.get("SCYLLA_OTEL_EXPORTER") else 0.0,
+        )
+        _startup_emitter.emit_gauge(
+            "scylla_config_json_logs_enabled",
+            1.0 if is_json_logging_enabled() else 0.0,
+        )
+    except Exception:
+        pass
 
 
 @cli.command()

--- a/src/scylla/e2e/judge_runner.py
+++ b/src/scylla/e2e/judge_runner.py
@@ -209,9 +209,15 @@ def _run_judge(  # noqa: C901  # multi-judge consensus with rate-limit/error bra
                     raise
                 finally:
                     try:
+                        _elapsed = float(_time.monotonic() - _judge_start)
                         _emitter.emit_gauge(
                             "scylla_judge_call_duration_seconds",
-                            float(_time.monotonic() - _judge_start),
+                            _elapsed,
+                            labels={"model": model},
+                        )
+                        _emitter.emit_histogram(
+                            "scylla_judge_call_seconds",
+                            _elapsed,
                             labels={"model": model},
                         )
                     except Exception as _e:  # never break judge call

--- a/src/scylla/e2e/log_context.py
+++ b/src/scylla/e2e/log_context.py
@@ -49,6 +49,11 @@ def clear_log_context() -> None:
     _context.run_num = None
 
 
+def current_tier_id() -> str:
+    """Return the tier_id from the current thread's log context, or empty string."""
+    return getattr(_context, "tier_id", "")
+
+
 class ContextFilter(logging.Filter):
     """Logging filter that injects thread-local tier/subtest/run context.
 

--- a/src/scylla/e2e/parallel_executor.py
+++ b/src/scylla/e2e/parallel_executor.py
@@ -16,6 +16,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
+from scylla.e2e.log_context import current_tier_id
 from scylla.e2e.models import (
     ExperimentConfig,
     SubTestResult,
@@ -30,6 +31,7 @@ from scylla.e2e.rate_limit import (
     is_weekly_limit,
     wait_for_rate_limit,
 )
+from scylla.metrics.emitter import get_default_emitter
 
 if TYPE_CHECKING:
     from scylla.e2e.models import SubTestConfig, TierBaseline
@@ -39,6 +41,7 @@ if TYPE_CHECKING:
     from scylla.persistence.checkpoint import E2ECheckpoint
 
 logger = logging.getLogger(__name__)
+_emitter = get_default_emitter()
 
 
 class RateLimitCoordinator:
@@ -248,8 +251,24 @@ def run_tier_subtests_parallel(
             logger.warning(
                 f"[SKIP] Subtest {subtest.id} skipped due to infrastructure failure: {e}"
             )
+            try:
+                _emitter.emit_counter(
+                    "scylla_errors_total",
+                    1,
+                    labels={"error_class": type(e).__name__, "tier": current_tier_id()},
+                )
+            except Exception as _me:
+                logger.warning(f"Error metric emission failed (non-fatal): {_me}")
             completed_count += 1
         except RateLimitError as e:
+            try:
+                _emitter.emit_counter(
+                    "scylla_errors_total",
+                    1,
+                    labels={"error_class": type(e).__name__, "tier": current_tier_id()},
+                )
+            except Exception as _me:
+                logger.warning(f"Error metric emission failed (non-fatal): {_me}")
             completed_count = _handle_rate_limit(
                 e,
                 executor=executor,

--- a/src/scylla/e2e/rate_limit.py
+++ b/src/scylla/e2e/rate_limit.py
@@ -19,11 +19,15 @@ from typing import TYPE_CHECKING
 from pydantic import BaseModel, model_validator
 
 from scylla.e2e.paths import get_agent_dir
+from scylla.metrics.emitter import get_default_emitter
+from scylla.utils.tracing import get_tracer
 
 if TYPE_CHECKING:
     from scylla.persistence.checkpoint import E2ECheckpoint
 
 logger = logging.getLogger(__name__)
+_tracer = get_tracer(__name__)
+_emitter = get_default_emitter()
 
 
 class RateLimitInfo(BaseModel):
@@ -400,6 +404,9 @@ def wait_for_rate_limit(
     # Ensure 10% buffer (should already be added by parse_retry_after)
     wait_time = retry_after
 
+    # Use checkpoint.rate_limit_source as the reason label for metrics/spans
+    reason = checkpoint.rate_limit_source or "unknown"
+
     # Update checkpoint with pause status
     from scylla.persistence.checkpoint import save_checkpoint
 
@@ -415,50 +422,64 @@ def wait_for_rate_limit(
         f"⏸️  Rate limit hit. Pausing for {wait_time:.0f}s (until {checkpoint.rate_limit_until})"
     )
 
-    # Wait with Fibonacci backoff for status updates (1s, 1s, 2s, 3s, 5s, 8s... up to 5 min)
-    remaining = wait_time
-    fib_prev, fib_curr = 1, 1  # Start Fibonacci sequence at 1 second
-    max_interval = 300  # Cap at 5 minutes (300 seconds)
+    _pause_start = time.monotonic()
+    with _tracer.start_as_current_span("scylla.rate_limit.pause") as _span:
+        _span.set_attribute("scylla.reason", reason)
+        _span.set_attribute("scylla.retry_after_seconds", float(retry_after or 0.0))
 
-    while remaining > 0:
-        # Calculate next interval with Fibonacci backoff, capped at 5 minutes
-        interval = min(fib_curr, max_interval)
-        sleep_chunk = min(interval, remaining)
-        time.sleep(sleep_chunk)
-        remaining -= sleep_chunk
+        # Wait with Fibonacci backoff for status updates (1s, 1s, 2s, 3s, 5s, 8s... up to 5 min)
+        remaining = wait_time
+        fib_prev, fib_curr = 1, 1  # Start Fibonacci sequence at 1 second
+        max_interval = 300  # Cap at 5 minutes (300 seconds)
 
-        # Check for shutdown between sleep iterations
-        from scylla.e2e.shutdown import ShutdownInterruptedError, is_shutdown_requested
+        while remaining > 0:
+            # Calculate next interval with Fibonacci backoff, capped at 5 minutes
+            interval = min(fib_curr, max_interval)
+            sleep_chunk = min(interval, remaining)
+            time.sleep(sleep_chunk)
+            remaining -= sleep_chunk
 
-        if is_shutdown_requested():
-            # Restore checkpoint to running state before raising
-            checkpoint.status = "running"
-            checkpoint.rate_limit_until = None
-            checkpoint.rate_limit_source = None
-            save_checkpoint(checkpoint, checkpoint_path)
-            raise ShutdownInterruptedError("Shutdown requested during rate limit wait")
+            # Check for shutdown between sleep iterations
+            from scylla.e2e.shutdown import ShutdownInterruptedError, is_shutdown_requested
 
-        if remaining > 0:
-            # Calculate when next update will occur
-            next_fib = fib_prev + fib_curr
-            next_update_sec = min(next_fib, max_interval, remaining)
+            if is_shutdown_requested():
+                # Restore checkpoint to running state before raising
+                checkpoint.status = "running"
+                checkpoint.rate_limit_until = None
+                checkpoint.rate_limit_source = None
+                save_checkpoint(checkpoint, checkpoint_path)
+                raise ShutdownInterruptedError("Shutdown requested during rate limit wait")
 
-            minutes = remaining / 60
-            next_update_min = next_update_sec / 60
+            if remaining > 0:
+                # Calculate when next update will occur
+                next_fib = fib_prev + fib_curr
+                next_update_sec = min(next_fib, max_interval, remaining)
 
-            if minutes >= 1:
-                log_func(
-                    f"   Rate limit wait: {minutes:.1f} minutes remaining "
-                    f"(next update in {next_update_min:.1f} min)"
-                )
-            else:
-                log_func(
-                    f"   Rate limit wait: {remaining:.0f} seconds remaining "
-                    f"(next update in {next_update_sec:.0f} sec)"
-                )
+                minutes = remaining / 60
+                next_update_min = next_update_sec / 60
 
-            # Update Fibonacci sequence for next iteration
-            fib_prev, fib_curr = fib_curr, next_fib
+                if minutes >= 1:
+                    log_func(
+                        f"   Rate limit wait: {minutes:.1f} minutes remaining "
+                        f"(next update in {next_update_min:.1f} min)"
+                    )
+                else:
+                    log_func(
+                        f"   Rate limit wait: {remaining:.0f} seconds remaining "
+                        f"(next update in {next_update_sec:.0f} sec)"
+                    )
+
+                # Update Fibonacci sequence for next iteration
+                fib_prev, fib_curr = fib_curr, next_fib
+
+    _elapsed = time.monotonic() - _pause_start
+    try:
+        _emitter.emit_counter("scylla_rate_limit_pauses_total", 1, labels={"reason": reason})
+        _emitter.emit_histogram(
+            "scylla_rate_limit_pause_seconds", _elapsed, labels={"reason": reason}
+        )
+    except Exception as _me:
+        logger.warning(f"Rate limit metric emission failed (non-fatal): {_me}")
 
     # Update checkpoint - resuming
     checkpoint.status = "running"

--- a/src/scylla/e2e/stages.py
+++ b/src/scylla/e2e/stages.py
@@ -604,9 +604,15 @@ def _emit_adapter_metrics(ctx: RunContext) -> None:
             "model": ctx.config.models[0] if ctx.config.models else "",
         }
         if ctx.agent_duration is not None:
+            _adapter_elapsed = float(ctx.agent_duration)
             emitter.emit_gauge(
                 "scylla_adapter_call_duration_seconds",
-                float(ctx.agent_duration),
+                _adapter_elapsed,
+                labels=labels,
+            )
+            emitter.emit_histogram(
+                "scylla_adapter_call_seconds",
+                _adapter_elapsed,
                 labels=labels,
             )
         if ctx.agent_result is not None:

--- a/src/scylla/e2e/subtest_executor.py
+++ b/src/scylla/e2e/subtest_executor.py
@@ -41,6 +41,7 @@ from scylla.e2e.judge_runner import (
     _run_judge,
     _save_judge_result,
 )
+from scylla.e2e.log_context import current_tier_id
 from scylla.e2e.models import (
     E2ERunResult,
     ExperimentConfig,
@@ -68,6 +69,7 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 _tracer = get_tracer(__name__)
+_emitter = get_default_emitter()
 
 __all__ = [
     "SubTestExecutor",
@@ -736,6 +738,18 @@ class SubTestExecutor:
                             if run_dir.exists():
                                 _move_to_failed(run_dir)
 
+                            try:
+                                _emitter.emit_counter(
+                                    "scylla_errors_total",
+                                    1,
+                                    labels={
+                                        "error_class": type(e).__name__,
+                                        "tier": current_tier_id(),
+                                    },
+                                )
+                            except Exception as _me:
+                                logger.warning(f"Error metric emission failed (non-fatal): {_me}")
+
                             # Signal coordinator if available
                             if coordinator:
                                 coordinator.signal_rate_limit(e.info)
@@ -743,6 +757,17 @@ class SubTestExecutor:
                             raise
 
                     except Exception as _exc:
+                        try:
+                            _emitter.emit_counter(
+                                "scylla_errors_total",
+                                1,
+                                labels={
+                                    "error_class": type(_exc).__name__,
+                                    "tier": current_tier_id(),
+                                },
+                            )
+                        except Exception as _me:
+                            logger.warning(f"Error metric emission failed (non-fatal): {_me}")
                         _run_span.record_exception(_exc)
                         raise
 

--- a/src/scylla/executor/docker.py
+++ b/src/scylla/executor/docker.py
@@ -14,16 +14,48 @@ Design Decisions (from plan review):
 from __future__ import annotations
 
 import contextlib
+import logging
 import os
 import subprocess
+import time
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import TYPE_CHECKING
 
 from scylla.config.models import ResourceLimitsConfig
+from scylla.metrics.emitter import get_default_emitter
+from scylla.utils.tracing import get_tracer
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
+
+logger = logging.getLogger(__name__)
+_tracer = get_tracer(__name__)
+_emitter = get_default_emitter()
+
+
+def _emit_container_lifecycle(event: str, image: str) -> None:
+    """Emit container lifecycle counter. Best-effort, never raises."""
+    try:
+        _emitter.emit_counter(
+            "scylla_container_lifecycle_total",
+            1,
+            labels={"event": event, "image": image},
+        )
+    except Exception as _e:
+        logger.warning(f"Container lifecycle metric emission failed (non-fatal): {_e}")
+
+
+def _emit_container_run_duration(elapsed: float, image: str) -> None:
+    """Emit container run duration histogram. Best-effort, never raises."""
+    try:
+        _emitter.emit_histogram(
+            "scylla_container_run_seconds",
+            elapsed,
+            labels={"image": image},
+        )
+    except Exception as _e:
+        logger.warning(f"Container run duration metric emission failed (non-fatal): {_e}")
 
 
 class DockerError(Exception):
@@ -263,42 +295,56 @@ class DockerExecutor:
 
         """
         cmd = self._build_run_command(config)
+        _run_start = time.monotonic()
 
-        try:
-            result = subprocess.run(
-                cmd,
-                capture_output=True,
-                text=True,
-                timeout=config.timeout_seconds,
-            )
+        with _tracer.start_as_current_span("scylla.container.run") as _span:
+            _span.set_attribute("scylla.image", config.image)
+            try:
+                _emit_container_lifecycle("start", config.image)
+                result = subprocess.run(
+                    cmd,
+                    capture_output=True,
+                    text=True,
+                    timeout=config.timeout_seconds,
+                )
 
-            # Extract container ID from output (for named containers, use name)
-            container_id = config.name or self._get_last_container_id()
+                # Extract container ID from output (for named containers, use name)
+                container_id = config.name or self._get_last_container_id()
+                _span.set_attribute("scylla.container_id", container_id or "unknown")
+                _span.set_attribute("scylla.exit_code", result.returncode)
+                _emit_container_lifecycle("stop", config.image)
+                _emit_container_run_duration(time.monotonic() - _run_start, config.image)
 
-            return ContainerResult(
-                container_id=container_id or "unknown",
-                exit_code=result.returncode,
-                stdout=result.stdout,
-                stderr=result.stderr,
-                timed_out=False,
-            )
+                return ContainerResult(
+                    container_id=container_id or "unknown",
+                    exit_code=result.returncode,
+                    stdout=result.stdout,
+                    stderr=result.stderr,
+                    timed_out=False,
+                )
 
-        except subprocess.TimeoutExpired as e:
-            # Container is still running - stop it
-            container_id = config.name or self._get_last_container_id()
-            if container_id:
-                self.stop(container_id)
+            except subprocess.TimeoutExpired as e:
+                _span.record_exception(e)
+                _emit_container_lifecycle("fail", config.image)
+                _emit_container_run_duration(time.monotonic() - _run_start, config.image)
+                # Container is still running - stop it
+                container_id = config.name or self._get_last_container_id()
+                if container_id:
+                    self.stop(container_id)
 
-            return ContainerResult(
-                container_id=container_id or "unknown",
-                exit_code=-1,
-                stdout=e.stdout.decode() if e.stdout else "",
-                stderr=e.stderr.decode() if e.stderr else "",
-                timed_out=True,
-            )
+                return ContainerResult(
+                    container_id=container_id or "unknown",
+                    exit_code=-1,
+                    stdout=e.stdout.decode() if e.stdout else "",
+                    stderr=e.stderr.decode() if e.stderr else "",
+                    timed_out=True,
+                )
 
-        except subprocess.SubprocessError as e:
-            raise ContainerError(f"Failed to run container: {e}") from e
+            except subprocess.SubprocessError as e:
+                _span.record_exception(e)
+                _emit_container_lifecycle("fail", config.image)
+                _emit_container_run_duration(time.monotonic() - _run_start, config.image)
+                raise ContainerError(f"Failed to run container: {e}") from e
 
     def run_detached(self, config: ContainerConfig) -> str:
         """Run a container in detached mode.
@@ -317,24 +363,32 @@ class DockerExecutor:
         # Insert -d flag after "docker run"
         cmd.insert(2, "-d")
 
-        try:
-            result = subprocess.run(
-                cmd,
-                capture_output=True,
-                text=True,
-                timeout=30,
-            )
+        with _tracer.start_as_current_span("scylla.container.run_detached") as _span:
+            _span.set_attribute("scylla.image", config.image)
+            try:
+                _emit_container_lifecycle("start", config.image)
+                result = subprocess.run(
+                    cmd,
+                    capture_output=True,
+                    text=True,
+                    timeout=30,
+                )
 
-            if result.returncode != 0:
-                raise ContainerError(f"Failed to start container: {result.stderr.strip()}")
+                if result.returncode != 0:
+                    raise ContainerError(f"Failed to start container: {result.stderr.strip()}")
 
-            container_id = result.stdout.strip()
-            return container_id
+                container_id = result.stdout.strip()
+                _span.set_attribute("scylla.container_id", container_id)
+                return container_id
 
-        except subprocess.TimeoutExpired:
-            raise ContainerError("Timed out starting container") from None
-        except subprocess.SubprocessError as e:
-            raise ContainerError(f"Failed to start container: {e}") from e
+            except subprocess.TimeoutExpired as e:
+                _span.record_exception(e)
+                _emit_container_lifecycle("fail", config.image)
+                raise ContainerError("Timed out starting container") from None
+            except subprocess.SubprocessError as e:
+                _span.record_exception(e)
+                _emit_container_lifecycle("fail", config.image)
+                raise ContainerError(f"Failed to start container: {e}") from e
 
     def stop(self, container_id: str, timeout: int = 10) -> None:
         """Stop a running container (preserves container for analysis).
@@ -347,24 +401,37 @@ class DockerExecutor:
             ContainerError: If stop operation fails.
 
         """
-        try:
-            result = subprocess.run(
-                ["docker", "stop", "-t", str(timeout), container_id],
-                capture_output=True,
-                text=True,
-                timeout=timeout + 30,  # Allow extra time for graceful shutdown
-            )
-
-            if result.returncode != 0 and "No such container" not in result.stderr:
-                raise ContainerError(
-                    f"Failed to stop container {container_id}: {result.stderr.strip()}"
+        _stop_start = time.monotonic()
+        with _tracer.start_as_current_span("scylla.container.stop") as _span:
+            _span.set_attribute("scylla.container_id", container_id)
+            try:
+                result = subprocess.run(
+                    ["docker", "stop", "-t", str(timeout), container_id],
+                    capture_output=True,
+                    text=True,
+                    timeout=timeout + 30,  # Allow extra time for graceful shutdown
                 )
 
-        except subprocess.TimeoutExpired:
-            # Force kill if stop times out
-            self._kill(container_id)
-        except subprocess.SubprocessError as e:
-            raise ContainerError(f"Failed to stop container: {e}") from e
+                if result.returncode != 0 and "No such container" not in result.stderr:
+                    raise ContainerError(
+                        f"Failed to stop container {container_id}: {result.stderr.strip()}"
+                    )
+
+            except subprocess.TimeoutExpired:
+                # Force kill if stop times out
+                self._kill(container_id)
+            except subprocess.SubprocessError as e:
+                raise ContainerError(f"Failed to stop container: {e}") from e
+
+        try:
+            _emitter.emit_counter("scylla_container_lifecycle_total", 1, labels={"event": "stop"})
+            _emitter.emit_histogram(
+                "scylla_container_stop_seconds",
+                time.monotonic() - _stop_start,
+                labels={"event": "stop"},
+            )
+        except Exception as _me:
+            logger.warning(f"Container stop metric emission failed (non-fatal): {_me}")
 
     def _kill(self, container_id: str) -> None:
         """Force kill a container.

--- a/src/scylla/metrics/emitter.py
+++ b/src/scylla/metrics/emitter.py
@@ -11,8 +11,8 @@ introduces no new runtime dependencies — the textfile output is plain text
 that the Prometheus node-exporter ``textfile`` collector (or VictoriaMetrics
 ``vmagent``) ingests natively.
 
-This is opt-in scaffolding only; no existing metrics call site is wired to an
-emitter yet. See ``docs/dev/metrics-emitter.md`` for the integration plan.
+See ``docs/dev/metrics-emitter.md`` for the full API reference and
+``docs/dev/tracing.md`` for the Instrumentation Map listing every wired site.
 """
 
 from __future__ import annotations
@@ -21,6 +21,7 @@ import contextlib
 import os
 import tempfile
 from abc import ABC, abstractmethod
+from dataclasses import dataclass, field
 from pathlib import Path
 from threading import Lock
 
@@ -30,6 +31,20 @@ __all__ = [
     "PrometheusTextfileEmitter",
     "get_default_emitter",
 ]
+
+# Default histogram bucket boundaries (seconds). +Inf is always appended.
+_BUCKETS: tuple[float, ...] = (0.1, 0.5, 1.0, 2.0, 5.0, 10.0, 30.0, 60.0)
+
+_LabelsKey = tuple[tuple[str, str], ...]
+
+
+@dataclass
+class _HistState:
+    """Accumulated state for one histogram series (name + label combination)."""
+
+    bucket_counts: list[int] = field(default_factory=lambda: [0] * (len(_BUCKETS) + 1))
+    sum: float = 0.0
+    count: int = 0
 
 
 def _format_labels(labels: dict[str, str] | None) -> str:
@@ -65,6 +80,19 @@ class MetricEmitter(ABC):
     ) -> None:
         """Emit a gauge sample."""
 
+    def emit_histogram(  # noqa: B027 — intentionally non-abstract for backward compat
+        self,
+        name: str,
+        value: float,
+        labels: dict[str, str] | None = None,
+    ) -> None:
+        """Emit a histogram observation.
+
+        The default implementation is a silent no-op so that existing
+        operator-implemented subclasses continue to work without changes.
+        Override in concrete emitters to record histogram data.
+        """
+
 
 class NoOpEmitter(MetricEmitter):
     """Default emitter that drops every sample."""
@@ -87,6 +115,15 @@ class NoOpEmitter(MetricEmitter):
         """Drop the sample (no-op)."""
         return
 
+    def emit_histogram(
+        self,
+        name: str,
+        value: float,
+        labels: dict[str, str] | None = None,
+    ) -> None:
+        """Drop the sample (no-op)."""
+        return
+
 
 class PrometheusTextfileEmitter(MetricEmitter):
     """Emit samples in Prometheus textfile-collector format.
@@ -94,12 +131,17 @@ class PrometheusTextfileEmitter(MetricEmitter):
     Each call appends one line to an in-memory buffer and atomically rewrites
     the target file (``write tmp + os.replace``) so a concurrent reader (the
     node-exporter textfile collector) never observes a partial line.
+
+    Histograms are stored separately in ``_histograms`` and rendered as
+    canonical Prometheus histogram blocks on each write so that repeated
+    observations never produce duplicate ``_bucket`` lines.
     """
 
     def __init__(self, path: str | os.PathLike[str]) -> None:
         """Create an emitter that writes to ``path`` (parent dirs auto-created)."""
         self._path = Path(path)
         self._lines: list[str] = []
+        self._histograms: dict[tuple[str, _LabelsKey], _HistState] = {}
         self._lock = Lock()
         # Ensure parent dir exists so the first emit doesn't crash.
         self._path.parent.mkdir(parents=True, exist_ok=True)
@@ -122,6 +164,33 @@ class PrometheusTextfileEmitter(MetricEmitter):
         """Append a gauge sample line and atomically rewrite the file."""
         self._append(name, float(value), labels)
 
+    def emit_histogram(
+        self,
+        name: str,
+        value: float,
+        labels: dict[str, str] | None = None,
+    ) -> None:
+        """Record a histogram observation and atomically rewrite the file.
+
+        Buckets follow ``_BUCKETS`` boundaries plus the implicit ``+Inf``
+        bucket. All mutations are guarded by ``self._lock``.
+        """
+        labels_key: _LabelsKey = tuple(sorted((labels or {}).items()))
+        key = (name, labels_key)
+        with self._lock:
+            state = self._histograms.get(key)
+            if state is None:
+                state = _HistState()
+                self._histograms[key] = state
+            for i, boundary in enumerate(_BUCKETS):
+                if value <= boundary:
+                    state.bucket_counts[i] += 1
+            # +Inf bucket always includes every observation
+            state.bucket_counts[len(_BUCKETS)] += 1
+            state.sum += value
+            state.count += 1
+            self._atomic_write()
+
     def _append(
         self,
         name: str,
@@ -136,7 +205,23 @@ class PrometheusTextfileEmitter(MetricEmitter):
     def _atomic_write(self) -> None:
         # Write to a sibling tmp file then os.replace — guaranteed atomic on
         # POSIX and Windows for files on the same filesystem.
-        body = "\n".join(self._lines) + "\n"
+        parts: list[str] = list(self._lines)
+        # Render histogram blocks: one canonical set of _bucket/_sum/_count
+        # lines per (name, labels) pair. Kept separate from self._lines so
+        # repeated observations never produce duplicate _bucket lines.
+        for (hist_name, labels_key), state in self._histograms.items():
+            label_dict = dict(labels_key)
+            for i, boundary in enumerate(_BUCKETS):
+                le_labels = {**label_dict, "le": str(boundary)}
+                parts.append(
+                    f"{hist_name}_bucket{_format_labels(le_labels)} {state.bucket_counts[i]}"
+                )
+            inf_labels = {**label_dict, "le": "+Inf"}
+            inf_count = state.bucket_counts[len(_BUCKETS)]
+            parts.append(f"{hist_name}_bucket{_format_labels(inf_labels)} {inf_count}")
+            parts.append(f"{hist_name}_sum{_format_labels(label_dict or None)} {state.sum}")
+            parts.append(f"{hist_name}_count{_format_labels(label_dict or None)} {state.count}")
+        body = "\n".join(parts) + "\n"
         fd, tmp_path = tempfile.mkstemp(
             prefix=self._path.name + ".",
             suffix=".tmp",

--- a/src/scylla/persistence/checkpoint.py
+++ b/src/scylla/persistence/checkpoint.py
@@ -575,9 +575,15 @@ def save_checkpoint(checkpoint: E2ECheckpoint, path: Path) -> None:
             try:
                 emitter = get_default_emitter()
                 labels = {"experiment": checkpoint.experiment_id}
+                _elapsed = float(_time.monotonic() - _save_start)
                 emitter.emit_gauge(
                     "scylla_checkpoint_save_duration_seconds",
-                    float(_time.monotonic() - _save_start),
+                    _elapsed,
+                    labels=labels,
+                )
+                emitter.emit_histogram(
+                    "scylla_checkpoint_save_seconds",
+                    _elapsed,
                     labels=labels,
                 )
                 emitter.emit_counter(

--- a/src/scylla/utils/tracing.py
+++ b/src/scylla/utils/tracing.py
@@ -28,8 +28,8 @@ Recognised values:
   ``OTEL_EXPORTER_OTLP_ENDPOINT`` env var (defaults to ``http://localhost:4317``)
 * unset / empty — NoOp tracing; no SDK imports happen
 
-Exhaustive instrumentation across every logging site is intentionally out of
-scope for this scaffold — see issue #1887 for the follow-up.
+See ``docs/dev/tracing.md`` for the complete Instrumentation Map and
+troubleshooting guide.
 """
 
 from __future__ import annotations

--- a/tests/unit/e2e/test_error_dispatch_observability.py
+++ b/tests/unit/e2e/test_error_dispatch_observability.py
@@ -1,0 +1,119 @@
+"""Tests for error-class counter emission at exception dispatch sites."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from pathlib import Path
+from unittest.mock import patch
+
+from scylla.e2e.log_context import current_tier_id, set_log_context
+from scylla.e2e.rate_limit import InfrastructureFailureError, RateLimitError, RateLimitInfo
+from scylla.metrics.emitter import PrometheusTextfileEmitter
+
+
+class TestCurrentTierId:
+    """Tests for the current_tier_id() accessor in log_context."""
+
+    def test_returns_empty_when_no_context(self) -> None:
+        """Returns empty string when no log context is set on this thread."""
+        # Ensure no context is set in this thread
+        from scylla.e2e.log_context import clear_log_context
+
+        clear_log_context()
+        assert current_tier_id() == ""
+
+    def test_returns_tier_id_when_set(self) -> None:
+        """Returns the tier_id that was previously set via set_log_context."""
+        set_log_context(tier_id="T3")
+        assert current_tier_id() == "T3"
+        from scylla.e2e.log_context import clear_log_context
+
+        clear_log_context()
+
+
+class TestParallelExecutorErrorEmit:
+    """Tests for scylla_errors_total counter at parallel_executor dispatch sites."""
+
+    def test_infrastructure_failure_emits_counter(self, tmp_path: Path) -> None:
+        """InfrastructureFailureError increments scylla_errors_total with correct labels."""
+        emitter = PrometheusTextfileEmitter(tmp_path / "test.prom")
+
+        with patch("scylla.e2e.parallel_executor._emitter", emitter):
+            from scylla.e2e.parallel_executor import _emitter as pe_emitter
+
+            # Simulate what the except InfrastructureFailureError block does
+            exc = InfrastructureFailureError("agent crashed")
+            set_log_context(tier_id="T1")
+            try:
+                pe_emitter.emit_counter(
+                    "scylla_errors_total",
+                    1,
+                    labels={"error_class": type(exc).__name__, "tier": current_tier_id()},
+                )
+            finally:
+                from scylla.e2e.log_context import clear_log_context
+
+                clear_log_context()
+
+        content = (tmp_path / "test.prom").read_text()
+        assert "scylla_errors_total" in content
+        assert 'error_class="InfrastructureFailureError"' in content
+        assert 'tier="T1"' in content
+
+    def test_rate_limit_error_emits_counter(self, tmp_path: Path) -> None:
+        """RateLimitError increments scylla_errors_total with error_class label."""
+        emitter = PrometheusTextfileEmitter(tmp_path / "test.prom")
+
+        with patch("scylla.e2e.parallel_executor._emitter", emitter):
+            from scylla.e2e.parallel_executor import _emitter as pe_emitter
+
+            info = RateLimitInfo(
+                source="judge",
+                error_message="rate limited",
+                retry_after_seconds=60,
+                detected_at=datetime.now(timezone.utc).isoformat(),
+            )
+            exc = RateLimitError(info)
+            set_log_context(tier_id="T2")
+            try:
+                pe_emitter.emit_counter(
+                    "scylla_errors_total",
+                    1,
+                    labels={"error_class": type(exc).__name__, "tier": current_tier_id()},
+                )
+            finally:
+                from scylla.e2e.log_context import clear_log_context
+
+                clear_log_context()
+
+        content = (tmp_path / "test.prom").read_text()
+        assert 'error_class="RateLimitError"' in content
+        assert 'tier="T2"' in content
+
+
+class TestSubtestExecutorErrorEmit:
+    """Tests for scylla_errors_total counter at subtest_executor dispatch sites."""
+
+    def test_emit_counter_uses_current_tier_id(self, tmp_path: Path) -> None:
+        """Generic exception increments scylla_errors_total with tier from log context."""
+        emitter = PrometheusTextfileEmitter(tmp_path / "test.prom")
+
+        with patch("scylla.e2e.subtest_executor._emitter", emitter):
+            from scylla.e2e.subtest_executor import _emitter as se_emitter
+
+            exc = ValueError("some error")
+            set_log_context(tier_id="T0")
+            try:
+                se_emitter.emit_counter(
+                    "scylla_errors_total",
+                    1,
+                    labels={"error_class": type(exc).__name__, "tier": current_tier_id()},
+                )
+            finally:
+                from scylla.e2e.log_context import clear_log_context
+
+                clear_log_context()
+
+        content = (tmp_path / "test.prom").read_text()
+        assert 'error_class="ValueError"' in content
+        assert 'tier="T0"' in content

--- a/tests/unit/e2e/test_rate_limit_observability.py
+++ b/tests/unit/e2e/test_rate_limit_observability.py
@@ -1,0 +1,129 @@
+"""Tests for rate limit observability instrumentation."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from scylla.e2e.rate_limit import wait_for_rate_limit
+from scylla.metrics.emitter import PrometheusTextfileEmitter
+
+
+def _make_checkpoint(source: str = "agent") -> MagicMock:
+    """Build a minimal checkpoint mock with rate_limit_source set."""
+    checkpoint = MagicMock()
+    checkpoint.experiment_id = "test-exp"
+    checkpoint.status = "running"
+    checkpoint.rate_limit_until = None
+    checkpoint.rate_limit_source = source
+    checkpoint.pause_count = 0
+    return checkpoint
+
+
+class TestRateLimitObservability:
+    """Tests for span and metric emission in wait_for_rate_limit()."""
+
+    def test_emits_pause_counter(self, tmp_path: Path) -> None:
+        """wait_for_rate_limit emits scylla_rate_limit_pauses_total with reason label."""
+        emitter = PrometheusTextfileEmitter(tmp_path / "test.prom")
+        checkpoint = _make_checkpoint(source="agent")
+
+        with (
+            patch("scylla.e2e.rate_limit._emitter", emitter),
+            patch("scylla.e2e.rate_limit.time.sleep"),
+            # is_shutdown_requested is imported lazily inside the function body
+            patch("scylla.e2e.shutdown.is_shutdown_requested", return_value=False),
+            patch("scylla.persistence.checkpoint.save_checkpoint"),
+        ):
+            wait_for_rate_limit(
+                retry_after=1.0,
+                checkpoint=checkpoint,
+                checkpoint_path=tmp_path / "cp.json",
+            )
+
+        content = (tmp_path / "test.prom").read_text()
+        assert "scylla_rate_limit_pauses_total" in content
+        assert 'reason="agent"' in content
+
+    def test_emits_pause_histogram(self, tmp_path: Path) -> None:
+        """wait_for_rate_limit emits scylla_rate_limit_pause_seconds histogram."""
+        emitter = PrometheusTextfileEmitter(tmp_path / "test.prom")
+        checkpoint = _make_checkpoint(source="judge")
+
+        with (
+            patch("scylla.e2e.rate_limit._emitter", emitter),
+            patch("scylla.e2e.rate_limit.time.sleep"),
+            patch("scylla.e2e.shutdown.is_shutdown_requested", return_value=False),
+            patch("scylla.persistence.checkpoint.save_checkpoint"),
+        ):
+            wait_for_rate_limit(
+                retry_after=0.5,
+                checkpoint=checkpoint,
+                checkpoint_path=tmp_path / "cp.json",
+            )
+
+        content = (tmp_path / "test.prom").read_text()
+        assert "scylla_rate_limit_pause_seconds_bucket" in content
+        assert "scylla_rate_limit_pause_seconds_count" in content
+        assert 'reason="judge"' in content
+
+    def test_span_attributes_set(self, tmp_path: Path) -> None:
+        """wait_for_rate_limit sets scylla.reason and scylla.retry_after_seconds on span."""
+        checkpoint = _make_checkpoint(source="agent")
+        span_attrs: dict[str, object] = {}
+
+        class _FakeSpan:
+            def set_attribute(self, k: str, v: object) -> None:
+                """Record span attribute."""
+                span_attrs[k] = v
+
+            def record_exception(self, exc: Exception) -> None:
+                """No-op record_exception."""
+
+            def __enter__(self) -> _FakeSpan:
+                """Return self as context manager."""
+                return self
+
+            def __exit__(self, *args: object) -> None:
+                """No-op exit."""
+
+        class _FakeTracer:
+            def start_as_current_span(self, name: str, **kwargs: object) -> _FakeSpan:
+                """Return a fake span."""
+                return _FakeSpan()
+
+        with (
+            patch("scylla.e2e.rate_limit._tracer", _FakeTracer()),
+            patch("scylla.e2e.rate_limit.time.sleep"),
+            patch("scylla.e2e.shutdown.is_shutdown_requested", return_value=False),
+            patch("scylla.persistence.checkpoint.save_checkpoint"),
+        ):
+            wait_for_rate_limit(
+                retry_after=2.0,
+                checkpoint=checkpoint,
+                checkpoint_path=tmp_path / "cp.json",
+            )
+
+        assert span_attrs.get("scylla.reason") == "agent"
+        assert "scylla.retry_after_seconds" in span_attrs
+
+    def test_unknown_source_when_none(self, tmp_path: Path) -> None:
+        """Reason label falls back to 'unknown' when rate_limit_source is None."""
+        emitter = PrometheusTextfileEmitter(tmp_path / "test.prom")
+        checkpoint = _make_checkpoint()
+        checkpoint.rate_limit_source = None
+
+        with (
+            patch("scylla.e2e.rate_limit._emitter", emitter),
+            patch("scylla.e2e.rate_limit.time.sleep"),
+            patch("scylla.e2e.shutdown.is_shutdown_requested", return_value=False),
+            patch("scylla.persistence.checkpoint.save_checkpoint"),
+        ):
+            wait_for_rate_limit(
+                retry_after=1.0,
+                checkpoint=checkpoint,
+                checkpoint_path=tmp_path / "cp.json",
+            )
+
+        content = (tmp_path / "test.prom").read_text()
+        assert 'reason="unknown"' in content

--- a/tests/unit/executor/test_docker_observability.py
+++ b/tests/unit/executor/test_docker_observability.py
@@ -1,0 +1,127 @@
+"""Tests for DockerExecutor observability instrumentation."""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from scylla.executor.docker import ContainerConfig, DockerExecutor
+from scylla.metrics.emitter import PrometheusTextfileEmitter
+
+
+def _make_config(image: str = "test-image:latest") -> ContainerConfig:
+    """Build a minimal ContainerConfig for testing."""
+    return ContainerConfig(image=image)
+
+
+class TestDockerRunObservability:
+    """Tests for span and metric emission in DockerExecutor lifecycle methods."""
+
+    def test_run_emits_start_and_stop_counter(self, tmp_path: Path) -> None:
+        """DockerExecutor.run emits start and stop lifecycle counters."""
+        emitter = PrometheusTextfileEmitter(tmp_path / "test.prom")
+
+        mock_result = MagicMock()
+        mock_result.returncode = 0
+        mock_result.stdout = ""
+        mock_result.stderr = ""
+
+        executor = DockerExecutor.__new__(DockerExecutor)
+        with (
+            patch("scylla.executor.docker._emitter", emitter),
+            patch("scylla.executor.docker.subprocess.run") as mock_run,
+            patch.object(executor, "_get_last_container_id", return_value="abc123"),
+        ):
+            mock_run.return_value = mock_result
+            config = _make_config()
+            executor.run(config)
+
+        content = (tmp_path / "test.prom").read_text()
+        assert 'scylla_container_lifecycle_total{event="start"' in content
+        assert 'scylla_container_lifecycle_total{event="stop"' in content
+
+    def test_run_emits_histogram(self, tmp_path: Path) -> None:
+        """DockerExecutor.run emits scylla_container_run_seconds histogram."""
+        emitter = PrometheusTextfileEmitter(tmp_path / "test.prom")
+
+        mock_result = MagicMock()
+        mock_result.returncode = 0
+        mock_result.stdout = ""
+        mock_result.stderr = ""
+
+        executor = DockerExecutor.__new__(DockerExecutor)
+        with (
+            patch("scylla.executor.docker._emitter", emitter),
+            patch("scylla.executor.docker.subprocess.run") as mock_run,
+            patch.object(executor, "_get_last_container_id", return_value="abc123"),
+        ):
+            mock_run.return_value = mock_result
+            config = _make_config()
+            executor.run(config)
+
+        content = (tmp_path / "test.prom").read_text()
+        assert "scylla_container_run_seconds_bucket" in content
+        assert "scylla_container_run_seconds_count" in content
+
+    def test_run_timeout_emits_fail_counter(self, tmp_path: Path) -> None:
+        """TimeoutExpired in DockerExecutor.run emits the fail lifecycle counter."""
+        emitter = PrometheusTextfileEmitter(tmp_path / "test.prom")
+
+        executor = DockerExecutor.__new__(DockerExecutor)
+        with (
+            patch("scylla.executor.docker._emitter", emitter),
+            patch("scylla.executor.docker.subprocess.run") as mock_run,
+            patch.object(executor, "_get_last_container_id", return_value="abc123"),
+            patch.object(executor, "stop"),
+        ):
+            mock_run.side_effect = subprocess.TimeoutExpired(cmd=["docker"], timeout=10)
+            config = _make_config()
+            result = executor.run(config)
+
+        assert result.timed_out is True
+        content = (tmp_path / "test.prom").read_text()
+        assert 'scylla_container_lifecycle_total{event="fail"' in content
+
+    def test_run_detached_emits_start_counter(self, tmp_path: Path) -> None:
+        """DockerExecutor.run_detached emits a start lifecycle counter."""
+        emitter = PrometheusTextfileEmitter(tmp_path / "test.prom")
+
+        mock_result = MagicMock()
+        mock_result.returncode = 0
+        mock_result.stdout = "container-id-123\n"
+        mock_result.stderr = ""
+
+        executor = DockerExecutor.__new__(DockerExecutor)
+        with (
+            patch("scylla.executor.docker._emitter", emitter),
+            patch("scylla.executor.docker.subprocess.run") as mock_run,
+        ):
+            mock_run.return_value = mock_result
+            config = _make_config()
+            container_id = executor.run_detached(config)
+
+        assert container_id == "container-id-123"
+        content = (tmp_path / "test.prom").read_text()
+        assert 'scylla_container_lifecycle_total{event="start"' in content
+
+    def test_stop_emits_stop_counter_and_histogram(self, tmp_path: Path) -> None:
+        """DockerExecutor.stop emits a stop lifecycle counter and duration histogram."""
+        emitter = PrometheusTextfileEmitter(tmp_path / "test.prom")
+
+        mock_result = MagicMock()
+        mock_result.returncode = 0
+        mock_result.stdout = ""
+        mock_result.stderr = ""
+
+        executor = DockerExecutor.__new__(DockerExecutor)
+        with (
+            patch("scylla.executor.docker._emitter", emitter),
+            patch("scylla.executor.docker.subprocess.run") as mock_run,
+        ):
+            mock_run.return_value = mock_result
+            executor.stop("abc123")
+
+        content = (tmp_path / "test.prom").read_text()
+        assert 'scylla_container_lifecycle_total{event="stop"' in content
+        assert "scylla_container_stop_seconds_count" in content

--- a/tests/unit/metrics/test_emitter_histogram.py
+++ b/tests/unit/metrics/test_emitter_histogram.py
@@ -1,0 +1,162 @@
+"""Tests for PrometheusTextfileEmitter.emit_histogram."""
+
+from __future__ import annotations
+
+import threading
+from pathlib import Path
+
+import pytest
+
+from scylla.metrics.emitter import (
+    MetricEmitter,
+    NoOpEmitter,
+    PrometheusTextfileEmitter,
+)
+
+
+def _read_prom(path: Path) -> str:
+    """Read the Prometheus textfile at path."""
+    return path.read_text()
+
+
+def _parse_prom(path: Path) -> dict[str, str]:
+    """Parse a Prometheus textfile into a dict mapping metric+labels -> value."""
+    content = path.read_text()
+    return {
+        line.split(" ")[0]: line.split(" ")[1]
+        for line in content.strip().splitlines()
+        if " " in line
+    }
+
+
+class TestEmitHistogram:
+    """Tests for PrometheusTextfileEmitter.emit_histogram and NoOpEmitter."""
+
+    def test_basic_observation_writes_buckets(self, tmp_path: Path) -> None:
+        """A single observation renders _bucket, _sum, and _count lines."""
+        emitter = PrometheusTextfileEmitter(tmp_path / "test.prom")
+        emitter.emit_histogram("scylla_latency_seconds", 1.5)
+        content = _read_prom(tmp_path / "test.prom")
+        assert "scylla_latency_seconds_bucket" in content
+        assert "scylla_latency_seconds_sum" in content
+        assert "scylla_latency_seconds_count" in content
+
+    def test_bucket_arithmetic_correct(self, tmp_path: Path) -> None:
+        """Value 0.3 lands in le=0.5 and all larger buckets including +Inf."""
+        emitter = PrometheusTextfileEmitter(tmp_path / "test.prom")
+        # Value 0.3 should fall in buckets >= 0.5 (0.5, 1.0, 2.0, 5.0, 10.0, 30.0, 60.0, +Inf)
+        emitter.emit_histogram("latency", 0.3)
+        prom_lines = _parse_prom(tmp_path / "test.prom")
+        # Bucket le=0.1 should be 0 (0.3 > 0.1)
+        assert prom_lines['latency_bucket{le="0.1"}'] == "0"
+        # Bucket le=0.5 should be 1 (0.3 <= 0.5)
+        assert prom_lines['latency_bucket{le="0.5"}'] == "1"
+        # +Inf always 1
+        assert prom_lines['latency_bucket{le="+Inf"}'] == "1"
+
+    def test_sum_and_count_correct(self, tmp_path: Path) -> None:
+        """Two observations produce count=2 and sum equal to both values."""
+        emitter = PrometheusTextfileEmitter(tmp_path / "test.prom")
+        emitter.emit_histogram("scylla_h", 1.0)
+        emitter.emit_histogram("scylla_h", 3.0)
+        prom_lines = _parse_prom(tmp_path / "test.prom")
+        assert prom_lines["scylla_h_count"] == "2"
+        assert float(prom_lines["scylla_h_sum"]) == pytest.approx(4.0)
+
+    def test_no_duplicate_bucket_lines_on_multiple_observations(self, tmp_path: Path) -> None:
+        """Five observations produce exactly one +Inf bucket line per series."""
+        emitter = PrometheusTextfileEmitter(tmp_path / "test.prom")
+        for _ in range(5):
+            emitter.emit_histogram("scylla_h", 1.0)
+        content = _read_prom(tmp_path / "test.prom")
+        # +Inf bucket should appear exactly once per (name, labels) pair
+        inf_lines = [line for line in content.splitlines() if 'le="+Inf"' in line]
+        assert len(inf_lines) == 1
+
+    def test_labels_included_in_bucket_lines(self, tmp_path: Path) -> None:
+        """Label key/value and le= appear in rendered histogram."""
+        emitter = PrometheusTextfileEmitter(tmp_path / "test.prom")
+        emitter.emit_histogram("scylla_h", 1.0, labels={"event": "start"})
+        content = _read_prom(tmp_path / "test.prom")
+        assert 'event="start"' in content
+        assert "le=" in content
+
+    def test_different_label_sets_render_separately(self, tmp_path: Path) -> None:
+        """Two distinct label sets each produce their own +Inf bucket line."""
+        emitter = PrometheusTextfileEmitter(tmp_path / "test.prom")
+        emitter.emit_histogram("scylla_h", 1.0, labels={"event": "start"})
+        emitter.emit_histogram("scylla_h", 2.0, labels={"event": "stop"})
+        content = _read_prom(tmp_path / "test.prom")
+        # Both label sets should produce +Inf lines
+        inf_lines = [line for line in content.splitlines() if 'le="+Inf"' in line]
+        assert len(inf_lines) == 2
+
+    def test_thread_safety_cumulative_counts(self, tmp_path: Path) -> None:
+        """10 threads x 100 observations each sum to 1000 under self._lock."""
+        emitter = PrometheusTextfileEmitter(tmp_path / "test.prom")
+        n_threads = 10
+        obs_per_thread = 100
+
+        def observe() -> None:
+            """Emit obs_per_thread histogram observations."""
+            for _ in range(obs_per_thread):
+                emitter.emit_histogram("scylla_h", 1.0)
+
+        threads = [threading.Thread(target=observe) for _ in range(n_threads)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        content = _read_prom(tmp_path / "test.prom")
+        prom_lines = {
+            line.split(" ")[0]: line.split(" ")[1] for line in content.strip().splitlines()
+        }
+        assert int(prom_lines["scylla_h_count"]) == n_threads * obs_per_thread
+        assert prom_lines['scylla_h_bucket{le="+Inf"}'] == str(n_threads * obs_per_thread)
+
+    def test_noop_emitter_emit_histogram_drops(self) -> None:
+        """NoOpEmitter.emit_histogram returns without error or side-effects."""
+        emitter = NoOpEmitter()
+        # Should not raise
+        emitter.emit_histogram("scylla_h", 1.0, labels={"event": "start"})
+
+    def test_base_class_default_pass_body_callable(self, tmp_path: Path) -> None:
+        """A subclass that doesn't override emit_histogram uses the base no-op."""
+
+        class MinimalEmitter(MetricEmitter):
+            """Minimal concrete emitter that omits emit_histogram."""
+
+            def emit_counter(
+                self, name: str, value: int, labels: dict[str, str] | None = None
+            ) -> None:
+                """No-op counter."""
+
+            def emit_gauge(
+                self, name: str, value: float, labels: dict[str, str] | None = None
+            ) -> None:
+                """No-op gauge."""
+
+        emitter = MinimalEmitter()
+        # Should not raise — default implementation is a silent no-op
+        emitter.emit_histogram("scylla_h", 1.0)
+
+    def test_plus_inf_bucket_literal_in_output(self, tmp_path: Path) -> None:
+        """The +Inf bucket label uses the exact Prometheus literal string."""
+        emitter = PrometheusTextfileEmitter(tmp_path / "test.prom")
+        emitter.emit_histogram("scylla_h", 999.0)
+        content = _read_prom(tmp_path / "test.prom")
+        # Prometheus requires the literal string +Inf (not inf or Inf)
+        assert 'le="+Inf"' in content
+
+    def test_inf_value_observation(self, tmp_path: Path) -> None:
+        """float('inf') observation lands in the +Inf bucket with count=1."""
+        emitter = PrometheusTextfileEmitter(tmp_path / "test.prom")
+        # A value of float('inf') should land in all buckets including +Inf
+        emitter.emit_histogram("scylla_h", float("inf"))
+        content = _read_prom(tmp_path / "test.prom")
+        prom_lines = {
+            line.split(" ")[0]: line.split(" ")[1] for line in content.strip().splitlines()
+        }
+        assert prom_lines['scylla_h_bucket{le="+Inf"}'] == "1"
+        assert int(prom_lines["scylla_h_count"]) == 1


### PR DESCRIPTION
## Summary

- Adds `emit_histogram` to `MetricEmitter` ABC with `PrometheusTextfileEmitter` implementation using a separate `_histograms` dict (canonical bucket/sum/count blocks, no duplicate `_bucket` lines on repeated observations, thread-safe under existing `_lock`)
- Wires OTel spans and Prometheus counters/histograms at the 3 remaining uninstrumented sites: container lifecycle (`executor/docker.py`), rate-limit pause (`e2e/rate_limit.py`), and error dispatch (`parallel_executor.py:245,252` + `subtest_executor.py:734,745`)
- Adds additive histograms alongside existing latency gauges at judge/checkpoint/adapter call sites; adds startup config gauges in `cli/main.py`
- Updates `docs/dev/tracing.md` with complete Instrumentation Map and Troubleshooting subsection; removes stale "not wired" banners from module docstrings and `docs/dev/metrics-emitter.md`
- 25 new tests covering histogram arithmetic, thread safety, container observability, rate-limit span/counter/histogram, and error-class counter emission

## Divergence from plan

- `parallel_executor.py:411` excluded per both R1 and R2 review findings — that site is inside `_find_rate_limit_from_failed_dirs()` (file-scanner helper), not a live subtest error classifier
- `wait_for_rate_limit()` uses `checkpoint.rate_limit_source` as the `reason` span attribute (no function signature change needed — the field is always set by callers before this function is invoked)
- `DockerExecutor` class used (not `DockerOrchestrator` — that was the plan's mistaken class name; `DockerExecutor` is the actual class)

Closes #1949

🤖 Generated with [Claude Code](https://claude.com/claude-code)