### PR TITLE
chore(config): remove Hephaestus plugin

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,7 +1,6 @@
 {
   "enabledPlugins": {
-    "plan-export@cc-marketplace": true,
-    "hephaestus@ProjectHephaestus": true
+    "plan-export@cc-marketplace": true
   },
   "alwaysThinkingEnabled": false
 }


### PR DESCRIPTION
## Summary

- Remove the enabled `hephaestus@ProjectHephaestus` entry from Claude settings.
- Retain the unrelated `plan-export` plugin.

## Why

Athena is the supported plugin; the retired Hephaestus plugin must not remain enabled in repository configuration.

## Validation

- Parsed `.claude/settings.json` as JSON.
- Confirmed no Hephaestus or ProjectHephaestus reference remains in the file.
- Ran `git diff --check`.
