### PR TITLE
ci: unify job naming to canonical 8-category scheme

### DIFF
--- a/.github/workflows/_required.yml
+++ b/.github/workflows/_required.yml
@@ -481,6 +481,83 @@ jobs:
           if-no-files-found: error
           retention-days: 7
 
+  # ── 6a. test (aggregate) ───────────────────────────────────────────────────
+  # Canonical 8-category `test` context. Aggregates the discrete suites
+  # (`unit-tests`, `integration-tests`) into a single roll-up so the Odysseus
+  # ecosystem board can show one clear `test` category while the per-suite
+  # checks remain visible. Pure fan-in: no test work of its own, just gates on
+  # the suites it `needs:`. Canonical CI naming (HomericIntelligence/Odysseus).
+  test:
+    name: test
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    needs: [unit-tests, integration-tests]
+    steps:
+      - name: Aggregate test result
+        run: echo "All required test suites (unit-tests, integration-tests) passed."
+
+  # ── 6b. package ────────────────────────────────────────────────────────────
+  # Canonical 8-category `package` context. Verifies the distributable
+  # artifacts produced by `build` are well-formed (twine check on the sdist +
+  # wheel). Consumes the `python-package` artifact so it does no rebuild.
+  package:
+    name: package
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    needs: [build]
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
+
+      - name: Set up Pixi
+        uses: ./.github/actions/setup-pixi
+
+      - name: Download built distributions
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
+        with:
+          name: python-package
+          path: dist/
+
+      - name: Validate distribution metadata (twine check)
+        run: |
+          pixi run pip install twine
+          pixi run twine check dist/*
+
+  # ── 6c. install ────────────────────────────────────────────────────────────
+  # Canonical 8-category `install` context. Installs the built wheel into a
+  # clean venv and smoke-tests the `scylla` console entry point, proving the
+  # package is installable end-to-end (not just buildable).
+  install:
+    name: install
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    needs: [build]
+    steps:
+      - name: Set up Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
+        with:
+          python-version: "3.12"
+
+      - name: Download built distributions
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
+        with:
+          name: python-package
+          path: dist/
+
+      - name: Install wheel into clean venv
+        run: |
+          python -m venv /tmp/scylla-install-venv
+          /tmp/scylla-install-venv/bin/pip install --upgrade pip
+          # Install the built wheel (not the source tree) to prove the package
+          # installs from its distributable artifact.
+          wheel=$(ls dist/*.whl | head -1)
+          echo "Installing ${wheel}"
+          /tmp/scylla-install-venv/bin/pip install "${wheel}"
+
+      - name: Smoke-test console entry point
+        run: |
+          /tmp/scylla-install-venv/bin/scylla --help
+          /tmp/scylla-install-venv/bin/python -c "import scylla; print('scylla', getattr(scylla, '__version__', 'imported'))"
+
   # ── 7. schema-validation ───────────────────────────────────────────────────
   schema-validation:
     name: schema-validation


### PR DESCRIPTION
## Canonical 8-category CI naming — Scylla pilot

Unifies Scylla's CI check-run names to the canonical 8-category scheme (build, test, lint, package, install, release, security, custom) so the Odysseus ecosystem board shows each category clearly. This is the **pilot**; the pattern rolls out to 12 more repos.

### What changed (`.github/workflows/_required.yml`)
Three new check-emitting jobs (all canonical names):
- **`test`** — aggregate fan-in job (`needs: [unit-tests, integration-tests]`). Per-suite checks (`unit-tests`, `integration-tests`, `bats`) stay visible.
- **`package`** — `twine check` on the sdist+wheel produced by `build` (consumes the existing `python-package` artifact; no rebuild).
- **`install`** — installs the built wheel into a clean venv and smoke-tests the `scylla` console entry point.

### Already canonical (unchanged)
`build`, `lint`, `security/dependency-scan`, `security/secrets-scan`.

### Category mapping
| Category | Emitting check | Status |
|---|---|---|
| build | `build` | already canonical |
| test | `test` (+ unit-tests / integration-tests / bats) | **added aggregate** |
| lint | `lint` | already canonical |
| package | `package` | **added** |
| install | `install` | **added** |
| release | — | gap, issue #2027 (tag-only PyPI publish, unsafe to wire to PR/main) |
| security | `security/dependency-scan`, `security/secrets-scan` | canonical; `Analyze (python)` gap issue #2028 (CodeQL default-setup, no YAML) |
| custom | markdownlint, pixi-check, justfile-check, symlink-check, schema-validation, deps/version-sync, forbid-suppressions | left as-is |

### Self-mergeable / emit-before-require
This branch emits the new names itself, and **no ruleset `required_status_checks` were changed**. New names can be added to the ruleset only after they are observed reporting on `main` (emit-before-require), avoiding the emitted-name-vs-required-name deadlock.

Gaps filed: #2027 (release), #2028 (security/codeql-python).

🤖 Generated with [Claude Code](https://claude.com/claude-code)