### PR TITLE
fix(ci): remove explicit wheel packages path causing ModuleNotFoundError

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,7 +67,9 @@ scylla = "scylla.cli.main:cli"
 sources = ["src"]
 
 [tool.hatch.build.targets.wheel]
-packages = ["src/scylla"]
+# With sources = ["src"] above, Hatchling auto-discovers scylla/ inside src/
+# and places it at site-packages/scylla/. Do NOT add packages = ["src/scylla"]
+# — that installs to site-packages/src/scylla/ breaking `import scylla`.
 
 [tool.hatch.build.targets.wheel.force-include]
 "src/scylla/analysis/schemas" = "scylla/analysis/schemas"


### PR DESCRIPTION
Fixes Required Checks install job failure: `ModuleNotFoundError: No module named scylla` after pip install.

Root cause: `packages = ["src/scylla"]` in `[tool.hatch.build.targets.wheel]` caused the wheel to install at `site-packages/src/scylla/` instead of `site-packages/scylla/`. With `sources = ["src"]` already set under `[tool.hatch.build]`, Hatchling auto-discovers the package correctly.

Fix: Remove the explicit `packages` line and add a comment explaining why.