### PR TITLE
ci: prepare required checks for merge queue

### DIFF
--- a/.github/workflows/_required.yml
+++ b/.github/workflows/_required.yml
@@ -23,6 +23,10 @@
 name: Required Checks
 
 on:
+  # Merge queues dispatch this event for the synthetic queue commit. Keep the
+  # activity explicit so future merge_group activity types do not run gates.
+  merge_group:
+    types: [checks_requested]
   pull_request:
   push:
     branches: [main]

--- a/docs/dev/merge-queue-readiness.md
+++ b/docs/dev/merge-queue-readiness.md
@@ -1,0 +1,61 @@
+# Merge queue readiness
+
+Scylla uses a staged merge-queue rollout for `main`. This repository prepares
+the required checks; Odysseus owns the later live activation and smoke test.
+
+## Workflow contract
+
+The `Required Checks` workflow is the only workflow that emits the status
+contexts required by the active `homeric-main-baseline` ruleset. It runs for:
+
+- pull requests;
+- pushes to `main`; and
+- `merge_group` events with the `checks_requested` activity.
+
+The required contexts remain:
+
+- `lint`
+- `unit-tests`
+- `integration-tests`
+- `security/dependency-scan`
+- `security/secrets-scan`
+- `build`
+- `schema-validation`
+- `deps/version-sync`
+- `test`
+- `package`
+- `install`
+
+Other workflows retain their existing triggers. In particular, merge-group
+runs must not trigger image publishing or release jobs. The required workflow
+retains read-only repository contents permission, and its dependency and secret
+scans remain required gates.
+
+## Activation authority
+
+Do not activate or modify the live merge queue from this repository. After this
+readiness change is merged and reviewed, Odysseus is the sole authority that may
+update Scylla's live ruleset. It must preserve unrelated rules, bypass actors,
+required contexts, and protections while adding this approved queue policy:
+
+| Parameter | Approved value |
+|-----------|----------------|
+| Merge method | `SQUASH` |
+| Grouping strategy | `ALLGREEN` |
+| Maximum entries building | `10` |
+| Maximum entries merged per group | `5` |
+| Minimum entries merged | `1` |
+| Minimum wait | `5` minutes |
+| Check response timeout | `60` minutes |
+
+Because readiness changes GitHub Actions behavior, a human reviewer must approve
+the implementation PR before it merges. Automated or AI review evidence does
+not satisfy that human-review gate.
+
+## Post-merge evidence
+
+Keep issue #2050 open through activation. Odysseus must record the live ruleset
+response, one `merge_group` / `checks_requested` workflow run containing every
+required context, and the representative queued merge result before the issue
+can be closed. If the queued smoke test fails, report the failure rather than
+bypassing or weakening any required check.

--- a/tests/unit/ci/test_merge_queue_readiness.py
+++ b/tests/unit/ci/test_merge_queue_readiness.py
@@ -1,0 +1,58 @@
+"""Regression coverage for the staged merge-queue workflow readiness."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+_PROJECT_ROOT = Path(__file__).resolve().parents[3]
+_WORKFLOWS = _PROJECT_ROOT / ".github" / "workflows"
+_REQUIRED_WORKFLOW = _WORKFLOWS / "_required.yml"
+
+_REQUIRED_JOBS = {
+    "lint": "lint",
+    "unit-tests": "unit-tests",
+    "integration-tests": "integration-tests",
+    "security-dependency-scan": "security/dependency-scan",
+    "security-secrets-scan": "security/secrets-scan",
+    "build": "build",
+    "schema-validation": "schema-validation",
+    "deps-version-sync": "deps/version-sync",
+    "test": "test",
+    "package": "package",
+    "install": "install",
+}
+
+
+def _load_workflow(path: Path) -> dict[str, Any]:
+    """Load a workflow without YAML 1.1 coercing the ``on`` key to boolean."""
+    workflow = yaml.load(path.read_text(), Loader=yaml.BaseLoader)
+    assert isinstance(workflow, dict)
+    return workflow
+
+
+def test_required_checks_run_for_merge_group_checks_requested() -> None:
+    """Required checks must report for the merge queue's supported event."""
+    workflow = _load_workflow(_REQUIRED_WORKFLOW)
+
+    assert workflow["on"]["merge_group"] == {"types": ["checks_requested"]}
+
+
+def test_existing_required_check_triggers_and_contexts_are_preserved() -> None:
+    """Queue readiness must not change existing PR/push gates or check names."""
+    workflow = _load_workflow(_REQUIRED_WORKFLOW)
+
+    assert workflow["on"]["pull_request"] == ""
+    assert workflow["on"]["push"] == {"branches": ["main"]}
+    assert workflow["permissions"] == {"contents": "read"}
+    emitted_required_jobs = {job_id: workflow["jobs"][job_id]["name"] for job_id in _REQUIRED_JOBS}
+    assert emitted_required_jobs == _REQUIRED_JOBS
+
+
+def test_merge_group_does_not_expand_publish_or_release_workflows() -> None:
+    """Merge groups must not gain package-publish or release side effects."""
+    for workflow_name in ("ci-image.yml", "release.yml"):
+        workflow = _load_workflow(_WORKFLOWS / workflow_name)
+        assert "merge_group" not in workflow["on"]


### PR DESCRIPTION
## Summary

- trigger the existing `Required Checks` workflow for `merge_group` / `checks_requested`
- preserve the pull-request and `main` push triggers, all 11 required contexts, read-only permissions, and security gates
- keep image publishing and release workflows outside merge-group execution
- document the Odysseus-owned activation policy, exact queue parameters, human-review gate, and post-merge evidence lifecycle

## Validation

- `.pixi/envs/default/bin/pytest tests/unit/ci --override-ini='addopts=' -q` — 47 passed
- `.pixi/envs/default/bin/ruff check tests/unit/ci/test_merge_queue_readiness.py` — passed
- `.pixi/envs/default/bin/ruff format --check tests/unit/ci/test_merge_queue_readiness.py` — passed
- `.pixi/envs/default/bin/mypy tests/unit/ci/test_merge_queue_readiness.py` — passed
- `.pixi/envs/default/bin/yamllint --config-file .yamllint.yaml .github/workflows/_required.yml` — exit 0 (four pre-existing line-length warnings)
- Markdown Lint pre-commit hook on `docs/dev/merge-queue-readiness.md` — passed
- `git diff --check` — passed

The full locked Pixi environment could not be materialized locally because the current `origin/main` lock selected CPython 3.14t and attempted Rust source builds for `vl-convert-python` / `grimp`. The changed-file pre-commit aggregate was also interrupted while installing its first-time gitleaks environment. CI remains the full-suite authority for this PR.

## Rollout state

- Live GitHub rulesets and branch protection were inspected read-only and were not mutated.
- Merge-queue activation and queued smoke evidence remain post-merge Odysseus actions.
- This workflow change requires human approval; automated or AI review does not satisfy that gate.
- Keep the issue open until activation evidence is recorded.

Refs #2050
