### PR TITLE
fix(ci): remove nonexistent labels from digest-check workflow

### DIFF
--- a/.github/workflows/digest-check.yml
+++ b/.github/workflows/digest-check.yml
@@ -71,14 +71,14 @@ jobs:
         if: steps.compare.outputs.status == 'stale'
         run: |
           LATEST_DIGEST="${{ steps.latest.outputs.digest }}"
-          EXISTING_ISSUE=$(gh issue list --label "chore" --search "update python:3.12-slim digest" --json number -q '.[0].number' 2>/dev/null || echo "")
+          EXISTING_ISSUE=$(gh issue list --search "update python:3.12-slim digest in:title" --json number -q '.[0].number' 2>/dev/null || echo "")
 
           if [ -n "$EXISTING_ISSUE" ]; then
             echo "Updating existing issue #${EXISTING_ISSUE}"
             gh issue comment "${EXISTING_ISSUE}" --body "Digest check: Latest digest is ${LATEST_DIGEST}"
           else
             echo "Creating new issue for digest update"
-            gh issue create --title "chore: update python:3.12-slim digest pins" --body "The python:3.12-slim digest pins need to be updated. Latest: ${LATEST_DIGEST}. Check ci/Containerfile and docker/Dockerfile." --label "chore" --label "dependencies"
+            gh issue create --title "chore: update python:3.12-slim digest pins" --body "The python:3.12-slim digest pins need to be updated. Latest: ${LATEST_DIGEST}. Check ci/Containerfile and docker/Dockerfile."
           fi
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Objective
The `Check Node Digest Pins` scheduled workflow has been failing on `main` (run 26752628581, 2026-06-01) at the issue-creation step:

```
Creating new issue for digest update
could not add label: 'chore' not found
##[error]Process completed with exit code 1.
```

Neither the `chore` nor `dependencies` label exists in this repo, so `gh issue create --label chore --label dependencies` (and the `gh issue list --label chore` filter) error out. This is a non-required check so it never blocked merges, but it leaves a red mark on `main` every run and the digest-staleness tracking issue is never actually filed.

## Change
Per the project's **Never use labels** rule, remove the `--label` flags from `gh issue create` and replace the `--label chore` filter on `gh issue list` with an `in:title` search. Two-line change; no behavior change beyond the workflow now succeeding.

## Verification
- `pre-commit run --files .github/workflows/digest-check.yml` → YAML lint + EOF/whitespace pass
- The workflow can be manually re-run via `workflow_dispatch` after merge to confirm green; it will file (or update) the digest tracking issue without the label error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)