### PR TITLE
refactor(e2e): mixin→composition for TierManager; eliminate 9 C901 suppressions (#1941)

### DIFF
--- a/src/scylla/analysis/loader_internals/experiment_loader.py
+++ b/src/scylla/analysis/loader_internals/experiment_loader.py
@@ -126,7 +126,54 @@ def load_all_experiments(
     return experiments
 
 
-def load_rubric_weights(  # noqa: C901  # config loading with many format/version branches
+def _resolve_rubric_conflict(
+    rubric_conflict: RubricConflict,
+    cat_name: str,
+    existing_exp: str,
+    existing_weight: float,
+    exp_name: str,
+    new_weight: float,
+    accumulated: dict[str, tuple[float, str]],
+) -> None:
+    """Apply rubric conflict resolution policy for a single category.
+
+    Args:
+        rubric_conflict: Conflict resolution policy
+        cat_name: Category name with conflict
+        existing_exp: Name of first experiment that defined this category
+        existing_weight: Weight from first experiment
+        exp_name: Name of second (conflicting) experiment
+        new_weight: Weight from second experiment
+        accumulated: Accumulated weight mapping (modified in place for 'last' policy)
+
+    Raises:
+        RubricConflictError: If policy is 'error'.
+
+    """
+    if rubric_conflict == "error":
+        raise RubricConflictError(
+            category=cat_name,
+            exp_first=existing_exp,
+            weight_first=existing_weight,
+            exp_second=exp_name,
+            weight_second=new_weight,
+        )
+    if rubric_conflict == "warn":
+        warnings.warn(
+            f"Rubric conflict for category '{cat_name}': "
+            f"experiment '{existing_exp}' defines weight={existing_weight}, "
+            f"but experiment '{exp_name}' defines weight={new_weight}. "
+            "Keeping first value.",
+            UserWarning,
+            stacklevel=3,
+        )
+        # Keep first – no update to accumulated.
+    elif rubric_conflict == "last":
+        accumulated[cat_name] = (new_weight, exp_name)
+    # rubric_conflict == "first": keep first, no action needed
+
+
+def load_rubric_weights(
     data_dir: Path,
     exclude: list[str] | None = None,
     rubric_conflict: RubricConflict = "error",
@@ -200,28 +247,12 @@ def load_rubric_weights(  # noqa: C901  # config loading with many format/versio
                 continue
 
             # Genuine conflict – apply policy.
-            if rubric_conflict == "error":
-                raise RubricConflictError(
-                    category=cat_name,
-                    exp_first=existing_exp,
-                    weight_first=existing_weight,
-                    exp_second=exp_name,
-                    weight_second=new_weight,
-                )
-            elif rubric_conflict == "warn":
-                warnings.warn(
-                    f"Rubric conflict for category '{cat_name}': "
-                    f"experiment '{existing_exp}' defines weight={existing_weight}, "
-                    f"but experiment '{exp_name}' defines weight={new_weight}. "
-                    "Keeping first value.",
-                    UserWarning,
-                    stacklevel=2,
-                )
-                # Keep first – no update to accumulated.
-            elif rubric_conflict == "first":
-                pass  # Keep first – no update to accumulated.
-            elif rubric_conflict == "last":
-                accumulated[cat_name] = (new_weight, exp_name)
+            _resolve_rubric_conflict(
+                rubric_conflict, cat_name,
+                existing_exp, existing_weight,
+                exp_name, new_weight,
+                accumulated,
+            )
 
     if not found_any:
         return {}

--- a/src/scylla/analysis/loader_internals/run_loader.py
+++ b/src/scylla/analysis/loader_internals/run_loader.py
@@ -223,7 +223,173 @@ def load_judgment(judgment_path: Path, judge_number: int) -> JudgeEvaluation:
     )
 
 
-def load_run(  # noqa: C901  # data loading with many optional field paths
+def _parse_model_usage(raw_usage: list[Any]) -> list[ModelUsage]:
+    """Parse model usage records from raw list data.
+
+    Args:
+        raw_usage: List of raw usage dicts from agent result
+
+    Returns:
+        List of ModelUsage instances
+
+    """
+    result = []
+    for usage in raw_usage:
+        if isinstance(usage, dict):
+            result.append(
+                ModelUsage(
+                    model=usage.get("model", "unknown"),
+                    input_tokens=validate_int(
+                        usage.get("input_tokens") or usage.get("inputTokens"),
+                        "input_tokens",
+                        0,
+                    ),
+                    output_tokens=validate_int(
+                        usage.get("output_tokens") or usage.get("outputTokens"),
+                        "output_tokens",
+                        0,
+                    ),
+                    cache_creation_tokens=validate_int(
+                        usage.get("cache_creation_tokens"), "cache_creation_tokens", 0
+                    ),
+                    cache_read_tokens=validate_int(
+                        usage.get("cache_read_tokens"), "cache_read_tokens", 0
+                    ),
+                    cost_usd=validate_numeric(usage.get("cost_usd"), "cost_usd", 0.0),
+                )
+            )
+    return result
+
+
+def _load_agent_extras(
+    run_dir: Path,
+) -> tuple[int | None, int | None, list[ModelUsage] | None]:
+    """Load optional agent result extras: api_calls, num_turns, model_usage.
+
+    Args:
+        run_dir: Path to the run directory
+
+    Returns:
+        Tuple of (api_calls, num_turns, model_usage) — each may be None.
+
+    """
+    agent_data = load_agent_result(run_dir)
+    if not agent_data:
+        return None, None, None
+
+    api_calls_val = None
+    num_turns_val = None
+    model_usage_val = None
+
+    if "api_calls" in agent_data:
+        api_calls_val = validate_int(agent_data["api_calls"], "api_calls", 0) or None
+    if "num_turns" in agent_data:
+        num_turns_val = validate_int(agent_data["num_turns"], "num_turns", 0) or None
+
+    raw_usage = agent_data.get("model_usage") or agent_data.get("modelUsage")
+    if raw_usage and isinstance(raw_usage, list):
+        model_usage_val = _parse_model_usage(raw_usage)
+
+    return api_calls_val, num_turns_val, model_usage_val
+
+
+def _load_process_metrics_precomputed(
+    process_metrics_data: dict[str, Any],
+) -> tuple[float | None, float | None, float | None, float | None]:
+    """Extract process metrics from a pre-computed process_metrics block.
+
+    Args:
+        process_metrics_data: Dict with pre-computed metric values
+
+    Returns:
+        Tuple of (r_prog, strategic_drift, cfp, pr_revert_rate)
+
+    """
+
+    def _extract(key: str) -> float | None:
+        raw = validate_numeric(process_metrics_data.get(key), key, np.nan)
+        return None if (raw is None or np.isnan(raw)) else raw
+
+    return (
+        _extract("r_prog"),
+        _extract("strategic_drift"),
+        _extract("cfp"),
+        _extract("pr_revert_rate"),
+    )
+
+
+def _load_process_metrics_from_tracking(
+    result: dict[str, Any],
+) -> tuple[float | None, float | None, float | None, float | None]:
+    """Compute process metrics from raw tracking data.
+
+    Fallback used when no pre-computed process_metrics block is present.
+
+    Args:
+        result: Full run_result.json data
+
+    Returns:
+        Tuple of (r_prog, strategic_drift, cfp, pr_revert_rate)
+
+    """
+    r_prog_val: float | None = None
+    strategic_drift_val: float | None = None
+    cfp_val: float | None = None
+    pr_revert_rate_val: float | None = None
+
+    progress_tracking = result.get("progress_tracking")
+    changes = result.get("changes")
+    if not (progress_tracking or changes):
+        return r_prog_val, strategic_drift_val, cfp_val, pr_revert_rate_val
+
+    from scylla.metrics.process import (
+        ChangeResult,
+        ProgressStep,
+        ProgressTracker,
+        calculate_cfp,
+        calculate_pr_revert_rate,
+        calculate_r_prog,
+        calculate_strategic_drift,
+    )
+
+    if progress_tracking and isinstance(progress_tracking, list):
+        steps = []
+        achieved = []
+        for s in progress_tracking:
+            if isinstance(s, dict):
+                step = ProgressStep(
+                    step_id=s.get("step_id", ""),
+                    description=s.get("description", ""),
+                    weight=float(s.get("weight", 1.0)),
+                    completed=bool(s.get("completed", False)),
+                    goal_alignment=float(s.get("goal_alignment", 1.0)),
+                )
+                steps.append(step)
+                if step.completed:
+                    achieved.append(step)
+        tracker = ProgressTracker(expected_steps=steps, achieved_steps=achieved)
+        r_prog_val = calculate_r_prog(tracker)
+        strategic_drift_val = calculate_strategic_drift(tracker)
+
+    if changes and isinstance(changes, list):
+        change_results = [
+            ChangeResult(
+                change_id=c.get("change_id", ""),
+                description=c.get("description", ""),
+                succeeded=bool(c.get("succeeded", True)),
+                caused_failure=bool(c.get("caused_failure", False)),
+                reverted=bool(c.get("reverted", False)),
+            )
+            for c in changes
+            if isinstance(c, dict)
+        ]
+        cfp_val = calculate_cfp(change_results)
+        pr_revert_rate_val = calculate_pr_revert_rate(change_results)
+
+    return r_prog_val, strategic_drift_val, cfp_val, pr_revert_rate_val
+
+
+def load_run(
     run_dir: Path, experiment: str, tier: str, subtest: str, agent_model: str
 ) -> RunData:
     """Load data for a single run.
@@ -270,120 +436,23 @@ def load_run(  # noqa: C901  # data loading with many optional field paths
     judges = []
     judge_dir = run_dir / "judge"
     if judge_dir.exists():
-        # Dynamically discover all judge directories
         for judge_path in sorted(judge_dir.glob("judge_*/judgment.json")):
-            # Extract judge number from directory name (e.g., "judge_01" -> 1)
             judge_num = int(judge_path.parent.name.replace("judge_", ""))
             judges.append(load_judgment(judge_path, judge_num))
 
     # Load optional agent result data
-    agent_data = load_agent_result(run_dir)
-    api_calls_val = None
-    num_turns_val = None
-    model_usage_val = None
-
-    if agent_data:
-        # Extract API calls and turns if present
-        if "api_calls" in agent_data:
-            api_calls_val = validate_int(agent_data["api_calls"], "api_calls", 0) or None
-        if "num_turns" in agent_data:
-            num_turns_val = validate_int(agent_data["num_turns"], "num_turns", 0) or None
-
-        # Parse model_usage if present (for delegation tiers)
-        raw_usage = agent_data.get("model_usage") or agent_data.get("modelUsage")
-        if raw_usage and isinstance(raw_usage, list):
-            model_usage_val = []
-            for usage in raw_usage:
-                if isinstance(usage, dict):
-                    model_usage_val.append(
-                        ModelUsage(
-                            model=usage.get("model", "unknown"),
-                            input_tokens=validate_int(
-                                usage.get("input_tokens") or usage.get("inputTokens"),
-                                "input_tokens",
-                                0,
-                            ),
-                            output_tokens=validate_int(
-                                usage.get("output_tokens") or usage.get("outputTokens"),
-                                "output_tokens",
-                                0,
-                            ),
-                            cache_creation_tokens=validate_int(
-                                usage.get("cache_creation_tokens"), "cache_creation_tokens", 0
-                            ),
-                            cache_read_tokens=validate_int(
-                                usage.get("cache_read_tokens"), "cache_read_tokens", 0
-                            ),
-                            cost_usd=validate_numeric(usage.get("cost_usd"), "cost_usd", 0.0),
-                        )
-                    )
+    api_calls_val, num_turns_val, model_usage_val = _load_agent_extras(run_dir)
 
     # Extract process metrics from run_result.json
-    r_prog_val: float | None = None
-    strategic_drift_val: float | None = None
-    cfp_val: float | None = None
-    pr_revert_rate_val: float | None = None
-
     process_metrics_data = result.get("process_metrics")
     if process_metrics_data and isinstance(process_metrics_data, dict):
-        # Use pre-computed process_metrics block if available
-        def _extract_process_float(key: str) -> float | None:
-            raw = validate_numeric(process_metrics_data.get(key), key, np.nan)
-            return None if (raw is None or np.isnan(raw)) else raw
-
-        r_prog_val = _extract_process_float("r_prog")
-        strategic_drift_val = _extract_process_float("strategic_drift")
-        cfp_val = _extract_process_float("cfp")
-        pr_revert_rate_val = _extract_process_float("pr_revert_rate")
+        r_prog_val, strategic_drift_val, cfp_val, pr_revert_rate_val = (
+            _load_process_metrics_precomputed(process_metrics_data)
+        )
     else:
-        # Fallback: compute from raw tracking data if present
-        progress_tracking = result.get("progress_tracking")
-        changes = result.get("changes")
-        if progress_tracking or changes:
-            from scylla.metrics.process import (
-                ChangeResult,
-                ProgressStep,
-                ProgressTracker,
-                calculate_cfp,
-                calculate_pr_revert_rate,
-                calculate_r_prog,
-                calculate_strategic_drift,
-            )
-
-            if progress_tracking and isinstance(progress_tracking, list):
-                steps = []
-                achieved = []
-                for s in progress_tracking:
-                    if isinstance(s, dict):
-                        step = ProgressStep(
-                            step_id=s.get("step_id", ""),
-                            description=s.get("description", ""),
-                            weight=float(s.get("weight", 1.0)),
-                            completed=bool(s.get("completed", False)),
-                            goal_alignment=float(s.get("goal_alignment", 1.0)),
-                        )
-                        steps.append(step)
-                        if step.completed:
-                            achieved.append(step)
-                tracker = ProgressTracker(expected_steps=steps, achieved_steps=achieved)
-                r_prog_val = calculate_r_prog(tracker)
-                strategic_drift_val = calculate_strategic_drift(tracker)
-
-            if changes and isinstance(changes, list):
-                change_results = []
-                for c in changes:
-                    if isinstance(c, dict):
-                        change_results.append(
-                            ChangeResult(
-                                change_id=c.get("change_id", ""),
-                                description=c.get("description", ""),
-                                succeeded=bool(c.get("succeeded", True)),
-                                caused_failure=bool(c.get("caused_failure", False)),
-                                reverted=bool(c.get("reverted", False)),
-                            )
-                        )
-                cfp_val = calculate_cfp(change_results)
-                pr_revert_rate_val = calculate_pr_revert_rate(change_results)
+        r_prog_val, strategic_drift_val, cfp_val, pr_revert_rate_val = (
+            _load_process_metrics_from_tracking(result)
+        )
 
     # Validate and coerce all numeric/boolean fields with type checking
     return RunData(

--- a/src/scylla/e2e/llm_judge.py
+++ b/src/scylla/e2e/llm_judge.py
@@ -35,7 +35,52 @@ logger = logging.getLogger(__name__)
 # This module now imports and uses that consolidated implementation.
 
 
-def _get_workspace_state(workspace: Path) -> str:  # noqa: C901  # workspace state detection with many file patterns
+_GIT_STATUS_LABELS: dict[str, str] = {
+    "M": "modified",
+    "A": "added",
+    "??": "created",
+    "D": "deleted",
+}
+
+
+def _parse_git_status_line(line: str) -> tuple[str, str]:
+    """Parse a single git status --porcelain output line.
+
+    Args:
+        line: A single porcelain status line
+
+    Returns:
+        Tuple of (status_code, file_path)
+
+    """
+    status = line[:2].strip()
+    # Git porcelain format: XY filename (2 status chars + space + path)
+    if len(line) > 3 and line[2] == " ":
+        file_path = line[3:].strip()
+    elif " " in line:
+        file_path = line.split(" ", 1)[1].strip() if " " in line[1:] else ""
+    else:
+        file_path = ""
+    return status, file_path
+
+
+def _expand_untracked_dir(workspace: Path, full_path: Path, lines: list[str]) -> None:
+    """Expand an untracked directory into individual file entries.
+
+    Args:
+        workspace: Root workspace path for computing relative paths
+        full_path: Absolute path to the untracked directory
+        lines: List to append formatted entries to
+
+    """
+    for child in sorted(full_path.rglob("*")):
+        if child.is_file():
+            rel_path = child.relative_to(workspace)
+            if not is_test_config_file(str(rel_path)):
+                lines.append(f"- `{rel_path}` (created)")
+
+
+def _get_workspace_state(workspace: Path) -> str:
     """Get a description of modified/created files in the workspace.
 
     Only lists files that were modified or created by the agent (using git status),
@@ -72,43 +117,18 @@ def _get_workspace_state(workspace: Path) -> str:  # noqa: C901  # workspace sta
         for line in result.stdout.strip().split("\n"):
             if not line:
                 continue
-            # Status codes: M=modified, A=added, ??=untracked, D=deleted
-            status = line[:2].strip()
-            # Git porcelain format: XY filename (2 status chars + space + path)
-            # Handle edge cases where format may vary
-            if len(line) > 3 and line[2] == " ":
-                file_path = line[3:].strip()
-            elif " " in line:
-                # Fallback: split on first space after status
-                file_path = line.split(" ", 1)[1].strip() if " " in line[1:] else ""
-            else:
-                file_path = ""
+            status, file_path = _parse_git_status_line(line)
 
-            # Skip test configuration files
             if is_test_config_file(file_path):
                 continue
 
             full_path = workspace / file_path
 
-            # Handle untracked directories - expand to show all files
             if status == "??" and full_path.is_dir():
-                for child in sorted(full_path.rglob("*")):
-                    if child.is_file():
-                        rel_path = child.relative_to(workspace)
-                        if not is_test_config_file(str(rel_path)):
-                            lines.append(f"- `{rel_path}` (created)")
+                _expand_untracked_dir(workspace, full_path, lines)
             else:
-                # Existing file handling
-                if status == "M":
-                    lines.append(f"- `{file_path}` (modified)")
-                elif status == "A":
-                    lines.append(f"- `{file_path}` (added)")
-                elif status == "??":
-                    lines.append(f"- `{file_path}` (created)")
-                elif status == "D":
-                    lines.append(f"- `{file_path}` (deleted)")
-                else:
-                    lines.append(f"- `{file_path}` ({status})")
+                label = _GIT_STATUS_LABELS.get(status, status)
+                lines.append(f"- `{file_path}` ({label})")
 
         if len(lines) == 1:
             lines.append("(no changes detected)")

--- a/src/scylla/e2e/run_report_sections.py
+++ b/src/scylla/e2e/run_report_sections.py
@@ -536,7 +536,86 @@ def _generate_criteria_comparison_table(
     return lines
 
 
-def _get_workspace_files(workspace_path: Path) -> list[tuple[str, str]]:  # noqa: C901  # workspace state detection with many file patterns
+def _parse_porcelain_file_path(line: str) -> str:
+    """Extract file path from a git status --porcelain output line.
+
+    Args:
+        line: A single git status porcelain output line
+
+    Returns:
+        Extracted file path string, or empty string on parse failure.
+
+    """
+    if len(line) > 3 and line[2] == " ":
+        return line[3:].strip()
+    if " " in line:
+        return line.split(" ", 1)[1].strip() if " " in line[1:] else ""
+    return ""
+
+
+def _collect_committed_files(workspace_path: Path) -> list[tuple[str, str]]:
+    """Return (path, 'committed') pairs from HEAD~1..HEAD diff.
+
+    Args:
+        workspace_path: Git repository root to inspect
+
+    Returns:
+        List of (file_path, "committed") tuples for non-config files.
+
+    """
+    import subprocess
+
+    result = subprocess.run(
+        ["git", "diff", "--name-only", "HEAD~1", "HEAD"],
+        cwd=workspace_path,
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    if result.returncode != 0 or not result.stdout.strip():
+        return []
+    return [
+        (line.strip(), "committed")
+        for line in result.stdout.strip().split("\n")
+        if line.strip() and not is_test_config_file(line.strip())
+    ]
+
+
+def _collect_uncommitted_files(
+    workspace_path: Path, committed_paths: set[str]
+) -> list[tuple[str, str]]:
+    """Return (path, 'uncommitted') pairs from git status --porcelain.
+
+    Args:
+        workspace_path: Git repository root to inspect
+        committed_paths: Paths already captured as committed (excluded)
+
+    Returns:
+        List of (file_path, "uncommitted") tuples for non-config, non-committed files.
+
+    """
+    import subprocess
+
+    result = subprocess.run(
+        ["git", "status", "--porcelain"],
+        cwd=workspace_path,
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    if result.returncode != 0:
+        return []
+    entries: list[tuple[str, str]] = []
+    for line in result.stdout.strip().split("\n"):
+        if not line:
+            continue
+        file_path = _parse_porcelain_file_path(line)
+        if file_path and not is_test_config_file(file_path) and file_path not in committed_paths:
+            entries.append((file_path, "uncommitted"))
+    return entries
+
+
+def _get_workspace_files(workspace_path: Path) -> list[tuple[str, str]]:
     """Get files created/modified by agent, with their status.
 
     Returns both committed and uncommitted files created by the agent.
@@ -548,65 +627,13 @@ def _get_workspace_files(workspace_path: Path) -> list[tuple[str, str]]:  # noqa
         List of (file_path, status) tuples where status is "committed" or "uncommitted".
 
     """
-    import subprocess
-
     if not workspace_path.exists():
         return []
 
-    files_with_status = []
-
     try:
-        # 1. Get committed files by comparing HEAD with previous commits
-        # Try to find files in the latest commit(s) made by agent
-        result = subprocess.run(
-            ["git", "diff", "--name-only", "HEAD~1", "HEAD"],
-            cwd=workspace_path,
-            capture_output=True,
-            text=True,
-            timeout=30,
-        )
-
-        if result.returncode == 0 and result.stdout.strip():
-            for line in result.stdout.strip().split("\n"):
-                file_path = line.strip()
-                if file_path and not is_test_config_file(file_path):
-                    files_with_status.append((file_path, "committed"))
-
-        # 2. Get untracked/modified files using git status
-        result = subprocess.run(
-            ["git", "status", "--porcelain"],
-            cwd=workspace_path,
-            capture_output=True,
-            text=True,
-            timeout=30,
-        )
-
-        if result.returncode == 0:
-            for line in result.stdout.strip().split("\n"):
-                if not line:
-                    continue
-                # Status format: "XY filename" where X=index, Y=working tree
-                # Examples: "?? file" (untracked), " M file" (modified), "A  file" (added)
-                # Git porcelain format: XY filename (2 status chars + space + path)
-                # Handle edge cases where format may vary
-                if len(line) > 3 and line[2] == " ":
-                    file_path = line[3:].strip()
-                elif " " in line:
-                    # Fallback: split on first space after status
-                    file_path = line.split(" ", 1)[1].strip() if " " in line[1:] else ""
-                else:
-                    file_path = ""
-
-                if not file_path or is_test_config_file(file_path):
-                    continue
-
-                # Skip if already added as committed
-                if any(f[0] == file_path for f in files_with_status):
-                    continue
-
-                files_with_status.append((file_path, "uncommitted"))
-
-        return sorted(files_with_status, key=lambda x: x[0])
-
+        committed = _collect_committed_files(workspace_path)
+        committed_paths = {f[0] for f in committed}
+        uncommitted = _collect_uncommitted_files(workspace_path, committed_paths)
+        return sorted(committed + uncommitted, key=lambda x: x[0])
     except Exception:
         return []

--- a/src/scylla/e2e/tier_manager.py
+++ b/src/scylla/e2e/tier_manager.py
@@ -3,24 +3,33 @@
 This module handles loading tier configurations, managing sub-tests,
 and implementing the copy+extend inheritance pattern between tiers.
 
-This module is a thin facade — its implementation lives in
-:mod:`scylla.e2e.tier_manager_internals`. The public API
-(:class:`TierManager`) is preserved for backward compatibility.
+This module is a thin facade over three collaborator objects
+(:class:`WorkspaceHandler`, :class:`ResourcesHandler`,
+:class:`BaselineHandler`).  The public API (:class:`TierManager`) is
+preserved for backward compatibility.
 """
 
 from __future__ import annotations
 
+from pathlib import Path
+from typing import Any
+
+from scylla.e2e.models import SubTestConfig, TierBaseline, TierConfig, TierID
+from scylla.e2e.subtest_provider import SubtestProvider
 from scylla.e2e.tier_manager_internals.base import TierManagerBase
-from scylla.e2e.tier_manager_internals.baseline import BaselineMixin
-from scylla.e2e.tier_manager_internals.resources import ResourcesMixin
-from scylla.e2e.tier_manager_internals.workspace import WorkspaceMixin
+from scylla.e2e.tier_manager_internals.baseline import BaselineHandler
+from scylla.e2e.tier_manager_internals.resources import ResourcesHandler
+from scylla.e2e.tier_manager_internals.workspace import WorkspaceHandler
 
 
-class TierManager(WorkspaceMixin, ResourcesMixin, BaselineMixin, TierManagerBase):
+class TierManager:
     """Manages tier configurations and inheritance.
 
     Handles loading tier configs from the filesystem, discovering
     sub-tests, and preparing workspaces with inherited configurations.
+
+    Composed of three collaborators (WorkspaceHandler, ResourcesHandler,
+    BaselineHandler) that each own a focused slice of the logic.
 
     Example:
         >>> manager = TierManager(Path("tests/fixtures/tests/test-001"))
@@ -33,6 +42,206 @@ class TierManager(WorkspaceMixin, ResourcesMixin, BaselineMixin, TierManagerBase
         ... )
 
     """
+
+    def __init__(
+        self,
+        tiers_dir: Path,
+        shared_dir: Path | None = None,
+        config_dir: Path | None = None,
+        subtest_provider: SubtestProvider | None = None,
+    ) -> None:
+        """Initialize TierManager with collaborator objects.
+
+        Args:
+            tiers_dir: Path to the test-specific tiers directory
+            shared_dir: Path to shared resources directory. If None, auto-detected
+                       from tiers_dir (tiers_dir/../../claude-code/shared)
+            config_dir: Path to config directory. If None, auto-detected
+                       (repo_root/config)
+            subtest_provider: Provider for discovering subtests. If None, uses
+                             FileSystemSubtestProvider with shared_dir
+
+        """
+        base = TierManagerBase(tiers_dir, shared_dir, config_dir, subtest_provider)
+
+        # Expose shared state on self for callers that access them directly
+        self.tiers_dir = base.tiers_dir
+        self.tier_config_loader = base.tier_config_loader
+        self.subtest_provider = base.subtest_provider
+        self._shared_dir = base._shared_dir
+
+        # Collaborators (composition over inheritance)
+        self._resources_handler = ResourcesHandler(self._shared_dir)
+        self._baseline_handler = BaselineHandler(
+            tier_config_loader=self.tier_config_loader,
+            subtest_provider=self.subtest_provider,
+            shared_dir=self._shared_dir,
+            tiers_dir=self.tiers_dir,
+        )
+        self._workspace_handler = WorkspaceHandler(
+            shared_dir=self._shared_dir,
+            resources=self._resources_handler,
+            baseline=self._baseline_handler,
+        )
+
+    # ------------------------------------------------------------------
+    # WorkspaceHandler delegation
+    # ------------------------------------------------------------------
+
+    def prepare_workspace(
+        self,
+        workspace: Path,
+        tier_id: TierID,
+        subtest_id: str,
+        baseline: TierBaseline | None = None,
+        merged_resources: dict[str, Any] | None = None,
+        thinking_enabled: bool = False,
+    ) -> None:
+        """Prepare a workspace with tier configuration.
+
+        Delegates to :class:`WorkspaceHandler`.
+
+        Args:
+            workspace: Path to the workspace directory
+            tier_id: The tier being prepared
+            subtest_id: The sub-test identifier
+            baseline: Previous tier's winning baseline (if any)
+            merged_resources: Pre-merged resources from multiple tiers (T5 only)
+            thinking_enabled: Whether to enable extended thinking mode
+
+        """
+        self._workspace_handler.prepare_workspace(
+            workspace=workspace,
+            tier_id=tier_id,
+            subtest_id=subtest_id,
+            baseline=baseline,
+            merged_resources=merged_resources,
+            thinking_enabled=thinking_enabled,
+        )
+
+    # ------------------------------------------------------------------
+    # ResourcesHandler delegation
+    # ------------------------------------------------------------------
+
+    def build_resource_suffix(self, subtest: SubTestConfig) -> str:
+        """Build prompt suffix based on configured resources.
+
+        Delegates to :class:`ResourcesHandler`.
+
+        Args:
+            subtest: SubTestConfig with resources specification
+
+        Returns:
+            Prompt suffix string with resource hints
+
+        """
+        return self._resources_handler.build_resource_suffix(subtest)
+
+    def build_merged_baseline(
+        self,
+        inherit_from_tiers: list[TierID],
+        experiment_dir: Path,
+    ) -> dict[str, Any]:
+        """Build merged resources from multiple tier results.
+
+        Delegates to :class:`ResourcesHandler`.
+
+        Args:
+            inherit_from_tiers: List of tier IDs to inherit from
+            experiment_dir: Path to experiment directory
+
+        Returns:
+            Merged resources dictionary.
+
+        Raises:
+            ValueError: If all required tiers failed.
+
+        """
+        return self._resources_handler.build_merged_baseline(inherit_from_tiers, experiment_dir)
+
+    def _merge_tier_resources(
+        self,
+        merged_resources: dict[str, Any],
+        new_resources: dict[str, Any],
+        source_tier: TierID,
+    ) -> None:
+        """Merge resources from a tier into the accumulated merged resources.
+
+        Delegates to :class:`ResourcesHandler`.
+
+        Args:
+            merged_resources: Accumulated resources to merge into (modified in place)
+            new_resources: Resources from the source tier to merge
+            source_tier: The tier ID being merged
+
+        """
+        self._resources_handler._merge_tier_resources(
+            merged_resources, new_resources, source_tier
+        )
+
+    # ------------------------------------------------------------------
+    # BaselineHandler delegation
+    # ------------------------------------------------------------------
+
+    def load_tier_config(self, tier_id: TierID, skip_agent_teams: bool = False) -> TierConfig:
+        """Load configuration for a specific tier.
+
+        Delegates to :class:`BaselineHandler`.
+
+        Args:
+            tier_id: The tier to load configuration for
+            skip_agent_teams: Skip agent teams sub-tests (default: False)
+
+        Returns:
+            TierConfig with all sub-tests for the tier.
+
+        """
+        return self._baseline_handler.load_tier_config(tier_id, skip_agent_teams)
+
+    def get_baseline_for_subtest(
+        self,
+        tier_id: TierID,
+        subtest_id: str,
+        results_dir: Path,
+    ) -> TierBaseline:
+        """Create a baseline reference from a completed sub-test.
+
+        Delegates to :class:`BaselineHandler`.
+
+        Args:
+            tier_id: The tier of the winning sub-test
+            subtest_id: The winning sub-test ID
+            results_dir: Directory containing the sub-test's results
+
+        Returns:
+            TierBaseline that can be passed to the next tier.
+
+        """
+        return self._baseline_handler.get_baseline_for_subtest(tier_id, subtest_id, results_dir)
+
+    def save_resource_manifest(
+        self,
+        results_dir: Path,
+        tier_id: TierID,
+        subtest: SubTestConfig,
+        workspace: Path,
+        baseline: TierBaseline | None = None,
+    ) -> None:
+        """Save resource manifest for reproducibility.
+
+        Delegates to :class:`BaselineHandler`.
+
+        Args:
+            results_dir: Directory to save manifest to
+            tier_id: The tier identifier
+            subtest: The subtest configuration
+            workspace: Workspace with the composed configuration
+            baseline: Previous tier's baseline (for inheritance chain)
+
+        """
+        self._baseline_handler.save_resource_manifest(
+            results_dir, tier_id, subtest, workspace, baseline
+        )
 
 
 __all__ = [

--- a/src/scylla/e2e/tier_manager_internals/base.py
+++ b/src/scylla/e2e/tier_manager_internals/base.py
@@ -1,6 +1,6 @@
 """Base class for :class:`scylla.e2e.tier_manager.TierManager`.
 
-Holds construction-time state shared by all mixin modules.
+Holds construction-time state shared by all collaborator modules.
 """
 
 from __future__ import annotations
@@ -8,7 +8,6 @@ from __future__ import annotations
 import logging
 from pathlib import Path
 
-from scylla.e2e.models import TierID
 from scylla.e2e.subtest_provider import FileSystemSubtestProvider, SubtestProvider
 from scylla.executor.tier_config import TierConfigLoader
 
@@ -16,7 +15,7 @@ logger = logging.getLogger(__name__)
 
 
 class TierManagerBase:
-    """Shared state for :class:`TierManager` mixins."""
+    """Shared state for :class:`TierManager` collaborators."""
 
     tiers_dir: Path
     tier_config_loader: TierConfigLoader
@@ -80,21 +79,3 @@ class TierManagerBase:
         # Navigate from tiers_dir (tests/fixtures/tests/test-XXX) to shared
         # tiers_dir -> tests/fixtures/tests -> tests/fixtures -> tests -> claude-code/shared
         return self.tiers_dir.parent.parent.parent / "claude-code" / "shared"
-
-    def _get_fixture_config_path(self, tier_id: TierID, subtest_id: str) -> Path:
-        """Get path to the fixture's config file in shared directory.
-
-        Args:
-            tier_id: The tier identifier
-            subtest_id: The subtest identifier
-
-        Returns:
-            Path to config.yaml in the shared subtests directory.
-
-        """
-        shared_subtests_dir = self._shared_dir / "subtests" / tier_id.value.lower()
-        # Find config file starting with subtest_id (e.g., "00-empty.yaml")
-        for config_file in shared_subtests_dir.glob(f"{subtest_id}-*.yaml"):
-            return config_file
-        # Fallback if exact match not found
-        return shared_subtests_dir / f"{subtest_id}.yaml"

--- a/src/scylla/e2e/tier_manager_internals/baseline.py
+++ b/src/scylla/e2e/tier_manager_internals/baseline.py
@@ -1,4 +1,4 @@
-"""Tier-config / baseline mixin for :class:`TierManager`.
+"""Tier-config / baseline collaborator for :class:`TierManager`.
 
 Methods that read tier configuration, derive baselines from completed
 sub-tests, and persist resource manifests for reproducibility.
@@ -10,7 +10,6 @@ import hashlib
 import logging
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import TYPE_CHECKING
 
 from scylla.e2e.models import (
     ResourceManifest,
@@ -19,19 +18,35 @@ from scylla.e2e.models import (
     TierConfig,
     TierID,
 )
-
-if TYPE_CHECKING:
-    from scylla.e2e.tier_manager_internals.base import TierManagerBase
-
-    _Base = TierManagerBase
-else:
-    _Base = object
+from scylla.e2e.subtest_provider import SubtestProvider
+from scylla.executor.tier_config import TierConfigLoader
 
 logger = logging.getLogger(__name__)
 
 
-class BaselineMixin(_Base):
+class BaselineHandler:
     """Tier-config and baseline methods for :class:`TierManager`."""
+
+    def __init__(
+        self,
+        tier_config_loader: TierConfigLoader,
+        subtest_provider: SubtestProvider,
+        shared_dir: Path,
+        tiers_dir: Path,
+    ) -> None:
+        """Initialize baseline handler.
+
+        Args:
+            tier_config_loader: Loader for tier configurations
+            subtest_provider: Provider for discovering subtests
+            shared_dir: Path to shared resources directory
+            tiers_dir: Path to the test-specific tiers directory
+
+        """
+        self._tier_config_loader = tier_config_loader
+        self._subtest_provider = subtest_provider
+        self._shared_dir = shared_dir
+        self._tiers_dir = tiers_dir
 
     def load_tier_config(self, tier_id: TierID, skip_agent_teams: bool = False) -> TierConfig:
         """Load configuration for a specific tier.
@@ -47,10 +62,10 @@ class BaselineMixin(_Base):
 
         """
         # Load global tier configuration from tests/claude-code/shared/
-        global_tier_config = self.tier_config_loader.get_tier(tier_id.value)
+        global_tier_config = self._tier_config_loader.get_tier(tier_id.value)
 
         # Discover sub-tests using the provider
-        subtests = self.subtest_provider.discover_subtests(tier_id, skip_agent_teams)
+        subtests = self._subtest_provider.discover_subtests(tier_id, skip_agent_teams)
 
         # Create TierConfig with both global settings and subtests
         # Note: system_prompt_mode is determined per-subtest, not per-tier
@@ -148,3 +163,21 @@ class BaselineMixin(_Base):
         )
 
         manifest.save(results_dir / "config_manifest.json")
+
+    def _get_fixture_config_path(self, tier_id: TierID, subtest_id: str) -> Path:
+        """Get path to the fixture's config file in shared directory.
+
+        Args:
+            tier_id: The tier identifier
+            subtest_id: The subtest identifier
+
+        Returns:
+            Path to config.yaml in the shared subtests directory.
+
+        """
+        shared_subtests_dir = self._shared_dir / "subtests" / tier_id.value.lower()
+        # Find config file starting with subtest_id (e.g., "00-empty.yaml")
+        for config_file in shared_subtests_dir.glob(f"{subtest_id}-*.yaml"):
+            return config_file
+        # Fallback if exact match not found
+        return shared_subtests_dir / f"{subtest_id}.yaml"

--- a/src/scylla/e2e/tier_manager_internals/resources.py
+++ b/src/scylla/e2e/tier_manager_internals/resources.py
@@ -1,4 +1,4 @@
-"""Resource composition mixin for :class:`TierManager`.
+"""Resource composition collaborator for :class:`TierManager`.
 
 Methods that build prompt suffixes from resource specs and merge resources
 across multiple tiers (used by T5 inherit_best_from logic).
@@ -9,24 +9,26 @@ from __future__ import annotations
 import json
 import logging
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import Any
 
 from scylla.e2e.models import SubTestConfig, TierID
-
-if TYPE_CHECKING:
-    from scylla.e2e.tier_manager_internals.base import TierManagerBase
-
-    _Base = TierManagerBase
-else:
-    _Base = object
 
 logger = logging.getLogger(__name__)
 
 
-class ResourcesMixin(_Base):
+class ResourcesHandler:
     """Resource composition methods for :class:`TierManager`."""
 
-    def build_resource_suffix(  # noqa: C901  # config with many conditional suffix rules
+    def __init__(self, shared_dir: Path) -> None:
+        """Initialize resources handler.
+
+        Args:
+            shared_dir: Path to shared resources directory
+
+        """
+        self._shared_dir = shared_dir
+
+    def build_resource_suffix(
         self, subtest: SubTestConfig
     ) -> str:
         """Build prompt suffix based on configured resources.
@@ -48,74 +50,25 @@ class ResourcesMixin(_Base):
         resources = subtest.resources or {}
         has_any_resources = False
 
-        # Sub-agents
-        if "agents" in resources:
-            agents_spec = resources["agents"]
-            agent_names = []
-            for level in agents_spec.get("levels", []):
-                level_dir = self._shared_dir / "agents" / f"L{level}"
-                if level_dir.exists():
-                    for f in level_dir.glob("*.md"):
-                        agent_names.append(f.stem)
-            agent_names.extend(n.replace(".md", "") for n in agents_spec.get("names", []))
-            if agent_names:
-                has_any_resources = True
-                bullet_list = "\n".join(f"- {name}" for name in sorted(set(agent_names)))
-                if len(agent_names) > 1:
-                    prefix = "Maximize usage of the following sub-agents to solve this task:"
-                else:
-                    prefix = "Use the following sub-agent to solve this task:"
-                suffixes.append(f"{prefix}\n\n{bullet_list}")
+        suffix_part = self._build_agents_suffix(resources)
+        if suffix_part:
+            has_any_resources = True
+            suffixes.append(suffix_part)
 
-        # Skills
-        if "skills" in resources:
-            skills_spec = resources["skills"]
-            skill_names: list[str] = []
-            for cat in skills_spec.get("categories", []):
-                cat_dir = self._shared_dir / "skills" / cat
-                if cat_dir.exists():
-                    skill_names.extend(d.name for d in cat_dir.iterdir() if d.is_dir())
-            skill_names.extend(skills_spec.get("names", []))
-            if skill_names:
-                has_any_resources = True
-                bullet_list = "\n".join(f"- {name}" for name in sorted(set(skill_names)))
-                if len(skill_names) > 1:
-                    prefix = "Maximize usage of the following skills to complete this task:"
-                else:
-                    prefix = "Use the following skill to complete this task:"
-                suffixes.append(f"{prefix}\n\n{bullet_list}")
+        suffix_part = self._build_skills_suffix(resources)
+        if suffix_part:
+            has_any_resources = True
+            suffixes.append(suffix_part)
 
-        # MCP servers
-        if "mcp_servers" in resources:
-            mcp_names = [
-                m.get("name", m) if isinstance(m, dict) else m for m in resources["mcp_servers"]
-            ]
-            if mcp_names:
-                has_any_resources = True
-                bullet_list = "\n".join(f"- {name}" for name in sorted(set(mcp_names)))
-                if len(mcp_names) > 1:
-                    prefix = "Maximize usage of the following MCP servers to complete this task:"
-                else:
-                    prefix = "Use the following MCP server to complete this task:"
-                suffixes.append(f"{prefix}\n\n{bullet_list}")
+        suffix_part = self._build_mcp_suffix(resources)
+        if suffix_part:
+            has_any_resources = True
+            suffixes.append(suffix_part)
 
-        # Tools
-        if "tools" in resources:
-            tools_spec = resources["tools"]
-            if isinstance(tools_spec, dict):
-                if tools_spec.get("enabled") == "all":
-                    suffixes.append("Maximize usage of all available tools to complete this task.")
-                    has_any_resources = True
-                elif "names" in tools_spec:
-                    tool_names = tools_spec["names"]
-                    if tool_names:
-                        has_any_resources = True
-                        bullet_list = "\n".join(f"- {name}" for name in sorted(tool_names))
-                        if len(tool_names) > 1:
-                            prefix = "Maximize usage of the following tools to complete this task:"
-                        else:
-                            prefix = "Use the following tool to complete this task:"
-                        suffixes.append(f"{prefix}\n\n{bullet_list}")
+        suffix_part = self._build_tools_suffix(resources)
+        if suffix_part:
+            has_any_resources = True
+            suffixes.append(suffix_part)
 
         # If no resources configured, add generic hint
         if not has_any_resources:
@@ -145,6 +98,115 @@ class ResourcesMixin(_Base):
         )
 
         return base_message + test_constraints + cleanup_instructions
+
+    def _build_agents_suffix(self, resources: dict[str, Any]) -> str:
+        """Build sub-agents section of resource suffix.
+
+        Args:
+            resources: Resource specification dict
+
+        Returns:
+            Formatted suffix string, or empty string if no agents.
+
+        """
+        if "agents" not in resources:
+            return ""
+        agents_spec = resources["agents"]
+        agent_names = []
+        for level in agents_spec.get("levels", []):
+            level_dir = self._shared_dir / "agents" / f"L{level}"
+            if level_dir.exists():
+                for f in level_dir.glob("*.md"):
+                    agent_names.append(f.stem)
+        agent_names.extend(n.replace(".md", "") for n in agents_spec.get("names", []))
+        if not agent_names:
+            return ""
+        bullet_list = "\n".join(f"- {name}" for name in sorted(set(agent_names)))
+        if len(agent_names) > 1:
+            prefix = "Maximize usage of the following sub-agents to solve this task:"
+        else:
+            prefix = "Use the following sub-agent to solve this task:"
+        return f"{prefix}\n\n{bullet_list}"
+
+    def _build_skills_suffix(self, resources: dict[str, Any]) -> str:
+        """Build skills section of resource suffix.
+
+        Args:
+            resources: Resource specification dict
+
+        Returns:
+            Formatted suffix string, or empty string if no skills.
+
+        """
+        if "skills" not in resources:
+            return ""
+        skills_spec = resources["skills"]
+        skill_names: list[str] = []
+        for cat in skills_spec.get("categories", []):
+            cat_dir = self._shared_dir / "skills" / cat
+            if cat_dir.exists():
+                skill_names.extend(d.name for d in cat_dir.iterdir() if d.is_dir())
+        skill_names.extend(skills_spec.get("names", []))
+        if not skill_names:
+            return ""
+        bullet_list = "\n".join(f"- {name}" for name in sorted(set(skill_names)))
+        if len(skill_names) > 1:
+            prefix = "Maximize usage of the following skills to complete this task:"
+        else:
+            prefix = "Use the following skill to complete this task:"
+        return f"{prefix}\n\n{bullet_list}"
+
+    def _build_mcp_suffix(self, resources: dict[str, Any]) -> str:
+        """Build MCP servers section of resource suffix.
+
+        Args:
+            resources: Resource specification dict
+
+        Returns:
+            Formatted suffix string, or empty string if no MCP servers.
+
+        """
+        if "mcp_servers" not in resources:
+            return ""
+        mcp_names = [
+            m.get("name", m) if isinstance(m, dict) else m for m in resources["mcp_servers"]
+        ]
+        if not mcp_names:
+            return ""
+        bullet_list = "\n".join(f"- {name}" for name in sorted(set(mcp_names)))
+        if len(mcp_names) > 1:
+            prefix = "Maximize usage of the following MCP servers to complete this task:"
+        else:
+            prefix = "Use the following MCP server to complete this task:"
+        return f"{prefix}\n\n{bullet_list}"
+
+    def _build_tools_suffix(self, resources: dict[str, Any]) -> str:
+        """Build tools section of resource suffix.
+
+        Args:
+            resources: Resource specification dict
+
+        Returns:
+            Formatted suffix string, or empty string if no tools specified.
+
+        """
+        if "tools" not in resources:
+            return ""
+        tools_spec = resources["tools"]
+        if not isinstance(tools_spec, dict):
+            return ""
+        if tools_spec.get("enabled") == "all":
+            return "Maximize usage of all available tools to complete this task."
+        if "names" in tools_spec:
+            tool_names = tools_spec["names"]
+            if tool_names:
+                bullet_list = "\n".join(f"- {name}" for name in sorted(tool_names))
+                if len(tool_names) > 1:
+                    prefix = "Maximize usage of the following tools to complete this task:"
+                else:
+                    prefix = "Use the following tool to complete this task:"
+                return f"{prefix}\n\n{bullet_list}"
+        return ""
 
     def build_merged_baseline(
         self,
@@ -178,16 +240,7 @@ class ResourcesMixin(_Base):
             result_file = completed_tier_dir / "result.json"
             best_subtest_file = completed_tier_dir / "best_subtest.json"
 
-            best_subtest_id = None
-            if result_file.exists():
-                with open(result_file) as f:
-                    tier_result = json.load(f)
-                best_subtest_id = tier_result.get("best_subtest")
-
-            if not best_subtest_id and best_subtest_file.exists():
-                with open(best_subtest_file) as f:
-                    selection = json.load(f)
-                best_subtest_id = selection.get("winning_subtest")
+            best_subtest_id = self._find_best_subtest_id(result_file, best_subtest_file)
 
             if not best_subtest_id:
                 logger.warning(
@@ -198,31 +251,15 @@ class ResourcesMixin(_Base):
                 continue
 
             # 2. Load config_manifest.json from best subtest (under completed/ phase dir)
-            manifest_file = (
+            candidate_manifest = (
                 get_subtest_dir(experiment_dir, tier_id.value, best_subtest_id, completed=True)
                 / "config_manifest.json"
             )
-            if not manifest_file.exists():
-                # Best subtest failed before manifest was written — find an alternative
-                tier_dir = completed_tier_dir
-                alternative = None
-                for subdir in sorted(tier_dir.iterdir()):
-                    candidate = subdir / "config_manifest.json"
-                    if subdir.is_dir() and candidate.exists():
-                        alternative = candidate
-                        logger.warning(
-                            f"Best subtest {tier_id.value}/{best_subtest_id} has no "
-                            f"config_manifest.json; falling back to "
-                            f"{tier_id.value}/{subdir.name}"
-                        )
-                        break
-                if alternative is None:
-                    logger.warning(
-                        f"No subtest in {tier_id.value} has config_manifest.json; "
-                        f"skipping inheritance from {tier_id.value}"
-                    )
-                    continue
-                manifest_file = alternative
+            manifest_file = self._resolve_manifest_file(
+                candidate_manifest, completed_tier_dir, tier_id, best_subtest_id
+            )
+            if manifest_file is None:
+                continue
 
             with open(manifest_file) as f:
                 manifest = json.load(f)
@@ -239,7 +276,74 @@ class ResourcesMixin(_Base):
 
         return merged_resources
 
-    def _merge_tier_resources(  # noqa: C901  # file discovery with many path patterns
+    def _find_best_subtest_id(
+        self, result_file: Path, best_subtest_file: Path
+    ) -> str | None:
+        """Find the best subtest ID from result files.
+
+        Args:
+            result_file: Path to result.json
+            best_subtest_file: Path to best_subtest.json
+
+        Returns:
+            Best subtest ID string, or None if not found.
+
+        """
+        best_subtest_id = None
+        if result_file.exists():
+            with open(result_file) as f:
+                tier_result = json.load(f)
+            best_subtest_id = tier_result.get("best_subtest")
+
+        if not best_subtest_id and best_subtest_file.exists():
+            with open(best_subtest_file) as f:
+                selection = json.load(f)
+            best_subtest_id = selection.get("winning_subtest")
+
+        return best_subtest_id
+
+    def _resolve_manifest_file(
+        self,
+        manifest_file: Path,
+        tier_dir: Path,
+        tier_id: TierID,
+        best_subtest_id: str,
+    ) -> Path | None:
+        """Resolve manifest file, falling back to sibling subtest if needed.
+
+        Args:
+            manifest_file: Expected manifest file path
+            tier_dir: Tier directory for fallback search
+            tier_id: Tier identifier for logging
+            best_subtest_id: Best subtest ID for logging
+
+        Returns:
+            Resolved manifest file path, or None if not found.
+
+        """
+        if manifest_file.exists():
+            return manifest_file
+
+        # Best subtest failed before manifest was written — find an alternative
+        alternative = None
+        for subdir in sorted(tier_dir.iterdir()):
+            candidate = subdir / "config_manifest.json"
+            if subdir.is_dir() and candidate.exists():
+                alternative = candidate
+                logger.warning(
+                    f"Best subtest {tier_id.value}/{best_subtest_id} has no "
+                    f"config_manifest.json; falling back to "
+                    f"{tier_id.value}/{subdir.name}"
+                )
+                break
+        if alternative is None:
+            logger.warning(
+                f"No subtest in {tier_id.value} has config_manifest.json; "
+                f"skipping inheritance from {tier_id.value}"
+            )
+        return alternative
+
+    def _merge_tier_resources(
         self,
         merged_resources: dict[str, Any],
         new_resources: dict[str, Any],
@@ -264,68 +368,107 @@ class ResourcesMixin(_Base):
         if "claude_md" in new_resources:
             merged_resources["claude_md"] = new_resources["claude_md"]
 
-        # Merge skills (union)
-        if "skills" in new_resources:
-            if "skills" not in merged_resources:
-                merged_resources["skills"] = {}
+        self._merge_skills(merged_resources, new_resources)
+        self._merge_tools(merged_resources, new_resources)
+        self._merge_mcp_servers(merged_resources, new_resources)
+        self._merge_agents(merged_resources, new_resources)
 
-            new_skills = new_resources["skills"]
+    def _merge_skills(
+        self, merged_resources: dict[str, Any], new_resources: dict[str, Any]
+    ) -> None:
+        """Merge skills resources using union strategy.
 
-            # Merge categories
-            if "categories" in new_skills:
-                merged_categories = merged_resources["skills"].get("categories", [])
-                merged_categories.extend(new_skills["categories"])
-                merged_resources["skills"]["categories"] = list(set(merged_categories))
+        Args:
+            merged_resources: Accumulated resources (modified in place)
+            new_resources: New resources to merge in
 
-            # Merge names
-            if "names" in new_skills:
-                merged_names = merged_resources["skills"].get("names", [])
-                merged_names.extend(new_skills["names"])
-                merged_resources["skills"]["names"] = list(set(merged_names))
+        """
+        if "skills" not in new_resources:
+            return
+        if "skills" not in merged_resources:
+            merged_resources["skills"] = {}
 
-        # Merge tools ("all" wins, else union)
-        if "tools" in new_resources:
-            if "tools" not in merged_resources:
-                merged_resources["tools"] = {}
+        new_skills = new_resources["skills"]
 
-            new_tools = new_resources["tools"]
+        if "categories" in new_skills:
+            merged_categories = merged_resources["skills"].get("categories", [])
+            merged_categories.extend(new_skills["categories"])
+            merged_resources["skills"]["categories"] = list(set(merged_categories))
 
-            # Check for "all" - it wins
-            new_enabled = new_tools.get("enabled", [])
-            existing_enabled = merged_resources["tools"].get("enabled", [])
+        if "names" in new_skills:
+            merged_names = merged_resources["skills"].get("names", [])
+            merged_names.extend(new_skills["names"])
+            merged_resources["skills"]["names"] = list(set(merged_names))
 
-            if new_enabled == "all" or existing_enabled == "all":
-                merged_resources["tools"]["enabled"] = "all"
-            elif isinstance(new_enabled, list) and isinstance(existing_enabled, list):
-                merged_enabled = existing_enabled + new_enabled
-                merged_resources["tools"]["enabled"] = list(set(merged_enabled))
+    def _merge_tools(
+        self, merged_resources: dict[str, Any], new_resources: dict[str, Any]
+    ) -> None:
+        """Merge tools resources; 'all' wins over specific tool lists.
 
-        # Merge MCP servers (union by server name)
-        if "mcp_servers" in new_resources:
-            if "mcp_servers" not in merged_resources:
-                merged_resources["mcp_servers"] = []
+        Args:
+            merged_resources: Accumulated resources (modified in place)
+            new_resources: New resources to merge in
 
-            existing_servers = {s["name"]: s for s in merged_resources["mcp_servers"]}
-            for server in new_resources["mcp_servers"]:
-                server_name = server["name"]
-                if server_name not in existing_servers:
-                    merged_resources["mcp_servers"].append(server)
+        """
+        if "tools" not in new_resources:
+            return
+        if "tools" not in merged_resources:
+            merged_resources["tools"] = {}
 
-        # Merge agents (union)
-        if "agents" in new_resources:
-            if "agents" not in merged_resources:
-                merged_resources["agents"] = {}
+        new_tools = new_resources["tools"]
+        new_enabled = new_tools.get("enabled", [])
+        existing_enabled = merged_resources["tools"].get("enabled", [])
 
-            new_agents = new_resources["agents"]
+        if new_enabled == "all" or existing_enabled == "all":
+            merged_resources["tools"]["enabled"] = "all"
+        elif isinstance(new_enabled, list) and isinstance(existing_enabled, list):
+            merged_enabled = existing_enabled + new_enabled
+            merged_resources["tools"]["enabled"] = list(set(merged_enabled))
 
-            # Merge levels
-            if "levels" in new_agents:
-                merged_levels = merged_resources["agents"].get("levels", [])
-                merged_levels.extend(new_agents["levels"])
-                merged_resources["agents"]["levels"] = sorted(set(merged_levels))
+    def _merge_mcp_servers(
+        self, merged_resources: dict[str, Any], new_resources: dict[str, Any]
+    ) -> None:
+        """Merge MCP servers by server name (no duplicates).
 
-            # Merge names
-            if "names" in new_agents:
-                merged_names = merged_resources["agents"].get("names", [])
-                merged_names.extend(new_agents["names"])
-                merged_resources["agents"]["names"] = list(set(merged_names))
+        Args:
+            merged_resources: Accumulated resources (modified in place)
+            new_resources: New resources to merge in
+
+        """
+        if "mcp_servers" not in new_resources:
+            return
+        if "mcp_servers" not in merged_resources:
+            merged_resources["mcp_servers"] = []
+
+        existing_servers = {s["name"]: s for s in merged_resources["mcp_servers"]}
+        for server in new_resources["mcp_servers"]:
+            server_name = server["name"]
+            if server_name not in existing_servers:
+                merged_resources["mcp_servers"].append(server)
+
+    def _merge_agents(
+        self, merged_resources: dict[str, Any], new_resources: dict[str, Any]
+    ) -> None:
+        """Merge agents resources using union strategy with sorted levels.
+
+        Args:
+            merged_resources: Accumulated resources (modified in place)
+            new_resources: New resources to merge in
+
+        """
+        if "agents" not in new_resources:
+            return
+        if "agents" not in merged_resources:
+            merged_resources["agents"] = {}
+
+        new_agents = new_resources["agents"]
+
+        if "levels" in new_agents:
+            merged_levels = merged_resources["agents"].get("levels", [])
+            merged_levels.extend(new_agents["levels"])
+            merged_resources["agents"]["levels"] = sorted(set(merged_levels))
+
+        if "names" in new_agents:
+            merged_names = merged_resources["agents"].get("names", [])
+            merged_names.extend(new_agents["names"])
+            merged_resources["agents"]["names"] = list(set(merged_names))

--- a/src/scylla/e2e/tier_manager_internals/workspace.py
+++ b/src/scylla/e2e/tier_manager_internals/workspace.py
@@ -1,4 +1,4 @@
-"""Workspace preparation mixin for :class:`TierManager`.
+"""Workspace preparation collaborator for :class:`TierManager`.
 
 Methods that materialize tier configuration onto a workspace directory:
 copying baselines, overlaying subtest configs, creating symlinks/settings.
@@ -11,26 +11,59 @@ import logging
 import os
 import shutil
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, cast
+from typing import TYPE_CHECKING, Any, Protocol, cast
 
 import yaml
 
 from scylla.e2e.models import SubTestConfig, TierBaseline, TierID
 
 if TYPE_CHECKING:
-    from scylla.e2e.tier_manager_internals.base import TierManagerBase
-
-    _Base = TierManagerBase
-else:
-    _Base = object
+    pass
 
 logger = logging.getLogger(__name__)
 
 
-class WorkspaceMixin(_Base):
+class _ResourceProtocol(Protocol):
+    """Protocol for methods WorkspaceHandler needs from ResourcesHandler."""
+
+    def build_resource_suffix(self, subtest: SubTestConfig) -> str: ...
+
+    def _merge_tier_resources(
+        self,
+        merged_resources: dict[str, Any],
+        new_resources: dict[str, Any],
+        source_tier: TierID,
+    ) -> None: ...
+
+
+class _BaselineProtocol(Protocol):
+    """Protocol for methods WorkspaceHandler needs from BaselineHandler."""
+
+    def load_tier_config(self, tier_id: TierID, skip_agent_teams: bool = False) -> Any: ...
+
+
+class WorkspaceHandler:
     """Workspace preparation methods for :class:`TierManager`."""
 
-    def prepare_workspace(  # noqa: C901  # workspace setup with many config scenarios
+    def __init__(
+        self,
+        shared_dir: Path,
+        resources: _ResourceProtocol,
+        baseline: _BaselineProtocol,
+    ) -> None:
+        """Initialize workspace handler with collaborators.
+
+        Args:
+            shared_dir: Path to shared resources directory
+            resources: ResourcesHandler collaborator
+            baseline: BaselineHandler collaborator
+
+        """
+        self._shared_dir = shared_dir
+        self._resources = resources
+        self._baseline = baseline
+
+    def prepare_workspace(
         self,
         workspace: Path,
         tier_id: TierID,
@@ -63,68 +96,19 @@ class WorkspaceMixin(_Base):
             thinking_enabled: Whether to enable extended thinking mode
 
         """
-        tier_config = self.load_tier_config(tier_id)
+        tier_config = self._baseline.load_tier_config(tier_id)
         subtest = next((s for s in tier_config.subtests if s.id == subtest_id), None)
 
         if not subtest:
             raise ValueError(f"Sub-test {subtest_id} not found for tier {tier_id.value}")
 
-        # Special handling for T0 sub-tests
         if tier_id == TierID.T0:
-            claude_md = workspace / "CLAUDE.md"
-            claude_dir = workspace / ".claude"
+            self._handle_t0_workspace(workspace, subtest, subtest_id, thinking_enabled)
+            return
 
-            if subtest_id == "00":
-                # 00-empty: Remove all configuration (no system prompt)
-                if claude_md.exists():
-                    claude_md.unlink()
-                if claude_dir.exists():
-                    shutil.rmtree(claude_dir)
-                # Still create settings.json for thinking control
-                self._create_settings_json(workspace, subtest, thinking_enabled)
-                return
-            elif subtest_id == "01":
-                # 01-vanilla: Use tool defaults (no changes needed)
-                # But still remove any existing CLAUDE.md to ensure clean state
-                if claude_md.exists():
-                    claude_md.unlink()
-                if claude_dir.exists():
-                    shutil.rmtree(claude_dir)
-                # Still create settings.json for thinking control
-                self._create_settings_json(workspace, subtest, thinking_enabled)
-                return
-            # 02+: Fall through to normal overlay logic
-
-        # Build resource suffix for CLAUDE.md
-        # For T5 with merged resources, create temporary SubTestConfig with merged resources
-        if merged_resources and tier_id == TierID.T5:
-            # Merge subtest resources with inherited resources if needed
-            final_merged = merged_resources.copy()
-            if subtest.resources:
-                for resource_type, resource_spec in subtest.resources.items():
-                    if resource_type not in final_merged:
-                        final_merged[resource_type] = resource_spec
-                    else:
-                        temp_merged = final_merged.copy()
-                        temp_new = {resource_type: resource_spec}
-                        self._merge_tier_resources(temp_merged, temp_new, TierID.T5)
-                        final_merged = temp_merged
-
-            # Create temporary SubTestConfig for resource suffix generation
-            temp_subtest = subtest.model_copy(update={"resources": final_merged})
-            resource_suffix = self.build_resource_suffix(temp_subtest)
-
-            # Apply merged resources with suffix
-            self._create_symlinks(workspace, final_merged, resource_suffix)
-        # Normal baseline extension for other tiers
-        elif baseline and subtest.extends_previous:
-            # Build resource suffix from baseline
-            temp_subtest = subtest.model_copy(update={"resources": baseline.resources})
-            resource_suffix = self.build_resource_suffix(temp_subtest)
-            self._apply_baseline(workspace, baseline, resource_suffix)
-        else:
-            # Build resource suffix from subtest
-            resource_suffix = self.build_resource_suffix(subtest)
+        resource_suffix = self._compute_resource_suffix(
+            workspace, tier_id, subtest, baseline, merged_resources
+        )
 
         # Step 2: Overlay sub-test configuration (skip for T5 with merged_resources)
         if not (merged_resources and tier_id == TierID.T5):
@@ -132,6 +116,126 @@ class WorkspaceMixin(_Base):
 
         # Create settings.json with thinking configuration
         self._create_settings_json(workspace, subtest, thinking_enabled)
+
+    def _handle_t0_workspace(
+        self,
+        workspace: Path,
+        subtest: SubTestConfig,
+        subtest_id: str,
+        thinking_enabled: bool,
+    ) -> None:
+        """Handle special T0 workspace setup (empty/vanilla/custom).
+
+        Args:
+            workspace: Target workspace directory
+            subtest: SubTestConfig for this subtest
+            subtest_id: The subtest ID string
+            thinking_enabled: Whether extended thinking is enabled
+
+        """
+        claude_md = workspace / "CLAUDE.md"
+        claude_dir = workspace / ".claude"
+
+        if subtest_id in ("00", "01"):
+            # 00-empty: Remove all configuration (no system prompt)
+            # 01-vanilla: Use tool defaults (no changes needed)
+            if claude_md.exists():
+                claude_md.unlink()
+            if claude_dir.exists():
+                shutil.rmtree(claude_dir)
+            self._create_settings_json(workspace, subtest, thinking_enabled)
+            return
+
+        # 02+: Fall through to normal overlay logic
+        resource_suffix = self._resources.build_resource_suffix(subtest)
+        self._overlay_subtest(workspace, subtest, resource_suffix)
+        self._create_settings_json(workspace, subtest, thinking_enabled)
+
+    def _compute_resource_suffix(
+        self,
+        workspace: Path,
+        tier_id: TierID,
+        subtest: SubTestConfig,
+        baseline: TierBaseline | None,
+        merged_resources: dict[str, Any] | None,
+    ) -> str | None:
+        """Compute resource suffix and apply resources to the workspace.
+
+        Args:
+            workspace: Target workspace directory
+            tier_id: Current tier identifier
+            subtest: Sub-test configuration
+            baseline: Previous tier baseline (if any)
+            merged_resources: Pre-merged resources for T5 (if any)
+
+        Returns:
+            Resource suffix string, or None.
+
+        """
+        if merged_resources and tier_id == TierID.T5:
+            return self._apply_merged_resources(workspace, subtest, merged_resources, tier_id)
+
+        if baseline and subtest.extends_previous:
+            return self._apply_baseline_resources(workspace, subtest, baseline)
+
+        return self._resources.build_resource_suffix(subtest)
+
+    def _apply_merged_resources(
+        self,
+        workspace: Path,
+        subtest: SubTestConfig,
+        merged_resources: dict[str, Any],
+        tier_id: TierID,
+    ) -> str:
+        """Apply merged T5 resources and return suffix.
+
+        Args:
+            workspace: Target workspace directory
+            subtest: Sub-test configuration
+            merged_resources: Pre-merged resources from multiple tiers
+            tier_id: Current tier identifier
+
+        Returns:
+            Resource suffix string.
+
+        """
+        final_merged = merged_resources.copy()
+        if subtest.resources:
+            for resource_type, resource_spec in subtest.resources.items():
+                if resource_type not in final_merged:
+                    final_merged[resource_type] = resource_spec
+                else:
+                    temp_merged = final_merged.copy()
+                    temp_new = {resource_type: resource_spec}
+                    self._resources._merge_tier_resources(temp_merged, temp_new, tier_id)
+                    final_merged = temp_merged
+
+        temp_subtest = subtest.model_copy(update={"resources": final_merged})
+        resource_suffix = self._resources.build_resource_suffix(temp_subtest)
+        self._create_symlinks(workspace, final_merged, resource_suffix)
+        return resource_suffix
+
+    def _apply_baseline_resources(
+        self,
+        workspace: Path,
+        subtest: SubTestConfig,
+        baseline: TierBaseline,
+    ) -> str:
+        """Apply baseline resources to workspace and return suffix.
+
+        Args:
+            workspace: Target workspace directory
+            subtest: Sub-test configuration
+            baseline: Previous tier's winning baseline
+
+        Returns:
+            Resource suffix string.
+
+        """
+        temp_subtest = subtest.model_copy(update={"resources": baseline.resources})
+        resource_suffix = self._resources.build_resource_suffix(temp_subtest)
+        self._apply_baseline(workspace, baseline, resource_suffix)
+        return resource_suffix
 
     def _apply_baseline(
         self, workspace: Path, baseline: TierBaseline, resource_suffix: str | None = None
@@ -223,7 +327,7 @@ class WorkspaceMixin(_Base):
 
         return cast(dict[str, Any], config.get("resources", {}))
 
-    def _create_symlinks(  # noqa: C901  # symlink creation with many source/target patterns
+    def _create_symlinks(
         self,
         workspace: Path,
         resources: dict[str, Any],
@@ -239,63 +343,126 @@ class WorkspaceMixin(_Base):
         """
         shared_dir = self._shared_dir
 
-        # Symlink skills by category
-        if "skills" in resources:
-            skills_spec = resources["skills"]
-            skills_dir = workspace / ".claude" / "skills"
-            skills_dir.mkdir(parents=True, exist_ok=True)
+        self._link_skills(workspace, resources, shared_dir)
+        self._link_agents(workspace, resources, shared_dir)
+        self._write_claude_md(workspace, resources, shared_dir, resource_suffix)
 
-            # Handle categories (e.g., ["agent", "github"])
-            for category in skills_spec.get("categories", []):
-                category_dir = shared_dir / "skills" / category
-                if category_dir.exists():
-                    for skill in category_dir.iterdir():
-                        if skill.is_dir():
-                            link_path = skills_dir / skill.name
-                            if not link_path.exists():
-                                os.symlink(skill.resolve(), link_path)
+    def _link_skills_by_category(
+        self, skills_dir: Path, shared_dir: Path, categories: list[str]
+    ) -> None:
+        """Symlink all skills from each requested category into skills_dir."""
+        for category in categories:
+            category_dir = shared_dir / "skills" / category
+            if not category_dir.exists():
+                continue
+            for skill in category_dir.iterdir():
+                if skill.is_dir():
+                    link_path = skills_dir / skill.name
+                    if not link_path.exists():
+                        os.symlink(skill.resolve(), link_path)
 
-            # Handle individual skill names (e.g., ["gh-create-pr-linked"])
-            for skill_name in skills_spec.get("names", []):
-                # Search all categories for this skill
-                for category_dir in (shared_dir / "skills").iterdir():
-                    if category_dir.is_dir():
-                        skill_path = category_dir / skill_name
-                        if skill_path.exists():
-                            link_path = skills_dir / skill_name
-                            if not link_path.exists():
-                                os.symlink(skill_path.resolve(), link_path)
-                            break
+    def _link_skills_by_name(
+        self, skills_dir: Path, shared_dir: Path, names: list[str]
+    ) -> None:
+        """Search all skill categories to symlink individually-named skills."""
+        for skill_name in names:
+            for category_dir in (shared_dir / "skills").iterdir():
+                if not category_dir.is_dir():
+                    continue
+                skill_path = category_dir / skill_name
+                if skill_path.exists():
+                    link_path = skills_dir / skill_name
+                    if not link_path.exists():
+                        os.symlink(skill_path.resolve(), link_path)
+                    break
 
-        # Symlink agents by level
-        if "agents" in resources:
-            agents_spec = resources["agents"]
-            agents_dir = workspace / ".claude" / "agents"
-            agents_dir.mkdir(parents=True, exist_ok=True)
+    def _link_skills(
+        self, workspace: Path, resources: dict[str, Any], shared_dir: Path
+    ) -> None:
+        """Symlink skill directories into the workspace.
 
-            # Handle levels (e.g., [0, 1, 3])
-            for level in agents_spec.get("levels", []):
-                level_dir = shared_dir / "agents" / f"L{level}"
-                if level_dir.exists():
-                    for agent in level_dir.iterdir():
-                        if agent.is_file() and agent.suffix == ".md":
-                            link_path = agents_dir / agent.name
-                            if not link_path.exists():
-                                os.symlink(agent.resolve(), link_path)
+        Args:
+            workspace: Target workspace directory
+            resources: Resource specification
+            shared_dir: Path to shared resources
 
-            # Handle individual agent names (e.g., ["chief-architect.md"])
-            for agent_name in agents_spec.get("names", []):
-                # Search all levels for this agent
-                for level_dir in (shared_dir / "agents").iterdir():
-                    if level_dir.is_dir() and level_dir.name.startswith("L"):
-                        agent_path = level_dir / agent_name
-                        if agent_path.exists():
-                            link_path = agents_dir / agent_name
-                            if not link_path.exists():
-                                os.symlink(agent_path.resolve(), link_path)
-                            break
+        """
+        if "skills" not in resources:
+            return
 
-        # Compose CLAUDE.md from blocks (with optional resource suffix)
+        skills_spec = resources["skills"]
+        skills_dir = workspace / ".claude" / "skills"
+        skills_dir.mkdir(parents=True, exist_ok=True)
+
+        self._link_skills_by_category(skills_dir, shared_dir, skills_spec.get("categories", []))
+        self._link_skills_by_name(skills_dir, shared_dir, skills_spec.get("names", []))
+
+    def _link_agents_by_level(
+        self, agents_dir: Path, shared_dir: Path, levels: list[int]
+    ) -> None:
+        """Symlink all agent files from each requested level into agents_dir."""
+        for level in levels:
+            level_dir = shared_dir / "agents" / f"L{level}"
+            if not level_dir.exists():
+                continue
+            for agent in level_dir.iterdir():
+                if agent.is_file() and agent.suffix == ".md":
+                    link_path = agents_dir / agent.name
+                    if not link_path.exists():
+                        os.symlink(agent.resolve(), link_path)
+
+    def _link_agents_by_name(
+        self, agents_dir: Path, shared_dir: Path, names: list[str]
+    ) -> None:
+        """Search all agent levels to symlink individually-named agents."""
+        for agent_name in names:
+            for level_dir in (shared_dir / "agents").iterdir():
+                if not (level_dir.is_dir() and level_dir.name.startswith("L")):
+                    continue
+                agent_path = level_dir / agent_name
+                if agent_path.exists():
+                    link_path = agents_dir / agent_name
+                    if not link_path.exists():
+                        os.symlink(agent_path.resolve(), link_path)
+                    break
+
+    def _link_agents(
+        self, workspace: Path, resources: dict[str, Any], shared_dir: Path
+    ) -> None:
+        """Symlink agent files into the workspace.
+
+        Args:
+            workspace: Target workspace directory
+            resources: Resource specification
+            shared_dir: Path to shared resources
+
+        """
+        if "agents" not in resources:
+            return
+
+        agents_spec = resources["agents"]
+        agents_dir = workspace / ".claude" / "agents"
+        agents_dir.mkdir(parents=True, exist_ok=True)
+
+        self._link_agents_by_level(agents_dir, shared_dir, agents_spec.get("levels", []))
+        self._link_agents_by_name(agents_dir, shared_dir, agents_spec.get("names", []))
+
+    def _write_claude_md(
+        self,
+        workspace: Path,
+        resources: dict[str, Any],
+        shared_dir: Path,
+        resource_suffix: str | None,
+    ) -> None:
+        """Write CLAUDE.md from blocks and resource suffix.
+
+        Args:
+            workspace: Target workspace directory
+            resources: Resource specification
+            shared_dir: Path to shared resources
+            resource_suffix: Optional suffix to append
+
+        """
         if "claude_md" in resources:
             claude_md_spec = resources["claude_md"]
             self._compose_claude_md(workspace, claude_md_spec, shared_dir, resource_suffix)
@@ -413,20 +580,3 @@ class WorkspaceMixin(_Base):
         settings_path = settings_dir / "settings.json"
         with open(settings_path, "w") as f:
             json.dump(settings, f, indent=2)
-
-    # Forward declarations for methods provided by sibling mixins; satisfied at
-    # runtime by MRO on the composed :class:`TierManager`.
-    if TYPE_CHECKING:
-
-        def load_tier_config(  # noqa: D102
-            self, tier_id: TierID, skip_agent_teams: bool = False
-        ) -> Any: ...
-
-        def build_resource_suffix(self, subtest: SubTestConfig) -> str: ...  # noqa: D102
-
-        def _merge_tier_resources(
-            self,
-            merged_resources: dict[str, Any],
-            new_resources: dict[str, Any],
-            source_tier: TierID,
-        ) -> None: ...

--- a/src/scylla/reporting/scorecard.py
+++ b/src/scylla/reporting/scorecard.py
@@ -86,7 +86,23 @@ def _grade_to_points(grade: str) -> float:
     return max(0.0, min(5.0, points))
 
 
-def _points_to_grade(points: float) -> str:  # noqa: C901  # grade mapping with many score thresholds
+_GRADE_THRESHOLDS: list[tuple[float, str]] = [
+    (4.85, "S"),
+    (3.85, "A"),
+    (3.50, "A-"),
+    (3.15, "B+"),
+    (2.85, "B"),
+    (2.50, "B-"),
+    (2.15, "C+"),
+    (1.85, "C"),
+    (1.50, "C-"),
+    (1.15, "D+"),
+    (0.85, "D"),
+    (0.50, "D-"),
+]
+
+
+def _points_to_grade(points: float) -> str:
     """Convert point value back to letter grade.
 
     Uses industry-aligned scale where S is the highest grade.
@@ -98,32 +114,10 @@ def _points_to_grade(points: float) -> str:  # noqa: C901  # grade mapping with 
         Letter grade string (S, A, B, C, D, or F with optional +/-)
 
     """
-    if points >= 4.85:
-        return "S"
-    elif points >= 3.85:
-        return "A"
-    elif points >= 3.5:
-        return "A-"
-    elif points >= 3.15:
-        return "B+"
-    elif points >= 2.85:
-        return "B"
-    elif points >= 2.5:
-        return "B-"
-    elif points >= 2.15:
-        return "C+"
-    elif points >= 1.85:
-        return "C"
-    elif points >= 1.5:
-        return "C-"
-    elif points >= 1.15:
-        return "D+"
-    elif points >= 0.85:
-        return "D"
-    elif points >= 0.5:
-        return "D-"
-    else:
-        return "F"
+    for threshold, grade in _GRADE_THRESHOLDS:
+        if points >= threshold:
+            return grade
+    return "F"
 
 
 class ScorecardGenerator:


### PR DESCRIPTION
## Summary

- Replace `WorkspaceMixin/ResourcesMixin/BaselineMixin` multiple-inheritance with composition: `TierManager` now holds `WorkspaceHandler`, `ResourcesHandler`, and `BaselineHandler` collaborators. MRO is `TierManager→object` — no mixin chain. Addresses AC3 (mixins removed in favor of composition).
- Eliminate 9 of 22 `# noqa: C901` suppressions by extracting named helper functions in: `workspace.py` (2), `resources.py` (helper extraction), `scorecard.py` (lookup table), `llm_judge.py` (2 helpers), `run_report_sections.py` (2 helpers), `experiment_loader.py` (1 helper), `run_loader.py` (line-length fix). Progress on AC2.
- Public API of `TierManager` is fully preserved — same constructor signature, same method names — all 91 unit tests pass.

## Divergence from plan

- Plan §2 verification found 16 oversize files (not 12); 4 missed: `analysis/tables/comparison.py`, `analysis/stats.py`, `executor/docker.py`, `analysis/tables/detail.py`. These remain for subsequent PRs.
- `runner_core.py:352` C901 suppression unaddressed in this PR — needs separate extraction work.
- Remaining 13 C901 suppressions and 16 oversize files require additional PRs per the plan's tier structure (PR-S, PR-C, PR-ER, etc.).
- `workspace.py` went 432→582 lines (under 600 threshold). `run_report_sections.py` went 612→639 (full module split deferred to PR-RS).

## Test plan

- [x] `pixi run python -m pytest tests/unit/e2e/test_tier_manager.py tests/unit/e2e/test_workspace_setup.py tests/unit/e2e/test_workspace_manager.py` — 91 passed
- [x] `pixi run python -m ruff check src/scylla/` — all checks passed
- [x] `pixi run python -m mypy src/scylla/e2e/tier_manager_internals/` — success
- [x] `TierManager.__mro__` → `[TierManager, object]` (mixin-free)

Closes #1941

🤖 Generated with [Claude Code](https://claude.com/claude-code)