### PR TITLE
chore(settings): swap hephaestus plugin → Athena marketplace

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,7 +1,37 @@
 {
   "enabledPlugins": {
     "plan-export@cc-marketplace": true,
-    "hephaestus@ProjectHephaestus": true
+    "advise@Athena": true,
+    "brainstorm@Athena": true,
+    "code-review@Athena": true,
+    "create-reusable-utilities@Athena": true,
+    "finish-branch@Athena": true,
+    "git-worktrees@Athena": true,
+    "github-actions-python-cicd@Athena": true,
+    "learn@Athena": true,
+    "myrmidon-swarm@Athena": true,
+    "python-repo-modernization@Athena": true,
+    "repo-analyze@Athena": true,
+    "repo-analyze-full@Athena": true,
+    "repo-analyze-quick@Athena": true,
+    "repo-analyze-quick-full@Athena": true,
+    "repo-analyze-strict@Athena": true,
+    "repo-analyze-strict-full@Athena": true,
+    "review-pr-strict@Athena": true,
+    "skill-advisor@Athena": true,
+    "systematic-debugging@Athena": true,
+    "test-driven-development@Athena": true,
+    "tidy@Athena": true,
+    "verification@Athena": true,
+    "worktree-cleanup@Athena": true
   },
-  "alwaysThinkingEnabled": false
+  "alwaysThinkingEnabled": false,
+  "extraKnownMarketplaces": {
+    "Athena": {
+      "source": {
+        "source": "git",
+        "url": "https://github.com/HomericIntelligence/Athena.git"
+      }
+    }
+  }
 }


### PR DESCRIPTION
Migrate `.claude/settings.json` from the stale `hephaestus@ProjectHephaestus` plugin to the new Athena marketplace.

The hephaestus plugin was carved out to HomericIntelligence/Athena, which publishes 23 per-skill plugins under the `Athena` marketplace.

## Changes
- Remove `hephaestus@ProjectHephaestus` from `enabledPlugins`
- Add the 23 `<skill>@Athena` per-skill plugin keys
- Register the `Athena` git marketplace under `extraKnownMarketplaces`

## Preserved
- `plan-export@cc-marketplace` plugin
- `alwaysThinkingEnabled: false`
- All other settings

Closes #2044