### PR TITLE
test(ci): guard Pixi environment cache ownership

### DIFF
--- a/tests/unit/ci/test_setup_pixi_cache.py
+++ b/tests/unit/ci/test_setup_pixi_cache.py
@@ -1,0 +1,33 @@
+"""Regression tests for the shared Pixi setup action."""
+
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+
+import yaml
+
+_PROJECT_ROOT = Path(__file__).resolve().parents[3]
+_SETUP_PIXI_ACTION = _PROJECT_ROOT / ".github" / "actions" / "setup-pixi" / "action.yml"
+
+
+class TestSetupPixiCache(unittest.TestCase):
+    """The shared setup action must own its environment cache safely."""
+
+    def test_delegates_environment_cache_to_setup_pixi(self) -> None:
+        """Use setup-pixi's cache instead of restoring a second `.pixi` archive."""
+        action = yaml.safe_load(_SETUP_PIXI_ACTION.read_text())
+        setup_steps = [
+            step
+            for step in action["runs"]["steps"]
+            if step.get("uses", "").startswith("prefix-dev/setup-pixi@")
+        ]
+        cache_steps = [
+            step
+            for step in action["runs"]["steps"]
+            if step.get("uses", "").startswith("actions/cache@")
+        ]
+
+        self.assertEqual(len(setup_steps), 1)
+        self.assertIs(setup_steps[0]["with"]["cache"], True)
+        self.assertEqual(cache_steps, [])


### PR DESCRIPTION
## Summary

- Add a regression test that requires the shared setup action to delegate environment caching to `prefix-dev/setup-pixi`.
- Prevent a second `actions/cache` step from restoring `.pixi` over the requested environment.

## Context

During the rebase, `main` incorporated the production fix in #2046: `prefix-dev/setup-pixi` now owns the cache through `cache: true`, and the redundant second cache step is gone. This PR therefore keeps only the guard that prevents that failure mode from returning.

## Validation

- `.pixi/envs/lint/bin/pytest tests/unit/ci/test_setup_pixi_cache.py -q --override-ini='addopts='`
- `.pixi/envs/lint/bin/ruff check tests/unit/ci/test_setup_pixi_cache.py`
- `.pixi/envs/lint/bin/ruff format --check tests/unit/ci/test_setup_pixi_cache.py`
- `.pixi/envs/lint/bin/mypy tests/unit/ci/test_setup_pixi_cache.py`
- Verified the strengthened condition rejects the pre-fix action.

Full pre-commit hook bootstrap did not complete locally; the PR checks will validate the complete workflow on GitHub's runner.
